### PR TITLE
Update latest and stable offset if it was in stabilizing state

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -3734,6 +3734,8 @@ public final class HttpClientFactory implements HttpStreamFactory
                                 break;
                             }
                             stream.remoteBudget = (int) newRemoteBudget;
+
+                            stream.flushRequestWindow(traceId, 0);
                         }
                     }
                 }

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/server.sent.100k.message/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/server.sent.100k.message/client.rpt
@@ -39,6 +39,8 @@ read zilla:begin.ext ${http:beginEx()
                              .header("content-length", "100000")
                              .build()}
 
+read notify HTTP2_SETTINGS_ACK_RECEIVED
+
 read [0..100000]
 
 read closed

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/server.sent.100k.message/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/server.sent.100k.message/server.rpt
@@ -39,6 +39,9 @@ write zilla:begin.ext ${http:beginEx()
                             .header("content-type", "text/html; charset=UTF-8")
                             .header("content-length", "100000")
                             .build()}
+write flush
+
+write await HTTP2_SETTINGS_ACK_RECEIVED
 
 write ${http:randomBytes(100000)}
 write flush

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/server.sent.100k.message/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/server.sent.100k.message/client.rpt
@@ -64,6 +64,8 @@ read [0x00 0x00 0x00]                   # length = 0
      [0x01]                             # ACK
      [0x00 0x00 0x00 0x00]              # stream_id = 0
 
+read notify HTTP2_SETTINGS_ACK_RECEIVED
+
 read [0x00 0x00 0x5c]                                         # length
      [0x01]                                                   # HTTP2 HEADERS frame
      [0x04]                                                   # END_HEADERS
@@ -73,6 +75,7 @@ read [0x00 0x00 0x5c]                                         # length
      [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"       # date
      [0x0f 0x10] [0x18] "text/html; charset=UTF-8"            # content-type
      [0x0f 0x0d] [0x06] "100000"                              # content-length
+
 
 read [0x00 0x40 0x00]                  # length = 16384
      [0x00]                            # HTTP2 DATA frame


### PR DESCRIPTION
## Description

This is a current understanding of the issue

```
zilla: offset <= stable <= latest
which means offset <= stable, stable <= latest, offset <= latest
kafka: offset < stable <= high water mark
which means offset < stable, stable <= high water mark, offset < high water mark
```

Due to this invariant sometimes we may get into a state where the fix to send a flush when stableOffset or latestOffset has advanced (with no records) after records have been sent or caught up to the latest offset so at least one FLUSH was already sent.

Fixes #666
