### PR TITLE
Move kafka-grpc options for grpc to with section of config

### DIFF
--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/config/AmqpBindingConfig.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/config/AmqpBindingConfig.java
@@ -34,7 +34,7 @@ public final class AmqpBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.entry;
+        this.entry = binding.name;
         this.kind = binding.kind;
         this.routes = binding.routes.stream().map(AmqpRouteConfig::new).collect(toList());
     }

--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/config/AmqpBindingConfig.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/config/AmqpBindingConfig.java
@@ -26,7 +26,7 @@ import io.aklivity.zilla.runtime.engine.config.KindConfig;
 public final class AmqpBindingConfig
 {
     public final long id;
-    public final String entry;
+    public final String name;
     public final KindConfig kind;
     public final List<AmqpRouteConfig> routes;
 
@@ -34,7 +34,7 @@ public final class AmqpBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.name;
+        this.name = binding.name;
         this.kind = binding.kind;
         this.routes = binding.routes.stream().map(AmqpRouteConfig::new).collect(toList());
     }

--- a/incubator/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaBindingConfig.java
+++ b/incubator/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaBindingConfig.java
@@ -30,7 +30,7 @@ import io.aklivity.zilla.runtime.engine.config.KindConfig;
 public final class GrpcKafkaBindingConfig
 {
     public final long id;
-    public final String entry;
+    public final String name;
     public final KindConfig kind;
     public final GrpcKafkaOptionsConfig options;
     public final List<GrpcKafkaRouteConfig> routes;
@@ -39,7 +39,7 @@ public final class GrpcKafkaBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.name;
+        this.name = binding.name;
         this.kind = binding.kind;
         this.options = Optional.ofNullable(binding.options)
                 .map(GrpcKafkaOptionsConfig.class::cast)

--- a/incubator/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaBindingConfig.java
+++ b/incubator/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaBindingConfig.java
@@ -39,7 +39,7 @@ public final class GrpcKafkaBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.entry;
+        this.entry = binding.name;
         this.kind = binding.kind;
         this.options = Optional.ofNullable(binding.options)
                 .map(GrpcKafkaOptionsConfig.class::cast)

--- a/incubator/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/stream/GrpcKafkaProxyFactory.java
+++ b/incubator/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/stream/GrpcKafkaProxyFactory.java
@@ -764,7 +764,7 @@ public final class GrpcKafkaProxyFactory implements GrpcKafkaStreamFactory
                 state = GrpcKafkaState.closeInitial(state);
 
                 doAbort(kafka, originId, routedId, initialId, initialSeq, initialAck, initialMax,
-                    traceId, authorization, extensionRO);
+                    traceId, authorization, emptyRO);
             }
         }
 

--- a/incubator/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcBindingConfig.java
+++ b/incubator/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcBindingConfig.java
@@ -59,7 +59,7 @@ public final class GrpcBindingConfig
     private final HttpGrpcHeaderHelper helper;
 
     public final long id;
-    public final String entry;
+    public final String name;
     public final KindConfig kind;
     public final GrpcOptionsConfig options;
     public final List<GrpcRouteConfig> routes;
@@ -70,7 +70,7 @@ public final class GrpcBindingConfig
         MutableDirectBuffer metadataBuffer)
     {
         this.id = binding.id;
-        this.entry = binding.name;
+        this.name = binding.name;
         this.kind = binding.kind;
         this.options = GrpcOptionsConfig.class.cast(binding.options);
         this.routes = binding.routes.stream().map(GrpcRouteConfig::new).collect(toList());

--- a/incubator/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcBindingConfig.java
+++ b/incubator/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcBindingConfig.java
@@ -70,7 +70,7 @@ public final class GrpcBindingConfig
         MutableDirectBuffer metadataBuffer)
     {
         this.id = binding.id;
-        this.entry = binding.entry;
+        this.entry = binding.name;
         this.kind = binding.kind;
         this.options = GrpcOptionsConfig.class.cast(binding.options);
         this.routes = binding.routes.stream().map(GrpcRouteConfig::new).collect(toList());

--- a/incubator/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/config/remote.server.rpc.yaml
+++ b/incubator/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/config/remote.server.rpc.yaml
@@ -20,9 +20,6 @@ bindings:
     type: kafka-grpc
     kind: remote_server
     options:
-      entry: kafka0
-      scheme: http
-      authority: localhost:8080
       acks: leader_only
     routes:
         - exit: grpc0
@@ -32,3 +29,7 @@ bindings:
               key: 59410e57-3e0f-4b61-9328-f645a7968ac8-d41d8cd98f00b204e9800998ecf8427e
               headers:
                 zilla:service: example.EchoService
+          with:
+            entry: kafka0
+            scheme: http
+            authority: localhost:8080

--- a/incubator/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/config/remote.server.rpc.yaml
+++ b/incubator/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/config/remote.server.rpc.yaml
@@ -19,6 +19,7 @@ bindings:
   remote_server0:
     type: kafka-grpc
     kind: remote_server
+    entry: kafka0
     options:
       acks: leader_only
     routes:
@@ -30,6 +31,5 @@ bindings:
               headers:
                 zilla:service: example.EchoService
           with:
-            entry: kafka0
             scheme: http
             authority: localhost:8080

--- a/incubator/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/schema/kafka.grpc.schema.patch.json
+++ b/incubator/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/schema/kafka.grpc.schema.patch.json
@@ -137,11 +137,6 @@
                                     {
                                         "title": "Authority",
                                         "type": "string"
-                                    },
-                                    "entry":
-                                    {
-                                        "title": "Entry",
-                                        "type": "string"
                                     }
                                 },
                                 "additionalProperties": false

--- a/incubator/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/schema/kafka.grpc.schema.patch.json
+++ b/incubator/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/schema/kafka.grpc.schema.patch.json
@@ -19,21 +19,6 @@
                 {
                     "properties":
                     {
-                        "scheme":
-                        {
-                            "title": "Scheme",
-                            "type": "string"
-                        },
-                        "authority":
-                        {
-                            "title": "Authority",
-                            "type": "string"
-                        },
-                        "entry":
-                        {
-                            "title": "Entry",
-                            "type": "string"
-                        },
                         "acks":
                         {
                             "title": "Acks",
@@ -92,13 +77,7 @@
                             },
                             "additionalProperties": false
                         }
-                    },
-                    "required":
-                    [
-                        "entry",
-                        "scheme",
-                        "authority"
-                    ]
+                    }
                 },
                 "routes":
                 {
@@ -145,26 +124,46 @@
                                     ]
                                 }
                             },
-                            "with": false,
+                            "with":
+                            {
+                                "properties":
+                                {
+                                    "scheme":
+                                    {
+                                        "title": "Scheme",
+                                        "type": "string"
+                                    },
+                                    "authority":
+                                    {
+                                        "title": "Authority",
+                                        "type": "string"
+                                    },
+                                    "entry":
+                                    {
+                                        "title": "Entry",
+                                        "type": "string"
+                                    }
+                                },
+                                "additionalProperties": false
+                            },
+                            "required":
+                            [
+                                "entry",
+                                "scheme",
+                                "authority"
+                            ]
                         }
-                    }
+                    },
+                    "required":
+                    [
+                        "with"
+                    ]
                 },
                 "exit": false
             },
-            "anyOf":
+            "required":
             [
-                {
-                    "required":
-                    [
-                        "exit"
-                    ]
-                },
-                {
-                    "required":
-                    [
-                        "routes"
-                    ]
-                }
+                "routes"
             ]
         }
     }

--- a/incubator/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/schema/kafka.grpc.schema.patch.json
+++ b/incubator/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/schema/kafka.grpc.schema.patch.json
@@ -143,7 +143,6 @@
                             },
                             "required":
                             [
-                                "entry",
                                 "scheme",
                                 "authority"
                             ]

