### PR TITLE
Use coordinator member list to check if the heartbeat is allowed

### DIFF
--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientGroupFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientGroupFactory.java
@@ -3946,7 +3946,10 @@ public final class KafkaClientGroupFactory extends KafkaClientSaslHandshaker imp
         private void doHeartbeatRequest(
             long traceId)
         {
-            if (!members.isEmpty())
+            final String memberId = delegate.groupMembership.memberIds.getOrDefault(delegate.groupId, UNKNOWN_MEMBER_ID);
+
+            if (KafkaState.initialOpened(state) &&
+                !memberId.equals(UNKNOWN_MEMBER_ID))
             {
                 if (heartbeatRequestId != NO_CANCEL_ID)
                 {

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientGroupFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientGroupFactory.java
@@ -3946,9 +3946,7 @@ public final class KafkaClientGroupFactory extends KafkaClientSaslHandshaker imp
         private void doHeartbeatRequest(
             long traceId)
         {
-            final String memberId = delegate.groupMembership.memberIds.getOrDefault(delegate.groupId, UNKNOWN_MEMBER_ID);
-
-            if (!memberId.equals(UNKNOWN_MEMBER_ID))
+            if (!members.isEmpty())
             {
                 if (heartbeatRequestId != NO_CANCEL_ID)
                 {


### PR DESCRIPTION
## Description

Unexpected flush causes NPE in the connection pool 

Fixes #546
