### PR TITLE
Fix NPE in connection pool due to race condition

### DIFF
--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientConnectionPool.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientConnectionPool.java
@@ -1756,15 +1756,18 @@ public final class KafkaClientConnectionPool extends KafkaClientSaslHandshaker
                 final long streamId = requests.peekLong();
                 KafkaClientStream stream = streamsByInitialId.get(streamId);
 
-                long streamAck = stream.initialAck;
-
-                stream.doStreamWindow(authorization, traceId);
-
-                credit = Math.max(credit - (int)(streamAck - stream.initialAck), 0);
-
-                if (stream.initialAck != stream.initialSeq)
+                if (stream != null)
                 {
-                    break;
+                    long streamAck = stream.initialAck;
+
+                    stream.doStreamWindow(authorization, traceId);
+
+                    credit = Math.max(credit - (int)(streamAck - stream.initialAck), 0);
+
+                    if (stream.initialAck != stream.initialSeq)
+                    {
+                        break;
+                    }
                 }
 
                 requests.removeLong();


### PR DESCRIPTION
## Description

Race condition causes streamsByInitialId to be cleaned up early then request gets acked causing NPE.

Fixes #762 