--- a/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcBindingConfig.java
+++ b/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcBindingConfig.java
@@ -18,10 +18,7 @@ import static io.aklivity.zilla.runtime.binding.kafka.grpc.internal.config.Kafka
 import static java.util.stream.Collectors.toList;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Consumer;
-import java.util.function.UnaryOperator;
 
 import io.aklivity.zilla.runtime.binding.kafka.grpc.internal.stream.KafkaGrpcFetchHeaderHelper;
 import io.aklivity.zilla.runtime.engine.config.BindingConfig;
@@ -30,7 +27,7 @@ import io.aklivity.zilla.runtime.engine.config.KindConfig;
 public final class KafkaGrpcBindingConfig
 {
     public final long id;
-    public final String entry;
+    public final long entryId;
     public final KindConfig kind;
     public final KafkaGrpcOptionsConfig options;
     public final KafkaGrpcFetchHeaderHelper helper;
@@ -40,24 +37,13 @@ public final class KafkaGrpcBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.entry;
+        this.entryId = binding.entryId;
         this.kind = binding.kind;
         this.options = Optional.ofNullable(binding.options)
                 .map(KafkaGrpcOptionsConfig.class::cast)
                 .orElse(DEFAULT);
-        this.routes = binding.routes.stream().map(r -> new KafkaGrpcRouteConfig(options, r, binding.resolveId))
+        this.routes = binding.routes.stream().map(r -> new KafkaGrpcRouteConfig(options, r))
             .collect(toList());
         this.helper = new KafkaGrpcFetchHeaderHelper(options.correlation);
-    }
-
-    private static <T> UnaryOperator<T> peek(
-        Consumer<T> action)
-    {
-        Objects.requireNonNull(action);
-        return u ->
-        {
-            action.accept(u);
-            return u;
-        };
     }
 }

--- a/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcBindingConfig.java
+++ b/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcBindingConfig.java
@@ -44,10 +44,10 @@ public final class KafkaGrpcBindingConfig
         this.kind = binding.kind;
         this.options = Optional.ofNullable(binding.options)
                 .map(KafkaGrpcOptionsConfig.class::cast)
-                .map(peek(o -> o.entryId = binding.resolveId.applyAsLong(o.entry)))
                 .orElse(DEFAULT);
+        this.routes = binding.routes.stream().map(r -> new KafkaGrpcRouteConfig(options, r, binding.resolveId))
+            .collect(toList());
         this.helper = new KafkaGrpcFetchHeaderHelper(options.correlation);
-        this.routes = binding.routes.stream().map(r -> new KafkaGrpcRouteConfig(options, r)).collect(toList());
     }
 
     private static <T> UnaryOperator<T> peek(

--- a/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcConditionResolver.java
+++ b/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcConditionResolver.java
@@ -26,14 +26,17 @@ public final class KafkaGrpcConditionResolver
 {
     private final KafkaGrpcOptionsConfig options;
     private final KafkaGrpcConditionConfig condition;
+    private final KafkaGrpcWithConfig with;
 
 
     public KafkaGrpcConditionResolver(
         KafkaGrpcOptionsConfig options,
-        KafkaGrpcConditionConfig condition)
+        KafkaGrpcConditionConfig condition,
+        KafkaGrpcWithConfig with)
     {
         this.options = options;
         this.condition = condition;
+        this.with = with;
     }
 
     public KafkaGrpcConditionResult resolve()
@@ -68,7 +71,7 @@ public final class KafkaGrpcConditionResolver
 
         String16FW replyTo = condition.replyTo;
 
-        return new KafkaGrpcConditionResult(options.scheme, options.authority, topic, acks,
+        return new KafkaGrpcConditionResult(with.scheme, with.authority, topic, acks,
             filters, replyTo, options.correlation);
     }
 }

--- a/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcOptionsConfigAdapter.java
+++ b/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcOptionsConfigAdapter.java
@@ -30,9 +30,6 @@ import io.aklivity.zilla.runtime.engine.config.OptionsConfigAdapterSpi;
 public class KafkaGrpcOptionsConfigAdapter implements OptionsConfigAdapterSpi, JsonbAdapter<OptionsConfig, JsonObject>
 {
     private static final KafkaAckMode ACKS_DEFAULT = KafkaAckMode.IN_SYNC_REPLICAS;
-    private static final String SCHEME_NAME = "scheme";
-    private static final String AUTHORITY_NAME = "authority";
-    private static final String ENTRY_NAME = "entry";
     private static final String ACKS_NAME = "acks";
 
     private static final String CORRELATION_NAME = "correlation";
@@ -49,7 +46,7 @@ public class KafkaGrpcOptionsConfigAdapter implements OptionsConfigAdapterSpi, J
         new KafkaGrpcCorrelationConfig(CORRELATION_HEADERS_CORRELATION_ID_DEFAULT,
             CORRELATION_HEADERS_SERVICE_DEFAULT, CORRELATION_HEADERS_METHOD_DEFAULT);
     public static final KafkaGrpcOptionsConfig DEFAULT =
-        new KafkaGrpcOptionsConfig(null, null, null, ACKS_DEFAULT, CORRELATION_DEFAULT);
+        new KafkaGrpcOptionsConfig(ACKS_DEFAULT, CORRELATION_DEFAULT);
 
     @Override
     public OptionsConfigAdapterSpi.Kind kind()
@@ -70,10 +67,6 @@ public class KafkaGrpcOptionsConfigAdapter implements OptionsConfigAdapterSpi, J
         KafkaGrpcOptionsConfig kafkaGrpcOptions = (KafkaGrpcOptionsConfig) options;
 
         JsonObjectBuilder object = Json.createObjectBuilder();
-
-        object.add(SCHEME_NAME, kafkaGrpcOptions.scheme.asString());
-        object.add(AUTHORITY_NAME, kafkaGrpcOptions.authority.asString());
-        object.add(ENTRY_NAME, kafkaGrpcOptions.entry);
 
         if (kafkaGrpcOptions.acks != ACKS_DEFAULT)
         {
@@ -118,10 +111,6 @@ public class KafkaGrpcOptionsConfigAdapter implements OptionsConfigAdapterSpi, J
             ? KafkaAckMode.valueOf(object.getString(ACKS_NAME).toUpperCase())
             : ACKS_DEFAULT;
 
-        String16FW newScheme = new String16FW(object.getString(SCHEME_NAME));
-        String16FW newAuthority = new String16FW(object.getString(AUTHORITY_NAME));
-        String newEntry = object.getString(ENTRY_NAME);
-
         KafkaGrpcCorrelationConfig newCorrelation = CORRELATION_DEFAULT;
         if (object.containsKey(CORRELATION_NAME))
         {
@@ -152,6 +141,6 @@ public class KafkaGrpcOptionsConfigAdapter implements OptionsConfigAdapterSpi, J
             }
         }
 
-        return new KafkaGrpcOptionsConfig(newScheme, newAuthority, newEntry, newProduceAcks, newCorrelation);
+        return new KafkaGrpcOptionsConfig(newProduceAcks, newCorrelation);
     }
 }

--- a/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcRouteConfig.java
+++ b/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcRouteConfig.java
@@ -18,7 +18,6 @@ import static java.util.stream.Collectors.toList;
 
 import java.util.List;
 import java.util.function.LongPredicate;
-import java.util.function.ToLongFunction;
 
 import io.aklivity.zilla.runtime.engine.config.OptionsConfig;
 import io.aklivity.zilla.runtime.engine.config.RouteConfig;
