### PR TITLE
Etag header field name MUST be converted to lowercase prior to their encoding in HTTP/2

### DIFF
--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/stream/HttpFileSystemProxyFactory.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/stream/HttpFileSystemProxyFactory.java
@@ -55,7 +55,7 @@ public final class HttpFileSystemProxyFactory implements HttpFileSystemStreamFac
     private static final String8FW HEADER_STATUS_NAME = new String8FW(":status");
     private static final String16FW HEADER_STATUS_VALUE_200 = new String16FW("200");
     private static final String16FW HEADER_STATUS_VALUE_304 = new String16FW("304");
-    private static final String8FW HEADER_ETAG_NAME = new String8FW("Etag");
+    private static final String8FW HEADER_ETAG_NAME = new String8FW("etag");
     private static final String8FW HEADER_CONTENT_TYPE_NAME = new String8FW("content-type");
     private static final String8FW HEADER_CONTENT_LENGTH_NAME = new String8FW("content-length");
     private static final int READ_PAYLOAD_MASK = 1 << FileSystemCapabilities.READ_PAYLOAD.ordinal();

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.map.modified/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.map.modified/client.rpt
@@ -36,7 +36,7 @@ read zilla:begin.ext ${http:beginEx()
                            .header(":status", "200")
                            .header("content-type", "text/html")
                            .header("content-length", "77")
-                           .header("Etag", "BBBBBBBBBBBBBBBB")
+                           .header("etag", "BBBBBBBBBBBBBBBB")
                            .build()}
 read "<html>\n"
      "<head><title>Welcome</title></head>\n"

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.map.modified/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.map.modified/server.rpt
@@ -37,7 +37,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":status", "200")
                             .header("content-type", "text/html")
                             .header("content-length", "77")
-                            .header("Etag", "BBBBBBBBBBBBBBBB")
+                            .header("etag", "BBBBBBBBBBBBBBBB")
                             .build()}
 write "<html>\n"
       "<head><title>Welcome</title></head>\n"

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.map.not.modified/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.map.not.modified/client.rpt
@@ -36,7 +36,7 @@ read zilla:begin.ext ${http:beginEx()
                            .header(":status", "304")
                            .header("content-type", "text/html")
                            .header("content-length", "0")
-                           .header("Etag", "AAAAAAAAAAAAAAAA")
+                           .header("etag", "AAAAAAAAAAAAAAAA")
                            .build()}
 
 read closed

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.map.not.modified/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.map.not.modified/server.rpt
@@ -37,6 +37,6 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":status", "304")
                             .header("content-type", "text/html")
                             .header("content-length", "0")
-                            .header("Etag", "AAAAAAAAAAAAAAAA")
+                            .header("etag", "AAAAAAAAAAAAAAAA")
                             .build()}
 write close

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.with.query/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.with.query/client.rpt
@@ -34,7 +34,7 @@ read zilla:begin.ext ${http:beginEx()
                            .header(":status", "200")
                            .header("content-type", "text/html")
                            .header("content-length", "77")
-                           .header("Etag", "c7183509522eb56e5cf927a3b2e8c15a")
+                           .header("etag", "c7183509522eb56e5cf927a3b2e8c15a")
                            .build()}
 read "<html>\n"
      "<head><title>Welcome</title></head>\n"

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.with.query/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.with.query/server.rpt
@@ -35,7 +35,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":status", "200")
                             .header("content-type", "text/html")
                             .header("content-length", "77")
-                            .header("Etag", "c7183509522eb56e5cf927a3b2e8c15a")
+                            .header("etag", "c7183509522eb56e5cf927a3b2e8c15a")
                             .build()}
 write "<html>\n"
       "<head><title>Welcome</title></head>\n"

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file/client.rpt
@@ -34,7 +34,7 @@ read zilla:begin.ext ${http:beginEx()
                            .header(":status", "200")
                            .header("content-type", "text/html")
                            .header("content-length", "77")
-                           .header("Etag", "c7183509522eb56e5cf927a3b2e8c15a")
+                           .header("etag", "c7183509522eb56e5cf927a3b2e8c15a")
                            .build()}
 read "<html>\n"
      "<head><title>Welcome</title></head>\n"

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file/server.rpt
@@ -35,7 +35,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":status", "200")
                             .header("content-type", "text/html")
                             .header("content-length", "77")
-                            .header("Etag", "c7183509522eb56e5cf927a3b2e8c15a")
+                            .header("etag", "c7183509522eb56e5cf927a3b2e8c15a")
                             .build()}
 write "<html>\n"
       "<head><title>Welcome</title></head>\n"


### PR DESCRIPTION
## Description

[Header field names MUST be converted to lowercase prior to their encoding in HTTP/2.](https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2)  Etag header name has upper case as first later

Fixes #551
