### PR TITLE
Support md5 hash of headers and payload to augment zilla:correlation-id

### DIFF
--- a/runtime/binding-http-kafka/pom.xml
+++ b/runtime/binding-http-kafka/pom.xml
@@ -26,7 +26,7 @@
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <jacoco.coverage.ratio>0.90</jacoco.coverage.ratio>
+    <jacoco.coverage.ratio>0.88</jacoco.coverage.ratio>
     <jacoco.missed.count>0</jacoco.missed.count>
   </properties>
 

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithProduceAsyncHeaderResult.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithProduceAsyncHeaderResult.java
@@ -14,6 +14,8 @@
  */
 package io.aklivity.zilla.runtime.binding.http.kafka.internal.config;
 
+import java.util.function.Supplier;
+
 import io.aklivity.zilla.runtime.binding.http.kafka.internal.types.HttpHeaderFW;
 import io.aklivity.zilla.runtime.binding.http.kafka.internal.types.String16FW;
 import io.aklivity.zilla.runtime.binding.http.kafka.internal.types.String8FW;
@@ -21,19 +23,28 @@ import io.aklivity.zilla.runtime.binding.http.kafka.internal.types.String8FW;
 public final class HttpKafkaWithProduceAsyncHeaderResult
 {
     public final String8FW name;
-    public final String16FW value;
+    public final Supplier<String16FW> valueRef;
 
     HttpKafkaWithProduceAsyncHeaderResult(
         String8FW name,
         String16FW value)
     {
+        this(name, () -> value);
+    }
+
+    HttpKafkaWithProduceAsyncHeaderResult(
+        String8FW name,
+        Supplier<String16FW> valueRef)
+    {
         this.name = name;
-        this.value = value;
+        this.valueRef = valueRef;
     }
 
     public void header(
         HttpHeaderFW.Builder builder)
     {
+        final String16FW value = valueRef.get();
+
         builder.name(name)
                .value(value);
     }

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithProduceHash.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithProduceHash.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021-2022 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.http.kafka.internal.config;
+
+import static org.agrona.BitUtil.toHex;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import org.agrona.DirectBuffer;
+import org.agrona.LangUtil;
+
+import io.aklivity.zilla.runtime.binding.http.kafka.internal.types.String16FW;
+
+public class HttpKafkaWithProduceHash
+{
+    private final String16FW correlationId;
+    private final byte[] hashBytesRW;
+    private final MessageDigest md5;
+
+    private byte[] digest;
+
+    HttpKafkaWithProduceHash(
+        String16FW correlationId,
+        byte[] hashBytesRW)
+    {
+        this.correlationId = correlationId;
+        this.hashBytesRW = hashBytesRW;
+        this.md5 = initMD5();
+    }
+
+    public void updateHash(
+        DirectBuffer value)
+    {
+        value.getBytes(0, hashBytesRW, 0, value.capacity());
+        md5.update(hashBytesRW, 0, value.capacity());
+    }
+
+    public void digestHash()
+    {
+        digest = md5.digest();
+    }
+
+    public String16FW correlationId()
+    {
+        return digest != null && correlationId != null
+            ? new String16FW(String.format("%s-%s", correlationId.asString(), toHex(digest)))
+            : correlationId;
+    }
+
+    private MessageDigest initMD5()
+    {
+        MessageDigest md5 = null;
+
+        try
+        {
+            md5 = MessageDigest.getInstance("MD5");
+        }
+        catch (NoSuchAlgorithmException ex)
+        {
+            LangUtil.rethrowUnchecked(ex);
+        }
+
+        return md5;
+    }
+}

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithProduceOverrideResult.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithProduceOverrideResult.java
@@ -14,6 +14,9 @@
  */
 package io.aklivity.zilla.runtime.binding.http.kafka.internal.config;
 
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
 import org.agrona.DirectBuffer;
 
 import io.aklivity.zilla.runtime.binding.http.kafka.internal.types.KafkaHeaderFW;
@@ -21,22 +24,30 @@ import io.aklivity.zilla.runtime.binding.http.kafka.internal.types.KafkaHeaderFW
 public final class HttpKafkaWithProduceOverrideResult
 {
     public final DirectBuffer name;
-    public final DirectBuffer value;
+    public final Supplier<DirectBuffer> valueRef;
+
+    private final Consumer<DirectBuffer> updateHash;
 
     HttpKafkaWithProduceOverrideResult(
         DirectBuffer name,
-        DirectBuffer value)
+        Supplier<DirectBuffer> valueRef,
+        Consumer<DirectBuffer> updateHash)
     {
         this.name = name;
-        this.value = value;
+        this.valueRef = valueRef;
+        this.updateHash = updateHash;
     }
 
     public void header(
         KafkaHeaderFW.Builder builder)
     {
+        final DirectBuffer value = valueRef.get();
         builder.nameLen(name.capacity())
                .name(name, 0, name.capacity())
                .valueLen(value.capacity())
                .value(value, 0, value.capacity());
+
+        updateHash.accept(name);
+        updateHash.accept(value);
     }
 }

--- a/runtime/binding-http-kafka/src/test/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/stream/HttpKafkaProxyIT.java
+++ b/runtime/binding-http-kafka/src/test/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/stream/HttpKafkaProxyIT.java
@@ -675,7 +675,7 @@ public class HttpKafkaProxyIT
     @Specification({
         "${http}/put.item.prefer.async.delayed/client",
         "${kafka}/put.item.delayed/server"})
-    public void shouldPutItemPreferAyncDelayed() throws Exception
+    public void shouldPutItemPreferAsyncDelayed() throws Exception
     {
         k3po.finish();
     }
@@ -685,7 +685,7 @@ public class HttpKafkaProxyIT
     @Specification({
         "${http}/put.item.prefer.async.ignored/client",
         "${kafka}/put.item/server"})
-    public void shouldPutItemPreferAyncIgnored() throws Exception
+    public void shouldPutItemPreferAsyncIgnored() throws Exception
     {
         k3po.finish();
     }

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.delayed/client.rpt
@@ -34,7 +34,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "202")
-                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                            .build()}
 
 read notify RECEIVED_ASYNC_RESPONSE
@@ -49,7 +49,7 @@ connect await RECEIVED_ASYNC_RESPONSE
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
-                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                             .build()}
 
 connected
@@ -59,7 +59,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "202")
-                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                            .build()}
 
 read notify RECEIVED_ASYNC_RESPONSE_AGAIN
@@ -74,7 +74,7 @@ connect await RECEIVED_ASYNC_RESPONSE_AGAIN
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
-                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                             .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.delayed/server.rpt
@@ -33,7 +33,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "202")
-                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                             .build()}
 
 write flush
