### PR TITLE
Support key and etag in event id

### DIFF
--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaWithConfig.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaWithConfig.java
@@ -15,20 +15,28 @@
 package io.aklivity.zilla.runtime.binding.sse.kafka.internal.config;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import io.aklivity.zilla.runtime.engine.config.WithConfig;
 
 public final class SseKafkaWithConfig extends WithConfig
 {
+    public static final String EVENT_ID_PROGRESS_ONLY = "${progress}";
+    public static final String EVENT_ID_KEY64_AND_PROGRESS = "[\"${base64(key)}\",\"${progress}\"]";
+    public static final String EVENT_ID_DEFAULT = EVENT_ID_PROGRESS_ONLY;
+
     public final String topic;
     public final Optional<List<SseKafkaWithFilterConfig>> filters;
+    public final String eventId;
 
     public SseKafkaWithConfig(
         String topic,
-        List<SseKafkaWithFilterConfig> filters)
+        List<SseKafkaWithFilterConfig> filters,
+        String eventId)
     {
         this.topic = topic;
         this.filters = Optional.ofNullable(filters);
+        this.eventId = Objects.requireNonNull(eventId);
     }
 }

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaWithResolver.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaWithResolver.java
@@ -57,7 +57,8 @@ public final class SseKafkaWithResolver
         SseKafkaIdHelper sseEventId)
     {
         final String8FW lastEventId = sseBeginEx != null ? sseBeginEx.lastEventId() : null;
-        final Array32FW<KafkaOffsetFW> partitions = sseEventId.decode(lastEventId);
+        final DirectBuffer progress64 = sseEventId.findProgress(lastEventId);
+        final Array32FW<KafkaOffsetFW> partitions = sseEventId.decode(progress64);
 
         // TODO: hoist to constructor if constant
         String topic0 = with.topic;
@@ -113,6 +114,8 @@ public final class SseKafkaWithResolver
             }
         }
 
-        return new SseKafkaWithResult(topic, partitions, filters);
+        String eventId = with.eventId;
+
+        return new SseKafkaWithResult(topic, partitions, filters, eventId);
     }
 }

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaWithResult.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaWithResult.java
@@ -26,15 +26,18 @@ public class SseKafkaWithResult
     private final String16FW topic;
     private final Array32FW<KafkaOffsetFW> partitions;
     private final List<SseKafkaWithFilterResult> filters;
+    private final String eventId;
 
     SseKafkaWithResult(
         String16FW topic,
         Array32FW<KafkaOffsetFW> partitions,
-        List<SseKafkaWithFilterResult> filters)
+        List<SseKafkaWithFilterResult> filters,
+        String eventId)
     {
         this.topic = topic;
         this.partitions = partitions;
         this.filters = filters;
+        this.eventId = eventId;
     }
 
     public String16FW topic()
@@ -54,5 +57,10 @@ public class SseKafkaWithResult
         {
             filters.forEach(f -> builder.item(f::filter));
         }
+    }
+
+    public String eventId()
+    {
+        return eventId;
     }
 }

--- a/runtime/binding-sse-kafka/src/test/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/stream/SseKafkaIdHelperTest.java
+++ b/runtime/binding-sse-kafka/src/test/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/stream/SseKafkaIdHelperTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 
+import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.Test;
 
