### PR TITLE
Ignore CacheFetchIT.shouldFetchFilterSyncWithData

### DIFF
--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheFetchIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheFetchIT.java
@@ -466,6 +466,7 @@ public class CacheFetchIT
     }
 
     @Test
+    @Ignore
     @Configuration("cache.yaml")
     @Specification({
         "${app}/filter.sync.with.data/client",


### PR DESCRIPTION
## Description

Set the flaky test `CacheFetchIT.shouldFetchFilterSyncWithData` to `@Ignore` for now to unblock builds.

Created an issue to fix it: #350