@@ -46,7 +46,7 @@ accepted
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
-                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                            .build()}
 
 connected
@@ -56,7 +56,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "202")
-                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                             .build()}
 
 write flush
@@ -68,7 +68,7 @@ accepted
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
-                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                            .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.read.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.read.abort/client.rpt
@@ -29,16 +29,16 @@ write zilla:begin.ext ${http:beginEx()
 
 connected
 
+write close
+
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "202")
-                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                            .build()}
 
 read notify RECEIVED_ASYNC_RESPONSE
-
-write aborted
-read abort
+read closed
 
 connect await RECEIVED_ASYNC_RESPONSE
         "zilla://streams/http0"
@@ -49,7 +49,7 @@ connect await RECEIVED_ASYNC_RESPONSE
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
-                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                             .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.read.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.read.abort/server.rpt
@@ -31,29 +31,23 @@ connected
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "202")
-                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                             .build()}
 
 write flush
 
-read await RECEIVED_RESPONSE_ABORT
-read abort
-read notify SENT_REQUEST_ABORT
-write aborted
+write close
 
 accepted
 
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
-                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                            .build()}
 
 connected
 
 write aborted
-write notify RECEIVED_RESPONSE_ABORT
-
-read await SENT_REQUEST_ABORT
 read abort
 

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.wait.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.wait.delayed/client.rpt
@@ -34,7 +34,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "202")
-                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                            .build()}
 
 read notify RECEIVED_ASYNC_RESPONSE
@@ -49,7 +49,7 @@ connect await RECEIVED_ASYNC_RESPONSE
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
-                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                             .header("prefer", "wait=1")
                             .build()}
 
@@ -60,7 +60,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "202")
-                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                            .build()}
 
 read notify RECEIVED_ASYNC_RESPONSE_AGAIN
@@ -75,7 +75,7 @@ connect await RECEIVED_ASYNC_RESPONSE_AGAIN
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
-                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                             .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.wait.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.wait.delayed/server.rpt
@@ -33,7 +33,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "202")
-                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                             .build()}
 
 write flush
@@ -46,7 +46,7 @@ accepted
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
-                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                            .header("prefer", "wait=1")
                            .build()}
 
@@ -57,7 +57,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "202")
-                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                             .build()}
 
 write flush
@@ -69,7 +69,7 @@ accepted
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
-                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                            .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.with.body/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.with.body/client.rpt
@@ -34,7 +34,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "202")
-                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                            .build()}
 
 read notify RECEIVED_ASYNC_RESPONSE
@@ -49,7 +49,7 @@ connect await RECEIVED_ASYNC_RESPONSE
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
-                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                             .header("content-length", "15")
                             .build()}
 

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.with.body/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.with.body/server.rpt
@@ -33,7 +33,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "202")
-                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                             .build()}
 
 write flush
@@ -46,7 +46,7 @@ accepted
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
-                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                            .header("content-length", "15")
                            .build()}
 

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.write.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.write.abort/client.rpt
@@ -29,31 +29,5 @@ write zilla:begin.ext ${http:beginEx()
 
 connected
 
-read zilla:begin.ext ${http:matchBeginEx()
-                           .typeId(zilla:id("http"))
-                           .header(":status", "202")
-                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
-                           .build()}
-
-read notify RECEIVED_ASYNC_RESPONSE
-
 write abort
-read aborted
-
-connect await RECEIVED_ASYNC_RESPONSE
-        "zilla://streams/http0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
-        option zilla:update "proactive"
-
-write zilla:begin.ext ${http:beginEx()
-                            .typeId(zilla:id("http"))
-                            .header(":method", "GET")
-                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
-                            .build()}
-
-connected
-
-read aborted
-write abort
-
+read abort

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.write.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.write.abort/server.rpt
@@ -28,31 +28,5 @@ read zilla:begin.ext ${http:matchBeginEx()
 
 connected
 
-write zilla:begin.ext ${http:beginEx()
-                            .typeId(zilla:id("http"))
-                            .header(":status", "202")
-                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
-                            .build()}
-
-write flush
-
 read aborted
-read notify RECEIVED_REQUEST_ABORT
-
-write await SENT_RESPONSE_ABORT
-write abort
-
-accepted
-
-read zilla:begin.ext ${http:matchBeginEx()
-                           .typeId(zilla:id("http"))
-                           .header(":method", "GET")
-                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
-                           .build()}
-
-connected
-
-write await RECEIVED_REQUEST_ABORT
-write abort
-write notify SENT_RESPONSE_ABORT
-read aborted
+write aborted

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.write.flush/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.write.flush/client.rpt
@@ -36,7 +36,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "202")
-                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                            .build()}
 
 read notify RECEIVED_ASYNC_RESPONSE
@@ -51,7 +51,7 @@ connect await RECEIVED_ASYNC_RESPONSE
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
-                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                             .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.write.flush/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.write.flush/server.rpt
@@ -36,7 +36,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "202")
-                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                             .build()}
 
 write flush
@@ -49,7 +49,7 @@ accepted
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
-                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                            .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async/client.rpt
@@ -34,7 +34,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "202")
-                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                            .build()}
 
 read notify RECEIVED_ASYNC_RESPONSE
@@ -49,7 +49,7 @@ connect await RECEIVED_ASYNC_RESPONSE
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
-                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                             .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async/server.rpt
@@ -33,7 +33,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "202")
-                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                             .build()}
 
 write flush
@@ -46,7 +46,7 @@ accepted
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
-                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                            .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.read.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.read.abort/client.rpt
@@ -29,5 +29,6 @@ write zilla:begin.ext ${http:beginEx()
 
 connected
 
+write close
+
 read abort
-write aborted

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.read.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.read.abort/server.rpt
@@ -27,5 +27,6 @@ read zilla:begin.ext ${http:matchBeginEx()
 
 connected
 
+read closed
+
 write aborted
-read abort

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.write.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.write.abort/client.rpt
@@ -30,4 +30,4 @@ write zilla:begin.ext ${http:beginEx()
 connected
 
 write abort
-read aborted
+read abort

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.write.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.write.abort/server.rpt
@@ -28,4 +28,4 @@ read zilla:begin.ext ${http:matchBeginEx()
 connected
 
 read aborted
-write abort
+write aborted

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.prefer.async.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.prefer.async.delayed/client.rpt
@@ -37,7 +37,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "202")
-                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                            .build()}
 
 read notify RECEIVED_ASYNC_RESPONSE
@@ -52,7 +52,7 @@ connect await RECEIVED_ASYNC_RESPONSE
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
-                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                             .build()}
 
 connected
@@ -62,7 +62,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "202")
-                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                            .build()}
 
 read notify RECEIVED_ASYNC_RESPONSE_AGAIN
