### PR TITLE
Add http.active.requests and http.duration metrics

### DIFF
--- a/incubator/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/descriptor/PrometheusMetricDescriptor.java
+++ b/incubator/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/descriptor/PrometheusMetricDescriptor.java
@@ -16,6 +16,7 @@ package io.aklivity.zilla.runtime.exporter.prometheus.internal.descriptor;
 
 import static io.aklivity.zilla.runtime.engine.metrics.Metric.Kind.COUNTER;
 import static io.aklivity.zilla.runtime.engine.metrics.Metric.Unit.BYTES;
+import static io.aklivity.zilla.runtime.engine.metrics.Metric.Unit.SECONDS;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -66,6 +67,10 @@ public class PrometheusMetricDescriptor implements MetricDescriptor
             if (metric.unit() == BYTES)
             {
                 result += "_bytes";
+            }
+            else if (metric.unit() == SECONDS)
+            {
+                result += "_seconds";
             }
             if (metric.kind() == COUNTER)
             {

--- a/incubator/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/descriptor/PrometheusMetricDescriptor.java
+++ b/incubator/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/descriptor/PrometheusMetricDescriptor.java
@@ -16,7 +16,7 @@ package io.aklivity.zilla.runtime.exporter.prometheus.internal.descriptor;
 
 import static io.aklivity.zilla.runtime.engine.metrics.Metric.Kind.COUNTER;
 import static io.aklivity.zilla.runtime.engine.metrics.Metric.Unit.BYTES;
-import static io.aklivity.zilla.runtime.engine.metrics.Metric.Unit.SECONDS;
+import static io.aklivity.zilla.runtime.engine.metrics.Metric.Unit.NANOSECONDS;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -72,9 +72,9 @@ public class PrometheusMetricDescriptor implements MetricDescriptor
         {
             result += "_bytes";
         }
-        else if (metric.unit() == SECONDS)
+        else if (metric.unit() == NANOSECONDS)
         {
-            result += "_seconds";
+            result += "_nanoseconds";
         }
         if (metric.kind() == COUNTER)
         {

--- a/incubator/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/descriptor/PrometheusMetricDescriptor.java
+++ b/incubator/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/descriptor/PrometheusMetricDescriptor.java
@@ -58,25 +58,27 @@ public class PrometheusMetricDescriptor implements MetricDescriptor
     public String name(
         String internalName)
     {
-        String result = names.get(internalName);
-        if (result == null)
+        return names.computeIfAbsent(internalName, this::externalName);
+    }
+
+    private String externalName(
+        String internalName)
+    {
+        String result;
+        Metric metric = metricResolver.apply(internalName);
+        result = metric.name();
+        result = result.replace('.', '_');
+        if (metric.unit() == BYTES)
         {
-            Metric metric = metricResolver.apply(internalName);
-            result = metric.name();
-            result = result.replace('.', '_');
-            if (metric.unit() == BYTES)
-            {
-                result += "_bytes";
-            }
-            else if (metric.unit() == SECONDS)
-            {
-                result += "_seconds";
-            }
-            if (metric.kind() == COUNTER)
-            {
-                result += "_total";
-            }
-            names.put(internalName, result);
+            result += "_bytes";
+        }
+        else if (metric.unit() == SECONDS)
+        {
+            result += "_seconds";
+        }
+        if (metric.kind() == COUNTER)
+        {
+            result += "_total";
         }
         return result;
     }

--- a/incubator/metrics-http.spec/src/main/scripts/io/aklivity/zilla/specs/metrics/http/schema/http.schema.patch.json
+++ b/incubator/metrics-http.spec/src/main/scripts/io/aklivity/zilla/specs/metrics/http/schema/http.schema.patch.json
@@ -8,5 +8,15 @@
     "op": "add",
     "path": "/$defs/telemetry/metrics/items/enum/-",
     "value": "http.response.size"
+  },
+  {
+    "op": "add",
+    "path": "/$defs/telemetry/metrics/items/enum/-",
+    "value": "http.active.requests"
+  },
+  {
+    "op": "add",
+    "path": "/$defs/telemetry/metrics/items/enum/-",
+    "value": "http.duration"
   }
 ]

--- a/incubator/metrics-http/pom.xml
+++ b/incubator/metrics-http/pom.xml
@@ -26,8 +26,8 @@
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <jacoco.coverage.ratio>0.90</jacoco.coverage.ratio>
-    <jacoco.missed.count>0</jacoco.missed.count>
+    <jacoco.coverage.ratio>0.00</jacoco.coverage.ratio>
+    <jacoco.missed.count>99</jacoco.missed.count>
   </properties>
 
   <dependencies>

--- a/incubator/metrics-http/pom.xml
+++ b/incubator/metrics-http/pom.xml
@@ -26,8 +26,8 @@
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <jacoco.coverage.ratio>0.00</jacoco.coverage.ratio>
-    <jacoco.missed.count>99</jacoco.missed.count>
+    <jacoco.coverage.ratio>0.90</jacoco.coverage.ratio>
+    <jacoco.missed.count>0</jacoco.missed.count>
   </properties>
 
   <dependencies>

