### PR TITLE
Request data length is non-negative

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpServerFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpServerFactory.java
@@ -2732,7 +2732,7 @@ public final class HttpServerFactory implements HttpStreamFactory
                 Flyweight extension)
             {
                 int requestNoAck = (int)(requestSeq - requestAck);
-                int length = Math.min(requestMax - requestNoAck - requestPad, limit - offset);
+                int length = Math.min(Math.max(requestMax - requestNoAck - requestPad, 0), limit - offset);
 
                 if (length > 0)
                 {


### PR DESCRIPTION
## Description

When request window maximum is too low, such as `0` for `sse` request window which expects only `GET` request with no body, then calculated available `length` could become negative, adversely affecting how we track progress through the request body.

Fixes #293