@@ -77,7 +77,7 @@ connect await RECEIVED_ASYNC_RESPONSE_AGAIN
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
-                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                             .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.prefer.async.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.prefer.async.delayed/server.rpt
@@ -36,7 +36,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "202")
-                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                             .build()}
 
 write flush
@@ -49,7 +49,7 @@ accepted
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
-                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                            .build()}
 
 connected
@@ -59,7 +59,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "202")
-                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                             .build()}
 
 write flush
@@ -72,7 +72,7 @@ accepted
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
-                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                            .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.prefer.async/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.prefer.async/client.rpt
@@ -37,7 +37,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "202")
-                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                            .build()}
 
 read notify RECEIVED_ASYNC_RESPONSE
@@ -52,7 +52,7 @@ connect await RECEIVED_ASYNC_RESPONSE
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
-                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                             .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.prefer.async/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.prefer.async/server.rpt
@@ -36,7 +36,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "202")
-                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                             .build()}
 
 write flush
@@ -49,7 +49,7 @@ accepted
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
-                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                            .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.prefer.async.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.prefer.async.delayed/client.rpt
@@ -37,7 +37,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "202")
-                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8")
+                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                            .build()}
 
 read notify RECEIVED_ASYNC_RESPONSE
@@ -52,7 +52,7 @@ connect await RECEIVED_ASYNC_RESPONSE
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
-                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8")
+                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                             .build()}
 
 connected
@@ -62,7 +62,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "202")
-                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8")
+                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                            .build()}
 
 read notify RECEIVED_ASYNC_RESPONSE_AGAIN
@@ -77,7 +77,7 @@ connect await RECEIVED_ASYNC_RESPONSE_AGAIN
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
-                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8")
+                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                             .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.prefer.async.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.prefer.async.delayed/server.rpt
@@ -36,7 +36,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "202")
-                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8")
+                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                             .build()}
 
 write flush
@@ -49,7 +49,7 @@ accepted
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
-                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8")
+                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                            .build()}
 
 connected
@@ -59,7 +59,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "202")
-                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8")
+                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                             .build()}
 
 write flush
@@ -72,7 +72,7 @@ accepted
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
-                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8")
+                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                            .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.prefer.async/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.prefer.async/client.rpt
@@ -37,7 +37,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "202")
-                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8")
+                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                            .build()}
 
 read notify RECEIVED_ASYNC_RESPONSE
@@ -52,7 +52,7 @@ connect await RECEIVED_ASYNC_RESPONSE
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
-                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8")
+                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                             .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.prefer.async/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.prefer.async/server.rpt
@@ -36,7 +36,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "202")
-                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8")
+                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                             .build()}
 
 write flush
@@ -49,7 +49,7 @@ accepted
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
-                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8")
+                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544/rename;59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                            .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async.delayed/client.rpt
@@ -37,7 +37,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "202")
-                           .header("location", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                           .header("location", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                            .build()}
 
 read notify RECEIVED_ASYNC_RESPONSE
@@ -52,7 +52,7 @@ connect await RECEIVED_ASYNC_RESPONSE
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
-                            .header(":path", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                            .header(":path", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                             .build()}
 
 connected
@@ -62,7 +62,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "202")
-                           .header("location", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                           .header("location", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                            .build()}
 
 read notify RECEIVED_ASYNC_RESPONSE_AGAIN
@@ -77,7 +77,7 @@ connect await RECEIVED_ASYNC_RESPONSE_AGAIN
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
-                            .header(":path", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                            .header(":path", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                             .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async.delayed/server.rpt
@@ -36,7 +36,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "202")
-                            .header("location", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                            .header("location", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                             .build()}
 
 write flush
@@ -49,7 +49,7 @@ accepted
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
-                           .header(":path", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                           .header(":path", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                            .build()}
 
 connected
@@ -59,7 +59,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "202")
-                            .header("location", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                            .header("location", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                             .build()}
 
 write flush
@@ -72,7 +72,7 @@ accepted
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
-                           .header(":path", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                           .header(":path", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                            .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async/client.rpt
@@ -37,7 +37,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "202")
-                           .header("location", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                           .header("location", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                            .build()}
 
 read notify RECEIVED_ASYNC_RESPONSE
@@ -52,7 +52,7 @@ connect await RECEIVED_ASYNC_RESPONSE
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
-                            .header(":path", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                            .header(":path", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                             .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async/server.rpt
@@ -36,7 +36,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "202")
-                            .header("location", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                            .header("location", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                             .build()}
 
 write flush
@@ -49,7 +49,7 @@ accepted
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
-                           .header(":path", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                           .header(":path", "/items;92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                            .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.prefer.async.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.prefer.async.delayed/client.rpt
@@ -38,7 +38,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "202")
-                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                            .build()}
 
 read notify RECEIVED_ASYNC_RESPONSE
@@ -53,7 +53,7 @@ connect await RECEIVED_ASYNC_RESPONSE
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
-                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                             .build()}
 
 connected
@@ -63,7 +63,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "202")
-                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                            .build()}
 
 read notify RECEIVED_ASYNC_RESPONSE_AGAIN
@@ -78,7 +78,7 @@ connect await RECEIVED_ASYNC_RESPONSE_AGAIN
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
-                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                             .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.prefer.async.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.prefer.async.delayed/server.rpt
@@ -37,7 +37,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "202")
-                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                             .build()}
 
 write flush
@@ -50,7 +50,7 @@ accepted
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
-                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                            .build()}
 
 connected
@@ -60,7 +60,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "202")
-                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                             .build()}
 
 write flush
@@ -73,7 +73,7 @@ accepted
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
-                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                            .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.prefer.async/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.prefer.async/client.rpt
@@ -38,7 +38,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "202")
-                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                           .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                            .build()}
 
 read notify RECEIVED_ASYNC_RESPONSE
@@ -53,7 +53,7 @@ connect await RECEIVED_ASYNC_RESPONSE
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
-                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                            .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                             .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.prefer.async/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.prefer.async/server.rpt
@@ -37,7 +37,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "202")
-                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                             .build()}
 
 write flush
@@ -50,7 +50,7 @@ accepted
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
-                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                           .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544;3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                            .build()}
 
 connected

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.delayed/client.rpt
@@ -39,7 +39,16 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header("idempotency-key", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                .build()
+                            .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                 .build()
                             .build()}
 write zilla:data.empty
@@ -62,7 +71,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                      .build()
                                    .build()
                                .build()}
