### PR TITLE
Encode kafka progress as last message id

### DIFF
--- a/incubator/binding-grpc-kafka.spec/pom.xml
+++ b/incubator/binding-grpc-kafka.spec/pom.xml
@@ -83,7 +83,7 @@
         <artifactId>flyweight-maven-plugin</artifactId>
         <version>${project.version}</version>
         <configuration>
-          <scopeNames>core grpc kafka</scopeNames>
+          <scopeNames>core grpc kafka grpc_kafka</scopeNames>
           <packageName>io.aklivity.zilla.specs.binding.grpc.kafka.internal.types</packageName>
         </configuration>
         <executions>

--- a/incubator/binding-grpc-kafka.spec/src/main/java/io/aklivity/zilla/specs/binding/grpc/kafka/internal/GrpcKafkaFunctions.java
+++ b/incubator/binding-grpc-kafka.spec/src/main/java/io/aklivity/zilla/specs/binding/grpc/kafka/internal/GrpcKafkaFunctions.java
@@ -45,22 +45,22 @@ public final class GrpcKafkaFunctions
         }
 
         public MessageIdBuilder partitionCount(
-            int fieldCount)
+            int partitionCount)
         {
             GrpcKafkaMessageFieldFW messageField =
-                messageFieldRW.v1(v1 -> v1.partitionCount(fieldCount)).build();
+                messageFieldRW.v1(v1 -> v1.partitionCount(partitionCount)).build();
             progressOffset = messageField.limit();
             return this;
         }
 
         public MessageIdBuilder partition(
             int partitionId,
-            long offset)
+            long partitionOffset)
         {
             MutableDirectBuffer buffer = messageFieldRW.buffer();
             progressOffset = partitionV1RW.wrap(buffer, progressOffset, buffer.capacity())
                 .partitionId(partitionId)
-                .partitionOffset(offset)
+                .partitionOffset(partitionOffset)
                 .build()
                 .limit();
             return this;

--- a/incubator/binding-grpc-kafka.spec/src/main/resources/META-INF/zilla/grpc_kafka.idl
+++ b/incubator/binding-grpc-kafka.spec/src/main/resources/META-INF/zilla/grpc_kafka.idl
@@ -12,24 +12,21 @@
  * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations under the License.
  */
-scope internal
+scope grpc_kafka
 {
-    scope codec
+    struct GrpcKafkaMessageFieldPartitionV1
     {
-        struct GrpcKafkaMessageFieldPartitionV1
-        {
-            varint32 partitionId;
-            varint64 partitionOffset;
-        }
+        varint32 partitionId;
+        varint64 partitionOffset;
+    }
 
-        struct GrpcKafkaMessageFieldV1
-        {
-            varint32 partitionCount;
-        }
+    struct GrpcKafkaMessageFieldV1
+    {
+        varint32 partitionCount;
+    }
 
-        union GrpcKafkaMessageField switch (uint8)
-        {
-            case 1: GrpcKafkaMessageFieldV1 v1;
-        }
+    union GrpcKafkaMessageField switch (uint8)
+    {
+        case 1: GrpcKafkaMessageFieldV1 v1;
     }
 }

--- a/incubator/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/reliable.unary.rpc/client.rpt
+++ b/incubator/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/reliable.unary.rpc/client.rpt
@@ -35,6 +35,7 @@ write close
 read ${grpc:protobuf()
            .string(1, "Hello World")
            .bytes(32767, grpc_kafka:messageId()
+               .partitionCount(2)
                .partition(0, 2)
                .partition(1, 1)
                .build())

--- a/incubator/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/reliable.unary.rpc/server.rpt
+++ b/incubator/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/reliable.unary.rpc/server.rpt
@@ -35,6 +35,7 @@ read closed
 write ${grpc:protobuf()
             .string(1, "Hello World")
             .bytes(32767, grpc_kafka:messageId()
+                .partitionCount(2)
                 .partition(0, 2)
                 .partition(1, 1)
                 .build())

--- a/incubator/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/unreliable.unary.rpc/client.rpt
+++ b/incubator/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/unreliable.unary.rpc/client.rpt
@@ -34,6 +34,7 @@ write close
 read ${grpc:protobuf()
            .string(1, "Hello World")
            .bytes(32767, grpc_kafka:messageId()
+               .partitionCount(2)
                .partition(0, 2)
                .partition(1, 1)
                .build())

--- a/incubator/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/unreliable.unary.rpc/server.rpt
+++ b/incubator/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/unreliable.unary.rpc/server.rpt
@@ -34,6 +34,7 @@ read closed
 write ${grpc:protobuf()
             .string(1, "Hello World")
             .bytes(32767, grpc_kafka:messageId()
+                .partitionCount(2)
                 .partition(0, 2)
                 .partition(1, 1)
                 .build())

--- a/incubator/binding-grpc-kafka/pom.xml
+++ b/incubator/binding-grpc-kafka/pom.xml
@@ -108,7 +108,7 @@
         <artifactId>flyweight-maven-plugin</artifactId>
         <version>${project.version}</version>
         <configuration>
-          <scopeNames>core grpc kafka internal</scopeNames>
+          <scopeNames>core grpc kafka grpc_kafka</scopeNames>
           <packageName>io.aklivity.zilla.runtime.binding.grpc.kafka.internal.types</packageName>
         </configuration>
         <executions>

--- a/incubator/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithFetchResult.java
+++ b/incubator/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithFetchResult.java
@@ -37,18 +37,18 @@ public class GrpcKafkaWithFetchResult
     private final Array32FW<KafkaOffsetFW> partitions;
     private final List<GrpcKafkaWithFetchFilterResult> filters;
     private final String16FW topic;
-    private final Varuint32FW messageId;
+    private final Varuint32FW fieldId;
 
     GrpcKafkaWithFetchResult(
         String16FW topic,
         Array32FW<KafkaOffsetFW> partitions,
         List<GrpcKafkaWithFetchFilterResult> filters,
-        Varuint32FW messageId)
+        Varuint32FW fieldId)
     {
         this.partitions = partitions;
         this.filters = filters;
         this.topic = topic;
-        this.messageId = messageId;
+        this.fieldId = fieldId;
     }
 
     public String16FW topic()
@@ -56,9 +56,9 @@ public class GrpcKafkaWithFetchResult
         return topic;
     }
 
-    public Varuint32FW messageId()
+    public Varuint32FW fieldId()
     {
-        return messageId;
+        return fieldId;
     }
 
     public void partitions(


### PR DESCRIPTION
## Description

We were sending kafka progress bytes as it is without encoding them to last message id.

Fixes # (issue)
