### PR TITLE
Fix number of signals in Kafka Grpc

### DIFF
--- a/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/KafkaGrpcBinding.java
+++ b/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/KafkaGrpcBinding.java
@@ -25,17 +25,18 @@ import io.aklivity.zilla.runtime.engine.config.KindConfig;
 
 public final class KafkaGrpcBinding implements Binding
 {
-    private static final int INITIAL_WORKER_COUNT = 0;
     public static final String NAME = "kafka-grpc";
 
-    private final ConcurrentMap<Long, AtomicInteger> workers = new ConcurrentHashMap<>();
+    private static final AtomicInteger WORKER_COUNT = new AtomicInteger();
 
+    private final ConcurrentMap<Long, AtomicInteger> workers;
     private final KafkaGrpcConfiguration config;
 
     KafkaGrpcBinding(
         KafkaGrpcConfiguration config)
     {
         this.config = config;
+        this.workers = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -67,7 +68,7 @@ public final class KafkaGrpcBinding implements Binding
     private boolean activate(
         long bindingId)
     {
-        final AtomicInteger worker = workers.computeIfAbsent(bindingId, id -> new AtomicInteger(INITIAL_WORKER_COUNT));
+        final AtomicInteger worker = workers.computeIfAbsent(bindingId, id -> new AtomicInteger());
         final int workerCount = worker.incrementAndGet();
 
         return workerCount <= 1;
@@ -79,6 +80,6 @@ public final class KafkaGrpcBinding implements Binding
         AtomicInteger worker = workers.get(bindingId);
         assert worker != null;
         worker.decrementAndGet();
-        workers.remove(bindingId, new AtomicInteger(INITIAL_WORKER_COUNT));
+        workers.remove(bindingId, WORKER_COUNT);
     }
 }

--- a/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/KafkaGrpcBinding.java
+++ b/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/KafkaGrpcBinding.java
@@ -27,7 +27,7 @@ public final class KafkaGrpcBinding implements Binding
 {
     public static final String NAME = "kafka-grpc";
 
-    private static final AtomicInteger WORKER_COUNT = new AtomicInteger();
+    private static final AtomicInteger WORKER_COUNT_ZERO = new AtomicInteger();
 
     private final ConcurrentMap<Long, AtomicInteger> workers;
     private final KafkaGrpcConfiguration config;
@@ -80,6 +80,6 @@ public final class KafkaGrpcBinding implements Binding
         AtomicInteger worker = workers.get(bindingId);
         assert worker != null;
         worker.decrementAndGet();
-        workers.remove(bindingId, WORKER_COUNT);
+        workers.remove(bindingId, WORKER_COUNT_ZERO);
     }
 }

--- a/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/KafkaGrpcBindingContext.java
+++ b/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/KafkaGrpcBindingContext.java
@@ -18,7 +18,8 @@ import static io.aklivity.zilla.runtime.engine.config.KindConfig.REMOTE_SERVER;
 import static java.util.Collections.singletonMap;
 
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.LongConsumer;
+import java.util.function.LongPredicate;
 
 import io.aklivity.zilla.runtime.binding.kafka.grpc.internal.stream.KafkaGrpcRemoteServerFactory;
 import io.aklivity.zilla.runtime.engine.EngineContext;
@@ -34,9 +35,10 @@ final class KafkaGrpcBindingContext implements BindingContext
     KafkaGrpcBindingContext(
         KafkaGrpcConfiguration config,
         EngineContext context,
-        Function<Long, Boolean> canInitiate)
+        LongPredicate activate,
+        LongConsumer deactivate)
     {
-        this.factories = singletonMap(REMOTE_SERVER, new KafkaGrpcRemoteServerFactory(config, context, canInitiate));
+        this.factories = singletonMap(REMOTE_SERVER, new KafkaGrpcRemoteServerFactory(config, context, activate, deactivate));
     }
 
     @Override

