### PR TITLE
update license exclude path to include both zpmw files

### DIFF
--- a/cloud/docker-image/pom.xml
+++ b/cloud/docker-image/pom.xml
@@ -284,7 +284,7 @@
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
           <excludes>
-            <exclude>src/main/docker/zpmw</exclude>
+            <exclude>src/main/docker/**/zpmw</exclude>
             <exclude>src/main/docker/zilla</exclude>
             <exclude>src/main/docker/zilla.properties</exclude>
             <exclude>src/main/docker/zilla.yaml</exclude>


### PR DESCRIPTION
## Description

The head of develop doesn't build with this error because the path in the exclusion config is to an old file location.

```
[ERROR] Failed to execute goal com.mycila:license-maven-plugin:4.2:check (default) on project docker-image: Unable to find a comment style definition for some files. You may want to add a custom mapping for the relevant file extensions. -> [Help 1]

```
