### PR TITLE
Support build after local docker zpm install

### DIFF
--- a/cloud/docker-image/pom.xml
+++ b/cloud/docker-image/pom.xml
@@ -203,6 +203,7 @@
             <exclude>src/main/docker/*/zpmw</exclude>
             <exclude>src/main/docker/*/zilla</exclude>
             <exclude>src/main/docker/*/zilla.properties</exclude>
+            <exclude>src/main/docker/*/.zilla/**</exclude>
             <exclude>src/main/docker/*/zpm.json.template</exclude>
             <exclude>src/main/docker/*/zpm.json</exclude>
             <exclude>src/main/docker/*/.zpm/**</exclude>


### PR DESCRIPTION
## Description

When building locally, license check was failing on locally generated `.zilla` engine directory.
