### PR TITLE
Document how to run the benchmark with Java 16+

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ cd zilla
 cd runtime/engine/target
 java -jar ./engine-develop-SNAPSHOT-shaded-tests.jar BufferBM
 ```
-<b>Note:</b> recommend using Java 15 or lower (for now) to avoid getting errors related to reflective access across Java module boundaries when running the benchmark.
+<b>Note:</b> with Java 16 or higher add ` --add-opens=java.base/java.io=ALL-UNNAMED` just after `java` to avoid getting errors related to reflective access across Java module boundaries when running the benchmark.
 
 ```
 Benchmark                  Mode  Cnt         Score        Error  Units


### PR DESCRIPTION
It worked well with Java 17 and Java 19:

```
Benchmark                  Mode  Cnt         Score         Error  Units
BufferBM.batched          thrpt   15  11663496.292 ±   32940.441  ops/s
BufferBM.multiple         thrpt   15  14837814.742 ± 2768697.168  ops/s
BufferBM.multiple:reader  thrpt   15   2884675.668 ± 2160878.065  ops/s
BufferBM.multiple:writer  thrpt   15  11953139.074 ± 2638964.717  ops/s
BufferBM.single           thrpt   15  11719456.989 ±   68473.560  ops/s
```
Side note: the numbers are surprisingly worse with an M1 and a newer version of Java. 

```                                                                                                                                                                                                                                                                                                                                                                                                                                                                System Version: macOS 12.6
Kernel Version: Darwin 21.6.0
Model Name: MacBook Pro
Model Identifier: MacBookPro18,2
Chip: Apple M1 Max
Total Number of Cores: 10 (8 performance and 2 efficiency)
Memory: 64 GB

```                                                                                                                                                                                                                        