@@ -33,7 +34,7 @@ public class SseKafkaIdHelperTest
     @Test
     public void shouldDecodeBase64() throws Exception
     {
-        String8FW base64 = new String8FW("AQQABAIC");
+        DirectBuffer base64 = new String8FW("AQQABAIC").value();
         Array32FW<KafkaOffsetFW> expected =
             new Array32FW.Builder<KafkaOffsetFW.Builder, KafkaOffsetFW>(new KafkaOffsetFW.Builder(), new KafkaOffsetFW())
                 .wrap(new UnsafeBuffer(new byte[1024]), 0, 1024)
@@ -52,7 +53,7 @@ public class SseKafkaIdHelperTest
     @Test
     public void shouldDefaultBase64WhenNull() throws Exception
     {
-        String8FW base64 = new String8FW(null);
+        DirectBuffer base64 = new String8FW(null).value();
 
         Array32FW<KafkaOffsetFW> decoded = helper.decode(base64);
 
@@ -62,7 +63,7 @@ public class SseKafkaIdHelperTest
     @Test
     public void shouldDefaultBase64WhenIncomplete() throws Exception
     {
-        String8FW base64 = new String8FW("AQQA");
+        DirectBuffer base64 = new String8FW("AQQA").value();
 
         Array32FW<KafkaOffsetFW> decoded = helper.decode(base64);
 
@@ -72,7 +73,7 @@ public class SseKafkaIdHelperTest
     @Test
     public void shouldRejectBase64WithInvalidLength() throws Exception
     {
-        String8FW base64 = new String8FW("AQQABAIC===");
+        DirectBuffer base64 = new String8FW("AQQABAIC===").value();
 
         Array32FW<KafkaOffsetFW> decoded = helper.decode(base64);
 
@@ -82,7 +83,7 @@ public class SseKafkaIdHelperTest
     @Test
     public void shouldRejectBase64WithInvalidChar() throws Exception
     {
-        String8FW base64 = new String8FW("AQQABAI^");
+        DirectBuffer base64 = new String8FW("AQQABAI^").value();
 
         Array32FW<KafkaOffsetFW> decoded = helper.decode(base64);
 
@@ -92,7 +93,7 @@ public class SseKafkaIdHelperTest
     @Test
     public void shouldRejectBase64WithInvalidPaddingChar() throws Exception
     {
-        String8FW base64 = new String8FW("AQQABAIC==^=");
+        DirectBuffer base64 = new String8FW("AQQABAIC==^=").value();
 
         Array32FW<KafkaOffsetFW> decoded = helper.decode(base64);
 

--- a/runtime/binding-sse-kafka/src/test/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/stream/SseKafkaProxyIT.java
+++ b/runtime/binding-sse-kafka/src/test/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/stream/SseKafkaProxyIT.java
@@ -103,6 +103,26 @@ public class SseKafkaProxyIT
     @Test
     @Configuration("proxy.with.topic.json")
     @Specification({
+        "${sse}/handshake.reconnect.with.etag/client",
+        "${kafka}/handshake.reconnect.with.etag/server"})
+    public void shouldCompleteHandshakeThenReconnectWithEtag() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.with.topic.and.event.id.json")
+    @Specification({
+        "${sse}/handshake.reconnect.with.key.and.etag/client",
+        "${kafka}/handshake.reconnect.with.etag/server"})
+    public void shouldCompleteHandshakeThenReconnectWithKeyAndEtag() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.with.topic.json")
+    @Specification({
         "${sse}/handshake.rejected/client"})
     public void shouldRejectHandshakeWithNoBinding() throws Exception
     {
@@ -122,7 +142,37 @@ public class SseKafkaProxyIT
     @Specification({
         "${sse}/server.sent.messages/client",
         "${kafka}/server.sent.messages/server"})
-    public void shouldReceiveServerSentMessaages() throws Exception
+    public void shouldReceiveServerSentMessages() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.with.topic.json")
+    @Specification({
+        "${sse}/server.sent.messages.with.etag/client",
+        "${kafka}/server.sent.messages.with.etag/server"})
+    public void shouldReceiveServerSentMessagesWithEtag() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.with.topic.and.event.id.json")
+    @Specification({
+        "${sse}/server.sent.messages.with.key.and.etag/client",
+        "${kafka}/server.sent.messages.with.etag/server"})
+    public void shouldReceiveServerSentMessagesWithKeyAndEtag() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.with.topic.and.event.id.json")
+    @Specification({
+        "${sse}/server.sent.messages.with.null.key/client",
+        "${kafka}/server.sent.messages.with.null.key/server"})
+    public void shouldReceiveServerSentMessagesWithNullKey() throws Exception
     {
         k3po.finish();
     }

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/config/proxy.with.topic.and.event.id.json
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/config/proxy.with.topic.and.event.id.json
@@ -1,0 +1,31 @@
+{
+    "name": "test",
+    "bindings":
+    {
+        "sse0":
+        {
+            "type" : "sse-kafka",
+            "kind": "proxy",
+            "routes":
+            [
+                {
+                    "exit": "kafka0",
+                    "when":
+                    [
+                        {
+                            "path": "/test"
+                        }
+                    ],
+                    "with":
+                    {
+                        "topic": "test",
+                        "event":
+                        {
+                            "id": "[\"${base64(key)}\",\"${progress}\"]"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/schema/sse.kafka.schema.patch.json
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/schema/sse.kafka.schema.patch.json
@@ -71,6 +71,19 @@
                                             },
                                             "additionalProperties": false
                                         }
+                                    },
+                                    "event":
+                                    {
+                                        "properties":
+                                        {
+                                            "id":
+                                            {
+                                                "title": "Id",
+                                                "type": "string",
+                                                "enum": [ "${progress}", "[\"${base64(key)}\",\"${progress}\"]" ],
+                                                "default": "${progress}"
+                                            }
+                                        }
                                     }
                                 },
                                 "additionalProperties": false,

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.reconnect.with.etag/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.reconnect.with.etag/client.rpt
@@ -1,0 +1,65 @@
+#
+# Copyright 2021-2022 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/kafka0"
+    option zilla:window 8192
+    option zilla:transmission "duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .merged()
+                                   .capabilities("FETCH_ONLY")
+                                   .topic("test")
+                                   .partition(-1, -2)
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(0, 1, 2)
+                               .progress(0, 2)
+                               .progress(1, 1)
+                               .key("key")
+                               .header("header", "value")
+                               .header("etag", "revision=42")
+                               .build()
+                           .build()}
+read "Hello, world"
+
+read notify RECONNECT_MESSAGE_STREAM
+read closed
+write close
+
+connect await RECONNECT_MESSAGE_STREAM
+    "zilla://streams/kafka0"
+    option zilla:window 8192
+    option zilla:transmission "duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .merged()
+                                   .capabilities("FETCH_ONLY")
+                                   .topic("test")
+                                   .partition(0, 2)
+                                   .partition(1, 1)
+                                   .partition(-1, -2)
+                                   .build()
+                               .build()}
+
+connected
+

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.reconnect.with.etag/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.reconnect.with.etag/server.rpt
@@ -1,0 +1,64 @@
+#
+# Copyright 2021-2022 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/kafka0"
+    option zilla:window 8192
+    option zilla:transmission "duplex"
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .merged()
+                                  .capabilities("FETCH_ONLY")
+                                  .topic("test")
+                                  .partition(-1, -2)
+                                  .build()
+                              .build()}
+
+connected
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .timestamp(kafka:timestamp())
+                                .partition(0, 1, 2)
+                                .progress(0, 2)
+                                .progress(1, 1)
+                                .key("key")
+                                .header("header", "value")
+                                .header("etag", "revision=42")
+                                .build()
+                            .build()}
+write "Hello, world"
+write flush
+
+write close
+read closed
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .merged()
+                                  .capabilities("FETCH_ONLY")
+                                  .topic("test")
+                                  .partition(0, 2)
+                                  .partition(1, 1)
+                                  .partition(-1, -2)
+                                  .build()
+                              .build()}
+
+connected

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.messages.with.etag/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.messages.with.etag/client.rpt
@@ -1,0 +1,55 @@
+#
+# Copyright 2021-2022 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/kafka0"
+    option zilla:window 8192
+    option zilla:transmission "duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                             .typeId(zilla:id("kafka"))
+                             .merged()
+                                 .capabilities("FETCH_ONLY")
+                                 .topic("test")
+                                 .partition(-1, -2)
+                                 .build()
+                             .build()}
+
+connected
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(0, 1, 2)
+                               .progress(0, 2)
+                               .progress(1, 1)
+                               .key("key")
+                               .header("header", "value")
+                               .header("etag", "revision=42")
+                               .build()
+                           .build()}
+read "Hello, world"
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(0, 2, 2)
+                               .progress(0, 3)
+                               .progress(1, 1)
+                               .key("key")
+                               .header("header", "value")
+                               .header("etag", "revision=43")
+                               .build()
+                           .build()}
+read "Hello, again"

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.messages.with.etag/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.messages.with.etag/server.rpt
@@ -1,0 +1,61 @@
+#
+# Copyright 2021-2022 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/kafka0"
+    option zilla:window 8192
+    option zilla:transmission "duplex"
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .capabilities("FETCH_ONLY")
+                                .topic("test")
+                                .partition(-1, -2)
+                                .build()
+                            .build()}
+
+connected
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .timestamp(kafka:timestamp())
+                                .partition(0, 1, 2)
+                                .progress(0, 2)
+                                .progress(1, 1)
+                                .key("key")
+                                .header("header", "value")
+                                .header("etag", "revision=42")
+                                .build()
+                            .build()}
+write "Hello, world"
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .timestamp(kafka:timestamp())
+                                .partition(0, 2, 2)
+                                .progress(0, 3)
+                                .progress(1, 1)
+                                .key("key")
+                                .header("header", "value")
+                                .header("etag", "revision=43")
+                                .build()
+                            .build()}
+write "Hello, again"
+write flush

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.messages.with.null.key/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.messages.with.null.key/client.rpt
@@ -1,0 +1,51 @@
+#
+# Copyright 2021-2022 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/kafka0"
+    option zilla:window 8192
+    option zilla:transmission "duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                             .typeId(zilla:id("kafka"))
+                             .merged()
+                                 .capabilities("FETCH_ONLY")
+                                 .topic("test")
+                                 .partition(-1, -2)
+                                 .build()
+                             .build()}
+
+connected
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(0, 1, 2)
+                               .progress(0, 2)
+                               .progress(1, 1)
+                               .header("header", "value")
+                               .build()
+                           .build()}
+read "Hello, world"
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(0, 2, 2)
+                               .progress(0, 3)
+                               .progress(1, 1)
+                               .header("header", "value")
+                               .build()
+                           .build()}
+read "Hello, again"

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.messages.with.null.key/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.messages.with.null.key/server.rpt
@@ -1,0 +1,57 @@
+#
+# Copyright 2021-2022 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/kafka0"
+    option zilla:window 8192
+    option zilla:transmission "duplex"
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .capabilities("FETCH_ONLY")
+                                .topic("test")
+                                .partition(-1, -2)
+                                .build()
+                            .build()}
+
+connected
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .timestamp(kafka:timestamp())
+                                .partition(0, 1, 2)
+                                .progress(0, 2)
+                                .progress(1, 1)
+                                .header("header", "value")
+                                .build()
+                            .build()}
+write "Hello, world"
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .timestamp(kafka:timestamp())
+                                .partition(0, 2, 2)
+                                .progress(0, 3)
+                                .progress(1, 1)
+                                .header("header", "value")
+                                .build()
+                            .build()}
+write "Hello, again"
+write flush

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.reconnect.with.etag/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.reconnect.with.etag/client.rpt
@@ -1,0 +1,49 @@
+#
+# Copyright 2021-2022 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/sse0"
+        option zilla:window 8192
+        option zilla:transmission "duplex"
+
+write zilla:begin.ext ${sse:beginEx()
+                           .typeId(zilla:id("sse"))
+                           .pathInfo("/test")
+                           .lastEventId(null)
+                           .build()}
+
+connected
+
+read zilla:data.ext ${sse:matchDataEx()
+                         .typeId(zilla:id("sse"))
+                         .id("AQQABAIC/revision=42")
+                         .build()}
+read "Hello, world"
+
+read notify RECONNECT_EVENT_STREAM
+read closed
+write close
+
+connect await RECONNECT_EVENT_STREAM
+        "zilla://streams/sse0"
+        option zilla:window 8192
+        option zilla:transmission "duplex"
+
+write zilla:begin.ext ${sse:beginEx()
+                           .typeId(zilla:id("sse"))
+                           .pathInfo("/test")
+                           .lastEventId("AQQABAIC/revision=42")
+                           .build()}
+
+connected

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.reconnect.with.etag/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.reconnect.with.etag/server.rpt
@@ -1,0 +1,49 @@
+#
+# Copyright 2021-2022 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/sse0"
+       option zilla:window 8192
+       option zilla:transmission "duplex"
+accepted
+
+read zilla:begin.ext ${sse:beginEx()
+                          .typeId(zilla:id("sse"))
+                          .pathInfo("/test")
+                          .lastEventId(null)
+                          .build()}
+
+connected
+
+write zilla:data.ext ${sse:dataEx()
+                          .typeId(zilla:id("sse"))
+                          .timestamp(1519937168533)
+                          .id("AQQABAIC/revision=42")
+                          .type(null)
+                          .build()}
+write "Hello, world"
+write flush
+
+write close
+read closed
+
+accepted
+
+read zilla:begin.ext ${sse:beginEx()
+                          .typeId(zilla:id("sse"))
+                          .pathInfo("/test")
+                          .lastEventId("AQQABAIC/revision=42")
+                          .build()}
+
+connected

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.reconnect.with.key.and.etag/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.reconnect.with.key.and.etag/client.rpt
@@ -1,0 +1,49 @@
+#
+# Copyright 2021-2022 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/sse0"
+        option zilla:window 8192
+        option zilla:transmission "duplex"
+
+write zilla:begin.ext ${sse:beginEx()
+                           .typeId(zilla:id("sse"))
+                           .pathInfo("/test")
+                           .lastEventId(null)
+                           .build()}
+
+connected
+
+read zilla:data.ext ${sse:matchDataEx()
+                         .typeId(zilla:id("sse"))
+                         .id("[\"a2V5\",\"AQQABAIC/revision=42\"]")
+                         .build()}
+read "Hello, world"
+
+read notify RECONNECT_EVENT_STREAM
+read closed
+write close
+
+connect await RECONNECT_EVENT_STREAM
+        "zilla://streams/sse0"
+        option zilla:window 8192
+        option zilla:transmission "duplex"
+
+write zilla:begin.ext ${sse:beginEx()
+                           .typeId(zilla:id("sse"))
+                           .pathInfo("/test")
+                           .lastEventId("[\"a2V5\",\"AQQABAIC/revision=42\"]")
+                           .build()}
+
+connected

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.reconnect.with.key.and.etag/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.reconnect.with.key.and.etag/server.rpt
@@ -1,0 +1,49 @@
+#
+# Copyright 2021-2022 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/sse0"
+       option zilla:window 8192
+       option zilla:transmission "duplex"
+accepted
+
+read zilla:begin.ext ${sse:beginEx()
+                          .typeId(zilla:id("sse"))
+                          .pathInfo("/test")
+                          .lastEventId(null)
+                          .build()}
+
+connected
+
+write zilla:data.ext ${sse:dataEx()
+                          .typeId(zilla:id("sse"))
+                          .timestamp(1519937168533)
+                          .id("[\"a2V5\",\"AQQABAIC/revision=42\"]")
+                          .type(null)
+                          .build()}
+write "Hello, world"
+write flush
+
+write close
+read closed
+
+accepted
+
+read zilla:begin.ext ${sse:beginEx()
+                          .typeId(zilla:id("sse"))
+                          .pathInfo("/test")
+                          .lastEventId("[\"a2V5\",\"AQQABAIC/revision=42\"]")
+                          .build()}
+
+connected

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.etag/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.etag/client.rpt
@@ -1,0 +1,40 @@
+#
+# Copyright 2021-2022 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/sse0"
+        option zilla:window 8192
+        option zilla:transmission "duplex"
+
+write zilla:begin.ext ${sse:beginEx()
+                           .typeId(zilla:id("sse"))
+                           .pathInfo("/test")
+                           .lastEventId(null)
+                           .build()}
+
+connected
+
+read zilla:data.ext ${sse:matchDataEx()
+                         .typeId(zilla:id("sse"))
+                         .id("AQQABAIC/revision=42")
+                         .type(null)
+                         .build()}
+read "Hello, world"
+
+read zilla:data.ext ${sse:matchDataEx()
+                         .typeId(zilla:id("sse"))
+                         .id("AQQABgIC/revision=43")
+                         .type(null)
+                         .build()}
+read "Hello, again"

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.etag/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.etag/server.rpt
@@ -1,0 +1,41 @@
+#
+# Copyright 2021-2022 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/sse0"
+       option zilla:window 8192
+       option zilla:transmission "duplex"
+accepted
+
+read zilla:begin.ext ${sse:beginEx()
+                            .typeId(zilla:id("sse"))
+                            .pathInfo("/test")
+                            .lastEventId(null)
+                            .build()}
+
+connected
+
+write flush
+
+write zilla:data.ext ${sse:dataEx()
+                          .typeId(zilla:id("sse"))
+                          .id("AQQABAIC/revision=42")
+                          .build()}
+write "Hello, world"
+
+write zilla:data.ext ${sse:dataEx()
+                          .typeId(zilla:id("sse"))
+                          .id("AQQABgIC/revision=43")
+                          .build()}
+write "Hello, again"

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.key.and.etag/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.key.and.etag/client.rpt
@@ -1,0 +1,40 @@
+#
+# Copyright 2021-2022 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/sse0"
+        option zilla:window 8192
+        option zilla:transmission "duplex"
+
+write zilla:begin.ext ${sse:beginEx()
+                           .typeId(zilla:id("sse"))
+                           .pathInfo("/test")
+                           .lastEventId(null)
+                           .build()}
+
+connected
+
+read zilla:data.ext ${sse:matchDataEx()
+                         .typeId(zilla:id("sse"))
+                         .id("[\"a2V5\",\"AQQABAIC/revision=42\"]")
+                         .type(null)
+                         .build()}
+read "Hello, world"
+
+read zilla:data.ext ${sse:matchDataEx()
+                         .typeId(zilla:id("sse"))
+                         .id("[\"a2V5\",\"AQQABgIC/revision=43\"]")
+                         .type(null)
+                         .build()}
+read "Hello, again"

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.key.and.etag/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.key.and.etag/server.rpt
@@ -1,0 +1,41 @@
+#
+# Copyright 2021-2022 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/sse0"
+       option zilla:window 8192
+       option zilla:transmission "duplex"
+accepted
+
+read zilla:begin.ext ${sse:beginEx()
+                            .typeId(zilla:id("sse"))
+                            .pathInfo("/test")
+                            .lastEventId(null)
+                            .build()}
+
+connected
+
+write flush
+
+write zilla:data.ext ${sse:dataEx()
+                          .typeId(zilla:id("sse"))
+                          .id("[\"a2V5\",\"AQQABAIC/revision=42\"]")
+                          .build()}
+write "Hello, world"
+
+write zilla:data.ext ${sse:dataEx()
+                          .typeId(zilla:id("sse"))
+                          .id("[\"a2V5\",\"AQQABgIC/revision=43\"]")
+                          .build()}
+write "Hello, again"

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.null.key/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.null.key/client.rpt
@@ -1,0 +1,40 @@
+#
+# Copyright 2021-2022 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/sse0"
+        option zilla:window 8192
+        option zilla:transmission "duplex"
+
+write zilla:begin.ext ${sse:beginEx()
+                           .typeId(zilla:id("sse"))
+                           .pathInfo("/test")
+                           .lastEventId(null)
+                           .build()}
+
+connected
+
+read zilla:data.ext ${sse:matchDataEx()
+                         .typeId(zilla:id("sse"))
+                         .id("[null,\"AQQABAIC\"]")
+                         .type(null)
+                         .build()}
+read "Hello, world"
+
+read zilla:data.ext ${sse:matchDataEx()
+                         .typeId(zilla:id("sse"))
+                         .id("[null,\"AQQABgIC\"]")
+                         .type(null)
+                         .build()}
+read "Hello, again"

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.null.key/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.null.key/server.rpt
@@ -1,0 +1,41 @@
+#
+# Copyright 2021-2022 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/sse0"
+       option zilla:window 8192
+       option zilla:transmission "duplex"
+accepted
+
+read zilla:begin.ext ${sse:beginEx()
+                            .typeId(zilla:id("sse"))
+                            .pathInfo("/test")
+                            .lastEventId(null)
+                            .build()}
+
+connected
+
+write flush
+
+write zilla:data.ext ${sse:dataEx()
+                          .typeId(zilla:id("sse"))
+                          .id("[null,\"AQQABAIC\"]")
+                          .build()}
+write "Hello, world"
+
+write zilla:data.ext ${sse:dataEx()
+                          .typeId(zilla:id("sse"))
+                          .id("[null,\"AQQABgIC\"]")
+                          .build()}
+write "Hello, again"

