### PR TITLE
Include metadata and partitionOffset into merge reply begin

### DIFF
--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaMergedFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaMergedFactory.java
@@ -37,6 +37,7 @@ import org.agrona.collections.Int2IntHashMap;
 import org.agrona.collections.Int2ObjectHashMap;
 import org.agrona.collections.Long2LongHashMap;
 import org.agrona.collections.MutableInteger;
+import org.agrona.collections.MutableLong;
 import org.agrona.collections.MutableReference;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -158,6 +159,8 @@ public final class KafkaMergedFactory implements BindingHandler
     private final MutableInteger initialNoAckRW = new MutableInteger();
     private final MutableInteger initialPadRW = new MutableInteger();
     private final MutableInteger initialMaxRW = new MutableInteger();
+    private final MutableLong partitionOffsetRW = new MutableLong();
+    private final StringBuilder metadataRW = new StringBuilder();
 
     private final int kafkaTypeId;
     private final MutableDirectBuffer writeBuffer;
@@ -1614,12 +1617,25 @@ public final class KafkaMergedFactory implements BindingHandler
             return builder ->
             {
                 builder.capabilities(c -> c.set(FETCH_ONLY)).topic(topic);
-                latestOffsetByPartitionId.longForEach((k, v) -> builder
-                    .partitionsItem(i -> i
-                        .partitionId((int) k)
-                        .partitionOffset(0L)
-                        .stableOffset(stableOffsetByPartitionId.get(k))
-                        .latestOffset(v)));
+                latestOffsetByPartitionId.longForEach((k, v) ->
+                {
+                    partitionOffsetRW.value = 0;
+                    metadataRW.setLength(0);
+                    if (!offsetsByPartitionId.isEmpty())
+                    {
+                        final KafkaPartitionOffset kafkaPartitionOffset = offsetsByPartitionId.get(k);
+                        partitionOffsetRW.value = kafkaPartitionOffset.partitionOffset;
+                        metadataRW.append(kafkaPartitionOffset.metadata);
+                    }
+
+                    builder
+                        .partitionsItem(i -> i
+                            .partitionId((int) k)
+                            .partitionOffset(partitionOffsetRW.value)
+                            .stableOffset(stableOffsetByPartitionId.get(k))
+                            .latestOffset(v)
+                            .metadata(metadataRW.toString()));
+                });
             };
         }
 

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaMergedFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaMergedFactory.java
@@ -1623,7 +1623,7 @@ public final class KafkaMergedFactory implements BindingHandler
                     metadataRW.setLength(0);
                     if (!offsetsByPartitionId.isEmpty())
                     {
-                        final KafkaPartitionOffset kafkaPartitionOffset = offsetsByPartitionId.get(k);
+                        final KafkaPartitionOffset kafkaPartitionOffset = offsetsByPartitionId.get((int) k);
                         partitionOffsetRW.value = kafkaPartitionOffset.partitionOffset;
                         metadataRW.append(kafkaPartitionOffset.metadata);
                     }
@@ -1964,7 +1964,7 @@ public final class KafkaMergedFactory implements BindingHandler
                     p.partitionOffset(),
                     0,
                     p.leaderEpoch(),
-                    null)));
+                    p.metadata().asString())));
 
             doFetchPartitionsIfNecessary(traceId);
         }

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaMergedFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaMergedFactory.java
@@ -1634,7 +1634,7 @@ public final class KafkaMergedFactory implements BindingHandler
                             .partitionOffset(partitionOffsetRW.value)
                             .stableOffset(stableOffsetByPartitionId.get(k))
                             .latestOffset(v)
-                            .metadata(metadataRW.toString()));
+                            .metadata(metadataRW.length() > 0 ? metadataRW.toString() : null));
                 });
             };
         }