@@ -32,12 +31,10 @@ public final class KafkaGrpcRouteConfig extends OptionsConfig
 
     public KafkaGrpcRouteConfig(
         KafkaGrpcOptionsConfig options,
-        RouteConfig route,
-        ToLongFunction<String> resolveId)
+        RouteConfig route)
     {
         this.id = route.id;
         this.with = (KafkaGrpcWithConfig) route.with;
-        this.with.entryId = resolveId.applyAsLong(with.entry);
         this.when = route.when.stream()
             .map(KafkaGrpcConditionConfig.class::cast)
             .map(c -> new KafkaGrpcConditionResolver(options, c, with))

--- a/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcRouteConfig.java
+++ b/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcRouteConfig.java
@@ -18,6 +18,7 @@ import static java.util.stream.Collectors.toList;
 
 import java.util.List;
 import java.util.function.LongPredicate;
+import java.util.function.ToLongFunction;
 
 import io.aklivity.zilla.runtime.engine.config.OptionsConfig;
 import io.aklivity.zilla.runtime.engine.config.RouteConfig;
@@ -25,18 +26,21 @@ import io.aklivity.zilla.runtime.engine.config.RouteConfig;
 public final class KafkaGrpcRouteConfig extends OptionsConfig
 {
     public final long id;
-
+    public final KafkaGrpcWithConfig with;
     public final List<KafkaGrpcConditionResolver> when;
     private final LongPredicate authorized;
 
     public KafkaGrpcRouteConfig(
         KafkaGrpcOptionsConfig options,
-        RouteConfig route)
+        RouteConfig route,
+        ToLongFunction<String> resolveId)
     {
         this.id = route.id;
+        this.with = (KafkaGrpcWithConfig) route.with;
+        this.with.entryId = resolveId.applyAsLong(with.entry);
         this.when = route.when.stream()
             .map(KafkaGrpcConditionConfig.class::cast)
-            .map(c -> new KafkaGrpcConditionResolver(options, c))
+            .map(c -> new KafkaGrpcConditionResolver(options, c, with))
             .collect(toList());
 
         this.authorized = route.authorized;

--- a/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcWithConfig.java
+++ b/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcWithConfig.java
@@ -19,18 +19,14 @@ import io.aklivity.zilla.runtime.engine.config.WithConfig;
 
 public final class KafkaGrpcWithConfig extends WithConfig
 {
-    public transient long entryId;
     public final String16FW scheme;
     public final String16FW authority;
-    public final String entry;
 
     public KafkaGrpcWithConfig(
         String16FW scheme,
-        String16FW authority,
-        String entry)
+        String16FW authority)
     {
         this.scheme = scheme;
         this.authority = authority;
-        this.entry = entry;
     }
 }

--- a/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcWithConfig.java
+++ b/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcWithConfig.java
@@ -14,19 +14,23 @@
  */
 package io.aklivity.zilla.runtime.binding.kafka.grpc.internal.config;
 
-import io.aklivity.zilla.runtime.binding.kafka.grpc.internal.types.KafkaAckMode;
-import io.aklivity.zilla.runtime.engine.config.OptionsConfig;
+import io.aklivity.zilla.runtime.binding.kafka.grpc.internal.types.String16FW;
+import io.aklivity.zilla.runtime.engine.config.WithConfig;
 
-public final class KafkaGrpcOptionsConfig extends OptionsConfig
+public final class KafkaGrpcWithConfig extends WithConfig
 {
-    public final KafkaAckMode acks;
-    public final KafkaGrpcCorrelationConfig correlation;
+    public transient long entryId;
+    public final String16FW scheme;
+    public final String16FW authority;
+    public final String entry;
 
-    public KafkaGrpcOptionsConfig(
-        KafkaAckMode acks,
-        KafkaGrpcCorrelationConfig correlation)
+    public KafkaGrpcWithConfig(
+        String16FW scheme,
+        String16FW authority,
+        String entry)
     {
-        this.acks = acks;
-        this.correlation = correlation;
+        this.scheme = scheme;
+        this.authority = authority;
+        this.entry = entry;
     }
 }

--- a/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcWithConfigAdapter.java
+++ b/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcWithConfigAdapter.java
@@ -28,7 +28,6 @@ public class KafkaGrpcWithConfigAdapter implements WithConfigAdapterSpi, JsonbAd
 {
     private static final String SCHEME_NAME = "scheme";
     private static final String AUTHORITY_NAME = "authority";
-    private static final String ENTRY_NAME = "entry";
 
     @Override
     public String type()
@@ -46,7 +45,6 @@ public class KafkaGrpcWithConfigAdapter implements WithConfigAdapterSpi, JsonbAd
 
         object.add(SCHEME_NAME, kafkaGrpcWith.scheme.asString());
         object.add(AUTHORITY_NAME, kafkaGrpcWith.authority.asString());
-        object.add(ENTRY_NAME, kafkaGrpcWith.entry);
 
         return object.build();
     }
@@ -57,8 +55,7 @@ public class KafkaGrpcWithConfigAdapter implements WithConfigAdapterSpi, JsonbAd
     {
         String16FW newScheme = new String16FW(object.getString(SCHEME_NAME));
         String16FW newAuthority = new String16FW(object.getString(AUTHORITY_NAME));
-        String newEntry = object.getString(ENTRY_NAME);
 
-        return new KafkaGrpcWithConfig(newScheme, newAuthority, newEntry);
+        return new KafkaGrpcWithConfig(newScheme, newAuthority);
     }
 }

--- a/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcWithConfigAdapter.java
+++ b/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcWithConfigAdapter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021-2022 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.kafka.grpc.internal.config;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.bind.adapter.JsonbAdapter;
+
+import io.aklivity.zilla.runtime.binding.kafka.grpc.internal.KafkaGrpcBinding;
+import io.aklivity.zilla.runtime.binding.kafka.grpc.internal.types.String16FW;
+import io.aklivity.zilla.runtime.engine.config.WithConfig;
+import io.aklivity.zilla.runtime.engine.config.WithConfigAdapterSpi;
+
+public class KafkaGrpcWithConfigAdapter implements WithConfigAdapterSpi, JsonbAdapter<WithConfig, JsonObject>
+{
+    private static final String SCHEME_NAME = "scheme";
+    private static final String AUTHORITY_NAME = "authority";
+    private static final String ENTRY_NAME = "entry";
+
+    @Override
+    public String type()
+    {
+        return KafkaGrpcBinding.NAME;
+    }
+
+    @Override
+    public JsonObject adaptToJson(
+        WithConfig with)
+    {
+        KafkaGrpcWithConfig kafkaGrpcWith = (KafkaGrpcWithConfig) with;
+
+        JsonObjectBuilder object = Json.createObjectBuilder();
+
+        object.add(SCHEME_NAME, kafkaGrpcWith.scheme.asString());
+        object.add(AUTHORITY_NAME, kafkaGrpcWith.authority.asString());
+        object.add(ENTRY_NAME, kafkaGrpcWith.entry);
+
+        return object.build();
+    }
+
+    @Override
+    public WithConfig adaptFromJson(
+        JsonObject object)
+    {
+        String16FW newScheme = new String16FW(object.getString(SCHEME_NAME));
+        String16FW newAuthority = new String16FW(object.getString(AUTHORITY_NAME));
+        String newEntry = object.getString(ENTRY_NAME);
+
+        return new KafkaGrpcWithConfig(newScheme, newAuthority, newEntry);
+    }
+}

