### PR TITLE
Use content-length instead of transfer-encoding chunked for correlated responses

### DIFF
--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/stream/HttpKafkaProxyFactory.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/stream/HttpKafkaProxyFactory.java
@@ -2567,11 +2567,12 @@ public final class HttpKafkaProxyFactory implements HttpKafkaStreamFactory
                     {
                         final KafkaMergedDataExFW kafkaMergedDataEx = kafkaDataEx.merged();
                         final Array32FW<KafkaHeaderFW> kafkaHeaders = kafkaMergedDataEx.headers();
+                        final int contentLength = payload != null ? payload.sizeof() + kafkaMergedDataEx.deferred() : 0;
 
                         httpBeginEx = httpBeginExRW
                                 .wrap(extBuffer, 0, extBuffer.capacity())
                                 .typeId(httpTypeId)
-                                .headers(hs -> delegate.resolved.correlated(kafkaHeaders, hs))
+                                .headers(hs -> delegate.resolved.correlated(kafkaHeaders, hs, contentLength))
                                 .build();
                     }
 
@@ -3383,15 +3384,17 @@ public final class HttpKafkaProxyFactory implements HttpKafkaStreamFactory
                     final KafkaDataExFW kafkaDataEx =
                             dataEx != null && dataEx.typeId() == kafkaTypeId ? extension.get(kafkaDataExRO::tryWrap) : null;
 
+
                     if (kafkaDataEx != null)
                     {
                         final KafkaMergedDataExFW kafkaMergedDataEx = kafkaDataEx.merged();
                         final Array32FW<KafkaHeaderFW> kafkaHeaders = kafkaMergedDataEx.headers();
+                        final int contentLength = payload != null ? payload.sizeof() + kafkaMergedDataEx.deferred() : 0;
 
                         httpBeginEx = httpBeginExRW
                                 .wrap(extBuffer, 0, extBuffer.capacity())
                                 .typeId(httpTypeId)
-                                .headers(hs -> correlater.resolved.correlated(kafkaHeaders, hs))
+                                .headers(hs -> correlater.resolved.correlated(kafkaHeaders, hs, contentLength))
                                 .build();
                     }
 

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async.delayed/client.rpt
@@ -89,6 +89,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "201")
                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                           .header("content-length", "20")
                            .build()}
 
 read '{ "name": "widget" }'

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async.delayed/server.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "201")
                             .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                            .header("content-length", "20")
                             .build()}
 
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async.ignored/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async.ignored/client.rpt
@@ -40,6 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "201")
                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                           .header("content-length", "20")
                            .build()}
 
 read '{ "name": "widget" }'

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async.ignored/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async.ignored/server.rpt
@@ -38,6 +38,7 @@ write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "201")
                             .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                            .header("content-length", "20")
                             .build()}
 
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async/client.rpt
@@ -64,6 +64,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "201")
                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                           .header("content-length", "20")
                            .build()}
 
 read '{ "name": "widget" }'

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async/server.rpt
@@ -61,6 +61,7 @@ write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "201")
                             .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                            .header("content-length", "20")
                             .build()}
 
 write flush

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items/client.rpt
@@ -39,6 +39,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "201")
                            .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                           .header("content-length", "20")
                            .build()}
 
 read '{ "name": "widget" }'

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items/server.rpt
@@ -37,6 +37,7 @@ write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "201")
                             .header("location", "/items/92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                            .header("content-length", "20")
                             .build()}
 
 write flush


### PR DESCRIPTION
Fix #45 