### PR TITLE
Use & as end of token separator for query parameter values

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpAuthorizationConfig.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpAuthorizationConfig.java
@@ -119,7 +119,7 @@ public final class HttpAuthorizationConfig
                         Pattern.compile(String.format(
                                     "(\\?|\\&)%s=%s",
                                     parametersName,
-                                    config.pattern.replace("{credentials}", "(?<credentials>[^\\s]+)")))
+                                    config.pattern.replace("{credentials}", "(?<credentials>[^\\&]+)")))
                                .matcher("");
 
                 accessor = orElseIfNull(accessor, hs ->

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/authorize.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/authorize.credentials.query/client.rpt
@@ -23,7 +23,7 @@ write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
                             .header(":scheme", "https")
-                            .header(":path", "/?access_token=TOKEN")
+                            .header(":path", "/?access_token=TOKEN&parameter=value")
                             .header(":authority", "example.com:9090")
                             .build()}
 connected

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/authorize.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/authorize.credentials.query/server.rpt
@@ -24,7 +24,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
                            .header(":scheme", "https")
-                           .header(":path", "/?access_token=TOKEN")
+                           .header(":path", "/?access_token=TOKEN&parameter=value")
                            .header(":authority", "example.com:9090")
                            .build()}
 connected

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/authorize.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/authorize.credentials.query/client.rpt
@@ -23,7 +23,7 @@ write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":method", "GET")
                             .header(":scheme", "https")
-                            .header(":path", "/?access_token=TOKEN")
+                            .header(":path", "/?access_token=TOKEN&parameter=value")
                             .header(":authority", "example.com:9090")
                             .build()}
 connected

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/authorize.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/authorize.credentials.query/server.rpt
@@ -24,7 +24,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "GET")
                            .header(":scheme", "https")
-                           .header(":path", "/?access_token=TOKEN")
+                           .header(":path", "/?access_token=TOKEN&parameter=value")
                            .header(":authority", "example.com:9090")
                            .build()}
 connected

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/authorize.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/authorize.credentials.query/client.rpt
@@ -31,7 +31,7 @@ write zilla:begin.ext ${proxy:beginEx()
 
 connected
 
-write "GET /?access_token=TOKEN HTTP/1.1" "\r\n"
+write "GET /?access_token=TOKEN&parameter=value HTTP/1.1" "\r\n"
       "Host: example.com:9090" "\r\n"
       "\r\n"
 write flush

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/authorize.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/authorize.credentials.query/server.rpt
@@ -30,7 +30,7 @@ read zilla:begin.ext ${proxy:matchBeginEx()
 
 connected
 
-read "GET /?access_token=TOKEN HTTP/1.1" "\r\n"
+read "GET /?access_token=TOKEN&parameter=value HTTP/1.1" "\r\n"
      "Host: example.com:9090" "\r\n"
      "\r\n"
 

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/authorize.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/authorize.credentials.query/client.rpt
@@ -52,14 +52,14 @@ write [0x00 0x00 0x00]                                     # length = 0
       [0x00 0x00 0x00 0x00]                                # stream_id = 0
 write flush
 
-write [0x00 0x00 0x30]                                     # length = 48
+write [0x00 0x00 0x40]                                     # length = 48
       [0x01]                                               # HEADERS frame
       [0x05]                                               # END_HEADERS | END_STREAM
       [0x00 0x00 0x00 0x01]                                # stream_id = 1
       [0x82]                                               # :method: GET
       [0x87]                                               # :scheme: https
       [0x40] [0x05] ":path"
-             [0x14] "/?access_token=TOKEN"                 # :path: /?access_token=TOKEN
+             [0x24] "/?access_token=TOKEN&parameter=value" # :path: /?access_token=TOKEN&parameter=value
       [0x01] [0x10] "example.com:9090"                     # :authority: example.com:9090
 write flush
 

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/authorize.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/authorize.credentials.query/server.rpt
@@ -52,14 +52,14 @@ read [0x00 0x00 0x00]                                      # length = 0
      [0x01]                                                # ACK
      [0x00 0x00 0x00 0x00]                                 # stream_id = 0
 
-read [0x00 0x00 0x30]                                      # length = 48
+read [0x00 0x00 0x40]                                      # length = 48
      [0x01]                                                # HEADERS frame
      [0x05]                                                # END_HEADERS | END_STREAM
      [0x00 0x00 0x00 0x01]                                 # stream_id = 1
      [0x82]                                                # :method: GET
      [0x87]                                                # :scheme: https
      [0x40] [0x05] ":path"
-            [0x14] "/?access_token=TOKEN"                  # :path: /?access_token=TOKEN
+            [0x24] "/?access_token=TOKEN&parameter=value"  # :path: /?access_token=TOKEN&parameter=value
      [0x01] [0x10] "example.com:9090"                      # :authority: example.com:9090
 
 write [0x00 0x00 0x45]                                     # length = 69


### PR DESCRIPTION
Fix #73 