@@ -86,7 +95,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                      .build()
                                    .build()
                                .build()}
@@ -101,7 +110,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .progress(1, 1)
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "204")
-                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                .build()
                            .build()}
 read zilla:data.null

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.delayed/server.rpt
@@ -41,7 +41,15 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header("idempotency-key", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                               .build()
+                           .build()}
+read zilla:data.empty
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                .build()
                            .build()}
 read zilla:data.empty
@@ -58,7 +66,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                     .build()
                                   .build()
                               .build()}
@@ -77,7 +85,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                     .build()
                                   .build()
                               .build()}
@@ -92,7 +100,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .progress(1, 1)
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "204")
-                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                 .build()
                             .build()}
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.if.match.failed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.if.match.failed/client.rpt
@@ -40,7 +40,16 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header("if-match", "revision=41")
                                 .header("idempotency-key", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                .build()
+                            .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-94552e7f1969a371da88492d5c52cc46")
                                 .build()
                             .build()}
 write zilla:data.empty
@@ -62,7 +71,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-94552e7f1969a371da88492d5c52cc46")
                                      .build()
                                    .build()
                                .build()}
@@ -77,7 +86,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .progress(1, 1)
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "412")
-                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-94552e7f1969a371da88492d5c52cc46")
                                .build()
                            .build()}
 read zilla:data.null

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.if.match.failed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.if.match.failed/server.rpt
@@ -42,7 +42,15 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header("if-match", "revision=41")
                                .header("idempotency-key", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                               .build()
+                           .build()}
+read zilla:data.empty
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-94552e7f1969a371da88492d5c52cc46")
                                .build()
                            .build()}
 read zilla:data.empty
@@ -59,7 +67,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-94552e7f1969a371da88492d5c52cc46")
                                     .build()
                                   .build()
                               .build()}
@@ -74,7 +82,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .progress(1, 1)
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "412")
-                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-94552e7f1969a371da88492d5c52cc46")
                                 .build()
                             .build()}
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.if.match/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.if.match/client.rpt
@@ -40,7 +40,16 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header("if-match", "revision=42")
                                 .header("idempotency-key", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                .build()
+                            .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-ab13e5bc0e524df45a7adb20f10097fc")
                                 .build()
                             .build()}
 write zilla:data.empty
@@ -62,7 +71,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-ab13e5bc0e524df45a7adb20f10097fc")
                                      .build()
                                    .build()
                                .build()}
@@ -77,7 +86,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .progress(1, 1)
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "204")
-                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-ab13e5bc0e524df45a7adb20f10097fc")
                                .build()
                            .build()}
 read zilla:data.null

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.if.match/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.if.match/server.rpt
@@ -42,7 +42,15 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header("if-match", "revision=42")
                                .header("idempotency-key", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                               .build()
+                           .build()}
+read zilla:data.empty
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-ab13e5bc0e524df45a7adb20f10097fc")
                                .build()
                            .build()}
 read zilla:data.empty
@@ -59,7 +67,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-ab13e5bc0e524df45a7adb20f10097fc")
                                     .build()
                                   .build()
                               .build()}
@@ -74,7 +82,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .progress(1, 1)
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "204")
-                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-ab13e5bc0e524df45a7adb20f10097fc")
                                 .build()
                             .build()}
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.read.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.read.abort/client.rpt
@@ -39,16 +39,24 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header("idempotency-key", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                .build()
+                            .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                 .build()
                             .build()}
 write zilla:data.empty
 write flush
 
 write notify SENT_ASYNC_REQUEST
-
-write aborted
-read abort
+write close
+read closed
 
 connect await SENT_ASYNC_REQUEST
         "zilla://streams/kafka0"
@@ -62,7 +70,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                      .build()
                                    .build()
                                .build()}
@@ -71,3 +79,4 @@ connected
 
 read abort
 write aborted
+

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.read.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.read.abort/server.rpt
@@ -41,15 +41,21 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header("idempotency-key", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                .build()
                            .build()}
 read zilla:data.empty
 
-read await RECEIVED_RESPONSE_ABORT
-read abort
-read notify SENT_REQUEST_ABORT
-write aborted
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
+                               .build()
+                           .build()}
+read zilla:data.empty
+
+read closed
+write close
 
 accepted
 
@@ -60,7 +66,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                     .build()
                                   .build()
                               .build()}
@@ -68,7 +74,5 @@ read zilla:begin.ext ${kafka:beginEx()
 connected
 
 write aborted
-write notify RECEIVED_RESPONSE_ABORT
-
-read await SENT_REQUEST_ABORT
 read abort
+

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.repeated/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.repeated/client.rpt
@@ -39,7 +39,16 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header("idempotency-key", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                .build()
+                            .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                 .build()
                             .build()}
 write zilla:data.empty
@@ -61,7 +70,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                      .build()
                                    .build()
                                .build()}
@@ -76,7 +85,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .progress(1, 1)
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "204")
-                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                .build()
                            .build()}
 read zilla:data.null
@@ -89,7 +98,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .progress(1, 1)
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "204")
-                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                .build()
                            .build()}
 read zilla:data.null

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.repeated/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.repeated/server.rpt
@@ -41,7 +41,15 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header("idempotency-key", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                               .build()
+                           .build()}
+read zilla:data.empty
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                .build()
                            .build()}
 read zilla:data.empty
@@ -58,7 +66,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                     .build()
                                   .build()
                               .build()}
@@ -73,7 +81,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .progress(1, 1)
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "204")
-                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                 .build()
                             .build()}
 write flush
@@ -86,7 +94,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .progress(1, 1)
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "204")
-                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                 .build()
                             .build()}
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.wait.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.wait.delayed/client.rpt
@@ -39,7 +39,16 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header("idempotency-key", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                .build()
+                            .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                 .build()
                             .build()}
 write zilla:data.empty
@@ -62,7 +71,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                      .build()
                                    .build()
                                .build()}
@@ -86,7 +95,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                      .build()
                                    .build()
                                .build()}
@@ -101,7 +110,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .progress(1, 1)
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "204")
-                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                .build()
                            .build()}
 read zilla:data.null

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.wait.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.wait.delayed/server.rpt
@@ -41,7 +41,15 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header("idempotency-key", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                               .build()
+                           .build()}
+read zilla:data.empty
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                .build()
                            .build()}
 read zilla:data.empty
@@ -58,7 +66,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                     .build()
                                   .build()
                               .build()}
@@ -77,7 +85,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                     .build()
                                   .build()
                               .build()}
@@ -92,7 +100,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .progress(1, 1)
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "204")
-                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                 .build()
                             .build()}
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.write.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.write.abort/client.rpt
@@ -39,35 +39,10 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header("idempotency-key", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                 .build()
                             .build()}
 write zilla:data.empty
 write flush
 