--- a/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcRemoteServerFactory.java
+++ b/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcRemoteServerFactory.java
@@ -171,7 +171,7 @@ public final class KafkaGrpcRemoteServerFactory implements KafkaGrpcStreamFactor
                 {
                     KafkaGrpcConditionResult condition = c.resolve();
                     servers.add(
-                        new KafkaRemoteServer(newBinding.id, r.with.entryId, r.id, condition, newBinding.helper));
+                        new KafkaRemoteServer(newBinding.id, newBinding.entryId, r.id, condition, newBinding.helper));
                 }));
 
             this.reconnectAt = signaler.signalAt(

--- a/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcRemoteServerFactory.java
+++ b/incubator/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcRemoteServerFactory.java
@@ -171,7 +171,7 @@ public final class KafkaGrpcRemoteServerFactory implements KafkaGrpcStreamFactor
                 {
                     KafkaGrpcConditionResult condition = c.resolve();
                     servers.add(
-                        new KafkaRemoteServer(newBinding.id, newBinding.options.entryId, r.id, condition, newBinding.helper));
+                        new KafkaRemoteServer(newBinding.id, r.with.entryId, r.id, condition, newBinding.helper));
                 }));
 
             this.reconnectAt = signaler.signalAt(

--- a/incubator/binding-kafka-grpc/src/main/moditect/module-info.java
+++ b/incubator/binding-kafka-grpc/src/main/moditect/module-info.java
@@ -24,4 +24,7 @@ module io.aklivity.zilla.runtime.binding.kafka.grpc
 
     provides io.aklivity.zilla.runtime.engine.config.OptionsConfigAdapterSpi
         with io.aklivity.zilla.runtime.binding.kafka.grpc.internal.config.KafkaGrpcOptionsConfigAdapter;
+
+    provides io.aklivity.zilla.runtime.engine.config.WithConfigAdapterSpi
+        with io.aklivity.zilla.runtime.binding.kafka.grpc.internal.config.KafkaGrpcWithConfigAdapter;
 }

--- a/incubator/binding-kafka-grpc/src/main/resources/META-INF/services/io.aklivity.zilla.runtime.engine.config.WithConfigAdapterSpi
+++ b/incubator/binding-kafka-grpc/src/main/resources/META-INF/services/io.aklivity.zilla.runtime.engine.config.WithConfigAdapterSpi
@@ -1,0 +1,1 @@
+io.aklivity.zilla.runtime.binding.kafka.grpc.internal.config.KafkaGrpcWithConfigAdapter

