### PR TITLE
Support binding config builder exit

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/BindingConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/BindingConfigBuilder.java
@@ -33,6 +33,7 @@ public final class BindingConfigBuilder<T> extends ConfigBuilder<T, BindingConfi
     private String type;
     private KindConfig kind;
     private String entry;
+    private String exit;
     private OptionsConfig options;
     private List<RouteConfig> routes;
     private TelemetryRefConfig telemetry;
@@ -85,6 +86,13 @@ public final class BindingConfigBuilder<T> extends ConfigBuilder<T, BindingConfi
         return this;
     }
 
+    public BindingConfigBuilder<T> exit(
+        String exit)
+    {
+        this.exit = exit;
+        return this;
+    }
+
     public <C extends ConfigBuilder<BindingConfigBuilder<T>, C>> C options(
         Function<Function<OptionsConfig, BindingConfigBuilder<T>>, C> options)
     {
@@ -100,7 +108,8 @@ public final class BindingConfigBuilder<T> extends ConfigBuilder<T, BindingConfi
 
     public RouteConfigBuilder<BindingConfigBuilder<T>> route()
     {
-        return new RouteConfigBuilder<>(this::route);
+        return new RouteConfigBuilder<>(this::route)
+            .order(routes != null ? routes.size() : 0);
     }
 
     public BindingConfigBuilder<T> route(
@@ -110,6 +119,9 @@ public final class BindingConfigBuilder<T> extends ConfigBuilder<T, BindingConfi
         {
             routes = new LinkedList<>();
         }
+
+        assert route.order == routes.size();
+
         routes.add(route);
         return this;
     }
@@ -129,6 +141,13 @@ public final class BindingConfigBuilder<T> extends ConfigBuilder<T, BindingConfi
     @Override
     public T build()
     {
+        if (exit != null)
+        {
+            route()
+                .exit(exit)
+                .build();
+        }
+
         return mapper.apply(new BindingConfig(
             vault,
             name,

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/BindingConfigsAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/BindingConfigsAdapter.java
@@ -151,9 +151,10 @@ public class BindingConfigsAdapter implements JsonbAdapter<BindingConfig[], Json
                 binding.options(options.adaptFromJson(item.getJsonObject(OPTIONS_NAME)));
             }
 
-            MutableInteger order = new MutableInteger();
             if (item.containsKey(ROUTES_NAME))
             {
+                MutableInteger order = new MutableInteger();
+
                 item.getJsonArray(ROUTES_NAME)
                     .stream()
                     .map(JsonValue::asJsonObject)
@@ -164,10 +165,7 @@ public class BindingConfigsAdapter implements JsonbAdapter<BindingConfig[], Json
 
             if (item.containsKey(EXIT_NAME))
             {
-                binding.route()
-                    .order(order.value++)
-                    .exit(item.getString(EXIT_NAME))
-                    .build();
+                binding.exit(item.getString(EXIT_NAME));
             }
 
             if (item.containsKey(TELEMETRY_NAME))

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/BindingConfigsAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/BindingConfigsAdapterTest.java
@@ -227,13 +227,11 @@ public class BindingConfigsAdapterTest
         BindingConfig[] bindings =
         {
             BindingConfig.builder()
+                .inject(identity())
                 .name("test")
                 .type("test")
                 .kind(SERVER)
-                .route()
-                    .inject(identity())
-                    .exit("test")
-                    .build()
+                .exit("test")
                 .build()
         };
 


### PR DESCRIPTION
## Description

Provide shorthand syntax for `BindingConfigBuilder.exit(...)` while ensuring that `route` `order` is preserved automatically.