--- a/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpActiveRequestsMetric.java
+++ b/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpActiveRequestsMetric.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021-2022 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.metrics.http.internal;
+
+import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.metrics.Metric;
+import io.aklivity.zilla.runtime.engine.metrics.MetricContext;
+
+public class HttpActiveRequestsMetric implements Metric
+{
+    private static final String GROUP = HttpMetricGroup.NAME;
+    private static final String NAME = String.format("%s.%s", GROUP, "active.requests");
+    private static final String DESCRIPTION = "Number of active HTTP requests";
+
+    @Override
+    public String name()
+    {
+        return NAME;
+    }
+
+    @Override
+    public Kind kind()
+    {
+        return Kind.GAUGE;
+    }
+
+    @Override
+    public Unit unit()
+    {
+        return Unit.COUNT;
+    }
+
+    @Override
+    public String description()
+    {
+        return DESCRIPTION;
+    }
+
+    @Override
+    public MetricContext supply(
+        EngineContext context)
+    {
+        return new HttpActiveRequestsMetricContext(GROUP, kind());
+    }
+}

--- a/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpActiveRequestsMetricContext.java
+++ b/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpActiveRequestsMetricContext.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2021-2022 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.metrics.http.internal;
+
+import static io.aklivity.zilla.runtime.engine.metrics.MetricContext.Direction.BOTH;
+import static io.aklivity.zilla.runtime.metrics.http.internal.HttpUtils.commonId;
+import static io.aklivity.zilla.runtime.metrics.http.internal.HttpUtils.streamDirection;
+
+import java.util.function.LongConsumer;
+
+import org.agrona.DirectBuffer;
+import org.agrona.collections.Long2LongHashMap;
+
+import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.metrics.Metric;
+import io.aklivity.zilla.runtime.engine.metrics.MetricContext;
+import io.aklivity.zilla.runtime.metrics.http.internal.types.stream.AbortFW;
+import io.aklivity.zilla.runtime.metrics.http.internal.types.stream.BeginFW;
+import io.aklivity.zilla.runtime.metrics.http.internal.types.stream.EndFW;
+import io.aklivity.zilla.runtime.metrics.http.internal.types.stream.FrameFW;
+import io.aklivity.zilla.runtime.metrics.http.internal.types.stream.ResetFW;
+
+public final class HttpActiveRequestsMetricContext implements MetricContext
+{
+    private final String group;
+    private final Metric.Kind kind;
+    private final FrameFW frameRO = new FrameFW();
+
+    public HttpActiveRequestsMetricContext(
+        String group,
+        Metric.Kind kind)
+    {
+        this.group = group;
+        this.kind = kind;
+    }
+
+    @Override
+    public String group()
+    {
+        return group;
+    }
+
+    @Override
+    public Metric.Kind kind()
+    {
+        return kind;
+    }
+
+    @Override
+    public Direction direction()
+    {
+        return BOTH;
+    }
+
+    @Override
+    public MessageConsumer supply(
+        LongConsumer recorder)
+    {
+        return new HttpActiveRequestsMetricHandler(recorder);
+    }
+
+    private final class HttpActiveRequestsMetricHandler implements MessageConsumer
+    {
+        private static final long INITIAL_STATUS = 0b11L;
+
+        private final LongConsumer recorder;
+        private final Long2LongHashMap streams = new Long2LongHashMap(0L);
+
+        private HttpActiveRequestsMetricHandler(
+            LongConsumer recorder)
+        {
+            this.recorder = recorder;
+        }
+
+        @Override
+        public void accept(
+            int msgTypeId,
+            DirectBuffer buffer,
+            int index,
+            int length)
+        {
+            final FrameFW frame = frameRO.wrap(buffer, index, index + length);
+            final long streamId = frame.streamId();
+            final long commonId = commonId(streamId);
+            long direction = streamDirection(streamId);
+            switch (msgTypeId)
+            {
+            case BeginFW.TYPE_ID:
+                if (direction == 1L) //received
+                {
+                    streams.put(commonId, INITIAL_STATUS);
+                    recorder.accept(1L);
+                }
+                break;
+            case ResetFW.TYPE_ID:
+            case AbortFW.TYPE_ID:
+            case EndFW.TYPE_ID:
+                long status = streams.get(commonId);
+                status = status & direction; // mark current direction as closed
+                if (status == 0L) // both received and sent streams are closed
+                {
+                    streams.remove(commonId);
+                    recorder.accept(-1L);
+                }
+                else
+                {
+                    streams.put(commonId, status);
+                }
+                break;
+            }
+        }
+    }
+}

--- a/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpActiveRequestsMetricContext.java
+++ b/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpActiveRequestsMetricContext.java
@@ -15,8 +15,7 @@
 package io.aklivity.zilla.runtime.metrics.http.internal;
 
 import static io.aklivity.zilla.runtime.engine.metrics.MetricContext.Direction.BOTH;
-import static io.aklivity.zilla.runtime.metrics.http.internal.HttpUtils.commonId;
-import static io.aklivity.zilla.runtime.metrics.http.internal.HttpUtils.streamDirection;
+import static io.aklivity.zilla.runtime.metrics.http.internal.HttpUtils.initialId;
 
 import java.util.function.LongConsumer;
 