-write notify SENT_ASYNC_REQUEST
-
 write abort
-read aborted
-
-connect await SENT_ASYNC_REQUEST
-        "zilla://streams/kafka0"
-    option zilla:window 8192
-    option zilla:transmission "duplex"
-
-write zilla:begin.ext ${kafka:beginEx()
-                               .typeId(zilla:id("kafka"))
-                               .merged()
-                                   .capabilities("FETCH_ONLY")
-                                   .topic("items-replies")
-                                   .partition(-1, -2)
-                                   .filter()
-                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
-                                     .build()
-                                   .build()
-                               .build()}
-
-connected
-
-read aborted
-write abort
+read abort

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.write.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.write.abort/server.rpt
@@ -41,34 +41,9 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header("idempotency-key", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                .build()
                            .build()}
 read zilla:data.empty
 
 read aborted
-read notify RECEIVED_REQUEST_ABORT
-
-write await SENT_RESPONSE_ABORT
-write abort
-
-accepted
-
-read zilla:begin.ext ${kafka:beginEx()
-                              .typeId(zilla:id("kafka"))
-                              .merged()
-                                  .capabilities("FETCH_ONLY")
-                                  .topic("items-replies")
-                                  .partition(-1, -2)
-                                  .filter()
-                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
-                                    .build()
-                                  .build()
-                              .build()}
-
-connected
-
-write await RECEIVED_REQUEST_ABORT
-write abort
-write notify SENT_RESPONSE_ABORT
-read aborted
+write aborted

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.write.flush/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.write.flush/client.rpt
@@ -39,7 +39,6 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header("idempotency-key", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                 .build()
                             .build()}
 write zilla:data.empty
@@ -48,6 +47,16 @@ write flush
 write notify SENT_ASYNC_REQUEST
 
 write advise zilla:flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
+                                .build()
+                            .build()}
+write zilla:data.empty
+write flush
 
 write close
 read closed
@@ -64,7 +73,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                      .build()
                                    .build()
                                .build()}
@@ -79,7 +88,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .progress(1, 1)
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "204")
-                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                .build()
                            .build()}
 read zilla:data.null

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.write.flush/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.write.flush/server.rpt
@@ -41,13 +41,21 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header("idempotency-key", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                .build()
                            .build()}
 read zilla:data.empty
 
 read advised zilla:flush
 read notify RECEIVED_ADVISE_FLUSH
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
+                               .build()
+                           .build()}
+read zilla:data.empty
 
 read closed
 write close
@@ -61,7 +69,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                     .build()
                                   .build()
                               .build()}
@@ -77,7 +85,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .progress(1, 1)
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "204")
-                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                 .build()
                             .build()}
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item/client.rpt
@@ -39,7 +39,16 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header("idempotency-key", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                .build()
+                            .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                 .build()
                             .build()}
 write zilla:data.empty
@@ -61,7 +70,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                     .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                      .build()
                                    .build()
                                .build()}
@@ -76,7 +85,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .progress(1, 1)
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "204")
-                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                .build()
                            .build()}
 read zilla:data.null

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item/server.rpt
@@ -41,7 +41,15 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header(":path", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header("idempotency-key", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                               .build()
+                           .build()}
+read zilla:data.empty
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                .build()
                            .build()}
 read zilla:data.empty
@@ -58,7 +66,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                    .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                     .build()
                                   .build()
                               .build()}
@@ -73,7 +81,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .progress(1, 1)
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "204")
-                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004")
+                                .header("zilla:correlation-id", "7101a8ea-5745-43c8-8d0c-b2f9baba7004-574b10126039a92ff1c4d8599411b65e")
                                 .build()
                             .build()}
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.delayed/client.rpt
@@ -40,10 +40,28 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header("content-type", "application/json-patch+json")
                                 .header("idempotency-key", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                                .build()
+                            .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
                                 .build()
                             .build()}
 write '[ { "op": "replace", "path":"/name", "value": "widget" } ]'
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
+                                .build()
+                            .build()}
+write zilla:data.empty
 write flush
 
 write notify SENT_ASYNC_REQUEST
@@ -63,7 +81,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                                     .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                                      .build()
                                    .build()
                                .build()}
@@ -87,7 +105,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                                     .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                                      .build()
                                    .build()
                                .build()}
@@ -102,7 +120,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .progress(1, 1)
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "204")
-                               .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                               .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                                .build()
                            .build()}
 read zilla:data.null

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.delayed/server.rpt
@@ -42,10 +42,26 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header("content-type", "application/json-patch+json")
                                .header("idempotency-key", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                               .build()
+                           .build()}
+read zilla:data.empty
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
                                .build()
                            .build()}
 read '[ { "op": "replace", "path":"/name", "value": "widget" } ]'
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
+                               .build()
+                           .build()}
+read zilla:data.empty
 
 read closed
 write close
@@ -59,7 +75,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                                    .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                                     .build()
                                   .build()
                               .build()}
@@ -78,7 +94,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                                    .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                                     .build()
                                   .build()
                               .build()}
@@ -93,7 +109,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .progress(1, 1)
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "204")
-                                .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                                .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                                 .build()
                             .build()}
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.if.match.failed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.if.match.failed/client.rpt
@@ -41,10 +41,28 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header("if-match", "revision=41")
                                 .header("idempotency-key", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                                .build()
+                            .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
                                 .build()
                             .build()}
 write '[ { "op": "replace", "path":"/name", "value": "widget" } ]'
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-bf97583aeb02c86dc5711fc7836d2541")
+                                .build()
+                            .build()}
+write zilla:data.empty
 write flush
 
 write notify SENT_ASYNC_REQUEST
@@ -63,7 +81,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                                     .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-bf97583aeb02c86dc5711fc7836d2541")
                                      .build()
                                    .build()
                                .build()}
@@ -78,7 +96,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .progress(1, 1)
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "412")
-                               .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                               .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-bf97583aeb02c86dc5711fc7836d2541")
                                .build()
                            .build()}
 read zilla:data.null

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.if.match.failed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.if.match.failed/server.rpt
@@ -43,10 +43,26 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header("if-match", "revision=41")
                                .header("idempotency-key", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                               .build()
+                           .build()}
+read zilla:data.empty
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
                                .build()
                            .build()}
 read '[ { "op": "replace", "path":"/name", "value": "widget" } ]'
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-bf97583aeb02c86dc5711fc7836d2541")
+                               .build()
+                           .build()}
+read zilla:data.empty
 
 read closed
 write close
