### PR TITLE
Include JDK 20 in build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 11, 17, 20 ]
 
     steps:
     - name: Checkout GitHub sources


### PR DESCRIPTION
## Description

Use JDK 20 in the GitHub Actions build.