@@ -73,15 +72,16 @@ public final class HttpActiveRequestsMetricContext implements MetricContext
 
     private final class HttpActiveRequestsMetricHandler implements MessageConsumer
     {
-        private static final long INITIAL_STATUS = 0b11L;
+        private static final long EXCHANGE_CLOSED = 0b11L;
 
         private final LongConsumer recorder;
-        private final Long2LongHashMap streams = new Long2LongHashMap(0L);
+        private final Long2LongHashMap exchanges;
 
         private HttpActiveRequestsMetricHandler(
             LongConsumer recorder)
         {
             this.recorder = recorder;
+            this.exchanges = new Long2LongHashMap(0L);
         }
 
         @Override
@@ -93,30 +93,29 @@ public final class HttpActiveRequestsMetricContext implements MetricContext
         {
             final FrameFW frame = frameRO.wrap(buffer, index, index + length);
             final long streamId = frame.streamId();
-            final long commonId = commonId(streamId);
-            long direction = streamDirection(streamId);
+            final long exchangeId = initialId(streamId);
+            long direction = HttpUtils.direction(streamId);
             switch (msgTypeId)
             {
             case BeginFW.TYPE_ID:
                 if (direction == 1L) //received
                 {
-                    streams.put(commonId, INITIAL_STATUS);
                     recorder.accept(1L);
                 }
                 break;
             case ResetFW.TYPE_ID:
             case AbortFW.TYPE_ID:
             case EndFW.TYPE_ID:
-                long status = streams.get(commonId);
-                status = status & direction; // mark current direction as closed
-                if (status == 0L) // both received and sent streams are closed
+                final long mask = 1L << direction;
+                final long status = exchanges.get(exchangeId) | mask; // mark current direction as closed
+                if (status == EXCHANGE_CLOSED) // both received and sent streams are closed
                 {
-                    streams.remove(commonId);
+                    exchanges.remove(exchangeId);
                     recorder.accept(-1L);
                 }
                 else
                 {
-                    streams.put(commonId, status);
+                    exchanges.put(exchangeId, status);
                 }
                 break;
             }

--- a/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpDurationMetric.java
+++ b/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpDurationMetric.java
@@ -39,7 +39,7 @@ public class HttpDurationMetric implements Metric
     @Override
     public Unit unit()
     {
-        return Unit.SECONDS;
+        return Unit.NANOSECONDS;
     }
 
     @Override

--- a/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpDurationMetric.java
+++ b/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpDurationMetric.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021-2022 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.metrics.http.internal;
+
+import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.metrics.Metric;
+import io.aklivity.zilla.runtime.engine.metrics.MetricContext;
+
+public class HttpDurationMetric implements Metric
+{
+    private static final String GROUP = HttpMetricGroup.NAME;
+    private static final String NAME = String.format("%s.%s", GROUP, "duration");
+    private static final String DESCRIPTION = "Duration of HTTP requests";
+
+    @Override
+    public String name()
+    {
+        return NAME;
+    }
+
+    @Override
+    public Kind kind()
+    {
+        return Kind.HISTOGRAM;
+    }
+
+    @Override
+    public Unit unit()
+    {
+        return Unit.SECONDS;
+    }
+
+    @Override
+    public String description()
+    {
+        return DESCRIPTION;
+    }
+
+    @Override
+    public MetricContext supply(
+        EngineContext context)
+    {
+        return new HttpDurationMetricContext(GROUP, kind());
+    }
+}

--- a/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpDurationMetricContext.java
+++ b/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpDurationMetricContext.java
@@ -17,7 +17,6 @@ package io.aklivity.zilla.runtime.metrics.http.internal;
 import static io.aklivity.zilla.runtime.engine.metrics.MetricContext.Direction.BOTH;
 import static io.aklivity.zilla.runtime.metrics.http.internal.HttpUtils.initialId;
 
-import java.util.concurrent.TimeUnit;
 import java.util.function.LongConsumer;
 
 import org.agrona.DirectBuffer;
@@ -122,7 +121,7 @@ public final class HttpDurationMetricContext implements MetricContext
                     long start = timestamps.remove(exchangeId);
                     if (start != INITIAL_VALUE)
                     {
-                        long duration = TimeUnit.NANOSECONDS.toSeconds(timestamp - start);
+                        long duration = timestamp - start;
                         recorder.accept(duration);
                     }
                 }

--- a/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpDurationMetricContext.java
+++ b/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpDurationMetricContext.java
@@ -122,7 +122,7 @@ public final class HttpDurationMetricContext implements MetricContext
                     long start = timestamps.remove(exchangeId);
                     if (start != INITIAL_VALUE)
                     {
-                        long duration = TimeUnit.MILLISECONDS.toSeconds(timestamp - start);
+                        long duration = TimeUnit.NANOSECONDS.toSeconds(timestamp - start);
                         recorder.accept(duration);
                     }
                 }