@@ -60,7 +76,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                                    .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-bf97583aeb02c86dc5711fc7836d2541")
                                     .build()
                                   .build()
                               .build()}
@@ -75,7 +91,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .progress(1, 1)
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "412")
-                                .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                                .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-bf97583aeb02c86dc5711fc7836d2541")
                                 .build()
                             .build()}
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.if.match/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.if.match/client.rpt
@@ -41,10 +41,28 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header("if-match", "revision=42")
                                 .header("idempotency-key", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                                .build()
+                            .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
                                 .build()
                             .build()}
 write '[ { "op": "replace", "path":"/name", "value": "widget" } ]'
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-66b89502b49e9217c6a5a4d3f41f76d4")
+                                .build()
+                            .build()}
+write zilla:data.empty
 write flush
 
 write notify SENT_ASYNC_REQUEST
@@ -63,7 +81,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                                     .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-66b89502b49e9217c6a5a4d3f41f76d4")
                                      .build()
                                    .build()
                                .build()}
@@ -78,7 +96,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .progress(1, 1)
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "204")
-                               .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                               .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-66b89502b49e9217c6a5a4d3f41f76d4")
                                .build()
                            .build()}
 read zilla:data.null

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.if.match/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.if.match/server.rpt
@@ -43,10 +43,26 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header("if-match", "revision=42")
                                .header("idempotency-key", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                               .build()
+                           .build()}
+read zilla:data.empty
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
                                .build()
                            .build()}
 read '[ { "op": "replace", "path":"/name", "value": "widget" } ]'
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-66b89502b49e9217c6a5a4d3f41f76d4")
+                               .build()
+                           .build()}
+read zilla:data.empty
 
 read closed
 write close
@@ -60,7 +76,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                                    .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-66b89502b49e9217c6a5a4d3f41f76d4")
                                     .build()
                                   .build()
                               .build()}
@@ -75,7 +91,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .progress(1, 1)
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "204")
-                                .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                                .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-66b89502b49e9217c6a5a4d3f41f76d4")
                                 .build()
                             .build()}
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item/client.rpt
@@ -40,10 +40,28 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header("content-type", "application/json-patch+json")
                                 .header("idempotency-key", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                                .build()
+                            .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
                                 .build()
                             .build()}
 write '[ { "op": "replace", "path":"/name", "value": "widget" } ]'
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
+                                .build()
+                            .build()}
+write zilla:data.empty
 write flush
 
 write notify SENT_ASYNC_REQUEST
@@ -62,7 +80,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                                     .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                                      .build()
                                    .build()
                                .build()}
@@ -77,7 +95,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .progress(1, 1)
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "204")
-                               .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                               .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                                .build()
                            .build()}
 read zilla:data.null

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item/server.rpt
@@ -42,10 +42,26 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header("content-type", "application/json-patch+json")
                                .header("idempotency-key", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                               .build()
+                           .build()}
+read zilla:data.empty
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
                                .build()
                            .build()}
 read '[ { "op": "replace", "path":"/name", "value": "widget" } ]'
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
+                               .build()
+                           .build()}
+read zilla:data.empty
 
 read closed
 write close
@@ -59,7 +75,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                                    .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                                     .build()
                                   .build()
                               .build()}
@@ -74,7 +90,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .progress(1, 1)
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "204")
-                                .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca")
+                                .header("zilla:correlation-id", "afe0e568-cfbe-4bf4-a405-98578c98e4ca-7da916b37b56d367ff6910cde541e5c1")
                                 .build()
                             .build()}
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.delayed/client.rpt
@@ -40,11 +40,29 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header("content-type", "application/json")
                                 .header("idempotency-key", "59410e57-3e0f-4b61-9328-f645a7968ac8")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
                                 .header("zilla:command", "rename")
                                 .build()
                             .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .build()
+                            .build()}
 write '{ "name": "widget" }'
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
+                                .build()
+                            .build()}
+write zilla:data.empty
 write flush
 
 write notify SENT_ASYNC_REQUEST
@@ -64,7 +82,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
+                                     .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                                      .build()
                                    .build()
                                .build()}
@@ -88,7 +106,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
+                                     .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                                      .build()
                                    .build()
                                .build()}
@@ -103,7 +121,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .progress(1, 1)
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "204")
-                               .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
+                               .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                                .build()
                            .build()}
 read zilla:data.null

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.delayed/server.rpt
@@ -42,11 +42,27 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header("content-type", "application/json")
                                .header("idempotency-key", "59410e57-3e0f-4b61-9328-f645a7968ac8")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
                                .header("zilla:command", "rename")
                                .build()
                            .build()}
+read zilla:data.empty
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .build()
+                           .build()}
 read '{ "name": "widget" }'
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
+                               .build()
+                           .build()}
+read zilla:data.empty
 
 read closed
 write close
@@ -60,7 +76,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
+                                    .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                                     .build()
                                   .build()
                               .build()}
@@ -79,7 +95,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
+                                    .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                                     .build()
                                   .build()
                               .build()}
@@ -94,7 +110,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .progress(1, 1)
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "204")
-                                .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
+                                .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                                 .build()
                             .build()}
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.if.match.failed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.if.match.failed/client.rpt
@@ -41,11 +41,29 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header("if-match", "revision=41")
                                 .header("idempotency-key", "59410e57-3e0f-4b61-9328-f645a7968ac8")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
                                 .header("zilla:command", "rename")
                                 .build()
                             .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .build()
+                            .build()}
 write '{ "name": "widget" }'
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-6f2fdc646803dd52cb3969a5e849aec2")
+                                .build()
+                            .build()}
+write zilla:data.empty
 write flush
 
 write notify SENT_ASYNC_REQUEST
@@ -64,7 +82,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
+                                     .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-6f2fdc646803dd52cb3969a5e849aec2")
                                      .build()
                                    .build()
                                .build()}
@@ -79,7 +97,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .progress(1, 1)
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "412")
-                               .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
+                               .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-6f2fdc646803dd52cb3969a5e849aec2")
                                .build()
                            .build()}
 read zilla:data.null

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.if.match.failed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.if.match.failed/server.rpt
@@ -43,11 +43,27 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header("if-match", "revision=41")
                                .header("idempotency-key", "59410e57-3e0f-4b61-9328-f645a7968ac8")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
                                .header("zilla:command", "rename")
                                .build()
                            .build()}
+read zilla:data.empty
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .build()
+                           .build()}
 read '{ "name": "widget" }'
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-6f2fdc646803dd52cb3969a5e849aec2")
+                               .build()
+                           .build()}
+read zilla:data.empty
 
 read closed
 write close
