### PR TITLE
Include data payload as hex in the output of log command

### DIFF
--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LogCommand.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LogCommand.java
@@ -72,7 +72,7 @@ public final class LogCommand
 
         final boolean hasVersion = cmdline.hasOption("version");
         final boolean hasDirectory = cmdline.hasOption("directory");
-        final boolean isPayloadIncluded = cmdline.hasOption("payload");
+        final boolean hasPayload = cmdline.hasOption("payload");
         final boolean hasHelp = cmdline.hasOption("help");
 
         if (hasVersion)
@@ -122,7 +122,7 @@ public final class LogCommand
                     frameTypes == null ? t -> true : Arrays.asList(frameTypes)::contains;
 
                 command = new LogStreamsCommand(config, out, hasFrameTypes, hasExtensionType, verbose,
-                    continuous, isPayloadIncluded, affinity, position);
+                    continuous, hasPayload, affinity, position);
             }
             else if ("buffers".equals(type))
             {

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LogCommand.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LogCommand.java
@@ -65,12 +65,14 @@ public final class LogCommand
         options.addOption(builder("i").hasArg().longOpt("interval").desc("run command continuously at interval").build());
         options.addOption(builder("s").longOpt("separator").desc("include thousands separator in integer values").build());
         options.addOption(builder("a").hasArg().longOpt("affinity").desc("affinity mask").build());
+        options.addOption(builder("p").longOpt("payload").desc("include data payloads as hex").build());
 
         final CommandLine cmdline = parser.parse(options, args);
         final Logger out = System.out::printf;
 
         final boolean hasVersion = cmdline.hasOption("version");
         final boolean hasDirectory = cmdline.hasOption("directory");
+        final boolean isPayloadIncluded = cmdline.hasOption("payload");
         final boolean hasHelp = cmdline.hasOption("help");
 
         if (hasVersion)
@@ -120,7 +122,7 @@ public final class LogCommand
                     frameTypes == null ? t -> true : Arrays.asList(frameTypes)::contains;
 
                 command = new LogStreamsCommand(config, out, hasFrameTypes, hasExtensionType, verbose,
-                    continuous, affinity, position);
+                    continuous, isPayloadIncluded, affinity, position);
             }
             else if ("buffers".equals(type))
             {

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LogStreamsCommand.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LogStreamsCommand.java
@@ -50,7 +50,7 @@ public final class LogStreamsCommand implements Runnable
     private final LabelManager labels;
     private final boolean verbose;
     private final boolean continuous;
-    private final boolean isPayloadIncluded;
+    private final boolean withPayload;
     private final long affinity;
     private final SpyPosition position;
     private final Logger out;
@@ -64,7 +64,7 @@ public final class LogStreamsCommand implements Runnable
         Predicate<String> hasExtensionType,
         boolean verbose,
         boolean continuous,
-        boolean isPayloadIncluded,
+        boolean withPayload,
         long affinity,
         SpyPosition position)
     {
@@ -72,7 +72,7 @@ public final class LogStreamsCommand implements Runnable
         this.labels = new LabelManager(directory);
         this.verbose = verbose;
         this.continuous = continuous;
-        this.isPayloadIncluded = isPayloadIncluded;
+        this.withPayload = withPayload;
         this.affinity = affinity;
         this.position = position;
         this.out = out;
@@ -107,7 +107,7 @@ public final class LogStreamsCommand implements Runnable
                 .spyAt(position)
                 .build();
 
-        return new LoggableStream(index, labels, layout, out, hasFrameType, hasExtensionType, isPayloadIncluded,
+        return new LoggableStream(index, labels, layout, out, hasFrameType, hasExtensionType, withPayload,
             this::nextTimestamp);
     }
 

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LogStreamsCommand.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LogStreamsCommand.java
@@ -50,6 +50,7 @@ public final class LogStreamsCommand implements Runnable
     private final LabelManager labels;
     private final boolean verbose;
     private final boolean continuous;
+    private final boolean isPayloadIncluded;
     private final long affinity;
     private final SpyPosition position;
     private final Logger out;
@@ -63,6 +64,7 @@ public final class LogStreamsCommand implements Runnable
         Predicate<String> hasExtensionType,
         boolean verbose,
         boolean continuous,
+        boolean isPayloadIncluded,
         long affinity,
         SpyPosition position)
     {
@@ -70,6 +72,7 @@ public final class LogStreamsCommand implements Runnable
         this.labels = new LabelManager(directory);
         this.verbose = verbose;
         this.continuous = continuous;
+        this.isPayloadIncluded = isPayloadIncluded;
         this.affinity = affinity;
         this.position = position;
         this.out = out;
@@ -104,7 +107,8 @@ public final class LogStreamsCommand implements Runnable
                 .spyAt(position)
                 .build();
 
-        return new LoggableStream(index, labels, layout, out, hasFrameType, hasExtensionType, this::nextTimestamp);
+        return new LoggableStream(index, labels, layout, out, hasFrameType, hasExtensionType, isPayloadIncluded,
+            this::nextTimestamp);
     }
 
     private void onDiscovered(

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LoggableStream.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LoggableStream.java
@@ -23,6 +23,7 @@ import java.util.function.Consumer;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
 
+import org.agrona.BitUtil;
 import org.agrona.DirectBuffer;
 import org.agrona.collections.Int2ObjectHashMap;
 
@@ -395,12 +396,9 @@ public final class LoggableStream implements AutoCloseable
             final OctetsFW payload = data.payload();
             if (payload != null)
             {
-                StringBuilder hexData = new StringBuilder();
-                for (int i = 0; i < data.length(); i++)
-                {
-                    hexData.append(String.format("%02x", payload.buffer().getByte(payload.offset() + i)));
-                    hexData.append(i < data.length() - 1 ? ':' : "");
-                }
+                byte[] bytes = new byte[data.length()];
+                payload.buffer().getBytes(0, bytes);
+                String hexData = BitUtil.toHex(bytes).replaceAll("(..)(?!$)", "$1:");
                 out.printf(verboseFormat, index, offset, timestamp, hexData);
             }
         }

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LoggableStream.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LoggableStream.java
@@ -157,7 +157,7 @@ public final class LoggableStream implements AutoCloseable
     private final StreamsLayout layout;
     private final RingBufferSpy streamsBuffer;
     private final Logger out;
