### PR TITLE
Include qualified vault name on binding

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
@@ -187,8 +187,20 @@ public final class Engine implements Collector, AutoCloseable
         final Map<String, Guard> guardsByType = guards.stream()
             .collect(Collectors.toMap(g -> g.name(), g -> g));
 
-        EngineManager manager = new EngineManager(schemaTypes, bindingsByType::get, guardsByType::get,
-            labels::supplyLabelId, maxWorkers, tuning, workers, logger, context, config, extensions, this::readURL);
+        EngineManager manager = new EngineManager(
+            schemaTypes,
+            bindingsByType::get,
+            guardsByType::get,
+            labels::supplyLabelId,
+            labels::lookupLabel,
+            maxWorkers,
+            tuning,
+            workers,
+            logger,
+            context,
+            config,
+            extensions,
+            this::readURL);
 
         this.configURL = config.configURL();
         String protocol = configURL.getProtocol();

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/BindingConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/BindingConfig.java
@@ -29,6 +29,7 @@ public class BindingConfig
     public transient ToLongFunction<String> resolveId;
 
     public transient long vaultId;
+    public transient String qvault;
 
     public transient long[] metricIds;
 

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineManager.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineManager.java
@@ -71,6 +71,7 @@ public class EngineManager
     private final Function<String, Binding> bindingByType;
     private final Function<String, Guard> guardByType;
     private final ToIntFunction<String> supplyId;
+    private final IntFunction<String> supplyName;
     private final IntFunction<ToIntFunction<KindConfig>> maxWorkers;
     private final Tuning tuning;
     private final Collection<EngineWorker> dispatchers;
@@ -89,6 +90,7 @@ public class EngineManager
         Function<String, Binding> bindingByType,
         Function<String, Guard> guardByType,
         ToIntFunction<String> supplyId,
+        IntFunction<String> supplyName,
         IntFunction<ToIntFunction<KindConfig>> maxWorkers,
         Tuning tuning,
         Collection<EngineWorker> dispatchers,
@@ -102,6 +104,7 @@ public class EngineManager
         this.bindingByType = bindingByType;
         this.guardByType = guardByType;
         this.supplyId = supplyId;
+        this.supplyName = supplyName;
         this.maxWorkers = maxWorkers;
         this.tuning = tuning;
         this.dispatchers = dispatchers;
@@ -242,6 +245,7 @@ public class EngineManager
             if (binding.vault != null)
             {
                 binding.vaultId = resolver.resolve(binding.vault);
+                binding.qvault = resolver.format(binding.vaultId);
             }
 
             if (binding.catalogs != null)
@@ -438,6 +442,14 @@ public class EngineManager
             }
 
             return id;
+        }
+
+        private String format(
+            long namespacedId)
+        {
+            return String.format("%s:%s",
+                    supplyName.apply(NamespacedId.namespaceId(namespacedId)),
+                    supplyName.apply(NamespacedId.localId(namespacedId)));
         }
     }
 

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/namespace/NamespacedId.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/namespace/NamespacedId.java
@@ -18,15 +18,15 @@ package io.aklivity.zilla.runtime.engine.namespace;
 public final class NamespacedId
 {
     public static int namespaceId(
-        long bindingId)
+        long namespacedId)
     {
-        return (int)(bindingId >> Integer.SIZE) & 0xffff_ffff;
+        return (int)(namespacedId >> Integer.SIZE) & 0xffff_ffff;
     }
 
     public static int localId(
-        long bindingId)
+        long namespacedId)
     {
-        return (int)(bindingId >> 0) & 0xffff_ffff;
+        return (int)(namespacedId >> 0) & 0xffff_ffff;
     }
 
     public static long id(


### PR DESCRIPTION
This is helpful for composite binding adapters referencing vaults that may themselves be cross-namespace.