--- a/incubator/binding-kafka-grpc/src/test/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcOptionsConfigAdapterTest.java
+++ b/incubator/binding-kafka-grpc/src/test/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcOptionsConfigAdapterTest.java
@@ -47,9 +47,6 @@ public class KafkaGrpcOptionsConfigAdapterTest
     {
         String text =
                 "{" +
-                    "\"scheme\":\"http\"," +
-                    "\"authority\":\"localhost:8080\"," +
-                    "\"entry\":\"grpc0\"," +
                     "\"acks\":\"leader_only\"," +
                     "\"correlation\":" +
                     "{" +
@@ -65,8 +62,6 @@ public class KafkaGrpcOptionsConfigAdapterTest
         KafkaGrpcOptionsConfig options = jsonb.fromJson(text, KafkaGrpcOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
-        assertThat(options.scheme.asString(), equalTo("http"));
-        assertThat(options.authority.asString(), equalTo("localhost:8080"));
         assertThat(options.acks, equalTo(LEADER_ONLY));
         assertThat(options.correlation, not(nullValue()));
         assertThat(options.correlation.service.asString(), equalTo("zilla:service"));
@@ -78,9 +73,6 @@ public class KafkaGrpcOptionsConfigAdapterTest
     public void shouldWriteOptions()
     {
         KafkaGrpcOptionsConfig options = new KafkaGrpcOptionsConfig(
-                new String16FW("http"),
-                new String16FW("localhost:8080"),
-                "grpc0",
                 LEADER_ONLY,
                 new KafkaGrpcCorrelationConfig(
                     new String16FW("zilla:x-correlation-id"),
@@ -92,9 +84,6 @@ public class KafkaGrpcOptionsConfigAdapterTest
         assertThat(text, not(nullValue()));
         assertThat(text, equalTo(
                 "{" +
-                    "\"scheme\":\"http\"," +
-                    "\"authority\":\"localhost:8080\"," +
-                    "\"entry\":\"grpc0\"," +
                     "\"acks\":\"leader_only\"," +
                     "\"correlation\":" +
                     "{" +

--- a/incubator/binding-kafka-grpc/src/test/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcWithConfigAdapterTest.java
+++ b/incubator/binding-kafka-grpc/src/test/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcWithConfigAdapterTest.java
@@ -46,8 +46,7 @@ public class KafkaGrpcWithConfigAdapterTest
         String text =
                 "{" +
                     "\"scheme\":\"http\"," +
-                    "\"authority\":\"localhost:8080\"," +
-                    "\"entry\":\"grpc0\"" +
+                    "\"authority\":\"localhost:8080\"" +
                 "}";
 
         KafkaGrpcWithConfig with = jsonb.fromJson(text, KafkaGrpcWithConfig.class);
@@ -55,7 +54,6 @@ public class KafkaGrpcWithConfigAdapterTest
         assertThat(with, not(nullValue()));
         assertThat(with.scheme.asString(), equalTo("http"));
         assertThat(with.authority.asString(), equalTo("localhost:8080"));
-        assertThat(with.entry, equalTo("grpc0"));
     }
 
     @Test
@@ -63,8 +61,7 @@ public class KafkaGrpcWithConfigAdapterTest
     {
         KafkaGrpcWithConfig options = new KafkaGrpcWithConfig(
                 new String16FW("http"),
-                new String16FW("localhost:8080"),
-                "grpc0");
+                new String16FW("localhost:8080"));
 
         String text = jsonb.toJson(options);
 
@@ -72,8 +69,7 @@ public class KafkaGrpcWithConfigAdapterTest
         assertThat(text, equalTo(
                 "{" +
                     "\"scheme\":\"http\"," +
-                    "\"authority\":\"localhost:8080\"," +
-                    "\"entry\":\"grpc0\"" +
+                    "\"authority\":\"localhost:8080\"" +
                 "}"));
     }
 }

--- a/incubator/binding-kafka-grpc/src/test/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcWithConfigAdapterTest.java
+++ b/incubator/binding-kafka-grpc/src/test/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcWithConfigAdapterTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021-2022 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.kafka.grpc.internal.config;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.JsonbConfig;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.binding.kafka.grpc.internal.types.String16FW;
+
+
+public class KafkaGrpcWithConfigAdapterTest
+{
+    private Jsonb jsonb;
+
+    @Before
+    public void initJson()
+    {
+        JsonbConfig config = new JsonbConfig()
+                .withAdapters(new KafkaGrpcWithConfigAdapter());
+        jsonb = JsonbBuilder.create(config);
+    }
+
+    @Test
+    public void shouldReadOptions()
+    {
+        String text =
+                "{" +
+                    "\"scheme\":\"http\"," +
+                    "\"authority\":\"localhost:8080\"," +
+                    "\"entry\":\"grpc0\"" +
+                "}";
+
+        KafkaGrpcWithConfig with = jsonb.fromJson(text, KafkaGrpcWithConfig.class);
+
+        assertThat(with, not(nullValue()));
+        assertThat(with.scheme.asString(), equalTo("http"));
+        assertThat(with.authority.asString(), equalTo("localhost:8080"));
+        assertThat(with.entry, equalTo("grpc0"));
+    }
+
+    @Test
+    public void shouldWriteOptions()
+    {
+        KafkaGrpcWithConfig options = new KafkaGrpcWithConfig(
+                new String16FW("http"),
+                new String16FW("localhost:8080"),
+                "grpc0");
+
+        String text = jsonb.toJson(options);
+
+        assertThat(text, not(nullValue()));
+        assertThat(text, equalTo(
+                "{" +
+                    "\"scheme\":\"http\"," +
+                    "\"authority\":\"localhost:8080\"," +
+                    "\"entry\":\"grpc0\"" +
+                "}"));
+    }
+}

--- a/incubator/binding-kafka-grpc/src/test/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcWithConfigAdapterTest.java
+++ b/incubator/binding-kafka-grpc/src/test/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcWithConfigAdapterTest.java
@@ -28,7 +28,6 @@ import org.junit.Test;
 
 import io.aklivity.zilla.runtime.binding.kafka.grpc.internal.types.String16FW;
 
-
 public class KafkaGrpcWithConfigAdapterTest
 {
     private Jsonb jsonb;
@@ -42,7 +41,7 @@ public class KafkaGrpcWithConfigAdapterTest
     }
 
     @Test
-    public void shouldReadOptions()
+    public void shouldReadWith()
     {
         String text =
                 "{" +
@@ -60,7 +59,7 @@ public class KafkaGrpcWithConfigAdapterTest
     }
 
     @Test
-    public void shouldWriteOptions()
+    public void shouldWriteWith()
     {
         KafkaGrpcWithConfig options = new KafkaGrpcWithConfig(
                 new String16FW("http"),

--- a/incubator/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttBindingConfig.java
+++ b/incubator/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttBindingConfig.java
@@ -34,7 +34,7 @@ public final class MqttBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.entry;
+        this.entry = binding.name;
         this.kind = binding.kind;
         this.routes = binding.routes.stream().map(MqttRouteConfig::new).collect(toList());
     }

--- a/incubator/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttBindingConfig.java
+++ b/incubator/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttBindingConfig.java
@@ -26,7 +26,7 @@ import io.aklivity.zilla.runtime.engine.config.KindConfig;
 public final class MqttBindingConfig
 {
     public final long id;
-    public final String entry;
+    public final String name;
     public final KindConfig kind;
     public final List<MqttRouteConfig> routes;
 
@@ -34,7 +34,7 @@ public final class MqttBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.name;
+        this.name = binding.name;
         this.kind = binding.kind;
         this.routes = binding.routes.stream().map(MqttRouteConfig::new).collect(toList());
     }

--- a/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/config/FileSystemBindingConfig.java
+++ b/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/config/FileSystemBindingConfig.java
@@ -28,7 +28,7 @@ public final class FileSystemBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.entry;
+        this.entry = binding.name;
         this.kind = binding.kind;
         this.options = FileSystemOptionsConfig.class.cast(binding.options);
     }

--- a/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/config/FileSystemBindingConfig.java
+++ b/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/config/FileSystemBindingConfig.java
@@ -20,7 +20,7 @@ import io.aklivity.zilla.runtime.engine.config.KindConfig;
 public final class FileSystemBindingConfig
 {
     public final long id;
-    public final String entry;
+    public final String name;
     public final FileSystemOptionsConfig options;
     public final KindConfig kind;
 
@@ -28,7 +28,7 @@ public final class FileSystemBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.name;
+        this.name = binding.name;
         this.kind = binding.kind;
         this.options = FileSystemOptionsConfig.class.cast(binding.options);
     }

--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemBindingConfig.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemBindingConfig.java
@@ -44,7 +44,7 @@ public final class HttpFileSystemBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.entry;
+        this.entry = binding.name;
         this.kind = binding.kind;
         this.routes = binding.routes.stream().map(HttpFileSystemRouteConfig::new).collect(toList());
     }

--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemBindingConfig.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemBindingConfig.java
@@ -36,7 +36,7 @@ public final class HttpFileSystemBindingConfig
     }
 
     public final long id;
-    public final String entry;
+    public final String name;
     public final KindConfig kind;
     public final List<HttpFileSystemRouteConfig> routes;
 
@@ -44,7 +44,7 @@ public final class HttpFileSystemBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.name;
+        this.name = binding.name;
         this.kind = binding.kind;
         this.routes = binding.routes.stream().map(HttpFileSystemRouteConfig::new).collect(toList());
     }

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaBindingConfig.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaBindingConfig.java
@@ -35,7 +35,7 @@ import io.aklivity.zilla.runtime.engine.config.KindConfig;
 public final class HttpKafkaBindingConfig
 {
     public final long id;
-    public final String entry;
+    public final String name;
     public final KindConfig kind;
     public final HttpKafkaOptionsConfig options;
     public final List<HttpKafkaRouteConfig> routes;
@@ -46,7 +46,7 @@ public final class HttpKafkaBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.name;
+        this.name = binding.name;
         this.kind = binding.kind;
         this.options = Optional.ofNullable(binding.options)
                 .map(HttpKafkaOptionsConfig.class::cast)

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaBindingConfig.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaBindingConfig.java
@@ -46,7 +46,7 @@ public final class HttpKafkaBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.entry;
+        this.entry = binding.name;
         this.kind = binding.kind;
         this.options = Optional.ofNullable(binding.options)
                 .map(HttpKafkaOptionsConfig.class::cast)

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpBindingConfig.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpBindingConfig.java
@@ -50,7 +50,7 @@ public final class HttpBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.entry;
+        this.entry = binding.name;
         this.kind = binding.kind;
         this.options = HttpOptionsConfig.class.cast(binding.options);
         this.routes = binding.routes.stream().map(HttpRouteConfig::new).collect(toList());

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpBindingConfig.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpBindingConfig.java
@@ -39,7 +39,7 @@ public final class HttpBindingConfig
     private static final HttpAccessControlConfig DEFAULT_ACCESS_CONTROL = new HttpAccessControlConfig(SAME_ORIGIN);
 
     public final long id;
-    public final String entry;
+    public final String name;
     public final HttpOptionsConfig options;
     public final KindConfig kind;
     public final List<HttpRouteConfig> routes;
@@ -50,7 +50,7 @@ public final class HttpBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.name;
+        this.name = binding.name;
         this.kind = binding.kind;
         this.options = HttpOptionsConfig.class.cast(binding.options);
         this.routes = binding.routes.stream().map(HttpRouteConfig::new).collect(toList());

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaBindingConfig.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaBindingConfig.java
@@ -34,7 +34,7 @@ public final class KafkaBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.entry;
+        this.entry = binding.name;
         this.kind = binding.kind;
         this.options = KafkaOptionsConfig.class.cast(binding.options);
         this.routes = binding.routes.stream().map(KafkaRouteConfig::new).collect(toList());

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaBindingConfig.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaBindingConfig.java
@@ -25,7 +25,7 @@ import io.aklivity.zilla.runtime.engine.config.KindConfig;
 public final class KafkaBindingConfig
 {
     public final long id;
-    public final String entry;
+    public final String name;
     public final KafkaOptionsConfig options;
     public final KindConfig kind;
     public final List<KafkaRouteConfig> routes;
@@ -34,7 +34,7 @@ public final class KafkaBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.name;
+        this.name = binding.name;
         this.kind = binding.kind;
         this.options = KafkaOptionsConfig.class.cast(binding.options);
         this.routes = binding.routes.stream().map(KafkaRouteConfig::new).collect(toList());

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyBindingConfig.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyBindingConfig.java
@@ -35,7 +35,7 @@ public final class ProxyBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.entry;
+        this.entry = binding.name;
         this.kind = binding.kind;
         this.options = ProxyOptionsConfig.class.cast(binding.options);
         this.routes = binding.routes.stream().map(ProxyRouteConfig::new).collect(toList());

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyBindingConfig.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyBindingConfig.java
@@ -26,7 +26,7 @@ import io.aklivity.zilla.runtime.engine.config.KindConfig;
 public final class ProxyBindingConfig
 {
     public final long id;
-    public final String entry;
+    public final String name;
     public final KindConfig kind;
     public final ProxyOptionsConfig options;
     public final List<ProxyRouteConfig> routes;
@@ -35,7 +35,7 @@ public final class ProxyBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.name;
+        this.name = binding.name;
         this.kind = binding.kind;
         this.options = ProxyOptionsConfig.class.cast(binding.options);
         this.routes = binding.routes.stream().map(ProxyRouteConfig::new).collect(toList());

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaBindingConfig.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaBindingConfig.java
@@ -25,7 +25,7 @@ import io.aklivity.zilla.runtime.engine.config.KindConfig;
 public final class SseKafkaBindingConfig
 {
     public final long id;
-    public final String entry;
+    public final String name;
     public final KindConfig kind;
     public final List<SseKafkaRouteConfig> routes;
 
@@ -33,7 +33,7 @@ public final class SseKafkaBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.name;
+        this.name = binding.name;
         this.kind = binding.kind;
         this.routes = binding.routes.stream().map(SseKafkaRouteConfig::new).collect(toList());
     }

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaBindingConfig.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaBindingConfig.java
@@ -33,7 +33,7 @@ public final class SseKafkaBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.entry;
+        this.entry = binding.name;
         this.kind = binding.kind;
         this.routes = binding.routes.stream().map(SseKafkaRouteConfig::new).collect(toList());
     }

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseBindingConfig.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseBindingConfig.java
@@ -27,7 +27,7 @@ public final class SseBindingConfig
     private static final SseOptionsConfig DEFAULT_OPTIONS = new SseOptionsConfig();
 
     public final long id;
-    public final String entry;
+    public final String name;
     public final SseOptionsConfig options;
     public final KindConfig kind;
     public final List<SseRouteConfig> routes;
@@ -36,7 +36,7 @@ public final class SseBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.name;
+        this.name = binding.name;
         this.kind = binding.kind;
         this.options = binding.options instanceof SseOptionsConfig ? (SseOptionsConfig) binding.options : DEFAULT_OPTIONS;
         this.routes = binding.routes.stream().map(SseRouteConfig::new).collect(toList());

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseBindingConfig.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseBindingConfig.java
@@ -36,7 +36,7 @@ public final class SseBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.entry;
+        this.entry = binding.name;
         this.kind = binding.kind;
         this.options = binding.options instanceof SseOptionsConfig ? (SseOptionsConfig) binding.options : DEFAULT_OPTIONS;
         this.routes = binding.routes.stream().map(SseRouteConfig::new).collect(toList());

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpBindingConfig.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpBindingConfig.java
@@ -31,7 +31,7 @@ public final class TcpBindingConfig
     private static final List<TcpRouteConfig> DEFAULT_CLIENT_ROUTES = initDefaultClientRoutes();
 
     public final long id;
-    public final String entry;
+    public final String name;
     public final KindConfig kind;
     public final TcpOptionsConfig options;
     public final List<TcpRouteConfig> routes;
@@ -42,7 +42,7 @@ public final class TcpBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.name;
+        this.name = binding.name;
         this.kind = binding.kind;
         this.options = TcpOptionsConfig.class.cast(binding.options);
         this.routes = binding.kind == KindConfig.CLIENT && binding.routes.isEmpty()

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpBindingConfig.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpBindingConfig.java
@@ -42,7 +42,7 @@ public final class TcpBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.entry;
+        this.entry = binding.name;
         this.kind = binding.kind;
         this.options = TcpOptionsConfig.class.cast(binding.options);
         this.routes = binding.kind == KindConfig.CLIENT && binding.routes.isEmpty()

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsBindingConfig.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsBindingConfig.java
@@ -64,7 +64,7 @@ public final class TlsBindingConfig
 
     public final long id;
     public final long vaultId;
-    public final String entry;
+    public final String name;
     public final TlsOptionsConfig options;
     public final KindConfig kind;
     public final List<TlsRouteConfig> routes;
@@ -76,7 +76,7 @@ public final class TlsBindingConfig
     {
         this.id = binding.id;
         this.vaultId = binding.vaultId;
-        this.entry = binding.name;
+        this.name = binding.name;
         this.kind = binding.kind;
         this.options = TlsOptionsConfig.class.cast(binding.options);
         this.routes = binding.routes.stream().map(TlsRouteConfig::new).collect(toList());

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsBindingConfig.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsBindingConfig.java
@@ -76,7 +76,7 @@ public final class TlsBindingConfig
     {
         this.id = binding.id;
         this.vaultId = binding.vaultId;
-        this.entry = binding.entry;
+        this.entry = binding.name;
         this.kind = binding.kind;
         this.options = TlsOptionsConfig.class.cast(binding.options);
         this.routes = binding.routes.stream().map(TlsRouteConfig::new).collect(toList());

--- a/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/config/WsBindingConfig.java
+++ b/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/config/WsBindingConfig.java
@@ -36,7 +36,7 @@ public final class WsBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.entry;
+        this.entry = binding.name;
         this.kind = binding.kind;
         this.options = binding.options instanceof WsOptionsConfig ? (WsOptionsConfig) binding.options : DEFAULT_OPTIONS;
         this.routes = binding.routes.stream().map(WsRouteConfig::new).collect(toList());

--- a/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/config/WsBindingConfig.java
+++ b/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/config/WsBindingConfig.java
@@ -27,7 +27,7 @@ public final class WsBindingConfig
     private static final WsOptionsConfig DEFAULT_OPTIONS = new WsOptionsConfig(null, null, null, null);
 
     public final long id;
-    public final String entry;
+    public final String name;
     public final WsOptionsConfig options;
     public final KindConfig kind;
     public final List<WsRouteConfig> routes;
@@ -36,7 +36,7 @@ public final class WsBindingConfig
         BindingConfig binding)
     {
         this.id = binding.id;
-        this.entry = binding.name;
+        this.name = binding.name;
         this.kind = binding.kind;
         this.options = binding.options instanceof WsOptionsConfig ? (WsOptionsConfig) binding.options : DEFAULT_OPTIONS;
         this.routes = binding.routes.stream().map(WsRouteConfig::new).collect(toList());

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/BindingConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/BindingConfig.java
@@ -30,9 +30,9 @@ public class BindingConfig
 
     public final String vault;
     public final String name;
-    public final String entry;
     public final String type;
     public final KindConfig kind;
+    public final String entry;
     public final OptionsConfig options;
     public final List<RouteConfig> routes;
 

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/BindingConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/BindingConfig.java
@@ -47,9 +47,9 @@ public class BindingConfig
     {
         this.vault = vault;
         this.name = name;
-        this.entry = entry;
         this.type = requireNonNull(type);
         this.kind = requireNonNull(kind);
+        this.entry = entry;
         this.options = options;
         this.routes = routes;
     }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/BindingConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/BindingConfig.java
@@ -23,11 +23,13 @@ import java.util.function.ToLongFunction;
 public class BindingConfig
 {
     public transient long id;
+    public transient long entryId;
     public transient ToLongFunction<String> resolveId;
 
     public transient long vaultId;
 
     public final String vault;
+    public final String name;
     public final String entry;
     public final String type;
     public final KindConfig kind;
@@ -36,6 +38,7 @@ public class BindingConfig
 
     public BindingConfig(
         String vault,
+        String name,
         String entry,
         String type,
         KindConfig kind,
@@ -43,6 +46,7 @@ public class BindingConfig
         List<RouteConfig> routes)
     {
         this.vault = vault;
+        this.name = name;
         this.entry = entry;
         this.type = requireNonNull(type);
         this.kind = requireNonNull(kind);

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/BindingConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/BindingConfig.java
@@ -39,9 +39,9 @@ public class BindingConfig
     public BindingConfig(
         String vault,
         String name,
-        String entry,
         String type,
         KindConfig kind,
+        String entry,
         OptionsConfig options,
         List<RouteConfig> routes)
     {

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/BindingConfigsAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/BindingConfigsAdapter.java
@@ -41,10 +41,10 @@ import io.aklivity.zilla.runtime.engine.config.RouteConfig;
 public class BindingConfigsAdapter implements JsonbAdapter<BindingConfig[], JsonObject>
 {
     private static final String VAULT_NAME = "vault";
-    private static final String ENTRY_NAME = "entry";
     private static final String EXIT_NAME = "exit";
     private static final String TYPE_NAME = "type";
     private static final String KIND_NAME = "kind";
+    private static final String ENTRY_NAME = "entry";
     private static final String OPTIONS_NAME = "options";
     private static final String ROUTES_NAME = "routes";
 

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/BindingConfigsAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/BindingConfigsAdapter.java
@@ -154,7 +154,7 @@ public class BindingConfigsAdapter implements JsonbAdapter<BindingConfig[], Json
                 ? item.getString(ENTRY_NAME)
                 : null;
 
-            bindings.add(new BindingConfig(vault, name, entry, type, kind, opts, routes));
+            bindings.add(new BindingConfig(vault, name, type, kind, entry, opts, routes));
         }
 
         return bindings.toArray(BindingConfig[]::new);

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/BindingConfigsAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/BindingConfigsAdapter.java
@@ -41,6 +41,7 @@ import io.aklivity.zilla.runtime.engine.config.RouteConfig;
 public class BindingConfigsAdapter implements JsonbAdapter<BindingConfig[], JsonObject>
 {
     private static final String VAULT_NAME = "vault";
+    private static final String ENTRY_NAME = "entry";
     private static final String EXIT_NAME = "exit";
     private static final String TYPE_NAME = "type";
     private static final String KIND_NAME = "kind";
@@ -83,6 +84,11 @@ public class BindingConfigsAdapter implements JsonbAdapter<BindingConfig[], Json
 
             item.add(KIND_NAME, kind.adaptToJson(binding.kind));
 
+            if (binding.entry != null)
+            {
+                item.add(ENTRY_NAME, binding.entry);
+            }
+
             if (binding.options != null)
             {
                 item.add(OPTIONS_NAME, options.adaptToJson(binding.options));
@@ -95,7 +101,7 @@ public class BindingConfigsAdapter implements JsonbAdapter<BindingConfig[], Json
                 item.add(ROUTES_NAME, routes);
             }
 
-            object.add(binding.entry, item);
+            object.add(binding.name, item);
         }
 
         return object.build();
@@ -107,9 +113,9 @@ public class BindingConfigsAdapter implements JsonbAdapter<BindingConfig[], Json
     {
         List<BindingConfig> bindings = new LinkedList<>();
 
-        for (String entry : object.keySet())
+        for (String name : object.keySet())
         {
-            JsonObject item = object.getJsonObject(entry);
+            JsonObject item = object.getJsonObject(name);
             String type = item.getString(TYPE_NAME);
 
             route.adaptType(type);
@@ -144,7 +150,11 @@ public class BindingConfigsAdapter implements JsonbAdapter<BindingConfig[], Json
                 routes = routesWithExit;
             }
 
-            bindings.add(new BindingConfig(vault, entry, type, kind, opts, routes));
+            String entry = item.containsKey(ENTRY_NAME)
+                ? item.getString(ENTRY_NAME)
+                : null;
+
+            bindings.add(new BindingConfig(vault, name, entry, type, kind, opts, routes));
         }
 
         return bindings.toArray(BindingConfig[]::new);

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/ConfigurationManager.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/ConfigurationManager.java
@@ -213,7 +213,8 @@ public class ConfigurationManager
 
             for (BindingConfig binding : namespace.bindings)
             {
-                binding.id = namespace.resolveId.applyAsLong(binding.entry);
+                binding.id = namespace.resolveId.applyAsLong(binding.name);
+                binding.entryId = namespace.resolveId.applyAsLong(binding.entry);
                 binding.resolveId = namespace.resolveId;
 
                 if (binding.vault != null)

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/DispatchAgent.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/DispatchAgent.java
@@ -527,7 +527,7 @@ public class DispatchAgent implements EngineContext, Agent
         BindingConfig binding)
     {
         final int namespaceId = labels.supplyLabelId(namespace.name);
-        final int bindingId = labels.supplyLabelId(binding.entry);
+        final int bindingId = labels.supplyLabelId(binding.name);
         return NamespacedId.id(namespaceId, bindingId);
     }
 

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/NamespaceRegistry.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/NamespaceRegistry.java
@@ -91,7 +91,7 @@ public class NamespaceRegistry
         BindingContext context = bindingsByType.apply(config.type);
         assert context != null : "Missing binding type: " + config.type;
 
-        int bindingId = supplyLabelId.applyAsInt(config.entry);
+        int bindingId = supplyLabelId.applyAsInt(config.name);
         BindingRegistry registry = new BindingRegistry(config, context);
         bindingsById.put(bindingId, registry);
         registry.attach();
@@ -101,7 +101,7 @@ public class NamespaceRegistry
     private void detachBinding(
         BindingConfig config)
     {
-        int bindingId = supplyLabelId.applyAsInt(config.entry);
+        int bindingId = supplyLabelId.applyAsInt(config.name);
         BindingRegistry context = bindingsById.remove(bindingId);
         if (context != null)
         {

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/BindingConfigsAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/BindingConfigsAdapterTest.java
@@ -15,6 +15,7 @@
  */
 package io.aklivity.zilla.runtime.engine.internal.config;
 
+import static io.aklivity.zilla.runtime.engine.config.KindConfig.REMOTE_SERVER;
 import static io.aklivity.zilla.runtime.engine.config.KindConfig.SERVER;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -85,7 +86,8 @@ public class BindingConfigsAdapterTest
     @Test
     public void shouldWriteBinding()
     {
-        BindingConfig[] bindings = { new BindingConfig(null, "test", "test", SERVER, null, emptyList()) };
+        BindingConfig[] bindings = { new BindingConfig(null, "test", null, "test",
+            SERVER, null, emptyList()) };
 
         String text = jsonb.toJson(bindings);
 
@@ -121,7 +123,7 @@ public class BindingConfigsAdapterTest
     @Test
     public void shouldWriteBindingWithVault()
     {
-        BindingConfig[] bindings = { new BindingConfig("test", "test", "test", SERVER, null, emptyList()) };
+        BindingConfig[] bindings = { new BindingConfig("test", "test",  null, "test", SERVER, null, emptyList()) };
 
         String text = jsonb.toJson(bindings);
 
@@ -148,7 +150,7 @@ public class BindingConfigsAdapterTest
         BindingConfig[] bindings = jsonb.fromJson(text, BindingConfig[].class);
 
         assertThat(bindings[0], not(nullValue()));
-        assertThat(bindings[0].entry, equalTo("test"));
+        assertThat(bindings[0].name, equalTo("test"));
         assertThat(bindings[0].kind, equalTo(SERVER));
         assertThat(bindings[0].options, instanceOf(TestBindingOptionsConfig.class));
         assertThat(((TestBindingOptionsConfig) bindings[0].options).mode, equalTo("test"));
@@ -158,7 +160,7 @@ public class BindingConfigsAdapterTest
     public void shouldWriteBindingWithOptions()
     {
         BindingConfig[] bindings =
-            { new BindingConfig(null, "test", "test", SERVER, new TestBindingOptionsConfig("test"), emptyList()) };
+            { new BindingConfig(null, "test",  null, "test", SERVER, new TestBindingOptionsConfig("test"), emptyList()) };
 
         String text = jsonb.toJson(bindings);
 
@@ -187,7 +189,7 @@ public class BindingConfigsAdapterTest
         BindingConfig[] bindings = jsonb.fromJson(text, BindingConfig[].class);
 
         assertThat(bindings[0], not(nullValue()));
-        assertThat(bindings[0].entry, equalTo("test"));
+        assertThat(bindings[0].name, equalTo("test"));
         assertThat(bindings[0].kind, equalTo(SERVER));
         assertThat(bindings[0].routes, hasSize(1));
         assertThat(bindings[0].routes.get(0).exit, equalTo("test"));
@@ -198,12 +200,56 @@ public class BindingConfigsAdapterTest
     public void shouldWriteBindingWithRoute()
     {
         BindingConfig[] bindings =
-            { new BindingConfig(null, "test", "test", SERVER, null, singletonList(new RouteConfig("test"))) };
+            { new BindingConfig(null, "test", null, "test", SERVER, null, singletonList(new RouteConfig("test"))) };
 
         String text = jsonb.toJson(bindings);
 
         assertThat(text, not(nullValue()));
         assertThat(text, equalTo("{\"test\":{\"type\":\"test\",\"kind\":\"server\",\"routes\":[{\"exit\":\"test\"}]}}"));
+    }
+
+    @Test
+    public void shouldReadBindingWithRemoteServerKind()
+    {
+        String text =
+            "{" +
+                "\"test\":" +
+                "{" +
+                "\"type\": \"test\"," +
+                "\"kind\": \"remote_server\"," +
+                "\"entry\": \"test_entry\"," +
+                "\"routes\":" +
+                "[" +
+                "{" +
+                "\"exit\": \"test\"" +
+                "}" +
+                "]" +
+                "}" +
+                "}";
+
+        BindingConfig[] bindings = jsonb.fromJson(text, BindingConfig[].class);
+
+        assertThat(bindings[0], not(nullValue()));
+        assertThat(bindings[0].name, equalTo("test"));
+        assertThat(bindings[0].kind, equalTo(REMOTE_SERVER));
+        assertThat(bindings[0].entry, equalTo("test_entry"));
+        assertThat(bindings[0].routes, hasSize(1));
+        assertThat(bindings[0].routes.get(0).exit, equalTo("test"));
+        assertThat(bindings[0].routes.get(0).when, empty());
+    }
+
+    @Test
+    public void shouldWriteBindingWithRemoteServerKind()
+    {
+        BindingConfig[] bindings =
+            { new BindingConfig(null, "test", "test_entry", "test", REMOTE_SERVER,
+                null, singletonList(new RouteConfig("test"))) };
+
+        String text = jsonb.toJson(bindings);
+
+        assertThat(text, not(nullValue()));
+        assertThat(text, equalTo("{\"test\":{\"type\":\"test\",\"kind\":\"remote_server\"," +
+            "\"entry\":\"test_entry\",\"routes\":[{\"exit\":\"test\"}]}}"));
     }
 
 }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/BindingConfigsAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/BindingConfigsAdapterTest.java
@@ -86,8 +86,8 @@ public class BindingConfigsAdapterTest
     @Test
     public void shouldWriteBinding()
     {
-        BindingConfig[] bindings = { new BindingConfig(null, "test", null, "test",
-            SERVER, null, emptyList()) };
+        BindingConfig[] bindings = { new BindingConfig(null, "test", "test", SERVER, null,
+            null, emptyList()) };
 
         String text = jsonb.toJson(bindings);
 
@@ -123,7 +123,7 @@ public class BindingConfigsAdapterTest
     @Test
     public void shouldWriteBindingWithVault()
     {
-        BindingConfig[] bindings = { new BindingConfig("test", "test",  null, "test", SERVER, null, emptyList()) };
+        BindingConfig[] bindings = { new BindingConfig("test", "test", "test", SERVER, null, null, emptyList()) };
 
         String text = jsonb.toJson(bindings);
 
@@ -160,7 +160,7 @@ public class BindingConfigsAdapterTest
     public void shouldWriteBindingWithOptions()
     {
         BindingConfig[] bindings =
-            { new BindingConfig(null, "test",  null, "test", SERVER, new TestBindingOptionsConfig("test"), emptyList()) };
+            { new BindingConfig(null, "test", "test", SERVER, null, new TestBindingOptionsConfig("test"), emptyList()) };
 
         String text = jsonb.toJson(bindings);
 
@@ -200,7 +200,7 @@ public class BindingConfigsAdapterTest
     public void shouldWriteBindingWithRoute()
     {
         BindingConfig[] bindings =
-            { new BindingConfig(null, "test", null, "test", SERVER, null, singletonList(new RouteConfig("test"))) };
+            { new BindingConfig(null, "test", "test", SERVER, null, null, singletonList(new RouteConfig("test"))) };
 
         String text = jsonb.toJson(bindings);
 
@@ -242,7 +242,7 @@ public class BindingConfigsAdapterTest
     public void shouldWriteBindingWithRemoteServerKind()
     {
         BindingConfig[] bindings =
-            { new BindingConfig(null, "test", "test_entry", "test", REMOTE_SERVER,
+            { new BindingConfig(null, "test", "test", REMOTE_SERVER, "test_entry",
                 null, singletonList(new RouteConfig("test"))) };
 
         String text = jsonb.toJson(bindings);

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/NamespaceConfigAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/NamespaceConfigAdapterTest.java
@@ -124,7 +124,7 @@ public class NamespaceConfigAdapterTest
         assertThat(config, not(nullValue()));
         assertThat(config.name, equalTo("test"));
         assertThat(config.bindings, hasSize(1));
-        assertThat(config.bindings.get(0).entry, equalTo("test"));
+        assertThat(config.bindings.get(0).name, equalTo("test"));
         assertThat(config.bindings.get(0).type, equalTo("test"));
         assertThat(config.bindings.get(0).kind, equalTo(SERVER));
         assertThat(config.vaults, emptyCollectionOf(VaultConfig.class));
@@ -134,7 +134,7 @@ public class NamespaceConfigAdapterTest
     @Test
     public void shouldWriteNamespaceWithBinding()
     {
-        BindingConfig binding = new BindingConfig(null, "test", "test", SERVER, null, emptyList());
+        BindingConfig binding = new BindingConfig(null, "test",  null, "test", SERVER, null, emptyList());
         NamespaceConfig namespace = new NamespaceConfig("test", emptyList(), singletonList(binding), emptyList(), emptyList());
 
         String text = jsonb.toJson(namespace);

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/NamespaceConfigAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/NamespaceConfigAdapterTest.java
@@ -134,7 +134,7 @@ public class NamespaceConfigAdapterTest
     @Test
     public void shouldWriteNamespaceWithBinding()
     {
-        BindingConfig binding = new BindingConfig(null, "test",  null, "test", SERVER, null, emptyList());
+        BindingConfig binding = new BindingConfig(null, "test", "test", SERVER, null, null, emptyList());
         NamespaceConfig namespace = new NamespaceConfig("test", emptyList(), singletonList(binding), emptyList(), emptyList());
 
         String text = jsonb.toJson(namespace);

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/schema/engine.schema.json
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/schema/engine.schema.json
@@ -127,7 +127,7 @@
                 "kind":
                 {
                     "title": "Kind",
-                    "type": "string"
+                    "enum": [ "client", "server", "proxy", "remote_server", "cache_client", "cache_server"]
                 },
                 "options":
                 {
@@ -197,6 +197,40 @@
             [
                 "type",
                 "kind"
+            ],
+            "anyOf":
+            [
+                {
+                    "properties":
+                    {
+                        "kind":
+                        {
+                            "const": "remote_server"
+                        },
+                        "entry":
+                        {
+                            "title": "Exit",
+                            "type": "string",
+                            "pattern": "^[a-zA-Z]+[a-zA-Z0-9\\._\\-]*$"
+                        }
+                    },
+                    "required":
+                    [
+                        "entry"
+                    ]
+                },
+                {
+                    "properties":
+                    {
+                        "kind":
+                        {
+                            "not":
+                            {
+                                "const": "remote_server"
+                            }
+                        }
+                    }
+                }
             ],
             "oneOf":
             [


### PR DESCRIPTION
## Description

In general, the options and when sections of binding should describe concepts aligned with the origin type, such as kafka in the case of kafka-grpc, and the with section should describe concepts aligned with the routed type, such as grpc in the case of kafka-grpc. 

Fixe #218 