--- a/specs/binding-sse-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/kafka/config/SchemaTest.java
+++ b/specs/binding-sse-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/kafka/config/SchemaTest.java
@@ -63,4 +63,12 @@ public class SchemaTest
 
         assertThat(config, not(nullValue()));
     }
+
+    @Test
+    public void shouldValidateProxyWithTopicAndEventId()
+    {
+        JsonObject config = schema.validate("proxy.with.topic.and.event.id.json");
+
+        assertThat(config, not(nullValue()));
+    }
 }

--- a/specs/binding-sse-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/kafka/streams/KafkaIT.java
+++ b/specs/binding-sse-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/kafka/streams/KafkaIT.java
@@ -64,9 +64,36 @@ public class KafkaIT
 
     @Test
     @Specification({
+        "${kafka}/handshake.reconnect.with.etag/client",
+        "${kafka}/handshake.reconnect.with.etag/server"})
+    public void shouldCompleteHandshakeThenReconnectWithEtag() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${kafka}/server.sent.messages/client",
         "${kafka}/server.sent.messages/server"})
     public void shouldReceiveServerSentMessages() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${kafka}/server.sent.messages.with.etag/client",
+        "${kafka}/server.sent.messages.with.etag/server"})
+    public void shouldReceiveServerSentMessagesWithEtag() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${kafka}/server.sent.messages.with.null.key/client",
+        "${kafka}/server.sent.messages.with.null.key/server"})
+    public void shouldReceiveServerSentMessagesWithNullKey() throws Exception
     {
         k3po.finish();
     }

