### PR TITLE
Http request validators feature flag

### DIFF
--- a/runtime/binding-http/pom.xml
+++ b/runtime/binding-http/pom.xml
@@ -137,7 +137,7 @@
                   </fileMappers>
                 </artifactItem>
               </artifactItems>
-              <includes>io/aklivity/zilla/specs/binding/http/schema/http.schema.patch.json</includes>
+              <includes>io/aklivity/zilla/specs/binding/http/schema/http*.schema.patch.json</includes>
               <outputDirectory>${project.build.directory}/classes</outputDirectory>
             </configuration>
           </execution>

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/HttpBinding.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/HttpBinding.java
@@ -41,7 +41,10 @@ public final class HttpBinding implements Binding
     @Override
     public URL type()
     {
-        return getClass().getResource("schema/http.schema.patch.json");
+        String patch = config.requestValidators()
+            ? "schema/http.with.validators.schema.patch.json"
+            : "schema/http.schema.patch.json";
+        return getClass().getResource(patch);
     }
 
     @Override

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/HttpConfiguration.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/HttpConfiguration.java
@@ -35,6 +35,7 @@ public class HttpConfiguration extends Configuration
     public static final IntPropertyDef HTTP_MAX_CONCURRENT_APPLICATION_HEADERS;
     public static final PropertyDef<String> HTTP_SERVER_HEADER;
     public static final PropertyDef<String> HTTP_USER_AGENT_HEADER;
+    public static final BooleanPropertyDef HTTP_REQUEST_VALIDATORS;
 
     private static final ConfigurationDef HTTP_CONFIG;
 
@@ -52,6 +53,7 @@ public class HttpConfiguration extends Configuration
         HTTP_MAX_CONCURRENT_STREAMS_CLEANUP = config.property("max.concurrent.streams.cleanup", 1000);
         HTTP_STREAMS_CLEANUP_DELAY = config.property("streams.cleanup.delay", 100);
         HTTP_MAX_CONCURRENT_APPLICATION_HEADERS = config.property("max.concurrent.application.headers", 10000);
+        HTTP_REQUEST_VALIDATORS = config.property("request.validators", false);
         HTTP_CONFIG = config;
     }
 
@@ -111,6 +113,11 @@ public class HttpConfiguration extends Configuration
     public int maxConcurrentApplicationHeaders()
     {
         return HTTP_MAX_CONCURRENT_APPLICATION_HEADERS.getAsInt(this);
+    }
+
+    public boolean requestValidators()
+    {
+        return HTTP_REQUEST_VALIDATORS.getAsBoolean(this);
     }
 
     public String16FW serverHeader()

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/schema/http.with.validators.schema.patch.json
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/schema/http.with.validators.schema.patch.json
@@ -237,6 +237,114 @@
                                 {
                                     "type": "string"
                                 }
+                            },
+                            "requests":
+                            {
+                                "type": "array",
+                                "items":
+                                {
+                                    "type": "object",
+                                    "properties":
+                                    {
+                                        "path":
+                                        {
+                                            "type": "string"
+                                        },
+                                        "method":
+                                        {
+                                            "type": "string",
+                                            "enum":
+                                            [
+                                                "GET",
+                                                "PUT",
+                                                "POST",
+                                                "DELETE",
+                                                "OPTIONS",
+                                                "HEAD",
+                                                "PATCH",
+                                                "TRACE"
+                                            ]
+                                        },
+                                        "content-type":
+                                        {
+                                            "type": "array",
+                                            "items":
+                                            {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "headers":
+                                        {
+                                            "type": "object",
+                                            "patternProperties":
+                                            {
+                                                "^[a-zA-Z]+[a-zA-Z0-9\\._\\-]*$":
+                                                {
+                                                    "$ref": "#/$defs/validator/type"
+                                                }
+                                            }
+                                        },
+                                        "params":
+                                        {
+                                            "type": "object",
+                                            "properties":
+                                            {
+                                                "path":
+                                                {
+                                                    "type": "object",
+                                                    "patternProperties":
+                                                    {
+                                                        "^[a-zA-Z]+[a-zA-Z0-9\\._\\-]*$":
+                                                        {
+                                                            "$ref": "#/$defs/validator/type"
+                                                        }
+                                                    }
+                                                },
+                                                "query":
+                                                {
+                                                    "type": "object",
+                                                    "patternProperties":
+                                                    {
+                                                        "^[a-zA-Z]+[a-zA-Z0-9\\._\\-]*$":
+                                                        {
+                                                            "$ref": "#/$defs/validator/type"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "content":
+                                        {
+                                            "$ref": "#/$defs/validator/type"
+                                        }
+                                    },
+                                    "anyOf":
+                                    [
+                                        {
+                                            "required":
+                                            [
+                                                "path",
+                                                "headers"
+                                            ]
+                                        },
+                                        {
+                                            "required":
+                                            [
+                                                "path",
+                                                "params"
+                                            ]
+                                        },
+                                        {
+                                            "required":
+                                            [
+                                                "path",
+                                                "content"
+                                            ]
+                                        }
+                                    ],
+                                    "additionalProperties": false
+                                }
                             }
                         },
                         "additionalProperties": false


### PR DESCRIPTION
## Description

Add http request validators feature flag to be enabled when http runtime enforcement is completed. Configuration syntax looks good, but disabled by default for now.