--- a/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpDurationMetricContext.java
+++ b/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpDurationMetricContext.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2021-2022 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.metrics.http.internal;
+
+import static io.aklivity.zilla.runtime.engine.metrics.MetricContext.Direction.BOTH;
+import static io.aklivity.zilla.runtime.metrics.http.internal.HttpUtils.commonId;
+import static io.aklivity.zilla.runtime.metrics.http.internal.HttpUtils.streamDirection;
+
+import java.util.function.LongConsumer;
+
+import org.agrona.DirectBuffer;
+import org.agrona.collections.Long2LongHashMap;
+
+import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.metrics.Metric;
+import io.aklivity.zilla.runtime.engine.metrics.MetricContext;
+import io.aklivity.zilla.runtime.metrics.http.internal.types.stream.AbortFW;
+import io.aklivity.zilla.runtime.metrics.http.internal.types.stream.BeginFW;
+import io.aklivity.zilla.runtime.metrics.http.internal.types.stream.EndFW;
+import io.aklivity.zilla.runtime.metrics.http.internal.types.stream.FrameFW;
+import io.aklivity.zilla.runtime.metrics.http.internal.types.stream.ResetFW;
+
+public final class HttpDurationMetricContext implements MetricContext
+{
+    private final String group;
+    private final Metric.Kind kind;
+    private final FrameFW frameRO = new FrameFW();
+
+    public HttpDurationMetricContext(
+        String group,
+        Metric.Kind kind)
+    {
+        this.group = group;
+        this.kind = kind;
+    }
+
+    @Override
+    public String group()
+    {
+        return group;
+    }
+
+    @Override
+    public Metric.Kind kind()
+    {
+        return kind;
+    }
+
+    @Override
+    public Direction direction()
+    {
+        return BOTH;
+    }
+
+    @Override
+    public MessageConsumer supply(
+        LongConsumer recorder)
+    {
+        return new HttpActiveRequestsMetricHandler(recorder);
+    }
+
+    private final class HttpActiveRequestsMetricHandler implements MessageConsumer
+    {
+        private static final long INITIAL_STATUS = 0b11L;
+
+        private final LongConsumer recorder;
+        private final Long2LongHashMap streams = new Long2LongHashMap(0L);
+        private final Long2LongHashMap timestamps = new Long2LongHashMap(0L);
+
+        private HttpActiveRequestsMetricHandler(
+            LongConsumer recorder)
+        {
+            this.recorder = recorder;
+        }
+
+        @Override
+        public void accept(
+            int msgTypeId,
+            DirectBuffer buffer,
+            int index,
+            int length)
+        {
+            final FrameFW frame = frameRO.wrap(buffer, index, index + length);
+            final long streamId = frame.streamId();
+            final long commonId = commonId(streamId);
+            long direction = streamDirection(streamId);
+            switch (msgTypeId)
+            {
+            case BeginFW.TYPE_ID:
+                if (direction == 1L) //received
+                {
+                    streams.put(commonId, INITIAL_STATUS);
+                    timestamps.put(commonId, System.currentTimeMillis());
+                }
+                break;
+            case ResetFW.TYPE_ID:
+            case AbortFW.TYPE_ID:
+            case EndFW.TYPE_ID:
+                long status = streams.get(commonId);
+                status = status & direction; // mark current direction as closed
+                if (status == 0L) // both received and sent streams are closed
+                {
+                    streams.remove(commonId);
+                    long start = timestamps.remove(commonId);
+                    long duration = (System.currentTimeMillis() - start) / 1000L;
+                    recorder.accept(duration);
+                }
+                else
+                {
+                    streams.put(commonId, status);
+                }
+                break;
+            }
+        }
+    }
+}

--- a/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpDurationMetricContext.java
+++ b/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpDurationMetricContext.java
@@ -99,10 +99,10 @@ public final class HttpDurationMetricContext implements MetricContext
             final long streamId = frame.streamId();
             final long exchangeId = initialId(streamId);
             long direction = HttpUtils.direction(streamId);
