### PR TITLE
Handle fragmentation in HttpFetchManyProxy

### DIFF
--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/stream/HttpKafkaProxyFactory.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/stream/HttpKafkaProxyFactory.java
@@ -1174,7 +1174,7 @@ public final class HttpKafkaProxyFactory implements HttpKafkaStreamFactory
 
                     replyPadAdjust = reservedPre;
                 }
-                else if (replyMsgs > 0)
+                else if ((flags & DATA_FLAG_INIT) != 0x00 && replyMsgs > 0)
                 {
                     OctetsFW preamble = fetcher.resolved.separator();
                     int reservedSep = preamble.sizeof();

--- a/runtime/binding-http-kafka/src/test/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/stream/HttpKafkaProxyIT.java
+++ b/runtime/binding-http-kafka/src/test/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/stream/HttpKafkaProxyIT.java
@@ -15,9 +15,11 @@
 package io.aklivity.zilla.runtime.binding.http.kafka.internal.stream;
 
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_BUFFER_SLOT_CAPACITY;
+import static io.aklivity.zilla.runtime.engine.test.EngineRule.ENGINE_BUFFER_SLOT_CAPACITY_NAME;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
+import io.aklivity.zilla.runtime.engine.test.annotation.Configure;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -424,6 +426,16 @@ public class HttpKafkaProxyIT
         "${http}/get.items/client",
         "${kafka}/get.items/server"})
     public void shouldGetItems() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.get.items.yaml")
+    @Specification({
+        "${http}/get.items.fragmented/client",
+        "${kafka}/get.items.fragmented/server"})
+    public void shouldGetItemsFragmented() throws Exception
     {
         k3po.finish();
     }

