### PR TITLE
BugFix: process configURL if the protocol is http

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/ConfigureTask.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/ConfigureTask.java
@@ -128,7 +128,7 @@ public class ConfigureTask implements Callable<Void>
         {
             configText = CONFIG_TEXT_DEFAULT;
         }
-        else if ("https".equals(configURL.getProtocol()) || "https".equals(configURL.getProtocol()))
+        else if ("http".equals(configURL.getProtocol()) || "https".equals(configURL.getProtocol()))
         {
             HttpClient client = HttpClient.newBuilder()
                 .version(HTTP_2)
@@ -143,9 +143,9 @@ public class ConfigureTask implements Callable<Void>
             HttpResponse<String> response = client.send(
                 request,
                 BodyHandlers.ofString());
-            String body = response.body();
 
-            configText = body;
+            configText = response.body();
+
         }
         else
         {


### PR DESCRIPTION
`https` is repeated twice in the if condition. This means that if the protocol in the URL to the Zilla JSON config file is `http`, then the `java.net.http.HttpClient` client is not used to retrieve the JSON configuration. Instead, a `URLConnection` is used.

@jfallows I think this will still work with a `configURL.openConnection()`. If this was the intended behavior, then i think the other approach will be to simply the if condition

Signed-off-by: Alfusainey Jallow <alf.jallow@gmail.com>