--- a/specs/binding-kafka.spec/src/main/java/io/aklivity/zilla/specs/binding/kafka/internal/KafkaFunctions.java
+++ b/specs/binding-kafka.spec/src/main/java/io/aklivity/zilla/specs/binding/kafka/internal/KafkaFunctions.java
@@ -1094,10 +1094,22 @@ public final class KafkaFunctions
                 long stableOffset,
                 long latestOffset)
             {
+                partition(partitionId, offset, stableOffset, latestOffset, null);
+                return this;
+            }
+
+            public KafkaMergedBeginExBuilder partition(
+                int partitionId,
+                long offset,
+                long stableOffset,
+                long latestOffset,
+                String metadata)
+            {
                 mergedBeginExRW.partitionsItem(p -> p.partitionId(partitionId)
-                                                     .partitionOffset(offset)
-                                                     .stableOffset(stableOffset)
-                                                     .latestOffset(latestOffset));
+                    .partitionOffset(offset)
+                    .stableOffset(stableOffset)
+                    .latestOffset(latestOffset)
+                    .metadata(metadata));
                 return this;
             }
 
@@ -5540,6 +5552,17 @@ public final class KafkaFunctions
                 long stableOffset,
                 long latestOffset)
             {
+                partition(partitionId, offset, stableOffset, latestOffset, null);
+                return this;
+            }
+
+            public KafkaMergedBeginExMatcherBuilder partition(
+                int partitionId,
+                long offset,
+                long stableOffset,
+                long latestOffset,
+                String metadata)
+            {
                 if (partitionsRW == null)
                 {
                     this.partitionsRW = new Array32FW.Builder<>(new KafkaOffsetFW.Builder(),
@@ -5549,7 +5572,8 @@ public final class KafkaFunctions
                     .partitionId(partitionId)
                     .partitionOffset(offset)
                     .stableOffset(stableOffset)
-                    .latestOffset(latestOffset));
+                    .latestOffset(latestOffset)
+                    .metadata(metadata));
                 return this;
             }
 

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.ack/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.ack/client.rpt
@@ -34,6 +34,15 @@ write zilla:begin.ext ${kafka:beginEx()
 
 connected
 
+read zilla:begin.ext ${kafka:matchBeginEx()
+                               .typeId(zilla:id("kafka"))
+                               .merged()
+                                   .capabilities("FETCH_ONLY")
+                                   .topic("test")
+                                   .partition(0, 2, 2, 2, "test-meta")
+                                   .build()
+                               .build()}
+
 read zilla:data.ext ${kafka:matchDataEx()
                              .typeId(zilla:id("kafka"))
                              .merged()

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.ack/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.ack/server.rpt
@@ -39,6 +39,16 @@ read zilla:begin.ext ${kafka:beginEx()
 
 connected
 
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .merged()
+                                   .capabilities("FETCH_ONLY")
+                                   .topic("test")
+                                   .partition(0, 2, 2, 2, "test-meta")
+                                   .build()
+                               .build()}
+write flush
+
 write zilla:data.ext ${kafka:dataEx()
                               .typeId(zilla:id("kafka"))
                               .merged()

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.fetch.message.ack/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.fetch.message.ack/client.rpt
@@ -99,7 +99,7 @@ read zilla:begin.ext ${kafka:beginEx()
 read zilla:data.ext ${kafka:dataEx()
                              .typeId(zilla:id("kafka"))
                              .meta()
-                                 .partition(0, 1)
+                                 .partition(0, 2)
                                  .partition(1, 2)
                                  .build()
                              .build()}

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.fetch.message.ack/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.fetch.message.ack/server.rpt
@@ -102,7 +102,7 @@ write flush
 write zilla:data.ext ${kafka:dataEx()
                               .typeId(zilla:id("kafka"))
                               .meta()
-                                  .partition(0, 1)
+                                  .partition(0, 2)
                                   .partition(1, 2)
                                   .build()
                               .build()}


### PR DESCRIPTION
## Description

We should include metadata as part of merge reply begin ex

```
read zilla:begin.ext ${kafka:matchBeginEx()
                               .typeId(zilla:id("kafka"))
                               .merged()
                                   .capabilities("FETCH_ONLY")
                                   .topic("test")
                                   .partition(0, 2, 2, 2, "test-meta")
                                   .build()
                               .build()}
```

Fixes #601
