### PR TITLE
Fix `java.util.MissingFormatArgumentException` when using Kafka debugging.

### DIFF
--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientProduceFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientProduceFactory.java
@@ -1313,6 +1313,8 @@ public final class KafkaClientProduceFactory extends KafkaClientSaslHandshaker i
                 stream.doApplicationBeginIfNecessary(traceId, authorization, topic, partitionId);
             }
 
+            private long networkBytesReceived;
+
             private void onNetworkData(
                 DataFW data)
             {
@@ -1324,6 +1326,7 @@ public final class KafkaClientProduceFactory extends KafkaClientSaslHandshaker i
                 assert acknowledge <= sequence;
                 assert sequence >= replySeq;
 
+                networkBytesReceived += Math.max(data.length(), 0);
                 authorization = data.authorization();
                 replySeq = sequence + data.reserved();
 
@@ -1385,7 +1388,8 @@ public final class KafkaClientProduceFactory extends KafkaClientSaslHandshaker i
 
                 if (KafkaConfiguration.DEBUG)
                 {
-                    System.out.format("[client] %s[%s] PRODUCE aborted (%d bytes)\n", topic, partitionId);
+                    System.out.format("[client] %s[%s] PRODUCE aborted (%d bytes)\n",
+                        topic, partitionId, network, networkBytesReceived);
                 }
 
                 state = KafkaState.closedReply(state);
@@ -1400,7 +1404,8 @@ public final class KafkaClientProduceFactory extends KafkaClientSaslHandshaker i
 
                 if (KafkaConfiguration.DEBUG)
                 {
-                    System.out.format("[client] %s[%d] PRODUCE reset (%d bytes)\n", topic, partitionId);
+                    System.out.format("[client] %s[%d] PRODUCE reset (%d bytes)\n",
+                        topic, partitionId, networkBytesReceived);
                 }
 
                 state = KafkaState.closedInitial(state);


### PR DESCRIPTION
While testing Zilla with `zilla.binding.kafka.debug=true`, I was encountering `java.util.MissingFormatArgumentException` errors that would cause Zilla to exit. This change mimics what I saw elsewhere in the Kafka binding where bytes were being logged.
