### PR TITLE
Ensure socket channel has finished connecting before attempting to read

### DIFF
--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpClientFactory.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpClientFactory.java
@@ -330,8 +330,14 @@ public class TcpClientFactory implements TcpStreamFactory
             ((Buffer) readByteBuffer).position(0);
             ((Buffer) readByteBuffer).limit(limit);
 
+            read:
             try
             {
+                if (!TcpState.opened(state))
+                {
+                    break read;
+                }
+
                 final int bytesRead = net.read(readByteBuffer);
 
                 if (bytesRead == -1)

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpState.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpState.java
@@ -122,6 +122,12 @@ final class TcpState
         return (state & REPLY_CLOSED) != 0;
     }
 
+    static boolean opened(
+        int state)
+    {
+        return initialOpened(state) && replyOpened(state);
+    }
+
     private TcpState()
     {
         // utility


### PR DESCRIPTION
## Description

If socket channel is still connecting asynchronously while `WINDOW` frame arrives proactively on reply stream before `BEGIN` is sent, then attempting to read from the socket channel causes a `NotYetConnectedException`.

If we guard against that, then the socket read will happen when the `OP_READ` handler is set after the socket channel connects successfully.