--- a/runtime/binding-http-kafka/src/test/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/stream/HttpKafkaProxyIT.java
+++ b/runtime/binding-http-kafka/src/test/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/stream/HttpKafkaProxyIT.java
@@ -15,11 +15,9 @@
 package io.aklivity.zilla.runtime.binding.http.kafka.internal.stream;
 
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_BUFFER_SLOT_CAPACITY;
-import static io.aklivity.zilla.runtime.engine.test.EngineRule.ENGINE_BUFFER_SLOT_CAPACITY_NAME;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
-import io.aklivity.zilla.runtime.engine.test.annotation.Configure;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.fragmented/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.fragmented/client.rpt
@@ -1,0 +1,48 @@
+#
+# Copyright 2021-2023 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/http0"
+        option zilla:window 64
+        option zilla:transmission "half-duplex"
+        option zilla:update "proactive"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "GET")
+                            .header(":scheme", "https")
+                            .header(":authority", "example.com:9090")
+                            .header(":path", "/items")
+                            .build()}
+
+connected
+
+write close
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":status", "200")
+                           .header("content-type", "application/json")
+                           .header("etag", "AQQAAgIC")
+                           .build()}
+
+read '['
+     '{ "key": "Irish_Pub", "icon": "airport_shuttle", "coordinate": [ -121.888074, 37.328473, 29 ] }'
+     ','
+     '{ "key": "ISO_Beers", "icon": "airport_shuttle", "coordinate": [ -121.888074, 37.328473, 29 ] }'
+
+read advised zilla:flush
+
+read ']'
+read closed

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.fragmented/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.fragmented/server.rpt
@@ -1,0 +1,47 @@
+#
+# Copyright 2021-2023 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/http0"
+       option zilla:window 64
+       option zilla:transmission "half-duplex"
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "GET")
+                           .header(":path", "/items")
+                           .build()}
+
+connected
+
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "200")
+                            .header("content-type", "application/json")
+                            .header("etag", "AQQAAgIC")
+                            .build()}
+
+write '['
+      '{ "key": "Irish_Pub", "icon": "airport_shuttle", "coordinate": [ -121.888074, 37.328473, 29 ] }'
+      ','
+      '{ "key": "ISO_Beers", "icon": "airport_shuttle", "coordinate": [ -121.888074, 37.328473, 29 ] }'
+
+write advise zilla:flush
+
+write ']'
+
+write close

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.fragmented/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.fragmented/client.rpt
@@ -1,0 +1,81 @@
+#
+# Copyright 2021-2023 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/kafka0"
+    option zilla:window 64
+    option zilla:transmission "duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                             .typeId(zilla:id("kafka"))
+                             .merged()
+                                 .capabilities("FETCH_ONLY")
+                                 .topic("items-snapshots")
+                                 .partition(-1, 0, -2)
+                                 .filter()
+                                     .header("zilla:identity", "test")
+                                     .build()
+                                 .build()
+                             .build()}
+
+read zilla:begin.ext ${kafka:matchBeginEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .capabilities("FETCH_ONLY")
+                                .topic("items-snapshots")
+                                .partition(0, 0, 1)
+                                .partition(1, 0, 1)
+                                .build()
+                            .build()}
+
+connected
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(0, 1, 1)
+                               .progress(0, 2)
+                               .progress(1, 1)
+                               .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                               .header("zilla:identity", "test")
+                               .header("content-type", "application/json")
+                               .header("etag", "revision=42")
+                               .build()
+                           .build()}
+read '{ "key": "Irish_Pub", "icon": "airport_shuttle", "coordinate": [ -121.888074, 37.328473, 29 ] }'
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                               .partition(1, 1, 1)
+                               .progress(0, 2)
+                               .progress(1, 2)
+                               .key("beb6ef9e-8da7-451f-b3c4-136d49a058f3")
+                               .header("zilla:identity", "test")
+                               .header("etag", "revision=237")
+                               .build()
+                           .build()}
+read '{ "key": "ISO_Beers", "icon": "airport_shuttle", "coordinate": [ -121.888074, 37.328473, 29 ] }'
+
+read advised zilla:flush ${kafka:matchFlushEx()
+                               .typeId(zilla:id("kafka"))
+                               .merged()
+                                 .fetch()
+                                   .progress(0, 1, 1, 1)
+                                   .progress(1, 1, 1, 1)
+                                   .build()
+                               .build()}
+
+read closed
+write close

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.fragmented/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.fragmented/server.rpt
@@ -1,0 +1,87 @@
+#
+# Copyright 2021-2023 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/kafka0"
+    option zilla:window 64
+    option zilla:transmission "duplex"
+
+accepted
+
+read zilla:begin.ext ${kafka:matchBeginEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .capabilities("FETCH_ONLY")
+                                .topic("items-snapshots")
+                                .partition(-1, 0, -2)
+                                .filter()
+                                    .header("zilla:identity", "test")
+                                    .build()
+                                .build()
+                            .build()}
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .merged()
+                                   .capabilities("FETCH_ONLY")
+                                   .topic("items-snapshots")
+                                   .partition(0, 0, 1)
+                                   .partition(1, 0, 1)
+                                   .build()
+                               .build()}
+
+connected
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .timestamp(kafka:timestamp())
+                                .partition(0, 1, 1)
+                                .progress(0, 2)
+                                .progress(1, 1)
+                                .key("92d0bf92-63e0-4cfc-ae73-71dee92d1544")
+                                .header("zilla:identity", "test")
+                                .header("content-type", "application/json")
+                                .header("etag", "revision=42")
+                                .build()
+                            .build()}
+write '{ "key": "Irish_Pub", "icon": "airport_shuttle", "coordinate": [ -121.888074, 37.328473, 29 ] }'
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .timestamp(kafka:timestamp())
+                                .partition(1, 1, 1)
+                                .progress(0, 2)
+                                .progress(1, 2)
+                                .key("beb6ef9e-8da7-451f-b3c4-136d49a058f3")
+                                .header("zilla:identity", "test")
+                                .header("etag", "revision=237")
+                                .build()
+                            .build()}
+write '{ "key": "ISO_Beers", "icon": "airport_shuttle", "coordinate": [ -121.888074, 37.328473, 29 ] }'
+write flush
+
+write advise zilla:flush ${kafka:flushEx()
+                               .typeId(zilla:id("kafka"))
+                               .merged()
+                                 .fetch()
+                                   .progress(0, 1, 1, 1)
+                                   .progress(1, 1, 1, 1)
+                                   .build()
+                               .build()}
+
+write close
+read closed

--- a/specs/binding-http-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/http/kafka/streams/HttpIT.java
+++ b/specs/binding-http-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/http/kafka/streams/HttpIT.java
@@ -325,6 +325,15 @@ public class HttpIT
 
     @Test
     @Specification({
+        "${http}/get.items.fragmented/client",
+        "${http}/get.items.fragmented/server"})
+    public void shouldGetItemsFragmented() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${http}/get.items.empty/client",
         "${http}/get.items.empty/server"})
     public void shouldGetItemsEmpty() throws Exception

--- a/specs/binding-http-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/http/kafka/streams/KafkaIT.java
+++ b/specs/binding-http-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/http/kafka/streams/KafkaIT.java
@@ -316,6 +316,15 @@ public class KafkaIT
 
     @Test
     @Specification({
+        "${kafka}/get.items.fragmented/client",
+        "${kafka}/get.items.fragmented/server"})
+    public void shouldGetItemsFragmented() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${kafka}/get.items.empty/client",
         "${kafka}/get.items.empty/server"})
     public void shouldGetItemsEmpty() throws Exception


### PR DESCRIPTION
## Description

Due to missing fragmentation support, we kept adding additional separators(`,`)  

Fixes #528
