### PR TITLE
update helm configs so appVersion is used as the tag

### DIFF
--- a/cloud/helm-chart/src/main/helm/templates/deployment.yaml
+++ b/cloud/helm-chart/src/main/helm/templates/deployment.yaml
@@ -50,9 +50,11 @@ spec:
           args:
             {{- toYaml .Values.args | nindent 12 }}
           env:
+            - name: ZILLA_VERSION
+              value: "{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- range $env := .Values.env }}
-          - name: {{ $env.name }}
-            value: {{ $env.value }}
+            - name: {{ $env.name }}
+              value: {{ $env.value }}
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/cloud/helm-chart/src/main/helm/values.yaml
+++ b/cloud/helm-chart/src/main/helm/values.yaml
@@ -17,8 +17,6 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/aklivity/zilla
-  pullPolicy: IfNotPresent
-  tag: latest
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Description

The default `values.yaml` doesn't need to override the desired image version and can be removed. This will enable a 1-1 relationship between the `chartVersion` and the `appVersion` that is already being set in the pom:

```
 <configuration>
          <chartDirectory>src/main/helm</chartDirectory>
          <chartVersion>${project.version}</chartVersion>
          <appVersion>${project.version}</appVersion>
          ...
```

The repository is the only unique value we need to default based on the `deployment.yaml`. Users will be able to overwrite these values in their own `values.yaml`:

```
 image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
```

Fixes #487 