--- a/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/KafkaGrpcBindingContext.java
+++ b/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/KafkaGrpcBindingContext.java
@@ -34,9 +34,9 @@ final class KafkaGrpcBindingContext implements BindingContext
     KafkaGrpcBindingContext(
         KafkaGrpcConfiguration config,
         EngineContext context,
-        Function<Long, Boolean> doSignal)
+        Function<Long, Boolean> canInitiate)
     {
-        this.factories = singletonMap(REMOTE_SERVER, new KafkaGrpcRemoteServerFactory(config, context, doSignal));
+        this.factories = singletonMap(REMOTE_SERVER, new KafkaGrpcRemoteServerFactory(config, context, canInitiate));
     }
 
     @Override

--- a/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/KafkaGrpcBindingContext.java
+++ b/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/KafkaGrpcBindingContext.java
@@ -18,6 +18,7 @@ import static io.aklivity.zilla.runtime.engine.config.KindConfig.REMOTE_SERVER;
 import static java.util.Collections.singletonMap;
 
 import java.util.Map;
+import java.util.function.Function;
 
 import io.aklivity.zilla.runtime.binding.kafka.grpc.internal.stream.KafkaGrpcRemoteServerFactory;
 import io.aklivity.zilla.runtime.engine.EngineContext;
@@ -32,9 +33,10 @@ final class KafkaGrpcBindingContext implements BindingContext
 
     KafkaGrpcBindingContext(
         KafkaGrpcConfiguration config,
-        EngineContext context)
+        EngineContext context,
+        Function<Long, Boolean> doSignal)
     {
-        this.factories = singletonMap(REMOTE_SERVER, new KafkaGrpcRemoteServerFactory(config, context));
+        this.factories = singletonMap(REMOTE_SERVER, new KafkaGrpcRemoteServerFactory(config, context, doSignal));
     }
 
     @Override

--- a/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcRemoteServerFactory.java
+++ b/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcRemoteServerFactory.java
@@ -126,7 +126,7 @@ public final class KafkaGrpcRemoteServerFactory implements KafkaGrpcStreamFactor
     private final LongUnaryOperator supplyInitialId;
     private final LongUnaryOperator supplyReplyId;
     private final LongSupplier supplyTraceId;
-    private final Function<Long, Boolean> doSignal;
+    private final Function<Long, Boolean> canInitiate;
     private final Signaler signaler;
     private final int grpcTypeId;
     private final int kafkaTypeId;
@@ -136,7 +136,7 @@ public final class KafkaGrpcRemoteServerFactory implements KafkaGrpcStreamFactor
     public KafkaGrpcRemoteServerFactory(
         KafkaGrpcConfiguration config,
         EngineContext context,
-        Function<Long, Boolean> doSignal)
+        Function<Long, Boolean> canInitiate)
     {
         this.bufferPool = context.bufferPool();
         this.writeBuffer = context.writeBuffer();
@@ -146,7 +146,7 @@ public final class KafkaGrpcRemoteServerFactory implements KafkaGrpcStreamFactor
         this.supplyReplyId = context::supplyReplyId;
         this.signaler = context.signaler();
         this.supplyTraceId = context::supplyTraceId;
-        this.doSignal = doSignal;
+        this.canInitiate = canInitiate;
         this.bindings = new Long2ObjectHashMap<>();
         this.servers = new ArrayList<>();
         this.grpcTypeId = context.supplyTypeId(GRPC_TYPE_NAME);
@@ -160,7 +160,7 @@ public final class KafkaGrpcRemoteServerFactory implements KafkaGrpcStreamFactor
         KafkaGrpcBindingConfig newBinding = new KafkaGrpcBindingConfig(binding);
         bindings.put(binding.id, newBinding);
 
-        if (doSignal.apply(binding.id))
+        if (canInitiate.apply(binding.id))
         {
             newBinding.routes.forEach(r ->
                 r.when.forEach(c ->


### PR DESCRIPTION
## Description

Kafka Grpc does signal based on the number of cores and causes to process the same message multiple times

