### PR TITLE
Fix the requirements versions in helm chart readme

### DIFF
--- a/cloud/helm-chart/src/main/helm/README.md
+++ b/cloud/helm-chart/src/main/helm/README.md
@@ -23,8 +23,8 @@ cluster using the [Helm](https://helm.sh) package manager.
 
 ## Requirements
 
-Kubernetes: `>=1.13.x`
-Helm: `>=3.0.x`
+Kubernetes: `>=1.23.x`
+Helm: `>=3.8.x`
 
 ## Install Chart
 


### PR DESCRIPTION
## Description

Fix the requirements versions in the helm chart's readme:

- Kubernetes: `>=1.23.x`
- Helm: `>=3.8.x`