+            long timestamp = frame.timestamp();
             switch (msgTypeId)
             {
             case BeginFW.TYPE_ID:
-                long timestamp = frame.timestamp();
                 if (direction == 1L && timestamp != INITIAL_VALUE) //received stream
                 {
                     timestamps.put(exchangeId, timestamp);
@@ -111,7 +111,6 @@ public final class HttpDurationMetricContext implements MetricContext
             case ResetFW.TYPE_ID:
             case AbortFW.TYPE_ID:
             case EndFW.TYPE_ID:
-                long timestamp1 = frame.timestamp();
                 final long mask = 1L << direction;
                 final long status = exchanges.get(exchangeId) | mask; // mark current direction as closed
                 if (status == EXCHANGE_CLOSED) // both received and sent streams are closed
@@ -120,7 +119,7 @@ public final class HttpDurationMetricContext implements MetricContext
                     long start = timestamps.remove(exchangeId);
                     if (msgTypeId == EndFW.TYPE_ID)
                     {
-                        long duration = TimeUnit.MILLISECONDS.toSeconds(timestamp1 - start);
+                        long duration = TimeUnit.MILLISECONDS.toSeconds(timestamp - start);
                         recorder.accept(duration);
                     }
                 }

--- a/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpDurationMetricContext.java
+++ b/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpDurationMetricContext.java
@@ -110,6 +110,9 @@ public final class HttpDurationMetricContext implements MetricContext
                 break;
             case ResetFW.TYPE_ID:
             case AbortFW.TYPE_ID:
+                exchanges.remove(exchangeId);
+                timestamps.remove(exchangeId);
+                break;
             case EndFW.TYPE_ID:
                 final long mask = 1L << direction;
                 final long status = exchanges.get(exchangeId) | mask; // mark current direction as closed
@@ -117,13 +120,13 @@ public final class HttpDurationMetricContext implements MetricContext
                 {
                     exchanges.remove(exchangeId);
                     long start = timestamps.remove(exchangeId);
-                    if (msgTypeId == EndFW.TYPE_ID)
+                    if (start != INITIAL_VALUE)
                     {
                         long duration = TimeUnit.MILLISECONDS.toSeconds(timestamp - start);
                         recorder.accept(duration);
                     }
                 }
-                else
+                else if (timestamps.containsKey(exchangeId)) // prevent memory leak if already aborted
                 {
                     exchanges.put(exchangeId, status);
                 }

--- a/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricGroup.java
+++ b/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricGroup.java
@@ -29,7 +29,9 @@ public class HttpMetricGroup implements MetricGroup
 
     private final Map<String, Supplier<Metric>> httpMetrics = Map.of(
         "http.request.size", HttpRequestSizeMetric::new,
-        "http.response.size", HttpResponseSizeMetric::new
+        "http.response.size", HttpResponseSizeMetric::new,
+        "http.active.requests", HttpActiveRequestsMetric::new,
+        "http.duration", HttpDurationMetric::new
     );
 
     public HttpMetricGroup(

--- a/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpUtils.java
+++ b/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpUtils.java
@@ -31,14 +31,14 @@ final class HttpUtils
     {
     }
 
-    public static long commonId(
+    public static long initialId(
         long streamId)
     {
-        // reduce both initial and reply stream ids to same id
+        // reduce both initial and reply stream ids to the same initial id
         return streamId & ~0b01L;
     }
 
-    public static long streamDirection(
+    public static long direction(
         long streamId)
     {
         // get stream direction (1: received; 0: sent)

--- a/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpUtils.java
+++ b/incubator/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpUtils.java
@@ -31,10 +31,18 @@ final class HttpUtils
     {
     }
 
-    public static boolean isInitial(
+    public static long commonId(
         long streamId)
     {
-        return (streamId & 0x0000_0000_0000_0001L) != 0L;
+        // reduce both initial and reply stream ids to same id
+        return streamId & ~0b01L;
+    }
+
+    public static long streamDirection(
+        long streamId)
+    {
+        // get stream direction (1: received; 0: sent)
+        return streamId & 0b01L;
     }
 
     public static HttpHeaderFW findContentLength(

--- a/incubator/metrics-http/src/test/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricGroupTest.java
+++ b/incubator/metrics-http/src/test/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricGroupTest.java
@@ -56,7 +56,12 @@ public class HttpMetricGroupTest
         Collection<String> metricNames = metricGroup.metricNames();
 
         // THEN
-        assertThat(metricNames, containsInAnyOrder("http.request.size", "http.response.size"));
+        assertThat(metricNames, containsInAnyOrder(
+            "http.request.size",
+            "http.response.size",
+            "http.active.requests",
+            "http.duration"
+        ));
     }
 
     @Test

--- a/incubator/metrics-http/src/test/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricGroupTest.java
+++ b/incubator/metrics-http/src/test/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricGroupTest.java
@@ -547,4 +547,171 @@ public class HttpMetricGroupTest
         // THEN
         verify(recorder, never()).accept(anyLong());
     }
+
+    @Test
+    public void shouldResolveHttpActiveRequests()
+    {
+        // GIVEN
+        Configuration config = new Configuration();
+        MetricGroup metricGroup = new HttpMetricGroup(config);
+
+        // WHEN
+        Metric metric = metricGroup.supply("http.active.requests");
+
+        // THEN
+        assertThat(metric, instanceOf(HttpActiveRequestsMetric.class));
+        assertThat(metric.name(), equalTo("http.active.requests"));
+        assertThat(metric.kind(), equalTo(Metric.Kind.GAUGE));
+        assertThat(metric.unit(), equalTo(Metric.Unit.COUNT));
+        assertThat(metric.description(), equalTo("Number of active HTTP requests"));
+    }
+
+    @Test
+    public void shouldResolveHttpActiveRequestsContext()
+    {
+        // GIVEN
+        Configuration config = new Configuration();
+        MetricGroup metricGroup = new HttpMetricGroup(config);
+        Metric metric = metricGroup.supply("http.active.requests");
+
+        // WHEN
+        MetricContext context = metric.supply(mock(EngineContext.class));
+
+        // THEN
+        assertThat(context, instanceOf(HttpActiveRequestsMetricContext.class));
+        assertThat(context.group(), equalTo("http"));
+        assertThat(context.kind(), equalTo(Metric.Kind.GAUGE));
+        assertThat(context.direction(), equalTo(MetricContext.Direction.BOTH));
+    }
+
+    @Test
+    public void shouldRecordHttpActiveRequests()
+    {
+        // GIVEN
+        Configuration config = new Configuration();
+        MetricGroup metricGroup = new HttpMetricGroup(config);
+        EngineContext engineContext = mock(EngineContext.class);
+        LongConsumer recorder = mock(LongConsumer.class);
+
+        // WHEN
+        Metric metric = metricGroup.supply("http.active.requests");
+        MetricContext context = metric.supply(engineContext);
+        MessageConsumer handler = context.supply(recorder);
+
+        // begin frame
+        HttpBeginExFW httpBeginEx = new HttpBeginExFW.Builder()
+            .wrap(new UnsafeBuffer(new byte[64]), 0, 64)
+            .typeId(0)
+            .headersItem(h -> h.name(":status").value("200"))
+            .headersItem(h -> h.name("content-length").value("42"))
+            .build();
+        AtomicBuffer beginBuffer = new UnsafeBuffer(new byte[256], 0, 256);
+        new BeginFW.Builder().wrap(beginBuffer, 0, beginBuffer.capacity())
+            .originId(0L).routedId(0L).streamId(1L) // received
+            .sequence(0L).acknowledge(0L).maximum(0).timestamp(0L)
+            .traceId(0L).authorization(0L).affinity(0L)
+            .extension(httpBeginEx.buffer(), 0, httpBeginEx.buffer().capacity()).build();
+        handler.accept(BeginFW.TYPE_ID, beginBuffer, 0, beginBuffer.capacity());
+
+        // end frames
+        AtomicBuffer endBuffer1 = new UnsafeBuffer(new byte[128], 0, 128);
+        new EndFW.Builder().wrap(endBuffer1, 0, endBuffer1.capacity())
+            .originId(0L).routedId(0L).streamId(1L) // received
+            .sequence(0L).acknowledge(0L).maximum(0).timestamp(0L)
+            .traceId(0L).authorization(0L).build();
+        handler.accept(EndFW.TYPE_ID, endBuffer1, 0, endBuffer1.capacity());
+        AtomicBuffer endBuffer2 = new UnsafeBuffer(new byte[128], 0, 128);
+        new EndFW.Builder().wrap(endBuffer2, 0, endBuffer2.capacity())
+            .originId(0L).routedId(0L).streamId(0L) // sent
+            .sequence(0L).acknowledge(0L).maximum(0).timestamp(0L)
+            .traceId(0L).authorization(0L).build();
+        handler.accept(EndFW.TYPE_ID, endBuffer2, 0, endBuffer2.capacity());
+
+        // THEN
+        verify(recorder, times(1)).accept(1L);
+        verify(recorder, times(1)).accept(-1L);
+    }
+
+    @Test
+    public void shouldResolveHttpDuration()
+    {
+        // GIVEN
+        Configuration config = new Configuration();
+        MetricGroup metricGroup = new HttpMetricGroup(config);
+
+        // WHEN
+        Metric metric = metricGroup.supply("http.duration");
+
+        // THEN
+        assertThat(metric, instanceOf(HttpDurationMetric.class));
+        assertThat(metric.name(), equalTo("http.duration"));
+        assertThat(metric.kind(), equalTo(Metric.Kind.HISTOGRAM));
+        assertThat(metric.unit(), equalTo(Metric.Unit.SECONDS));
+        assertThat(metric.description(), equalTo("Duration of HTTP requests"));
+    }
+
+    @Test
+    public void shouldResolveHttpDurationContext()
+    {
+        // GIVEN
+        Configuration config = new Configuration();
+        MetricGroup metricGroup = new HttpMetricGroup(config);
+        Metric metric = metricGroup.supply("http.duration");
+
+        // WHEN
+        MetricContext context = metric.supply(mock(EngineContext.class));
+
+        // THEN
+        assertThat(context, instanceOf(HttpDurationMetricContext.class));
+        assertThat(context.group(), equalTo("http"));
+        assertThat(context.kind(), equalTo(Metric.Kind.HISTOGRAM));
+        assertThat(context.direction(), equalTo(MetricContext.Direction.BOTH));
+    }
+
+    @Test
+    public void shouldRecordHttpDuration()
+    {
+        // GIVEN
+        Configuration config = new Configuration();
+        MetricGroup metricGroup = new HttpMetricGroup(config);
+        EngineContext engineContext = mock(EngineContext.class);
+        LongConsumer recorder = mock(LongConsumer.class);
+
+        // WHEN
+        Metric metric = metricGroup.supply("http.duration");
+        MetricContext context = metric.supply(engineContext);
+        MessageConsumer handler = context.supply(recorder);
+
+        // begin frame
+        HttpBeginExFW httpBeginEx = new HttpBeginExFW.Builder()
+            .wrap(new UnsafeBuffer(new byte[64]), 0, 64)
+            .typeId(0)
+            .headersItem(h -> h.name(":status").value("200"))
+            .headersItem(h -> h.name("content-length").value("42"))
+            .build();
+        AtomicBuffer beginBuffer = new UnsafeBuffer(new byte[256], 0, 256);
+        new BeginFW.Builder().wrap(beginBuffer, 0, beginBuffer.capacity())
+            .originId(0L).routedId(0L).streamId(1L) // received
+            .sequence(0L).acknowledge(0L).maximum(0).timestamp(0L)
+            .traceId(0L).authorization(0L).affinity(0L)
+            .extension(httpBeginEx.buffer(), 0, httpBeginEx.buffer().capacity()).build();
+        handler.accept(BeginFW.TYPE_ID, beginBuffer, 0, beginBuffer.capacity());
+
+        // end frames
+        AtomicBuffer endBuffer1 = new UnsafeBuffer(new byte[128], 0, 128);
+        new EndFW.Builder().wrap(endBuffer1, 0, endBuffer1.capacity())
+            .originId(0L).routedId(0L).streamId(1L) // received
+            .sequence(0L).acknowledge(0L).maximum(0).timestamp(0L)
+            .traceId(0L).authorization(0L).build();
+        handler.accept(EndFW.TYPE_ID, endBuffer1, 0, endBuffer1.capacity());
+        AtomicBuffer endBuffer2 = new UnsafeBuffer(new byte[128], 0, 128);
+        new EndFW.Builder().wrap(endBuffer2, 0, endBuffer2.capacity())
+            .originId(0L).routedId(0L).streamId(0L) // sent
+            .sequence(0L).acknowledge(0L).maximum(0).timestamp(0L)
+            .traceId(0L).authorization(0L).build();
+        handler.accept(EndFW.TYPE_ID, endBuffer2, 0, endBuffer2.capacity());
+
+        // THEN
+        verify(recorder, times(1)).accept(anyLong());
+    }
 }

--- a/incubator/metrics-http/src/test/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricGroupTest.java
+++ b/incubator/metrics-http/src/test/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricGroupTest.java
@@ -693,7 +693,7 @@ public class HttpMetricGroupTest
         AtomicBuffer beginBuffer = new UnsafeBuffer(new byte[256], 0, 256);
         new BeginFW.Builder().wrap(beginBuffer, 0, beginBuffer.capacity())
             .originId(0L).routedId(0L).streamId(1L) // received
-            .sequence(0L).acknowledge(0L).maximum(0).timestamp(42_000L)
+            .sequence(0L).acknowledge(0L).maximum(0).timestamp(42_000_000_000L)
             .traceId(0L).authorization(0L).affinity(0L)
             .extension(httpBeginEx.buffer(), 0, httpBeginEx.buffer().capacity()).build();
         handler.accept(BeginFW.TYPE_ID, beginBuffer, 0, beginBuffer.capacity());
@@ -702,7 +702,7 @@ public class HttpMetricGroupTest
         AtomicBuffer endBuffer1 = new UnsafeBuffer(new byte[128], 0, 128);
         new EndFW.Builder().wrap(endBuffer1, 0, endBuffer1.capacity())
             .originId(0L).routedId(0L).streamId(1L) // received
-            .sequence(0L).acknowledge(0L).maximum(0).timestamp(72_000L)
+            .sequence(0L).acknowledge(0L).maximum(0).timestamp(72_000_000_000L)
             .traceId(0L).authorization(0L).build();
         handler.accept(EndFW.TYPE_ID, endBuffer1, 0, endBuffer1.capacity());
 
@@ -710,7 +710,7 @@ public class HttpMetricGroupTest
         AtomicBuffer endBuffer2 = new UnsafeBuffer(new byte[128], 0, 128);
         new EndFW.Builder().wrap(endBuffer2, 0, endBuffer2.capacity())
             .originId(0L).routedId(0L).streamId(0L) // sent
-            .sequence(0L).acknowledge(0L).maximum(0).timestamp(77_000L)
+            .sequence(0L).acknowledge(0L).maximum(0).timestamp(77_000_000_000L)
             .traceId(0L).authorization(0L).build();
         handler.accept(EndFW.TYPE_ID, endBuffer2, 0, endBuffer2.capacity());
 
@@ -742,7 +742,7 @@ public class HttpMetricGroupTest
         AtomicBuffer beginBuffer = new UnsafeBuffer(new byte[256], 0, 256);
         new BeginFW.Builder().wrap(beginBuffer, 0, beginBuffer.capacity())
             .originId(0L).routedId(0L).streamId(1L) // received
-            .sequence(0L).acknowledge(0L).maximum(0).timestamp(42_000L)
+            .sequence(0L).acknowledge(0L).maximum(0).timestamp(42_000_000_000L)
             .traceId(0L).authorization(0L).affinity(0L)
             .extension(httpBeginEx.buffer(), 0, httpBeginEx.buffer().capacity()).build();
         handler.accept(BeginFW.TYPE_ID, beginBuffer, 0, beginBuffer.capacity());
@@ -751,7 +751,7 @@ public class HttpMetricGroupTest
         AtomicBuffer abortBuffer = new UnsafeBuffer(new byte[256], 0, 256);
         new AbortFW.Builder().wrap(abortBuffer, 0, abortBuffer.capacity())
             .originId(0L).routedId(0L).streamId(1L) // received
-            .sequence(0L).acknowledge(0L).maximum(0).timestamp(72_000L)
+            .sequence(0L).acknowledge(0L).maximum(0).timestamp(72_000_000_000L)
             .traceId(0L).authorization(0L).build();
         handler.accept(AbortFW.TYPE_ID, abortBuffer, 0, abortBuffer.capacity());
 
@@ -759,7 +759,7 @@ public class HttpMetricGroupTest
         AtomicBuffer endBuffer = new UnsafeBuffer(new byte[128], 0, 128);
         new EndFW.Builder().wrap(endBuffer, 0, endBuffer.capacity())
             .originId(0L).routedId(0L).streamId(0L) // sent
-            .sequence(0L).acknowledge(0L).maximum(0).timestamp(77_000L)
+            .sequence(0L).acknowledge(0L).maximum(0).timestamp(77_000_000_000L)
             .traceId(0L).authorization(0L).build();
         handler.accept(EndFW.TYPE_ID, endBuffer, 0, endBuffer.capacity());
 
@@ -791,7 +791,7 @@ public class HttpMetricGroupTest
         AtomicBuffer beginBuffer = new UnsafeBuffer(new byte[256], 0, 256);
         new BeginFW.Builder().wrap(beginBuffer, 0, beginBuffer.capacity())
             .originId(0L).routedId(0L).streamId(1L) // received
-            .sequence(0L).acknowledge(0L).maximum(0).timestamp(42_000L)
+            .sequence(0L).acknowledge(0L).maximum(0).timestamp(42_000_000_000L)
             .traceId(0L).authorization(0L).affinity(0L)
             .extension(httpBeginEx.buffer(), 0, httpBeginEx.buffer().capacity()).build();
         handler.accept(BeginFW.TYPE_ID, beginBuffer, 0, beginBuffer.capacity());
@@ -800,7 +800,7 @@ public class HttpMetricGroupTest
         AtomicBuffer endBuffer0 = new UnsafeBuffer(new byte[128], 0, 128);
         new EndFW.Builder().wrap(endBuffer0, 0, endBuffer0.capacity())
             .originId(0L).routedId(0L).streamId(1L) // received
-            .sequence(0L).acknowledge(0L).maximum(0).timestamp(72_000L)
+            .sequence(0L).acknowledge(0L).maximum(0).timestamp(72_000_000_000L)
             .traceId(0L).authorization(0L).build();
         handler.accept(EndFW.TYPE_ID, endBuffer0, 0, endBuffer0.capacity());
 
@@ -808,7 +808,7 @@ public class HttpMetricGroupTest
         AtomicBuffer resetBuffer = new UnsafeBuffer(new byte[256], 0, 256);
         new ResetFW.Builder().wrap(resetBuffer, 0, resetBuffer.capacity())
             .originId(0L).routedId(0L).streamId(0L) // sent
-            .sequence(0L).acknowledge(0L).maximum(0).timestamp(77_000L)
+            .sequence(0L).acknowledge(0L).maximum(0).timestamp(77_000_000_000L)
             .traceId(0L).authorization(0L).build();
         handler.accept(ResetFW.TYPE_ID, resetBuffer, 0, resetBuffer.capacity());
 

--- a/incubator/metrics-http/src/test/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricGroupTest.java
+++ b/incubator/metrics-http/src/test/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricGroupTest.java
@@ -647,7 +647,7 @@ public class HttpMetricGroupTest
         assertThat(metric, instanceOf(HttpDurationMetric.class));
         assertThat(metric.name(), equalTo("http.duration"));
         assertThat(metric.kind(), equalTo(Metric.Kind.HISTOGRAM));
-        assertThat(metric.unit(), equalTo(Metric.Unit.SECONDS));
+        assertThat(metric.unit(), equalTo(Metric.Unit.NANOSECONDS));
         assertThat(metric.description(), equalTo("Duration of HTTP requests"));
     }
 
@@ -715,7 +715,7 @@ public class HttpMetricGroupTest
         handler.accept(EndFW.TYPE_ID, endBuffer2, 0, endBuffer2.capacity());
 
         // THEN
-        verify(recorder, times(1)).accept(35L);
+        verify(recorder, times(1)).accept(35_000_000_000L);
     }
 
     @Test

--- a/incubator/metrics-http/src/test/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricGroupTest.java
+++ b/incubator/metrics-http/src/test/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricGroupTest.java
@@ -692,7 +692,7 @@ public class HttpMetricGroupTest
         AtomicBuffer beginBuffer = new UnsafeBuffer(new byte[256], 0, 256);
         new BeginFW.Builder().wrap(beginBuffer, 0, beginBuffer.capacity())
             .originId(0L).routedId(0L).streamId(1L) // received
-            .sequence(0L).acknowledge(0L).maximum(0).timestamp(0L)
+            .sequence(0L).acknowledge(0L).maximum(0).timestamp(42_000L)
             .traceId(0L).authorization(0L).affinity(0L)
             .extension(httpBeginEx.buffer(), 0, httpBeginEx.buffer().capacity()).build();
         handler.accept(BeginFW.TYPE_ID, beginBuffer, 0, beginBuffer.capacity());
@@ -701,17 +701,17 @@ public class HttpMetricGroupTest
         AtomicBuffer endBuffer1 = new UnsafeBuffer(new byte[128], 0, 128);
         new EndFW.Builder().wrap(endBuffer1, 0, endBuffer1.capacity())
             .originId(0L).routedId(0L).streamId(1L) // received
-            .sequence(0L).acknowledge(0L).maximum(0).timestamp(0L)
+            .sequence(0L).acknowledge(0L).maximum(0).timestamp(72_000L)
             .traceId(0L).authorization(0L).build();
         handler.accept(EndFW.TYPE_ID, endBuffer1, 0, endBuffer1.capacity());
         AtomicBuffer endBuffer2 = new UnsafeBuffer(new byte[128], 0, 128);
         new EndFW.Builder().wrap(endBuffer2, 0, endBuffer2.capacity())
             .originId(0L).routedId(0L).streamId(0L) // sent
-            .sequence(0L).acknowledge(0L).maximum(0).timestamp(0L)
+            .sequence(0L).acknowledge(0L).maximum(0).timestamp(77_000L)
             .traceId(0L).authorization(0L).build();
         handler.accept(EndFW.TYPE_ID, endBuffer2, 0, endBuffer2.capacity());
 
         // THEN
-        verify(recorder, times(1)).accept(anyLong());
+        verify(recorder, times(1)).accept(35L);
     }
 }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/DispatchAgent.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/DispatchAgent.java
@@ -1325,7 +1325,7 @@ public class DispatchAgent implements EngineContext, Agent
         {
             MessageConsumer sentMetricHandler = supplyMetricRecorder(originId, ORIGIN, SENT)
                 .andThen(supplyMetricRecorder(routedId, ROUTED, SENT));
-            final MessageConsumer replyTo = sentMetricHandler.andThen(supplyReplyTo(initialId));
+            final MessageConsumer replyTo = supplyReplyTo(initialId).andThen(sentMetricHandler);
             newStream = streamFactory.newStream(msgTypeId, buffer, index, length, replyTo);
             if (newStream != null)
             {

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/Metric.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/Metric.java
@@ -29,6 +29,7 @@ public interface Metric
     enum Unit
     {
         BYTES,
+        SECONDS,
         COUNT
     }
 

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/Metric.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/Metric.java
@@ -29,7 +29,7 @@ public interface Metric
     enum Unit
     {
         BYTES,
-        SECONDS,
+        NANOSECONDS,
         COUNT
     }
 


### PR DESCRIPTION
## Description

This change adds these metrics:

- `http.active.requests` to track the number of currently active http requests (gauge) 
- `http.duration` to track to track the duration of http requests (histogram)

Fixes #111 
