### PR TITLE
Don't close group stream on cluster and describe streams closer

### DIFF
--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientGroupFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientGroupFactory.java
@@ -425,35 +425,6 @@ public final class KafkaClientGroupFactory extends KafkaClientSaslHandshaker imp
         long traceId,
         long authorization,
         long affinity,
-        Consumer<OctetsFW.Builder> extension)
-    {
-        final BeginFW begin = beginRW.wrap(writeBuffer, 0, writeBuffer.capacity())
-                .originId(originId)
-                .routedId(routedId)
-                .streamId(streamId)
-                .sequence(sequence)
-                .acknowledge(acknowledge)
-                .maximum(maximum)
-                .traceId(traceId)
-                .authorization(authorization)
-                .affinity(affinity)
-                .extension(extension)
-                .build();
-
-        receiver.accept(begin.typeId(), begin.buffer(), begin.offset(), begin.sizeof());
-    }
-
-    private void doBegin(
-        MessageConsumer receiver,
-        long originId,
-        long routedId,
-        long streamId,
-        long sequence,
-        long acknowledge,
-        int maximum,
-        long traceId,
-        long authorization,
-        long affinity,
         Flyweight extension)
     {
         final BeginFW begin = beginRW.wrap(writeBuffer, 0, writeBuffer.capacity())
@@ -1861,20 +1832,9 @@ public final class KafkaClientGroupFactory extends KafkaClientSaslHandshaker imp
         private void onNetworkEnd(
             EndFW end)
         {
-            final long traceId = end.traceId();
-
             state = KafkaState.closedReply(state);
 
             cleanupDecodeSlotIfNecessary();
-
-            if (!delegate.isApplicationReplyOpen())
-            {
-                onError(traceId);
-            }
-            else if (decodeSlot == NO_SLOT)
-            {
-                delegate.doApplicationEnd(traceId);
-            }
         }
 
         private void onNetworkAbort(
@@ -2560,20 +2520,9 @@ public final class KafkaClientGroupFactory extends KafkaClientSaslHandshaker imp
         private void onNetworkEnd(
             EndFW end)
         {
-            final long traceId = end.traceId();
-
             state = KafkaState.closedReply(state);
 
             cleanupDecodeSlotIfNecessary();
-
-            if (!KafkaState.replyOpened(delegate.state))
-            {
-                cleanupNetwork(traceId);
-            }
-            else if (decodeSlot == NO_SLOT)
-            {
-                delegate.doApplicationEnd(traceId);
-            }
         }
 
         private void onNetworkAbort(

--- a/runtime/binding-kafka/src/main/zilla/protocol.idl
+++ b/runtime/binding-kafka/src/main/zilla/protocol.idl
@@ -484,6 +484,7 @@ scope protocol
 
             struct OffsetFetchResponse
             {
+                int32 correlationId;
                 int32 topicCount;
             }
 

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientGroupIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientGroupIT.java
@@ -85,7 +85,7 @@ public class ClientGroupIT
     @Specification({
         "${app}/leader/client",
         "${net}/coordinator.reject.invalid.consumer/server"})
-    public void shouldHRejectInvalidConsumer() throws Exception
+    public void shouldRejectInvalidConsumer() throws Exception
     {
         k3po.finish();
     }

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v0/topic.offset.info/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v0/topic.offset.info/client.rpt
@@ -39,7 +39,8 @@ write 38                                # size
         1                               # partitions
           0                             # partition
 
-read 30                                 # size
+read 34                                 # size
+     (int:newRequestId)
      1                                  # topics
        4s "test"                          # "test" topic
        1                                  # partitions

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v0/topic.offset.info/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v0/topic.offset.info/server.rpt
@@ -36,7 +36,8 @@ read  38                                # size
         1                               # partitions
           0                             # partition
 
-write 30                                 # size
+write 34                                 # size
+      ${newRequestId}
       1                                  # topics
         4s "test"                          # "test" topic
         1                                  # partitions


### PR DESCRIPTION
## Description

Currently, we are closing the group application stream once we are done finding coordinator or describe configs. It is passing now because the scripts are not complete. We are going to change the scripts in connections pool PR.