-    private final boolean isPayloadIncluded;
+    private final boolean withPayload;
     private final LongPredicate nextTimestamp;
 
     private final Int2ObjectHashMap<MessageConsumer> frameHandlers;
@@ -174,7 +174,7 @@ public final class LoggableStream implements AutoCloseable
         Logger logger,
         Predicate<String> hasFrameType,
         Predicate<String> hasExtensionType,
-        boolean isPayloadIncluded,
+        boolean withPayload,
         LongPredicate nextTimestamp)
     {
         this.index = index;
@@ -186,7 +186,7 @@ public final class LoggableStream implements AutoCloseable
         this.layout = layout;
         this.streamsBuffer = layout.streamsBuffer();
         this.out = logger;
-        this.isPayloadIncluded = isPayloadIncluded;
+        this.withPayload = withPayload;
         this.nextTimestamp = nextTimestamp;
 
         final Int2ObjectHashMap<MessageConsumer> frameHandlers = new Int2ObjectHashMap<>();
@@ -390,9 +390,19 @@ public final class LoggableStream implements AutoCloseable
             sequence - acknowledge + reserved, maximum, format("DATA [0x%016x] [%d] [%d] [%x] [0x%016x]",
                     budgetId, length, reserved, flags, authorization));
 
-        if (isPayloadIncluded)
+        if (withPayload)
         {
-            onDataPayload(data);
+            final OctetsFW payload = data.payload();
+            if (payload != null)
+            {
+                StringBuilder hexData = new StringBuilder();
+                for (int i = 0; i < data.length(); i++)
+                {
+                    hexData.append(String.format("%02x", payload.buffer().getByte(payload.offset() + i)));
+                    hexData.append(i < data.length() - 1 ? ':' : "");
+                }
+                out.printf(verboseFormat, index, offset, timestamp, hexData);
+            }
         }
 
         final ExtensionFW extension = data.extension().get(extensionRO::tryWrap);
@@ -403,25 +413,6 @@ public final class LoggableStream implements AutoCloseable
             {
                 dataHandler.accept(data);
             }
-        }
-    }
-
-    private void onDataPayload(
-        final DataFW data)
-    {
-        final int offset = data.offset() - HEADER_LENGTH;
-        final long timestamp = data.timestamp();
-        final OctetsFW payload = data.payload();
-
-        if (payload != null)
-        {
-            StringBuilder hexData = new StringBuilder();
-            for (int i = 0; i < data.length(); i++)
-            {
-                hexData.append(String.format("%02x", payload.buffer().getByte(payload.offset() + i)));
-                hexData.append(i < data.length() - 1 ? ':' : "");
-            }
-            out.printf(verboseFormat, index, offset, timestamp, hexData);
         }
     }
 


### PR DESCRIPTION
## Description

Create a command line switch `-p` or `--payload` to include the payload of the `DATA` frames as a hex string in the output of the `log` command.

Fixes # (issue)
