### PR TITLE
Add extraEnv to Deployment in the helm chart

### DIFF
--- a/cloud/helm-chart/src/main/helm/templates/deployment.yaml
+++ b/cloud/helm-chart/src/main/helm/templates/deployment.yaml
@@ -56,6 +56,9 @@ spec:
             - name: {{ $env.name }}
               value: {{ $env.value }}
           {{- end }}
+          {{- if .Values.extraEnv }}
+          {{- toYaml .Values.extraEnv | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/cloud/helm-chart/src/main/helm/values.yaml
+++ b/cloud/helm-chart/src/main/helm/values.yaml
@@ -35,6 +35,7 @@ initContainers: []
 
 args: ["start", "-v", "-e"]
 env: []
+extraEnv: []
 configPath: /etc/zilla
 configMaps: {}
 secrets: {}

--- a/cloud/helm-chart/src/main/helm/values.yaml
+++ b/cloud/helm-chart/src/main/helm/values.yaml
@@ -34,7 +34,6 @@ readinessProbePort: 0
 initContainers: []
 
 args: ["start", "-v", "-e"]
-env: []
 extraEnv: []
 configPath: /etc/zilla
 configMaps: {}


### PR DESCRIPTION
## Description

Add `extraEnv` option to offer an easier way of overriding environment variables.

Fixes #520 