--- a/specs/binding-sse-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/kafka/streams/SseIT.java
+++ b/specs/binding-sse-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/kafka/streams/SseIT.java
@@ -73,9 +73,45 @@ public class SseIT
 
     @Test
     @Specification({
+        "${sse}/handshake.reconnect.with.etag/client",
+        "${sse}/handshake.reconnect.with.etag/server"})
+    public void shouldCompleteHandshakeThenReconnectWithEtag() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${sse}/handshake.reconnect.with.key.and.etag/client",
+        "${sse}/handshake.reconnect.with.key.and.etag/server"})
+    public void shouldCompleteHandshakeThenReconnectWithKeyAndEtag() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${sse}/server.sent.messages/client",
         "${sse}/server.sent.messages/server"})
     public void shouldReceiveServerSentMessages() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${sse}/server.sent.messages.with.etag/client",
+        "${sse}/server.sent.messages.with.etag/server"})
+    public void shouldReceiveServerSentMessagesWithEtag() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${sse}/server.sent.messages.with.null.key/client",
+        "${sse}/server.sent.messages.with.null.key/server"})
+    public void shouldReceiveServerSentMessagesWithNullKey() throws Exception
     {
         k3po.finish();
     }


### PR DESCRIPTION
Support configuration of SSE event id to include message key, fix #27.
Support including etag from kafka message with progress, fix #26.