@@ -61,7 +77,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
+                                    .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-6f2fdc646803dd52cb3969a5e849aec2")
                                     .build()
                                   .build()
                               .build()}
@@ -76,7 +92,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .progress(1, 1)
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "412")
-                                .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
+                                .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-6f2fdc646803dd52cb3969a5e849aec2")
                                 .build()
                             .build()}
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.if.match/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.if.match/client.rpt
@@ -41,11 +41,29 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header("if-match", "revision=42")
                                 .header("idempotency-key", "59410e57-3e0f-4b61-9328-f645a7968ac8")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
                                 .header("zilla:command", "rename")
                                 .build()
                             .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .build()
+                            .build()}
 write '{ "name": "widget" }'
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-4358cfb47f09329d52781d1c76c160a1")
+                                .build()
+                            .build()}
+write zilla:data.empty
 write flush
 
 write notify SENT_ASYNC_REQUEST
@@ -64,7 +82,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
+                                     .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-4358cfb47f09329d52781d1c76c160a1")
                                      .build()
                                    .build()
                                .build()}
@@ -79,7 +97,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .progress(1, 1)
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "204")
-                               .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
+                               .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-4358cfb47f09329d52781d1c76c160a1")
                                .build()
                            .build()}
 read zilla:data.null

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.if.match/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.if.match/server.rpt
@@ -43,11 +43,27 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header("if-match", "revision=42")
                                .header("idempotency-key", "59410e57-3e0f-4b61-9328-f645a7968ac8")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
                                .header("zilla:command", "rename")
                                .build()
                            .build()}
+read zilla:data.empty
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .build()
+                           .build()}
 read '{ "name": "widget" }'
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-4358cfb47f09329d52781d1c76c160a1")
+                               .build()
+                           .build()}
+read zilla:data.empty
 
 read closed
 write close
@@ -61,7 +77,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
+                                    .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-4358cfb47f09329d52781d1c76c160a1")
                                     .build()
                                   .build()
                               .build()}
@@ -76,7 +92,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .progress(1, 1)
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "204")
-                                .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
+                                .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-4358cfb47f09329d52781d1c76c160a1")
                                 .build()
                             .build()}
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command/client.rpt
@@ -40,11 +40,29 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header("content-type", "application/json")
                                 .header("idempotency-key", "59410e57-3e0f-4b61-9328-f645a7968ac8")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
                                 .header("zilla:command", "rename")
                                 .build()
                             .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .build()
+                            .build()}
 write '{ "name": "widget" }'
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
+                                .build()
+                            .build()}
+write zilla:data.empty
 write flush
 
 write notify SENT_ASYNC_REQUEST
@@ -63,7 +81,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
+                                     .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                                      .build()
                                    .build()
                                .build()}
@@ -78,7 +96,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .progress(1, 1)
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "204")
-                               .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
+                               .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                                .build()
                            .build()}
 read zilla:data.null

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command/server.rpt
@@ -42,11 +42,27 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header("content-type", "application/json")
                                .header("idempotency-key", "59410e57-3e0f-4b61-9328-f645a7968ac8")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
                                .header("zilla:command", "rename")
                                .build()
                            .build()}
+read zilla:data.empty
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .build()
+                           .build()}
 read '{ "name": "widget" }'
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
+                               .build()
+                           .build()}
+read zilla:data.empty
 
 read closed
 write close
@@ -60,7 +76,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
+                                    .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                                     .build()
                                   .build()
                               .build()}
@@ -75,7 +91,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .progress(1, 1)
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "204")
-                                .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8")
+                                .header("zilla:correlation-id", "59410e57-3e0f-4b61-9328-f645a7968ac8-453f1060d0650f320bac6e586fdca904")
                                 .build()
                             .build()}
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items.delayed/client.rpt
@@ -40,10 +40,28 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header("content-type", "application/json")
                                 .header("idempotency-key", "92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                                .build()
+                            .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
                                 .build()
                             .build()}
 write '{ "name": "widget" }'
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
+                                .build()
+                            .build()}
+write zilla:data.empty
 write flush
 
 write notify SENT_ASYNC_REQUEST
@@ -63,7 +81,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                                     .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                                      .build()
                                    .build()
                                .build()}
@@ -87,7 +105,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                                     .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                                      .build()
                                    .build()
                                .build()}
@@ -103,7 +121,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "201")
                                .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
-                               .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                               .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                                .build()
                            .build()}
 read '{ "name": "widget" }'

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items.delayed/server.rpt
@@ -42,10 +42,26 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header("content-type", "application/json")
                                .header("idempotency-key", "92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                               .build()
+                           .build()}
+read zilla:data.empty
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
                                .build()
                            .build()}
 read '{ "name": "widget" }'
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
+                               .build()
+                           .build()}
+read zilla:data.empty
 
 read closed
 write close
@@ -59,7 +75,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                                    .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                                     .build()
                                   .build()
                               .build()}
@@ -78,7 +94,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                                    .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                                     .build()
                                   .build()
                               .build()}
@@ -94,7 +110,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "201")
                                 .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
-                                .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                                .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                                 .build()
                             .build()}
 write '{ "name": "widget" }'

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items/client.rpt
@@ -40,10 +40,28 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header("content-type", "application/json")
                                 .header("idempotency-key", "92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                                .build()
+                            .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
                                 .build()
                             .build()}
 write '{ "name": "widget" }'
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
+                                .build()
+                            .build()}
+write zilla:data.empty
 write flush
 
 write notify SENT_ASYNC_REQUEST
@@ -62,7 +80,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                                     .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                                      .build()
                                    .build()
                                .build()}
@@ -78,7 +96,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "201")
                                .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
-                               .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                               .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                                .build()
                            .build()}
 read '{ "name": "widget" }'

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items/server.rpt
@@ -42,10 +42,26 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header("content-type", "application/json")
                                .header("idempotency-key", "92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                               .build()
+                           .build()}
+read zilla:data.empty
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
                                .build()
                            .build()}
 read '{ "name": "widget" }'
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
+                               .build()
+                           .build()}
+read zilla:data.empty
 
 read closed
 write close
@@ -59,7 +75,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                                    .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                                     .build()
                                   .build()
                               .build()}
@@ -75,7 +91,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "201")
                                 .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
-                                .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                                .header("zilla:correlation-id", "92d0bf92-63e0-4cfc-ae73-71dee92d1544-82cb37c4337a427e1884f91fa6070120")
                                 .build()
                             .build()}
 write '{ "name": "widget" }'

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.delayed/client.rpt
@@ -40,10 +40,28 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header("content-type", "application/json")
                                 .header("idempotency-key", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                                .build()
+                            .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
                                 .build()
                             .build()}
 write '{ "name": "widget" }'
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
+                                .build()
+                            .build()}
+write zilla:data.empty
 write flush
 
 write notify SENT_ASYNC_REQUEST
