### PR TITLE
Support dynamic behavior injection in config builder fluent API

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpAccessControlConfigBuilder.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpAccessControlConfigBuilder.java
@@ -20,7 +20,7 @@ import java.util.function.Function;
 
 import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
 
-public final class HttpAccessControlConfigBuilder<T> implements ConfigBuilder<T>
+public final class HttpAccessControlConfigBuilder<T> extends ConfigBuilder<T, HttpAccessControlConfigBuilder<T>>
 {
     private final Function<HttpAccessControlConfig, T> mapper;
 
@@ -33,6 +33,13 @@ public final class HttpAccessControlConfigBuilder<T> implements ConfigBuilder<T>
         Function<HttpAccessControlConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Class<HttpAccessControlConfigBuilder<T>> thisType()
+    {
+        return (Class<HttpAccessControlConfigBuilder<T>>) getClass();
     }
 
     public HttpAccessControlConfigBuilder<T> policy(

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpAllowConfigBuilder.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpAllowConfigBuilder.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
 
 import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
 
-public final class HttpAllowConfigBuilder<T> implements ConfigBuilder<T>
+public final class HttpAllowConfigBuilder<T> extends ConfigBuilder<T, HttpAllowConfigBuilder<T>>
 {
     private final Function<HttpAllowConfig, T> mapper;
 
@@ -34,6 +34,13 @@ public final class HttpAllowConfigBuilder<T> implements ConfigBuilder<T>
         Function<HttpAllowConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<HttpAllowConfigBuilder<T>> thisType()
+    {
+        return (Class<HttpAllowConfigBuilder<T>>) getClass();
     }
 
     public HttpAllowConfigBuilder<T>  origin(

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpAuthorizationConfigBuilder.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpAuthorizationConfigBuilder.java
@@ -19,7 +19,7 @@ import java.util.function.Function;
 
 import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
 
-public final class HttpAuthorizationConfigBuilder<T> implements ConfigBuilder<T>
+public final class HttpAuthorizationConfigBuilder<T> extends ConfigBuilder<T, HttpAuthorizationConfigBuilder<T>>
 {
     private final Function<HttpAuthorizationConfig, T> mapper;
 
@@ -30,6 +30,13 @@ public final class HttpAuthorizationConfigBuilder<T> implements ConfigBuilder<T>
         Function<HttpAuthorizationConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<HttpAuthorizationConfigBuilder<T>> thisType()
+    {
+        return (Class<HttpAuthorizationConfigBuilder<T>>) getClass();
     }
 
     public HttpAuthorizationConfigBuilder<T> name(

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpConditionConfigBuilder.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpConditionConfigBuilder.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
 import io.aklivity.zilla.runtime.engine.config.ConditionConfig;
 import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
 
-public final class HttpConditionConfigBuilder<T> implements ConfigBuilder<T>
+public final class HttpConditionConfigBuilder<T> extends ConfigBuilder<T, HttpConditionConfigBuilder<T>>
 {
     private final Function<ConditionConfig, T> mapper;
 
@@ -32,6 +32,13 @@ public final class HttpConditionConfigBuilder<T> implements ConfigBuilder<T>
         Function<ConditionConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<HttpConditionConfigBuilder<T>> thisType()
+    {
+        return (Class<HttpConditionConfigBuilder<T>>) getClass();
     }
 
     public HttpConditionConfigBuilder<T> header(

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpCredentialsConfigBuilder.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpCredentialsConfigBuilder.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
 
 import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
 
-public final class HttpCredentialsConfigBuilder<T> implements ConfigBuilder<T>
+public final class HttpCredentialsConfigBuilder<T> extends ConfigBuilder<T, HttpCredentialsConfigBuilder<T>>
 {
     private final Function<HttpCredentialsConfig, T> mapper;
 
@@ -33,6 +33,13 @@ public final class HttpCredentialsConfigBuilder<T> implements ConfigBuilder<T>
         Function<HttpCredentialsConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<HttpCredentialsConfigBuilder<T>> thisType()
+    {
+        return (Class<HttpCredentialsConfigBuilder<T>>) getClass();
     }
 
     public HttpPatternConfigBuilder<HttpCredentialsConfigBuilder<T>> header()

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpExposeConfigBuilder.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpExposeConfigBuilder.java
@@ -21,16 +21,23 @@ import java.util.function.Function;
 
 import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
 
-public final class HttpExposeConfigBuilder<T> implements ConfigBuilder<T>
+public final class HttpExposeConfigBuilder<T> extends ConfigBuilder<T, HttpExposeConfigBuilder<T>>
 {
     private final Function<HttpExposeConfig, T> mapper;
 
     private Set<String> headers;
 
-    public HttpExposeConfigBuilder(
+    HttpExposeConfigBuilder(
         Function<HttpExposeConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<HttpExposeConfigBuilder<T>> thisType()
+    {
+        return (Class<HttpExposeConfigBuilder<T>>) getClass();
     }
 
     public HttpExposeConfigBuilder<T> header(

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpOptionsConfigBuilder.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpOptionsConfigBuilder.java
@@ -26,7 +26,7 @@ import io.aklivity.zilla.runtime.binding.http.internal.types.String8FW;
 import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfig;
 
-public final class HttpOptionsConfigBuilder<T> implements ConfigBuilder<T>
+public final class HttpOptionsConfigBuilder<T> extends ConfigBuilder<T, HttpOptionsConfigBuilder<T>>
 {
     private final Function<OptionsConfig, T> mapper;
 
@@ -39,6 +39,13 @@ public final class HttpOptionsConfigBuilder<T> implements ConfigBuilder<T>
         Function<OptionsConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<HttpOptionsConfigBuilder<T>> thisType()
+    {
+        return (Class<HttpOptionsConfigBuilder<T>>) getClass();
     }
 
     public HttpOptionsConfigBuilder<T> version(

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpPatternConfigBuilder.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpPatternConfigBuilder.java
@@ -19,7 +19,7 @@ import java.util.function.Function;
 
 import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
 
-public final class HttpPatternConfigBuilder<T> implements ConfigBuilder<T>
+public final class HttpPatternConfigBuilder<T> extends ConfigBuilder<T, HttpPatternConfigBuilder<T>>
 {
     private final Function<HttpPatternConfig, T> mapper;
 
@@ -30,6 +30,13 @@ public final class HttpPatternConfigBuilder<T> implements ConfigBuilder<T>
         Function<HttpPatternConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<HttpPatternConfigBuilder<T>> thisType()
+    {
+        return (Class<HttpPatternConfigBuilder<T>>) getClass();
     }
 
     public HttpPatternConfigBuilder<T> name(

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpConditionConfigAdapterTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpConditionConfigAdapterTest.java
@@ -16,6 +16,7 @@
 package io.aklivity.zilla.runtime.binding.http.internal.config;
 
 import static java.util.Collections.singletonMap;
+import static java.util.function.Function.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -63,6 +64,7 @@ public class HttpConditionConfigAdapterTest
     public void shouldWriteCondition()
     {
         HttpConditionConfig condition = HttpConditionConfig.builder()
+            .inject(identity())
             .header(":authority", "example.net:443")
             .build();
 

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpOptionsConfigAdapterTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpOptionsConfigAdapterTest.java
@@ -18,6 +18,7 @@ package io.aklivity.zilla.runtime.binding.http.internal.config;
 import static io.aklivity.zilla.runtime.binding.http.config.HttpPolicyConfig.CROSS_ORIGIN;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
+import static java.util.function.Function.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -125,12 +126,15 @@ public class HttpOptionsConfigAdapterTest
     public void shouldWriteOptions()
     {
         HttpOptionsConfig options = HttpOptionsConfig.builder()
+            .inject(identity())
             .version(HttpVersion.HTTP_1_1)
             .version(HttpVersion.HTTP_2)
             .override(new String8FW(":authority"), new String16FW("example.com:443"))
             .access()
+                .inject(identity())
                 .policy(CROSS_ORIGIN)
                 .allow()
+                    .inject(identity())
                     .origin("https://example.com:9090")
                     .method("DELETE")
                     .header("x-api-key")
@@ -138,13 +142,16 @@ public class HttpOptionsConfigAdapterTest
                     .build()
                 .maxAge(Duration.ofSeconds(10))
                 .expose()
+                    .inject(identity())
                     .header("x-custom-header")
                     .build()
                 .build()
             .authorization()
                 .name("test0")
                 .credentials()
+                    .inject(identity())
                     .header()
+                        .inject(identity())
                         .name("authorization")
                         .pattern("Bearer {credentials}")
                         .build()

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/config/TcpConditionConfigBuilder.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/config/TcpConditionConfigBuilder.java
@@ -20,7 +20,7 @@ import java.util.function.Function;
 import io.aklivity.zilla.runtime.engine.config.ConditionConfig;
 import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
 
-public final class TcpConditionConfigBuilder<T> implements ConfigBuilder<T>
+public final class TcpConditionConfigBuilder<T> extends ConfigBuilder<T, TcpConditionConfigBuilder<T>>
 {
     private final Function<ConditionConfig, T> mapper;
 
@@ -32,6 +32,13 @@ public final class TcpConditionConfigBuilder<T> implements ConfigBuilder<T>
         Function<ConditionConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<TcpConditionConfigBuilder<T>> thisType()
+    {
+        return (Class<TcpConditionConfigBuilder<T>>) getClass();
     }
 
     public TcpConditionConfigBuilder<T> cidr(

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/config/TcpOptionsConfigBuilder.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/config/TcpOptionsConfigBuilder.java
@@ -20,7 +20,7 @@ import java.util.function.Function;
 import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfig;
 
-public final class TcpOptionsConfigBuilder<T> implements ConfigBuilder<T>
+public final class TcpOptionsConfigBuilder<T> extends ConfigBuilder<T, TcpOptionsConfigBuilder<T>>
 {
     public static final int BACKLOG_DEFAULT = 0;
     public static final boolean NODELAY_DEFAULT = true;
@@ -38,6 +38,13 @@ public final class TcpOptionsConfigBuilder<T> implements ConfigBuilder<T>
         Function<OptionsConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<TcpOptionsConfigBuilder<T>> thisType()
+    {
+        return (Class<TcpOptionsConfigBuilder<T>>) getClass();
     }
 
     public TcpOptionsConfigBuilder<T> host(

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpConditionConfigAdapterTest.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpConditionConfigAdapterTest.java
@@ -15,6 +15,7 @@
  */
 package io.aklivity.zilla.runtime.binding.tcp.internal.config;
 
+import static java.util.function.Function.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -65,6 +66,7 @@ public class TcpConditionConfigAdapterTest
     public void shouldWriteCondition()
     {
         TcpConditionConfig condition = TcpConditionConfig.builder()
+            .inject(identity())
             .cidr("127.0.0.0/24")
             .authority("*.example.net")
             .ports(new int[] { 8080 })

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpOptionsConfigAdapterTest.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpOptionsConfigAdapterTest.java
@@ -15,6 +15,7 @@
  */
 package io.aklivity.zilla.runtime.binding.tcp.internal.config;
 
+import static java.util.function.Function.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -100,6 +101,7 @@ public class TcpOptionsConfigAdapterTest
     public void shouldWriteOptions()
     {
         TcpOptionsConfig options = TcpOptionsConfig.builder()
+            .inject(identity())
             .host("localhost")
             .ports(new int[] { 8080 })
             .build();
@@ -134,6 +136,7 @@ public class TcpOptionsConfigAdapterTest
     public void shouldWriteOptionsWithBacklog()
     {
         TcpOptionsConfig options = TcpOptionsConfig.builder()
+                .inject(identity())
                 .host("localhost")
                 .ports(new int[] { 8080 })
                 .backlog(1000)

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/config/TlsConditionConfigBuilder.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/config/TlsConditionConfigBuilder.java
@@ -20,7 +20,7 @@ import java.util.function.Function;
 import io.aklivity.zilla.runtime.engine.config.ConditionConfig;
 import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
 
-public final class TlsConditionConfigBuilder<T> implements ConfigBuilder<T>
+public final class TlsConditionConfigBuilder<T> extends ConfigBuilder<T, TlsConditionConfigBuilder<T>>
 {
     private final Function<ConditionConfig, T> mapper;
 
@@ -31,6 +31,13 @@ public final class TlsConditionConfigBuilder<T> implements ConfigBuilder<T>
         Function<ConditionConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<TlsConditionConfigBuilder<T>> thisType()
+    {
+        return (Class<TlsConditionConfigBuilder<T>>) getClass();
     }
 
     public TlsConditionConfigBuilder<T> authority(

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/config/TlsOptionsConfigBuilder.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/config/TlsOptionsConfigBuilder.java
@@ -23,7 +23,7 @@ import java.util.function.Function;
 import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfig;
 
-public final class TlsOptionsConfigBuilder<T> implements ConfigBuilder<T>
+public final class TlsOptionsConfigBuilder<T> extends ConfigBuilder<T, TlsOptionsConfigBuilder<T>>
 {
     private final Function<OptionsConfig, T> mapper;
 
@@ -40,6 +40,13 @@ public final class TlsOptionsConfigBuilder<T> implements ConfigBuilder<T>
         Function<OptionsConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<TlsOptionsConfigBuilder<T>> thisType()
+    {
+        return (Class<TlsOptionsConfigBuilder<T>>) getClass();
     }
 
     public TlsOptionsConfigBuilder<T> version(

--- a/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsConditionConfigAdapterTest.java
+++ b/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsConditionConfigAdapterTest.java
@@ -15,6 +15,7 @@
  */
 package io.aklivity.zilla.runtime.binding.tls.internal.config;
 
+import static java.util.function.Function.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -61,6 +62,7 @@ public class TlsConditionConfigAdapterTest
     public void shouldWriteCondition()
     {
         TlsConditionConfig condition = TlsConditionConfig.builder()
+            .inject(identity())
             .authority("example.net")
             .alpn("echo")
             .build();

--- a/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsOptionsConfigAdapterTest.java
+++ b/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsOptionsConfigAdapterTest.java
@@ -17,6 +17,7 @@ package io.aklivity.zilla.runtime.binding.tls.internal.config;
 
 import static io.aklivity.zilla.runtime.binding.tls.config.TlsMutualConfig.REQUESTED;
 import static java.util.Arrays.asList;
+import static java.util.function.Function.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -61,6 +62,7 @@ public class TlsOptionsConfigAdapterTest
     public void shouldWriteOptions()
     {
         TlsOptionsConfig options = TlsOptionsConfig.builder()
+            .inject(identity())
             .version("TLSv1.2")
             .build();
 
@@ -88,6 +90,7 @@ public class TlsOptionsConfigAdapterTest
     public void shouldWriteOptionsWithKeys()
     {
         TlsOptionsConfig options = TlsOptionsConfig.builder()
+                .inject(identity())
                 .keys(asList("localhost"))
                 .build();
 
@@ -115,6 +118,7 @@ public class TlsOptionsConfigAdapterTest
     public void shouldWriteOptionsWithTrust()
     {
         TlsOptionsConfig options = TlsOptionsConfig.builder()
+            .inject(identity())
             .trust(asList("serverca"))
             .build();
 
@@ -142,6 +146,7 @@ public class TlsOptionsConfigAdapterTest
     public void shouldWriteOptionsWithTrustcacerts()
     {
         TlsOptionsConfig options = TlsOptionsConfig.builder()
+            .inject(identity())
             .trustcacerts(true)
             .build();
 
@@ -169,6 +174,7 @@ public class TlsOptionsConfigAdapterTest
     public void shouldWriteOptionsWithServerName()
     {
         TlsOptionsConfig options = TlsOptionsConfig.builder()
+            .inject(identity())
             .sni(asList("example.net"))
             .build();
 
@@ -196,6 +202,7 @@ public class TlsOptionsConfigAdapterTest
     public void shouldWriteOptionsWithAlpn()
     {
         TlsOptionsConfig options = TlsOptionsConfig.builder()
+            .inject(identity())
             .alpn(asList("echo"))
             .build();
 
@@ -223,6 +230,7 @@ public class TlsOptionsConfigAdapterTest
     public void shouldWriteOptionsWithMutual()
     {
         TlsOptionsConfig options = TlsOptionsConfig.builder()
+            .inject(identity())
             .mutual(REQUESTED)
             .build();
 
@@ -250,6 +258,7 @@ public class TlsOptionsConfigAdapterTest
     public void shouldWriteOptionsWithSigners()
     {
         TlsOptionsConfig options = TlsOptionsConfig.builder()
+            .inject(identity())
             .signers(asList("clientca"))
             .build();
 

--- a/runtime/command-start/src/main/java/io/aklivity/zilla/runtime/command/start/internal/airline/ZillaStartCommand.java
+++ b/runtime/command-start/src/main/java/io/aklivity/zilla/runtime/command/start/internal/airline/ZillaStartCommand.java
@@ -176,6 +176,7 @@ public final class ZillaStartCommand extends ZillaCommand
         catch (Throwable ex)
         {
             System.out.println("error");
+            onError.onError(ex);
             rethrowUnchecked(ex);
         }
     }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/AttributeConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/AttributeConfigBuilder.java
@@ -17,7 +17,7 @@ package io.aklivity.zilla.runtime.engine.config;
 
 import java.util.function.Function;
 
-public final class AttributeConfigBuilder<T> implements ConfigBuilder<T>
+public final class AttributeConfigBuilder<T> extends ConfigBuilder<T, AttributeConfigBuilder<T>>
 {
     private final Function<AttributeConfig, T> mapper;
 
@@ -28,6 +28,13 @@ public final class AttributeConfigBuilder<T> implements ConfigBuilder<T>
         Function<AttributeConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<AttributeConfigBuilder<T>> thisType()
+    {
+        return (Class<AttributeConfigBuilder<T>>) getClass();
     }
 
     public AttributeConfigBuilder<T> name(

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/BindingConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/BindingConfigBuilder.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-public final class BindingConfigBuilder<T> implements ConfigBuilder<T>
+public final class BindingConfigBuilder<T> extends ConfigBuilder<T, BindingConfigBuilder<T>>
 {
     public static final List<RouteConfig> ROUTES_DEFAULT = emptyList();
 
@@ -41,6 +41,13 @@ public final class BindingConfigBuilder<T> implements ConfigBuilder<T>
         Function<BindingConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<BindingConfigBuilder<T>> thisType()
+    {
+        return (Class<BindingConfigBuilder<T>>) getClass();
     }
 
     public BindingConfigBuilder<T> vault(
@@ -78,7 +85,7 @@ public final class BindingConfigBuilder<T> implements ConfigBuilder<T>
         return this;
     }
 
-    public <C extends ConfigBuilder<BindingConfigBuilder<T>>> C options(
+    public <C extends ConfigBuilder<BindingConfigBuilder<T>, C>> C options(
         Function<Function<OptionsConfig, BindingConfigBuilder<T>>, C> options)
     {
         return options.apply(this::options);

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ConfigBuilder.java
@@ -15,7 +15,17 @@
  */
 package io.aklivity.zilla.runtime.engine.config;
 
-public interface ConfigBuilder<T>
+import java.util.function.Function;
+
+public abstract class ConfigBuilder<T, B extends ConfigBuilder<T, B>>
 {
-    T build();
+    protected abstract Class<B> thisType();
+
+    public final <R> R inject(
+        Function<B, R> visitor)
+    {
+        return visitor.apply(thisType().cast(this));
+    }
+
+    public abstract T build();
 }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ExporterConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ExporterConfigBuilder.java
@@ -17,7 +17,7 @@ package io.aklivity.zilla.runtime.engine.config;
 
 import java.util.function.Function;
 
-public final class ExporterConfigBuilder<T> implements ConfigBuilder<T>
+public final class ExporterConfigBuilder<T> extends ConfigBuilder<T, ExporterConfigBuilder<T>>
 {
     private final Function<ExporterConfig, T> mapper;
 
@@ -29,6 +29,13 @@ public final class ExporterConfigBuilder<T> implements ConfigBuilder<T>
         Function<ExporterConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<ExporterConfigBuilder<T>> thisType()
+    {
+        return (Class<ExporterConfigBuilder<T>>) getClass();
     }
 
     public ExporterConfigBuilder<T> name(
@@ -45,7 +52,7 @@ public final class ExporterConfigBuilder<T> implements ConfigBuilder<T>
         return this;
     }
 
-    public <C extends ConfigBuilder<ExporterConfigBuilder<T>>> C options(
+    public <C extends ConfigBuilder<ExporterConfigBuilder<T>, C>> C options(
         Function<Function<OptionsConfig, ExporterConfigBuilder<T>>, C> options)
     {
         return options.apply(this::options);

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/GuardConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/GuardConfigBuilder.java
@@ -17,7 +17,7 @@ package io.aklivity.zilla.runtime.engine.config;
 
 import java.util.function.Function;
 
-public final class GuardConfigBuilder<T> implements ConfigBuilder<T>
+public final class GuardConfigBuilder<T> extends ConfigBuilder<T, GuardConfigBuilder<T>>
 {
     private final Function<GuardConfig, T> mapper;
 
@@ -29,6 +29,13 @@ public final class GuardConfigBuilder<T> implements ConfigBuilder<T>
         Function<GuardConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<GuardConfigBuilder<T>> thisType()
+    {
+        return (Class<GuardConfigBuilder<T>>) getClass();
     }
 
     public GuardConfigBuilder<T> name(
@@ -45,7 +52,7 @@ public final class GuardConfigBuilder<T> implements ConfigBuilder<T>
         return this;
     }
 
-    public <C extends ConfigBuilder<GuardConfigBuilder<T>>> C options(
+    public <C extends ConfigBuilder<GuardConfigBuilder<T>, C>> C options(
         Function<Function<OptionsConfig, GuardConfigBuilder<T>>, C> options)
     {
         return options.apply(this::options);

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/GuardedConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/GuardedConfigBuilder.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-public final class GuardedConfigBuilder<T> implements ConfigBuilder<T>
+public final class GuardedConfigBuilder<T> extends ConfigBuilder<T, GuardedConfigBuilder<T>>
 {
     public static final List<String> ROLES_DEFAULT = emptyList();
 
@@ -35,6 +35,13 @@ public final class GuardedConfigBuilder<T> implements ConfigBuilder<T>
         Function<GuardedConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<GuardedConfigBuilder<T>> thisType()
+    {
+        return (Class<GuardedConfigBuilder<T>>) getClass();
     }
 
     public GuardedConfigBuilder<T> name(

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/MetricConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/MetricConfigBuilder.java
@@ -17,7 +17,7 @@ package io.aklivity.zilla.runtime.engine.config;
 
 import java.util.function.Function;
 
-public final class MetricConfigBuilder<T> implements ConfigBuilder<T>
+public final class MetricConfigBuilder<T> extends ConfigBuilder<T, MetricConfigBuilder<T>>
 {
     private final Function<MetricConfig, T> mapper;
 
@@ -28,6 +28,13 @@ public final class MetricConfigBuilder<T> implements ConfigBuilder<T>
         Function<MetricConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<MetricConfigBuilder<T>> thisType()
+    {
+        return (Class<MetricConfigBuilder<T>>) getClass();
     }
 
     public MetricConfigBuilder<T> group(

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/MetricRefConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/MetricRefConfigBuilder.java
@@ -17,7 +17,7 @@ package io.aklivity.zilla.runtime.engine.config;
 
 import java.util.function.Function;
 
-public final class MetricRefConfigBuilder<T> implements ConfigBuilder<T>
+public final class MetricRefConfigBuilder<T> extends ConfigBuilder<T, MetricRefConfigBuilder<T>>
 {
     private final Function<MetricRefConfig, T> mapper;
 
@@ -27,6 +27,13 @@ public final class MetricRefConfigBuilder<T> implements ConfigBuilder<T>
         Function<MetricRefConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<MetricRefConfigBuilder<T>> thisType()
+    {
+        return (Class<MetricRefConfigBuilder<T>>) getClass();
     }
 
     public MetricRefConfigBuilder<T> name(

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/NamespaceConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/NamespaceConfigBuilder.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-public class NamespaceConfigBuilder<T>
+public final class NamespaceConfigBuilder<T> extends ConfigBuilder<T, NamespaceConfigBuilder<T>>
 {
     public static final List<NamespaceRefConfig> NAMESPACES_DEFAULT = emptyList();
     public static final List<BindingConfig> BINDINGS_DEFAULT = emptyList();
@@ -43,6 +43,13 @@ public class NamespaceConfigBuilder<T>
         Function<NamespaceConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<NamespaceConfigBuilder<T>> thisType()
+    {
+        return (Class<NamespaceConfigBuilder<T>>) getClass();
     }
 
     public NamespaceConfigBuilder<T> name(

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/NamespaceRefConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/NamespaceRefConfigBuilder.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
-public final class NamespaceRefConfigBuilder<T> implements ConfigBuilder<T>
+public final class NamespaceRefConfigBuilder<T> extends ConfigBuilder<T, NamespaceRefConfigBuilder<T>>
 {
     public static final Map<String, String> LINKS_DEFAULT = emptyMap();
 
@@ -35,6 +35,13 @@ public final class NamespaceRefConfigBuilder<T> implements ConfigBuilder<T>
         Function<NamespaceRefConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<NamespaceRefConfigBuilder<T>> thisType()
+    {
+        return (Class<NamespaceRefConfigBuilder<T>>) getClass();
     }
 
     public NamespaceRefConfigBuilder<T> name(

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/RouteConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/RouteConfigBuilder.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-public final class RouteConfigBuilder<T> implements ConfigBuilder<T>
+public final class RouteConfigBuilder<T> extends ConfigBuilder<T, RouteConfigBuilder<T>>
 {
     public static final List<ConditionConfig> WHEN_DEFAULT = emptyList();
     public static final List<GuardedConfig> GUARDED_DEFAULT = emptyList();
@@ -41,6 +41,13 @@ public final class RouteConfigBuilder<T> implements ConfigBuilder<T>
         this.mapper = mapper;
     }
 
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<RouteConfigBuilder<T>> thisType()
+    {
+        return (Class<RouteConfigBuilder<T>>) getClass();
+    }
+
     public RouteConfigBuilder<T> order(
         int order)
     {
@@ -55,7 +62,7 @@ public final class RouteConfigBuilder<T> implements ConfigBuilder<T>
         return this;
     }
 
-    public <C extends ConfigBuilder<RouteConfigBuilder<T>>> C when(
+    public <C extends ConfigBuilder<RouteConfigBuilder<T>, C>> C when(
         Function<Function<ConditionConfig, RouteConfigBuilder<T>>, C> condition)
     {
         return condition.apply(this::when);
@@ -72,7 +79,7 @@ public final class RouteConfigBuilder<T> implements ConfigBuilder<T>
         return this;
     }
 
-    public <B extends ConfigBuilder<RouteConfigBuilder<T>>> B with(
+    public <B extends ConfigBuilder<RouteConfigBuilder<T>, B>> B with(
         Function<Function<WithConfig, RouteConfigBuilder<T>>, B> with)
     {
         return with.apply(this::with);

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/TelemetryConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/TelemetryConfigBuilder.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-public final class TelemetryConfigBuilder<T> implements ConfigBuilder<T>
+public final class TelemetryConfigBuilder<T> extends ConfigBuilder<T, TelemetryConfigBuilder<T>>
 {
     public static final List<AttributeConfig> ATTRIBUTES_DEFAULT = List.of();
     public static final List<MetricConfig> METRICS_DEFAULT = List.of();
@@ -36,6 +36,13 @@ public final class TelemetryConfigBuilder<T> implements ConfigBuilder<T>
         Function<TelemetryConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<TelemetryConfigBuilder<T>> thisType()
+    {
+        return (Class<TelemetryConfigBuilder<T>>) getClass();
     }
 
     public AttributeConfigBuilder<TelemetryConfigBuilder<T>> attribute()

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/TelemetryRefConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/TelemetryRefConfigBuilder.java
@@ -19,7 +19,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
 
-public final class TelemetryRefConfigBuilder<T> implements ConfigBuilder<T>
+public final class TelemetryRefConfigBuilder<T> extends ConfigBuilder<T, TelemetryRefConfigBuilder<T>>
 {
     private final Function<TelemetryRefConfig, T> mapper;
 
@@ -29,6 +29,13 @@ public final class TelemetryRefConfigBuilder<T> implements ConfigBuilder<T>
         Function<TelemetryRefConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<TelemetryRefConfigBuilder<T>> thisType()
+    {
+        return (Class<TelemetryRefConfigBuilder<T>>) getClass();
     }
 
     public MetricRefConfigBuilder<TelemetryRefConfigBuilder<T>> metric()

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/VaultConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/VaultConfigBuilder.java
@@ -19,7 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.function.Function;
 
-public final class VaultConfigBuilder<T> implements ConfigBuilder<T>
+public final class VaultConfigBuilder<T> extends ConfigBuilder<T, VaultConfigBuilder<T>>
 {
     private final Function<VaultConfig, T> mapper;
 
@@ -31,6 +31,13 @@ public final class VaultConfigBuilder<T> implements ConfigBuilder<T>
         Function<VaultConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<VaultConfigBuilder<T>> thisType()
+    {
+        return (Class<VaultConfigBuilder<T>>) getClass();
     }
 
     public VaultConfigBuilder<T> name(
@@ -47,7 +54,7 @@ public final class VaultConfigBuilder<T> implements ConfigBuilder<T>
         return this;
     }
 
-    public <C extends ConfigBuilder<VaultConfigBuilder<T>>> C options(
+    public <C extends ConfigBuilder<VaultConfigBuilder<T>, C>> C options(
         Function<Function<OptionsConfig, VaultConfigBuilder<T>>, C> options)
     {
         return options.apply(this::options);

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/config/ConfigWriterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/config/ConfigWriterTest.java
@@ -16,6 +16,7 @@
 package io.aklivity.zilla.runtime.engine.config;
 
 import static io.aklivity.zilla.runtime.engine.config.KindConfig.SERVER;
+import static java.util.function.Function.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -54,14 +55,18 @@ public class ConfigWriterTest
         NamespaceConfig config = NamespaceConfig.builder()
                 .name("test")
                 .binding()
+                    .inject(identity())
                     .name("test0")
                     .type("test")
                     .kind(SERVER)
                     .options(TestBindingOptionsConfig::builder)
+                        .inject(identity())
                         .mode("test")
                         .build()
                     .route()
+                        .inject(identity())
                         .when(TestConditionConfig::builder)
+                            .inject(identity())
                             .match("test")
                             .build()
                         .exit("exit0")

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/BindingConfigsAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/BindingConfigsAdapterTest.java
@@ -17,6 +17,7 @@ package io.aklivity.zilla.runtime.engine.internal.config;
 
 import static io.aklivity.zilla.runtime.engine.config.KindConfig.REMOTE_SERVER;
 import static io.aklivity.zilla.runtime.engine.config.KindConfig.SERVER;
+import static java.util.function.Function.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyCollectionOf;
@@ -87,6 +88,7 @@ public class BindingConfigsAdapterTest
         BindingConfig[] bindings =
         {
             BindingConfig.builder()
+                .inject(identity())
                 .name("test")
                 .type("test")
                 .kind(SERVER)
@@ -130,6 +132,7 @@ public class BindingConfigsAdapterTest
         BindingConfig[] bindings =
         {
             BindingConfig.builder()
+                .inject(identity())
                 .vault("test")
                 .name("test")
                 .type("test")
@@ -178,6 +181,7 @@ public class BindingConfigsAdapterTest
                 .type("test")
                 .kind(SERVER)
                 .options(TestBindingOptionsConfig::builder)
+                    .inject(identity())
                     .mode("test")
                     .build()
                 .build()
@@ -227,6 +231,7 @@ public class BindingConfigsAdapterTest
                 .type("test")
                 .kind(SERVER)
                 .route()
+                    .inject(identity())
                     .exit("test")
                     .build()
                 .build()
@@ -249,6 +254,7 @@ public class BindingConfigsAdapterTest
                 .route()
                     .exit("test")
                     .guarded()
+                        .inject(identity())
                         .name("test0")
                         .role("read")
                         .build()

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/ConditionConfigAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/ConditionConfigAdapterTest.java
@@ -124,7 +124,7 @@ public class ConditionConfigAdapterTest
         }
     }
 
-    public static final class TestConditionConfigBuilder<T> implements ConfigBuilder<T>
+    public static final class TestConditionConfigBuilder<T> extends ConfigBuilder<T, TestConditionConfigBuilder<T>>
     {
         private final Function<ConditionConfig, T> mapper;
 
@@ -134,6 +134,13 @@ public class ConditionConfigAdapterTest
             Function<ConditionConfig, T> mapper)
         {
             this.mapper = mapper;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        protected Class<TestConditionConfigBuilder<T>> thisType()
+        {
+            return (Class<TestConditionConfigBuilder<T>>) getClass();
         }
 
         public TestConditionConfigBuilder<T> match(

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/NamespaceConfigAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/NamespaceConfigAdapterTest.java
@@ -17,6 +17,7 @@ package io.aklivity.zilla.runtime.engine.internal.config;
 
 import static io.aklivity.zilla.runtime.engine.config.KindConfig.SERVER;
 import static java.util.Collections.emptyMap;
+import static java.util.function.Function.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyCollectionOf;
 import static org.hamcrest.Matchers.equalTo;
@@ -140,6 +141,7 @@ public class NamespaceConfigAdapterTest
     public void shouldWriteNamespaceWithBinding()
     {
         NamespaceConfig config = NamespaceConfig.builder()
+                .inject(identity())
                 .name("test")
                 .binding()
                     .name("test")
@@ -185,6 +187,7 @@ public class NamespaceConfigAdapterTest
     public void shouldWriteNamespaceWithGuard()
     {
         NamespaceConfig config = NamespaceConfig.builder()
+                .inject(identity())
                 .name("test")
                 .guard()
                     .name("default")
@@ -234,6 +237,7 @@ public class NamespaceConfigAdapterTest
     public void shouldWriteNamespaceWithVault()
     {
         NamespaceConfig config = NamespaceConfig.builder()
+                .inject(identity())
                 .name("test")
                 .vault()
                     .name("default")
@@ -281,6 +285,7 @@ public class NamespaceConfigAdapterTest
     public void shouldWriteNamespaceWithTelemetry()
     {
         NamespaceConfig config = NamespaceConfig.builder()
+                .inject(identity())
                 .name("test")
                 .telemetry()
                     .attribute()
@@ -340,6 +345,7 @@ public class NamespaceConfigAdapterTest
     public void shouldWriteNamespaceWithReference()
     {
         NamespaceConfig config = NamespaceConfig.builder()
+                .inject(identity())
                 .name("test")
                 .namespace()
                     .name("test")

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/NamespaceRefConfigAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/NamespaceRefConfigAdapterTest.java
@@ -17,6 +17,7 @@ package io.aklivity.zilla.runtime.engine.internal.config;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
+import static java.util.function.Function.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -107,6 +108,7 @@ public class NamespaceRefConfigAdapterTest
     public void shouldWriteReferenceWithLink()
     {
         NamespaceRefConfig reference = NamespaceRefConfig.builder()
+                .inject(identity())
                 .name("test")
                 .link("self", "/test")
                 .build();

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/RouteConfigAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/RouteConfigAdapterTest.java
@@ -16,6 +16,7 @@
 package io.aklivity.zilla.runtime.engine.internal.config;
 
 import static java.util.Collections.singletonList;
+import static java.util.function.Function.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -110,8 +111,10 @@ public class RouteConfigAdapterTest
     public void shouldWriteRouteGuarded()
     {
         RouteConfig route = RouteConfig.builder()
+                .inject(identity())
                 .exit("test")
                 .guarded()
+                    .inject(identity())
                     .name("test")
                     .role("role")
                     .build()
@@ -147,8 +150,10 @@ public class RouteConfigAdapterTest
     public void shouldWriteRouteWhenMatch()
     {
         RouteConfig route = RouteConfig.builder()
+                .inject(identity())
                 .exit("test")
                 .when(TestConditionConfig::builder)
+                    .inject(identity())
                     .match("test")
                     .build()
                 .build();

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/TelemetryConfigsAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/TelemetryConfigsAdapterTest.java
@@ -15,6 +15,7 @@
  */
 package io.aklivity.zilla.runtime.engine.internal.config;
 
+import static java.util.function.Function.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -101,15 +102,19 @@ public class TelemetryConfigsAdapterTest
     {
         // GIVEN
         TelemetryConfig telemetry = TelemetryConfig.builder()
+                .inject(identity())
                 .attribute()
+                    .inject(identity())
                     .name("test.attribute")
                     .value("example")
                     .build()
                 .metric()
+                    .inject(identity())
                     .group("test")
                     .name("test.counter")
                     .build()
                 .exporter()
+                    .inject(identity())
                     .name("test0")
                     .type("test")
                     .build()
@@ -176,18 +181,23 @@ public class TelemetryConfigsAdapterTest
     {
         // GIVEN
         TelemetryConfig telemetry = TelemetryConfig.builder()
+                .inject(identity())
                 .attribute()
+                    .inject(identity())
                     .name("test.attribute")
                     .value("example")
                     .build()
                 .metric()
+                    .inject(identity())
                     .group("test")
                     .name("test.counter")
                     .build()
                 .exporter()
+                    .inject(identity())
                     .name("test0")
                     .type("test")
                     .options(TestExporterOptionsConfig::builder)
+                        .inject(identity())
                         .mode("test42")
                         .build()
                     .build()

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestBindingOptionsConfigBuilder.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestBindingOptionsConfigBuilder.java
@@ -20,7 +20,7 @@ import java.util.function.Function;
 import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfig;
 
-public final class TestBindingOptionsConfigBuilder<T> implements ConfigBuilder<T>
+public final class TestBindingOptionsConfigBuilder<T> extends ConfigBuilder<T, TestBindingOptionsConfigBuilder<T>>
 {
     private final Function<OptionsConfig, T> mapper;
 
@@ -30,6 +30,13 @@ public final class TestBindingOptionsConfigBuilder<T> implements ConfigBuilder<T
         Function<OptionsConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<TestBindingOptionsConfigBuilder<T>> thisType()
+    {
+        return (Class<TestBindingOptionsConfigBuilder<T>>) getClass();
     }
 
     public TestBindingOptionsConfigBuilder<T> mode(

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/exporter/config/TestExporterOptionsConfigAdapter.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/exporter/config/TestExporterOptionsConfigAdapter.java
@@ -15,6 +15,8 @@
  */
 package io.aklivity.zilla.runtime.engine.test.internal.exporter.config;
 
+import static java.util.function.Function.identity;
+
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
@@ -55,7 +57,8 @@ public final class TestExporterOptionsConfigAdapter implements OptionsConfigAdap
     public OptionsConfig adaptFromJson(
         JsonObject object)
     {
-        TestExporterOptionsConfigBuilder<TestExporterOptionsConfig> testOptions = TestExporterOptionsConfig.builder();
+        TestExporterOptionsConfigBuilder<TestExporterOptionsConfig> testOptions = TestExporterOptionsConfig.builder()
+                .inject(identity());
 
         if (object != null)
         {

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/exporter/config/TestExporterOptionsConfigBuilder.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/exporter/config/TestExporterOptionsConfigBuilder.java
@@ -20,7 +20,7 @@ import java.util.function.Function;
 import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfig;
 
-public final class TestExporterOptionsConfigBuilder<T> implements ConfigBuilder<T>
+public final class TestExporterOptionsConfigBuilder<T> extends ConfigBuilder<T, TestExporterOptionsConfigBuilder<T>>
 {
     private final Function<OptionsConfig, T> mapper;
 
@@ -30,6 +30,13 @@ public final class TestExporterOptionsConfigBuilder<T> implements ConfigBuilder<
         Function<OptionsConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<TestExporterOptionsConfigBuilder<T>> thisType()
+    {
+        return (Class<TestExporterOptionsConfigBuilder<T>>) getClass();
     }
 
     public TestExporterOptionsConfigBuilder<T> mode(

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/config/TestGuardOptionsConfigBuilder.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/config/TestGuardOptionsConfigBuilder.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfig;
 
-public final class TestGuardOptionsConfigBuilder<T> implements ConfigBuilder<T>
+public final class TestGuardOptionsConfigBuilder<T> extends ConfigBuilder<T, TestGuardOptionsConfigBuilder<T>>
 {
     private final Function<OptionsConfig, T> mapper;
 
@@ -42,6 +42,13 @@ public final class TestGuardOptionsConfigBuilder<T> implements ConfigBuilder<T>
         Function<OptionsConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<TestGuardOptionsConfigBuilder<T>> thisType()
+    {
+        return (Class<TestGuardOptionsConfigBuilder<T>>) getClass();
     }
 
     public TestGuardOptionsConfigBuilder<T> credentials(

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/config/TestVaultOptionsConfigBuilder.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/config/TestVaultOptionsConfigBuilder.java
@@ -20,7 +20,7 @@ import java.util.function.Function;
 import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfig;
 
-public final class TestVaultOptionsConfigBuilder<T> implements ConfigBuilder<T>
+public final class TestVaultOptionsConfigBuilder<T> extends ConfigBuilder<T, TestVaultOptionsConfigBuilder<T>>
 {
     private final Function<OptionsConfig, T> mapper;
 
@@ -30,6 +30,13 @@ public final class TestVaultOptionsConfigBuilder<T> implements ConfigBuilder<T>
         Function<OptionsConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<TestVaultOptionsConfigBuilder<T>> thisType()
+    {
+        return (Class<TestVaultOptionsConfigBuilder<T>>) getClass();
     }
 
     public TestVaultOptionsConfigBuilder<T> mode(

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/config/JwtKeyConfigBuilder.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/config/JwtKeyConfigBuilder.java
@@ -18,7 +18,7 @@ import java.util.function.Function;
 
 import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
 
-public class JwtKeyConfigBuilder<T> implements ConfigBuilder<T>
+public class JwtKeyConfigBuilder<T> extends ConfigBuilder<T, JwtKeyConfigBuilder<T>>
 {
     private final Function<JwtKeyConfig, T> mapper;
 
@@ -36,6 +36,13 @@ public class JwtKeyConfigBuilder<T> implements ConfigBuilder<T>
         Function<JwtKeyConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<JwtKeyConfigBuilder<T>> thisType()
+    {
+        return (Class<JwtKeyConfigBuilder<T>>) getClass();
     }
 
     public JwtKeyConfigBuilder<T> kty(

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/config/JwtOptionsConfigBuilder.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/config/JwtOptionsConfigBuilder.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
 import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfig;
 
-public class JwtOptionsConfigBuilder<T> implements ConfigBuilder<T>
+public class JwtOptionsConfigBuilder<T> extends ConfigBuilder<T, JwtOptionsConfigBuilder<T>>
 {
     private final Function<OptionsConfig, T> mapper;
 
@@ -36,6 +36,13 @@ public class JwtOptionsConfigBuilder<T> implements ConfigBuilder<T>
         Function<OptionsConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<JwtOptionsConfigBuilder<T>> thisType()
+    {
+        return (Class<JwtOptionsConfigBuilder<T>>) getClass();
     }
 
     public JwtOptionsConfigBuilder<T> issuer(

--- a/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardHandlerTest.java
+++ b/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardHandlerTest.java
@@ -18,6 +18,7 @@ import static io.aklivity.zilla.runtime.guard.jwt.internal.keys.JwtKeyConfigs.RF
 import static io.aklivity.zilla.specs.guard.jwt.keys.JwtKeys.RFC7515_RS256;
 import static java.time.Duration.ofSeconds;
 import static java.util.Arrays.asList;
+import static java.util.function.Function.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -46,6 +47,7 @@ public class JwtGuardHandlerTest
     {
         Duration challenge = ofSeconds(3L);
         JwtOptionsConfig options = JwtOptionsConfig.builder()
+            .inject(identity())
             .issuer("test issuer")
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
@@ -78,6 +80,7 @@ public class JwtGuardHandlerTest
     {
         Duration challenge = ofSeconds(3L);
         JwtOptionsConfig options = JwtOptionsConfig.builder()
+            .inject(identity())
             .issuer("test issuer")
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
@@ -106,6 +109,7 @@ public class JwtGuardHandlerTest
     {
         Duration challenge = ofSeconds(3L);
         JwtOptionsConfig options = JwtOptionsConfig.builder()
+            .inject(identity())
             .issuer("test issuer")
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
@@ -133,6 +137,7 @@ public class JwtGuardHandlerTest
     {
         Duration challenge = ofSeconds(3L);
         JwtOptionsConfig options = JwtOptionsConfig.builder()
+            .inject(identity())
             .issuer("test issuer")
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
@@ -161,6 +166,7 @@ public class JwtGuardHandlerTest
     {
         Duration challenge = ofSeconds(3L);
         JwtOptionsConfig options = JwtOptionsConfig.builder()
+            .inject(identity())
             .issuer("test issuer")
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
@@ -190,6 +196,7 @@ public class JwtGuardHandlerTest
     public void shouldNotAuthorizeWhenAlgorithmDiffers() throws Exception
     {
         JwtOptionsConfig options = JwtOptionsConfig.builder()
+            .inject(identity())
             .issuer("test issuer")
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
@@ -211,6 +218,7 @@ public class JwtGuardHandlerTest
     public void shouldNotAuthorizeWhenSignatureInvalid() throws Exception
     {
         JwtOptionsConfig options = JwtOptionsConfig.builder()
+            .inject(identity())
             .issuer("test issuer")
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
@@ -234,6 +242,7 @@ public class JwtGuardHandlerTest
     public void shouldNotAuthorizeWhenIssuerDiffers() throws Exception
     {
         JwtOptionsConfig options = JwtOptionsConfig.builder()
+            .inject(identity())
             .issuer("test issuer")
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
@@ -255,6 +264,7 @@ public class JwtGuardHandlerTest
     public void shouldNotAuthorizeWhenAudienceDiffers() throws Exception
     {
         JwtOptionsConfig options = JwtOptionsConfig.builder()
+            .inject(identity())
             .issuer("test issuer")
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
@@ -276,6 +286,7 @@ public class JwtGuardHandlerTest
     public void shouldNotAuthorizeWhenExpired() throws Exception
     {
         JwtOptionsConfig options = JwtOptionsConfig.builder()
+            .inject(identity())
             .issuer("test issuer")
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
@@ -300,6 +311,7 @@ public class JwtGuardHandlerTest
     public void shouldNotAuthorizeWhenNotYetValid() throws Exception
     {
         JwtOptionsConfig options = JwtOptionsConfig.builder()
+            .inject(identity())
             .issuer("test issuer")
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
@@ -325,6 +337,7 @@ public class JwtGuardHandlerTest
     {
         Duration challenge = ofSeconds(30L);
         JwtOptionsConfig options = JwtOptionsConfig.builder()
+            .inject(identity())
             .issuer("test issuer")
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
@@ -350,6 +363,7 @@ public class JwtGuardHandlerTest
     {
         Duration challenge = ofSeconds(3L);
         JwtOptionsConfig options = JwtOptionsConfig.builder()
+            .inject(identity())
             .issuer("test issuer")
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
@@ -384,6 +398,7 @@ public class JwtGuardHandlerTest
     {
         Duration challenge = ofSeconds(3L);
         JwtOptionsConfig options = JwtOptionsConfig.builder()
+            .inject(identity())
             .issuer("test issuer")
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
@@ -419,6 +434,7 @@ public class JwtGuardHandlerTest
     {
         Duration challenge = ofSeconds(3L);
         JwtOptionsConfig options = JwtOptionsConfig.builder()
+            .inject(identity())
             .issuer("test issuer")
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
@@ -453,6 +469,7 @@ public class JwtGuardHandlerTest
     {
         Duration challenge = ofSeconds(3L);
         JwtOptionsConfig options = JwtOptionsConfig.builder()
+            .inject(identity())
             .issuer("test issuer")
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
@@ -489,6 +506,7 @@ public class JwtGuardHandlerTest
     {
         Duration challenge = ofSeconds(3L);
         JwtOptionsConfig options = JwtOptionsConfig.builder()
+            .inject(identity())
             .issuer("test issuer")
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
@@ -525,6 +543,7 @@ public class JwtGuardHandlerTest
     {
         Duration challenge = ofSeconds(3L);
         JwtOptionsConfig options = JwtOptionsConfig.builder()
+            .inject(identity())
             .issuer("test issuer")
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
@@ -560,6 +579,7 @@ public class JwtGuardHandlerTest
     {
         Duration challenge = ofSeconds(30L);
         JwtOptionsConfig options = JwtOptionsConfig.builder()
+            .inject(identity())
             .issuer("test issuer")
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)

--- a/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardTest.java
+++ b/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardTest.java
@@ -18,6 +18,7 @@ import static io.aklivity.zilla.runtime.guard.jwt.internal.JwtGuardHandlerTest.s
 import static io.aklivity.zilla.runtime.guard.jwt.internal.keys.JwtKeyConfigs.RFC7515_RS256_CONFIG;
 import static io.aklivity.zilla.specs.guard.jwt.keys.JwtKeys.RFC7515_RS256;
 import static java.time.Duration.ofSeconds;
+import static java.util.function.Function.identity;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -48,6 +49,7 @@ public class JwtGuardTest
     public void shouldNotVerifyMissingContext() throws Exception
     {
         GuardedConfig guarded = GuardedConfig.builder()
+                .inject(identity())
                 .name("test0")
                 .role("read:stream")
                 .role("write:stream")
@@ -70,6 +72,7 @@ public class JwtGuardTest
         when(engine.index()).thenReturn(0);
 
         GuardedConfig guarded = GuardedConfig.builder()
+                .inject(identity())
                 .name("test0")
                 .role("read:stream")
                 .role("write:stream")
@@ -94,6 +97,7 @@ public class JwtGuardTest
         when(engine.index()).thenReturn(0);
 
         GuardedConfig guarded = GuardedConfig.builder()
+                .inject(identity())
                 .name("test0")
                 .role("read:stream")
                 .role("write:stream")
@@ -105,6 +109,7 @@ public class JwtGuardTest
 
         GuardContext context = guard.supply(engine);
         context.attach(GuardConfig.builder()
+                .inject(identity())
                 .name("test0")
                 .type("jwt")
                 .options(JwtOptionsConfig.builder().build())
@@ -135,9 +140,11 @@ public class JwtGuardTest
         GuardContext context = guard.supply(engine);
 
         GuardHandler handler = context.attach(GuardConfig.builder()
+            .inject(identity())
             .name("test0")
             .type("jwt")
             .options(JwtOptionsConfig::builder)
+                .inject(identity())
                 .issuer("test issuer")
                 .audience("testAudience")
                 .key(RFC7515_RS256_CONFIG)
@@ -172,6 +179,7 @@ public class JwtGuardTest
         when(engine.supplyAuthorizedId()).thenReturn(1L);
 
         GuardedConfig guarded = GuardedConfig.builder()
+                .inject(identity())
                 .name("test0")
                 .role("read:stream")
                 .role("write:stream")
@@ -184,9 +192,11 @@ public class JwtGuardTest
         GuardContext context = guard.supply(engine);
 
         GuardHandler handler = context.attach(GuardConfig.builder()
+            .inject(identity())
             .name("test0")
             .type("jwt")
             .options(JwtOptionsConfig::builder)
+                .inject(identity())
                 .issuer("test issuer")
                 .audience("testAudience")
                 .key(RFC7515_RS256_CONFIG)
@@ -221,6 +231,7 @@ public class JwtGuardTest
         when(engine.supplyAuthorizedId()).thenReturn(1L);
 
         GuardedConfig guarded = GuardedConfig.builder()
+                .inject(identity())
                 .name("test0")
                 .role("read:stream")
                 .build();
@@ -232,9 +243,11 @@ public class JwtGuardTest
         GuardContext context = guard.supply(engine);
 
         GuardHandler handler = context.attach(GuardConfig.builder()
+            .inject(identity())
             .name("test0")
             .type("jwt")
             .options(JwtOptionsConfig::builder)
+                .inject(identity())
                 .issuer("test issuer")
                 .audience("testAudience")
                 .key(RFC7515_RS256_CONFIG)
@@ -269,6 +282,7 @@ public class JwtGuardTest
         when(engine.supplyAuthorizedId()).thenReturn(1L);
 
         GuardedConfig guarded = GuardedConfig.builder()
+                .inject(identity())
                 .name("test0")
                 .build();
 
@@ -279,9 +293,11 @@ public class JwtGuardTest
         GuardContext context = guard.supply(engine);
 
         GuardHandler handler = context.attach(GuardConfig.builder()
+            .inject(identity())
             .name("test0")
             .type("jwt")
             .options(JwtOptionsConfig::builder)
+                .inject(identity())
                 .issuer("test issuer")
                 .audience("testAudience")
                 .key(RFC7515_RS256_CONFIG)
@@ -321,9 +337,11 @@ public class JwtGuardTest
         GuardContext context = guard.supply(engine);
 
         GuardConfig config = GuardConfig.builder()
+            .inject(identity())
             .name("test0")
             .type("jwt")
             .options(JwtOptionsConfig::builder)
+                .inject(identity())
                 .issuer("test issuer")
                 .audience("testAudience")
                 .key(RFC7515_RS256_CONFIG)
@@ -364,6 +382,7 @@ public class JwtGuardTest
         when(engine.supplyAuthorizedId()).thenReturn(1L);
 
         GuardedConfig guarded = GuardedConfig.builder()
+                .inject(identity())
                 .name("test0")
                 .build();
 
@@ -374,9 +393,11 @@ public class JwtGuardTest
         GuardContext context = guard.supply(engine);
 
         GuardHandler handler = context.attach(GuardConfig.builder()
+                .inject(identity())
                 .name("test0")
                 .type("jwt")
                 .options(JwtOptionsConfig::builder)
+                    .inject(identity())
                     .issuer("test issuer")
                     .audience("testAudience")
                     .key(RFC7515_RS256_CONFIG)
@@ -417,9 +438,11 @@ public class JwtGuardTest
 
         Duration challenge = ofSeconds(3L);
         GuardConfig config = GuardConfig.builder()
+            .inject(identity())
             .name("test0")
             .type("jwt")
             .options(JwtOptionsConfig::builder)
+                .inject(identity())
                 .issuer("test issuer")
                 .audience("testAudience")
                 .key(RFC7515_RS256_CONFIG)

--- a/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/config/FileSystemOptionsConfigBuilder.java
+++ b/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/config/FileSystemOptionsConfigBuilder.java
@@ -20,7 +20,7 @@ import java.util.function.Function;
 import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfig;
 
-public final class FileSystemOptionsConfigBuilder<T> implements ConfigBuilder<T>
+public final class FileSystemOptionsConfigBuilder<T> extends ConfigBuilder<T, FileSystemOptionsConfigBuilder<T>>
 {
     private final Function<OptionsConfig, T> mapper;
 
@@ -32,6 +32,13 @@ public final class FileSystemOptionsConfigBuilder<T> implements ConfigBuilder<T>
         Function<OptionsConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<FileSystemOptionsConfigBuilder<T>> thisType()
+    {
+        return (Class<FileSystemOptionsConfigBuilder<T>>) getClass();
     }
 
     public FileSystemStoreConfigBuilder<FileSystemOptionsConfigBuilder<T>> keys()

--- a/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/config/FileSystemStoreConfigBuilder.java
+++ b/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/config/FileSystemStoreConfigBuilder.java
@@ -19,7 +19,7 @@ import java.util.function.Function;
 
 import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
 
-public final class FileSystemStoreConfigBuilder<T> implements ConfigBuilder<T>
+public final class FileSystemStoreConfigBuilder<T> extends ConfigBuilder<T, FileSystemStoreConfigBuilder<T>>
 {
     private final Function<FileSystemStoreConfig, T> mapper;
 
@@ -31,6 +31,13 @@ public final class FileSystemStoreConfigBuilder<T> implements ConfigBuilder<T>
         Function<FileSystemStoreConfig, T> mapper)
     {
         this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<FileSystemStoreConfigBuilder<T>> thisType()
+    {
+        return (Class<FileSystemStoreConfigBuilder<T>>) getClass();
     }
 
     public FileSystemStoreConfigBuilder<T> store(

--- a/runtime/vault-filesystem/src/test/java/io/aklivity/zilla/runtime/vault/filesystem/internal/config/FileSystemOptionsConfigAdapterTest.java
+++ b/runtime/vault-filesystem/src/test/java/io/aklivity/zilla/runtime/vault/filesystem/internal/config/FileSystemOptionsConfigAdapterTest.java
@@ -15,6 +15,7 @@
  */
 package io.aklivity.zilla.runtime.vault.filesystem.internal.config;
 
+import static java.util.function.Function.identity;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -93,7 +94,9 @@ public class FileSystemOptionsConfigAdapterTest
     public void shouldWriteOptionsWithKeys()
     {
         FileSystemOptionsConfig options = FileSystemOptionsConfig.builder()
+            .inject(identity())
             .keys()
+                .inject(identity())
                 .store("localhost.p12")
                 .type("pkcs12")
                 .password("generated")


### PR DESCRIPTION
## Description

Allows conditional logic to be injected at any point in the config builder hierarchy while maintaining a linear flow all the way to `.build()` at the end.
