### PR TITLE
Eliminate zilla.json warning if file not present

### DIFF
--- a/runtime/command-start/src/main/java/io/aklivity/zilla/runtime/command/start/internal/airline/ZillaStartCommand.java
+++ b/runtime/command-start/src/main/java/io/aklivity/zilla/runtime/command/start/internal/airline/ZillaStartCommand.java
@@ -127,20 +127,22 @@ public final class ZillaStartCommand extends ZillaCommand
         }
 
         EngineConfiguration config = new EngineConfiguration(props);
+
         URL configURL = config.configURL();
         if ("file".equals(configURL.getProtocol()))
         {
-            Path configPath = Paths.get(configURL.getPath());
+            final Path configPath = Paths.get(configURL.getPath());
+
             if (configPath.endsWith("zilla.yaml") && Files.notExists(configPath))
             {
-                String configJSON = String.format("file:%s", configPath.resolveSibling("zilla.json"));
-                props.setProperty(ENGINE_CONFIG_URL.name(), configJSON);
-                configPath = Paths.get(config.configURL().getPath());
-                System.out.println("zilla.yaml file not found, loading zilla.json instead");
-            }
-            if (configPath.getFileName().toString().endsWith(".json"))
-            {
-                System.out.println("warning: json syntax is deprecated, migrate to yaml");
+                Path configJson = configPath.resolveSibling("zilla.json");
+
+                if (Files.exists(configJson))
+                {
+                    System.out.format("WARNING %s is deprecated, use %s instead\n", configJson, configPath);
+
+                    props.setProperty(ENGINE_CONFIG_URL.name(), String.format("file:%s", configJson));
+                }
             }
         }
 

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/ConfigurationManager.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/ConfigurationManager.java
@@ -75,7 +75,8 @@ import io.aklivity.zilla.runtime.engine.internal.stream.NamespacedId;
 
 public class ConfigurationManager
 {
-    protected static final String CONFIG_TEXT_DEFAULT = "{\n  \"name\": \"default\"\n}\n";
+    private static final String CONFIG_TEXT_DEFAULT = "name: default\n";
+
     private final Collection<URL> schemaTypes;
     private final Function<String, Guard> guardByType;
     private final ToIntFunction<String> supplyId;


### PR DESCRIPTION
## Description

Simplify `zilla start` output when `zilla.json` not found.