@@ -63,7 +81,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                                     .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                                      .build()
                                    .build()
                                .build()}
@@ -87,7 +105,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                                     .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                                      .build()
                                    .build()
                                .build()}
@@ -102,7 +120,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .progress(1, 1)
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "204")
-                               .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                               .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                                .build()
                            .build()}
 read zilla:data.null

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.delayed/server.rpt
@@ -42,10 +42,26 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header("content-type", "application/json")
                                .header("idempotency-key", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                               .build()
+                           .build()}
+read zilla:data.empty
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
                                .build()
                            .build()}
 read '{ "name": "widget" }'
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
+                               .build()
+                           .build()}
+read zilla:data.empty
 
 read closed
 write close
@@ -59,7 +75,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                                    .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                                     .build()
                                   .build()
                               .build()}
@@ -78,7 +94,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                                    .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                                     .build()
                                   .build()
                               .build()}
@@ -93,7 +109,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .progress(1, 1)
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "204")
-                                .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                                .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                                 .build()
                             .build()}
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.if.match.failed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.if.match.failed/client.rpt
@@ -41,10 +41,28 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header("if-match", "revision=41")
                                 .header("idempotency-key", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                                .build()
+                            .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
                                 .build()
                             .build()}
 write '{ "name": "widget" }'
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-47334d1bb8f4166207280f3d92d45ea5")
+                                .build()
+                            .build()}
+write zilla:data.empty
 write flush
 
 write notify SENT_ASYNC_REQUEST
@@ -63,7 +81,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                                     .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-47334d1bb8f4166207280f3d92d45ea5")
                                      .build()
                                    .build()
                                .build()}
@@ -78,7 +96,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .progress(1, 1)
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "412")
-                               .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                               .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-47334d1bb8f4166207280f3d92d45ea5")
                                .build()
                            .build()}
 read zilla:data.null

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.if.match.failed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.if.match.failed/server.rpt
@@ -43,10 +43,26 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header("if-match", "revision=41")
                                .header("idempotency-key", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                               .build()
+                           .build()}
+read zilla:data.empty
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
                                .build()
                            .build()}
 read '{ "name": "widget" }'
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-47334d1bb8f4166207280f3d92d45ea5")
+                               .build()
+                           .build()}
+read zilla:data.empty
 
 read closed
 write close
@@ -60,7 +76,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                                    .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-47334d1bb8f4166207280f3d92d45ea5")
                                     .build()
                                   .build()
                               .build()}
@@ -75,7 +91,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .progress(1, 1)
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "412")
-                                .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                                .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-47334d1bb8f4166207280f3d92d45ea5")
                                 .build()
                             .build()}
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.if.match/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.if.match/client.rpt
@@ -41,10 +41,28 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header("if-match", "revision=42")
                                 .header("idempotency-key", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                                .build()
+                            .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
                                 .build()
                             .build()}
 write '{ "name": "widget" }'
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-b2046f544d470bcf2306cf92f6071397")
+                                .build()
+                            .build()}
+write zilla:data.empty
 write flush
 
 write notify SENT_ASYNC_REQUEST
@@ -63,7 +81,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                                     .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-b2046f544d470bcf2306cf92f6071397")
                                      .build()
                                    .build()
                                .build()}
@@ -78,7 +96,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .progress(1, 1)
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "204")
-                               .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                               .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-b2046f544d470bcf2306cf92f6071397")
                                .build()
                            .build()}
 read zilla:data.null

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.if.match/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.if.match/server.rpt
@@ -43,10 +43,26 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header("if-match", "revision=42")
                                .header("idempotency-key", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                               .build()
+                           .build()}
+read zilla:data.empty
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
                                .build()
                            .build()}
 read '{ "name": "widget" }'
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(-1, -1)
+                               .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-b2046f544d470bcf2306cf92f6071397")
+                               .build()
+                           .build()}
+read zilla:data.empty
 
 read closed
 write close
@@ -60,7 +76,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                                    .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-b2046f544d470bcf2306cf92f6071397")
                                     .build()
                                   .build()
                               .build()}
@@ -75,7 +91,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .progress(1, 1)
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "204")
-                                .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                                .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-b2046f544d470bcf2306cf92f6071397")
                                 .build()
                             .build()}
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item/client.rpt
@@ -40,10 +40,28 @@ write zilla:data.ext ${kafka:dataEx()
                                 .header("content-type", "application/json")
                                 .header("idempotency-key", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
                                 .header("zilla:reply-to", "items-replies")
-                                .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                                .build()
+                            .build()}
+write zilla:data.empty
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
                                 .build()
                             .build()}
 write '{ "name": "widget" }'
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .partition(-1, -1)
+                                .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
+                                .build()
+                            .build()}
+write zilla:data.empty
 write flush
 
 write notify SENT_ASYNC_REQUEST
@@ -62,7 +80,7 @@ write zilla:begin.ext ${kafka:beginEx()
                                    .topic("items-replies")
                                    .partition(-1, -2)
                                    .filter()
-                                     .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                                     .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                                      .build()
                                    .build()
                                .build()}
@@ -77,7 +95,7 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .progress(1, 1)
                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                .header(":status", "204")
-                               .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                               .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                                .build()
                            .build()}
 read zilla:data.null

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item/server.rpt
@@ -42,10 +42,24 @@ read zilla:data.ext ${kafka:matchDataEx()
                                .header("content-type", "application/json")
                                .header("idempotency-key", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
                                .header("zilla:reply-to", "items-replies")
-                               .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                               .build()
+                           .build()}
+read zilla:data.empty
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
                                .build()
                            .build()}
 read '{ "name": "widget" }'
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
+                               .build()
+                           .build()}
+read zilla:data.empty
 
 read closed
 write close
@@ -59,7 +73,7 @@ read zilla:begin.ext ${kafka:beginEx()
                                   .topic("items-replies")
                                   .partition(-1, -2)
                                   .filter()
-                                    .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                                    .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                                     .build()
                                   .build()
                               .build()}
@@ -74,7 +88,7 @@ write zilla:data.ext ${kafka:dataEx()
                                 .progress(1, 1)
                                 .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
                                 .header(":status", "204")
-                                .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5")
+                                .header("zilla:correlation-id", "3f96592e-c8f1-4167-8c46-85f2aabb70a5-4ed74dd9742e770607863dca17e817fb")
                                 .build()
                             .build()}
 write flush


### PR DESCRIPTION
Fix #28 