### PR TITLE
Minimize performance overhead for metric collection

### DIFF
--- a/incubator/exporter-prometheus.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/prometheus/schema/prometheus.schema.patch.json
+++ b/incubator/exporter-prometheus.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/prometheus/schema/prometheus.schema.patch.json
@@ -24,7 +24,10 @@
                                     "scheme":
                                     {
                                         "title": "Scheme",
-                                        "type": "string"
+                                        "enum":
+                                        [
+                                            "http"
+                                        ]
                                     },
                                     "port":
                                     {

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/stream/Target.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/stream/Target.java
@@ -63,8 +63,6 @@ public final class Target implements AutoCloseable
     private final Int2ObjectHashMap<MessageConsumer>[] throttles;
     private final MessageConsumer writeHandler;
     private final LongFunction<LoadEntry> supplyLoadEntry;
-    private final LongFunction<MessageConsumer> supplyOriginMetricRecorder;
-    private final LongFunction<MessageConsumer> supplyRoutedMetricRecorder;
 
     private MessagePredicate streamsBuffer;
 
@@ -77,9 +75,7 @@ public final class Target implements AutoCloseable
         Int2ObjectHashMap<MessageConsumer>[] streams,
         Long2ObjectHashMap<LongHashSet> streamSets,
         Int2ObjectHashMap<MessageConsumer>[] throttles,
-        LongFunction<LoadEntry> supplyLoadEntry,
-        LongFunction<MessageConsumer> supplyOriginMetricRecorder,
-        LongFunction<MessageConsumer> supplyRoutedMetricRecorder)
+        LongFunction<LoadEntry> supplyLoadEntry)
     {
         this.timestamps = config.timestamps();
         this.localIndex = index;
@@ -97,8 +93,6 @@ public final class Target implements AutoCloseable
 
         this.writeBuffer = writeBuffer;
         this.supplyLoadEntry = supplyLoadEntry;
-        this.supplyOriginMetricRecorder = supplyOriginMetricRecorder;
-        this.supplyRoutedMetricRecorder = supplyRoutedMetricRecorder;
         this.correlations = correlations;
         this.streams = streams;
         this.streamSets = streamSets;
@@ -234,8 +228,6 @@ public final class Target implements AutoCloseable
         }
         else
         {
-            supplyOriginMetricRecorder.apply(originId).accept(msgTypeId, buffer, index, length);
-            supplyRoutedMetricRecorder.apply(routedId).accept(msgTypeId, buffer, index, length);
             switch (msgTypeId)
             {
             case WindowFW.TYPE_ID:
@@ -279,8 +271,6 @@ public final class Target implements AutoCloseable
 
         if ((msgTypeId & 0x4000_0000) == 0)
         {
-            supplyOriginMetricRecorder.apply(originId).accept(msgTypeId, buffer, index, length);
-            supplyRoutedMetricRecorder.apply(routedId).accept(msgTypeId, buffer, index, length);
             switch (msgTypeId)
             {
             case BeginFW.TYPE_ID:


### PR DESCRIPTION
## Description

Chaining MessageConsumers and MetricHandlers allows optimal composition of metrics and stream handlers, with zero overhead when no metrics are collected, and minimal overhead when metrics are collected.

Fix #213
