### PR TITLE
Structured models require `catalog` config

### DIFF
--- a/incubator/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/schema/avro.schema.patch.json
+++ b/incubator/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/schema/avro.schema.patch.json
@@ -129,6 +129,10 @@
                         "maxProperties": 1
                     }
                 },
+                "required":
+                [
+                    "catalog"
+                ],
                 "additionalProperties": false
             }
         }

--- a/incubator/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/schema/json.schema.patch.json
+++ b/incubator/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/schema/json.schema.patch.json
@@ -121,6 +121,10 @@
                         "maxProperties": 1
                     }
                 },
+                "required":
+                [
+                    "catalog"
+                ],
                 "additionalProperties": false
             }
         }
@@ -247,6 +251,10 @@
                         "maxProperties": 1
                     }
                 },
+                "required":
+                [
+                    "catalog"
+                ],
                 "additionalProperties": false
             }
         }

--- a/incubator/model-protobuf.spec/src/main/scripts/io/aklivity/zilla/specs/model/protobuf/schema/protobuf.schema.patch.json
+++ b/incubator/model-protobuf.spec/src/main/scripts/io/aklivity/zilla/specs/model/protobuf/schema/protobuf.schema.patch.json
@@ -62,7 +62,8 @@
                                             },
                                             "required":
                                             [
-                                                "id"
+                                                "id",
+                                                "record"
                                             ],
                                             "additionalProperties": false
                                         },
@@ -86,7 +87,8 @@
                                             },
                                             "required":
                                             [
-                                                "schema"
+                                                "schema",
+                                                "record"
                                             ],
                                             "additionalProperties": false
                                         },
@@ -110,7 +112,8 @@
                                             },
                                             "required":
                                             [
-                                                "strategy"
+                                                "strategy",
+                                                "record"
                                             ],
                                             "additionalProperties": false
                                         },
@@ -134,7 +137,8 @@
                                             },
                                             "required":
                                             [
-                                                "subject"
+                                                "subject",
+                                                "record"
                                             ],
                                             "additionalProperties": false
                                         }
@@ -145,6 +149,10 @@
                         "maxProperties": 1
                     }
                 },
+                "required":
+                [
+                    "catalog"
+                ],
                 "additionalProperties": false
             }
         }


### PR DESCRIPTION
Issue: We can configure structure Model without specifying Catalog. But for any structure Model validation catalog is required.

Fix: Schema change for Structured Model [`avro, json, protobuf`] to require Catalog config.