### PR TITLE
Fix kafka sasl schema validation to support expressions

### DIFF
--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/schema/kafka.schema.patch.json
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/schema/kafka.schema.patch.json
@@ -112,110 +112,23 @@
                                         "title": "Mechanism",
                                         "type": "string",
                                         "enum": [ "plain", "scram-sha-1", "scram-sha-256", "scram-sha-512" ]
+                                    },
+                                    "username":
+                                    {
+                                        "title": "Username",
+                                        "type": "string"
+                                    },
+                                    "password":
+                                    {
+                                        "title": "Password",
+                                        "type": "string"
                                     }
                                 },
-                                "oneOf":
+                                "required":
                                 [
-                                    {
-                                        "additionalProperties": false,
-                                        "properties":
-                                        {
-                                            "mechanism":
-                                            {
-                                                "const": "plain"
-                                            },
-                                            "username":
-                                            {
-                                                "title": "Username",
-                                                "type": "string"
-                                            },
-                                            "password":
-                                            {
-                                                "title": "Password",
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required":
-                                        [
-                                            "username",
-                                            "password"
-                                        ]
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties":
-                                        {
-                                            "mechanism":
-                                            {
-                                                "const": "scram-sha-1"
-                                            },
-                                            "username":
-                                            {
-                                                "title": "Username",
-                                                "type": "string"
-                                            },
-                                            "password":
-                                            {
-                                                "title": "Password",
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required":
-                                        [
-                                            "username",
-                                            "password"
-                                        ]
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties":
-                                        {
-                                            "mechanism":
-                                            {
-                                                "const": "scram-sha-256"
-                                            },
-                                            "username":
-                                            {
-                                                "title": "Username",
-                                                "type": "string"
-                                            },
-                                            "password":
-                                            {
-                                                "title": "Password",
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required":
-                                        [
-                                            "username",
-                                            "password"
-                                        ]
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties":
-                                        {
-                                            "mechanism":
-                                            {
-                                                "const": "scram-sha-512"
-                                            },
-                                            "username":
-                                            {
-                                                "title": "Username",
-                                                "type": "string"
-                                            },
-                                            "password":
-                                            {
-                                                "title": "Password",
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required":
-                                        [
-                                            "username",
-                                            "password"
-                                        ]
-                                    }
+                                    "mechanism",
+                                    "username",
+                                    "password"
                                 ]
                             }
                         },


### PR DESCRIPTION
## Description

Fix kafka sasl schema validation to support expressions

Fixes #795 
