### PR TITLE
Implement JoinGroup request as first class stream

### DIFF
--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/KafkaConfiguration.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/KafkaConfiguration.java
@@ -84,7 +84,7 @@ public class KafkaConfiguration extends Configuration
     static
     {
         final ConfigurationDef config = new ConfigurationDef("zilla.binding.kafka");
-        KAFKA_CLIENT_ID = config.property("client.id", "zilla");
+        KAFKA_CLIENT_ID = config.property("client.id");
         KAFKA_CLIENT_INSTANCE_ID = config.property(InstanceIdSupplier.class, "client.instance.id",
             KafkaConfiguration::decodeInstanceId, KafkaConfiguration::defaultInstanceId);
         KAFKA_CLIENT_MAX_IDLE_MILLIS = config.property("client.max.idle.ms", 1 * 60 * 1000);

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/KafkaConfiguration.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/KafkaConfiguration.java
@@ -73,6 +73,7 @@ public class KafkaConfiguration extends Configuration
     public static final PropertyDef<Duration> KAFKA_CLIENT_GROUP_REBALANCE_TIMEOUT;
     public static final IntPropertyDef KAFKA_CLIENT_GROUP_MIN_SESSION_TIMEOUT_DEFAULT;
     public static final IntPropertyDef KAFKA_CLIENT_GROUP_MAX_SESSION_TIMEOUT_DEFAULT;
+    public static final IntPropertyDef KAFKA_CLIENT_GROUP_INITIAL_REBALANCE_DELAY_DEFAULT;
     public static final PropertyDef<String> KAFKA_CLIENT_ID;
     public static final PropertyDef<InstanceIdSupplier> KAFKA_CLIENT_INSTANCE_ID;
     public static final BooleanPropertyDef KAFKA_CLIENT_CONNECTION_POOL;
@@ -105,6 +106,8 @@ public class KafkaConfiguration extends Configuration
             (int) Duration.ofSeconds(6).toMillis());
         KAFKA_CLIENT_GROUP_MAX_SESSION_TIMEOUT_DEFAULT = config.property("client.group.max.session.timeout.default",
             (int) Duration.ofMinutes(5).toMillis());
+        KAFKA_CLIENT_GROUP_INITIAL_REBALANCE_DELAY_DEFAULT = config.property("client.group.initial.rebalance.delay.default",
+            0);
         KAFKA_CACHE_DIRECTORY = config.property(Path.class, "cache.directory",
             KafkaConfiguration::cacheDirectory, KafkaBinding.NAME);
         KAFKA_CACHE_SERVER_BOOTSTRAP = config.property("cache.server.bootstrap", true);
@@ -313,6 +316,11 @@ public class KafkaConfiguration extends Configuration
     public int clientGroupMaxSessionTimeoutDefault()
     {
         return KAFKA_CLIENT_GROUP_MAX_SESSION_TIMEOUT_DEFAULT.get(this);
+    }
+
+    public int clientGroupInitialRebalanceDelayDefault()
+    {
+        return KAFKA_CLIENT_GROUP_INITIAL_REBALANCE_DELAY_DEFAULT.get(this);
     }
 
     private static boolean supplyVerbose(

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/KafkaConfiguration.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/KafkaConfiguration.java
@@ -83,7 +83,7 @@ public class KafkaConfiguration extends Configuration
     static
     {
         final ConfigurationDef config = new ConfigurationDef("zilla.binding.kafka");
-        KAFKA_CLIENT_ID = config.property("client.id");
+        KAFKA_CLIENT_ID = config.property("client.id", "zilla");
         KAFKA_CLIENT_INSTANCE_ID = config.property(InstanceIdSupplier.class, "client.instance.id",
             KafkaConfiguration::decodeInstanceId, KafkaConfiguration::defaultInstanceId);
         KAFKA_CLIENT_MAX_IDLE_MILLIS = config.property("client.max.idle.ms", 1 * 60 * 1000);

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientFactory.java
@@ -15,7 +15,7 @@
  */
 package io.aklivity.zilla.runtime.binding.kafka.internal.stream;
 
-import java.util.function.Function;
+import java.util.function.IntFunction;
 import java.util.function.LongFunction;
 import java.util.function.UnaryOperator;
 
@@ -63,19 +63,19 @@ public final class KafkaClientFactory implements KafkaStreamFactory
         final BindingHandler streamFactory = config.clientConnectionPool() ? connectionPool.streamFactory() :
                 context.streamFactory();
 
-        final Function<Integer, BindingHandler> streamFactorySupplier = d ->
+        final IntFunction<BindingHandler> streamFactorySupplier = d ->
             d == 0 ? streamFactory : context.streamFactory();
 
         final UnaryOperator<KafkaSaslConfig> resolveSasl = config.clientConnectionPool() ? c -> null :
             UnaryOperator.identity();
 
-        final Function<Integer, UnaryOperator<KafkaSaslConfig>> resolveSaslSupplier = d ->
+        final IntFunction<UnaryOperator<KafkaSaslConfig>> resolveSaslSupplier = d ->
             d == 0 ? resolveSasl : UnaryOperator.identity();
 
         final Signaler signaler = config.clientConnectionPool() ? connectionPool.signaler() :
                 context.signaler();
 
-        final Function<Integer, Signaler> signalSupplier = d -> d == 0 ? signaler : context.signaler();
+        final IntFunction<Signaler> signalSupplier = d -> d == 0 ? signaler : context.signaler();
 
         final KafkaClientMetaFactory clientMetaFactory = new KafkaClientMetaFactory(
                 config, context, bindings::get, accountant::supplyDebitor, supplyClientRoute,

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientFactory.java
@@ -17,7 +17,6 @@ package io.aklivity.zilla.runtime.binding.kafka.internal.stream;
 
 import java.util.function.Function;
 import java.util.function.LongFunction;
-import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
 import org.agrona.DirectBuffer;
@@ -76,6 +75,8 @@ public final class KafkaClientFactory implements KafkaStreamFactory
         final Signaler signaler = config.clientConnectionPool() ? connectionPool.signaler() :
                 context.signaler();
 
+        final Function<Integer, Signaler> signalSupplier = d -> d == 0 ? signaler : context.signaler();
+
         final KafkaClientMetaFactory clientMetaFactory = new KafkaClientMetaFactory(
                 config, context, bindings::get, accountant::supplyDebitor, supplyClientRoute,
                 signaler, streamFactory, resolveSasl);
@@ -84,7 +85,7 @@ public final class KafkaClientFactory implements KafkaStreamFactory
                 config, context, bindings::get, accountant::supplyDebitor, signaler, streamFactory, resolveSasl);
 
         final KafkaClientGroupFactory clientGroupFactory = new KafkaClientGroupFactory(
-            config, context, bindings::get, accountant::supplyDebitor, signaler, streamFactorySupplier,
+            config, context, bindings::get, accountant::supplyDebitor, signalSupplier, streamFactorySupplier,
             resolveSaslSupplier, supplyClientRoute);
 
         final KafkaClientFetchFactory clientFetchFactory = new KafkaClientFetchFactory(

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientGroupIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientGroupIT.java
@@ -129,6 +129,17 @@ public class ClientGroupIT
     @Test
     @Configuration("client.yaml")
     @Specification({
+        "${app}/leader.assignment/client",
+        "${net}/initial.delay.config/server"})
+    public void shouldCreateConnectionForJoinGroup() throws Exception
+    {
+        k3po.finish();
+    }
+
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
         "${app}/rebalance.protocol.highlander.migrate.leader/client",
         "${net}/rebalance.protocol.highlander.migrate.leader/server"})
     public void shouldRebalanceProtocolHighlanderMigrateLeader() throws Exception

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/client.sent.read.abort.after.sync.group.response/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/client.sent.read.abort.after.sync.group.response/client.rpt
@@ -58,7 +58,7 @@ connect await ROUTED_CLUSTER_SERVER
 
 connected
 
-write 87                                                 # size
+write 121                                                 # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
@@ -66,11 +66,12 @@ write 87                                                 # size
       1                                                  # resources
         [0x04]                                           # broker resource
         1s "0"                                           # "node" topic
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
 
-read 103                                                # size
+read 143                                                # size
       (int:newRequestId)
       0
       1                                                  # resources
@@ -78,7 +79,7 @@ read 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
@@ -86,6 +87,11 @@ read 103                                                # size
           [0x00]                                          # not sensitive
           28s "group.max.session.timeout.ms"             # name
           5s "30000"                                     # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/client.sent.read.abort.after.sync.group.response/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/client.sent.read.abort.after.sync.group.response/server.rpt
@@ -48,7 +48,7 @@ accepted
 
 connected
 
-read 87                                                 # size
+read 121                                                 # size
      32s                                                # describe configs
      0s                                                 # v0
      (int:requestId)
@@ -56,11 +56,12 @@ read 87                                                 # size
      1                                                  # resources
        [0x04]                                           # broker resource
        1s "0"                                           # "node" topic
-       2                                                # configs
+       3                                                # configs
          28s "group.min.session.timeout.ms"             # name
          28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
 
-write 103                                                # size
+write 143                                                # size
       ${requestId}
       0
       1                                                  # resources
@@ -68,14 +69,19 @@ write 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/client.sent.write.abort.after.sync.group.response/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/client.sent.write.abort.after.sync.group.response/client.rpt
@@ -59,7 +59,7 @@ connect await ROUTED_CLUSTER_SERVER
 
 connected
 
-write 87                                                 # size
+write 121                                                 # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
@@ -67,11 +67,12 @@ write 87                                                 # size
       1                                                  # resources
         [0x04]                                           # broker resource
         1s "0"                                           # "node" topic
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
 
-read 103                                                # size
+read 143                                                # size
       (int:newRequestId)
       0
       1                                                  # resources
@@ -79,7 +80,7 @@ read 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
@@ -87,6 +88,11 @@ read 103                                                # size
           [0x00]                                          # not sensitive
           28s "group.max.session.timeout.ms"             # name
           5s "30000"                                     # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/client.sent.write.abort.after.sync.group.response/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/client.sent.write.abort.after.sync.group.response/server.rpt
@@ -49,7 +49,7 @@ accepted
 
 connected
 
-read 87                                                 # size
+read 121                                                 # size
      32s                                                # describe configs
      0s                                                 # v0
      (int:requestId)
@@ -57,11 +57,12 @@ read 87                                                 # size
      1                                                  # resources
        [0x04]                                           # broker resource
        1s "0"                                           # "node" topic
-       2                                                # configs
+       3                                                # configs
          28s "group.min.session.timeout.ms"             # name
          28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
 
-write 103                                                # size
+write 143                                                # size
       ${requestId}
       0
       1                                                  # resources
@@ -69,14 +70,19 @@ write 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/coordinator.not.available/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/coordinator.not.available/client.rpt
@@ -73,7 +73,7 @@ connect await ROUTED_DESCRIBE_SERVER
 
 connected
 
-write 87                                                 # size
+write 121                                                 # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
@@ -81,11 +81,12 @@ write 87                                                 # size
       1                                                  # resources
         [0x04]                                           # broker resource
         1s "0"                                           # "node" topic
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
 
-read 103                                                # size
+read 143                                                # size
       (int:newRequestId)
       0
       1                                                  # resources
@@ -93,7 +94,7 @@ read 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
@@ -101,6 +102,11 @@ read 103                                                # size
           [0x00]                                          # not sensitive
           28s "group.max.session.timeout.ms"             # name
           5s "30000"                                     # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/coordinator.not.available/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/coordinator.not.available/server.rpt
@@ -63,7 +63,7 @@ accepted
 
 connected
 
-read 87                                                 # size
+read 121                                                 # size
      32s                                                # describe configs
      0s                                                 # v0
      (int:requestId)
@@ -71,11 +71,12 @@ read 87                                                 # size
      1                                                  # resources
        [0x04]                                           # broker resource
        1s "0"                                           # "node" topic
-       2                                                # configs
+       3                                                # configs
          28s "group.min.session.timeout.ms"             # name
          28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
 
-write 103                                                # size
+write 143                                                # size
       ${requestId}
       0
       1                                                  # resources
@@ -83,14 +84,19 @@ write 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/coordinator.reject.invalid.consumer/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/coordinator.reject.invalid.consumer/client.rpt
@@ -73,7 +73,7 @@ connect await ROUTED_DESCRIBE_SERVER
 
 connected
 
-write 87                                                 # size
+write 121                                                # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
@@ -81,11 +81,12 @@ write 87                                                 # size
       1                                                  # resources
         [0x04]                                           # broker resource
         1s "0"                                           # "node" topic
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
 
-read 103                                                # size
+read 143                                                 # size
       (int:newRequestId)
       0
       1                                                  # resources
@@ -93,7 +94,7 @@ read 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
@@ -101,6 +102,11 @@ read 103                                                # size
           [0x00]                                          # not sensitive
           28s "group.max.session.timeout.ms"              # name
           5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
@@ -131,7 +137,7 @@ read  24                                                # size
       0s                                                # not a coordinator for a consumer
       0                                                 # members
 
-write 87                                                 # size
+write 121                                                # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
@@ -139,11 +145,12 @@ write 87                                                 # size
       1                                                  # resources
         [0x04]                                           # broker resource
         1s "0"                                           # "node" topic
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
 
-read 103                                                # size
+read 143                                                 # size
       (int:newRequestId)
       0
       1                                                  # resources
@@ -151,7 +158,7 @@ read 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
@@ -159,6 +166,11 @@ read 103                                                # size
           [0x00]                                          # not sensitive
           28s "group.max.session.timeout.ms"              # name
           5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/coordinator.reject.invalid.consumer/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/coordinator.reject.invalid.consumer/server.rpt
@@ -63,7 +63,7 @@ accepted
 
 connected
 
-read 87                                                 # size
+read 121                                                 # size
      32s                                                # describe configs
      0s                                                 # v0
      (int:requestId)
@@ -71,11 +71,12 @@ read 87                                                 # size
      1                                                  # resources
        [0x04]                                           # broker resource
        1s "0"                                           # "node" topic
-       2                                                # configs
+       3                                                # configs
          28s "group.min.session.timeout.ms"             # name
          28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
 
-write 103                                                # size
+write 143                                                # size
       ${requestId}
       0
       1                                                  # resources
@@ -83,14 +84,19 @@ write 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
@@ -121,7 +127,7 @@ write 24                                                # size
       0s                                                # not a coordinator for a consumer
       0                                                 # members
 
-read 87                                                 # size
+read 121                                                 # size
      32s                                                # describe configs
      0s                                                 # v0
      (int:requestId)
@@ -129,11 +135,12 @@ read 87                                                 # size
      1                                                  # resources
        [0x04]                                           # broker resource
        1s "0"                                           # "node" topic
-       2                                                # configs
+       3                                                # configs
          28s "group.min.session.timeout.ms"             # name
          28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
 
-write 103                                                # size
+write 143                                                # size
       ${requestId}
       0
       1                                                  # resources
@@ -141,14 +148,19 @@ write 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/ignore.heartbeat.before.handshake/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/ignore.heartbeat.before.handshake/client.rpt
@@ -56,7 +56,7 @@ connect await ROUTED_CLUSTER_SERVER
 
 connected
 
-write 87                                                 # size
+write 121                                                # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
@@ -64,11 +64,12 @@ write 87                                                 # size
       1                                                  # resources
         [0x04]                                           # broker resource
         1s "0"                                           # "node" topic
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
 
-read 103                                                # size
+read 143                                                 # size
       (int:newRequestId)
       0
       1                                                  # resources
@@ -76,14 +77,19 @@ read 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/ignore.heartbeat.before.handshake/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/ignore.heartbeat.before.handshake/server.rpt
@@ -46,7 +46,7 @@ accepted
 
 connected
 
-read 87                                                 # size
+read 121                                                 # size
      32s                                                # describe configs
      0s                                                 # v0
      (int:requestId)
@@ -54,11 +54,12 @@ read 87                                                 # size
      1                                                  # resources
        [0x04]                                           # broker resource
        1s "0"                                           # "node" topic
-       2                                                # configs
+       3                                                # configs
          28s "group.min.session.timeout.ms"             # name
          28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
 
-write 103                                                # size
+write 143                                                # size
       ${requestId}
       0
       1                                                  # resources
@@ -66,14 +67,19 @@ write 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/initial.delay.config/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/initial.delay.config/client.rpt
@@ -1,0 +1,270 @@
+#
+# Copyright 2021-2023 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property networkConnectWindow 8192
+
+
+property newRequestId ${kafka:newRequestId()}
+property fetchWaitMax 500
+property fetchBytesMax 65535
+property partitionBytesMax 8192
+
+connect "zilla://streams/net0"
+  option zilla:window ${networkConnectWindow}
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+connected
+
+write  22                                # size
+       10s                               # find coordinator
+       1s                                # v1
+       ${newRequestId}
+       5s "zilla"                        # client id
+       4s "test"                         # "session" coordinator key
+       [0x00]                            # coordinator group type
+
+read  45                                 # size
+      (int:newRequestId)
+      0                                  # throttle time
+      0s                                 # no error
+      4s "none"                          # error message none
+      0                                  # coordinator node
+      19s "broker1.example.com"          # host
+      9092                               # port
+
+read notify ROUTED_DESCRIBE_SERVER
+
+connect await ROUTED_DESCRIBE_SERVER
+        "zilla://streams/net0"
+  option zilla:window ${networkConnectWindow}
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+connected
+
+write 121                                                # size
+      32s                                                # describe configs
+      0s                                                 # v0
+      ${newRequestId}
+      5s "zilla"                                         # client id
+      1                                                  # resources
+        [0x04]                                           # broker resource
+        1s "0"                                           # "node" topic
+        3                                                # configs
+          28s "group.min.session.timeout.ms"             # name
+          28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
+
+read 143                                                 # size
+      (int:newRequestId)
+      0
+      1                                                  # resources
+        0s                                               # no error
+        -1s                                              # error message
+        [0x04]                                           # broker resource
+        1s "0"                                           # "0" nodeId
+        3                                                # configs
+          28s "group.min.session.timeout.ms"             # name
+          4s "6000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+
+write 82                                # size
+      11s                               # join group
+      5s                                # v5
+      ${newRequestId}
+      5s "zilla"                        # client id
+      4s "test"                         # consumer group
+      30000                             # session timeout
+      4000                              # rebalance timeout
+      0s                                # consumer group member
+      5s "zilla"                        # group instance id
+      8s "consumer"                     # protocol type
+      1                                 # group protocol
+        10s "highlander"                    # protocol name
+        14                                   # metadata size
+        ${kafka:randomBytes(14)}             # metadata
+
+read  34                                                # size
+      (int:newRequestId)
+      0                                                 # throttle time
+      79s                                               # member id required
+      -1                                                # generated id
+      0s                                                # protocol name
+      0s                                                # leader id
+      10s "memberId-1"                                  # consumer member group id
+      0                                                 # members
+
+write 92                               # size
+      11s                               # join group
+      5s                                # v5
+      ${newRequestId}
+      5s "zilla"                        # client id
+      4s "test"                         # consumer group
+      30000                             # session timeout
+      4000                              # rebalance timeout
+      10s "memberId-1"                  # consumer group member
+      5s "zilla"                                # group instance id
+      8s "consumer"                     # protocol type
+      1                                 # group protocol
+        10s "highlander"                    # protocol name
+        14                                   # metadata size
+        ${kafka:randomBytes(14)}             # metadata
+
+read  91                                               # size
+      (int:newRequestId)
+      0                                                 # throttle time
+      0s                                                # no error
+      0                                                 # generated id
+      10s "highlander"                                  # protocol name
+      10s "memberId-1"                                  # leader id
+      10s "memberId-1"                                  # consumer member group id
+      1                                                 # members
+         10s "memberId-1"                                  # consumer member group id
+         5s "zilla"                                       # group instance id
+         14                                                # metadata size
+         2s                                                # version
+         0                                                 # topics
+         0                                                 # userdata
+         0                                                 # partitions
+
+write 64                                            # size
+      14s                                           # sync group
+      3s                                            # v3
+      ${newRequestId}
+      5s "zilla"                                    # client id
+      4s "test"                                     # consumer group
+      0                                             # generation id
+      10s "memberId-1"                              # consumer member group id
+      5s "zilla"                             # group instance id
+      1                                             # assignments
+        10s "memberId-1"                             # consumer member group id
+        0                                            # metadata
+
+read  14                                                # size
+      (int:newRequestId)
+      0                                                 # throttle time
+      0s                                                # no error
+      0                                                 # assignment
+
+write 44                                            # size
+      12s                                           # heartbeat
+      3s                                            # v3
+      ${newRequestId}
+      5s "zilla"                                    # client id
+      4s "test"                                     # consumer group
+      0                                             # generation id
+      10s "memberId-1"                              # consumer member group id
+      5s "zilla"                             # group instance id
+
+read  10                                                # size
+      (int:newRequestId)
+      0                                                 # throttle time
+      27s                                               # REBALANCE_IN_PROGRESS
+
+write 92                               # size
+      11s                               # join group
+      5s                                # v5
+      ${newRequestId}
+      5s "zilla"                        # client id
+      4s "test"                         # consumer group
+      30000                             # session timeout
+      4000                              # rebalance timeout
+      10s "memberId-1"                  # consumer member group id
+      5s "zilla"                                # group instance id
+      8s "consumer"                     # protocol type
+      1                                 # group protocol
+        10s "highlander"                    # protocol name
+        14                                  # metadata size
+        ${kafka:randomBytes(14)}            # metadata
+
+
+read  128                                               # size
+      (int:newRequestId)
+      0                                                 # throttle time
+      0s                                                # no error
+      0                                                 # generated id
+      10s "highlander"                                  # protocol name
+      10s "memberId-1"                                  # leader id
+      10s "memberId-1"                                  # consumer member group id
+      2                                                 # members
+         10s "memberId-1"                                  # consumer member group id
+         5s "zilla"                                       # group instance id
+         14                                                # metadata size
+         2s                                               # version
+         0                                                # topics
+         0                                                # userdata
+         0                                                # partitions
+         10s "memberId-2"                                  # consumer member group id
+         5s "zilla"                                       # group instance id
+         14                                                # metadata size
+         2s                                                # version
+         0                                                 # topics
+         0                                                 # userdata
+         0                                                 # partitions
+
+write 80                                            # size
+      14s                                           # sync group
+      3s                                            # v3
+      ${newRequestId}
+      5s "zilla"                                    # client id
+      4s "test"                                     # consumer group
+      0                                             # generation id
+      10s "memberId-1"                              # consumer member group id
+      5s "zilla"                                    # group instance id
+      2                                             # assignments
+        10s "memberId-1"                             # consumer member group id
+        0                                            # metadata
+        10s "memberId-2"                             # consumer member group id
+        0                                            # metadata
+
+read  14                                                # size
+      (int:newRequestId)
+      0                                                 # throttle time
+      0s                                                # no error
+      0                                                 # assignment
+
+write 44                                            # size
+      13s                                           # leave group
+      3s                                            # v3
+      ${newRequestId}
+      5s "zilla"                                    # client id
+      4s "test"                                     # consumer group
+      1                                             # assignments
+        10s "memberId-1"                             # consumer member group id
+        5s "zilla"                            # group instance id
+
+read  35                                           # size
+      (int:newRequestId)
+      0                                            # throttle time
+      0s                                           # no error
+      1                                            # assignments
+        10s "memberId-1"                             # consumer member group id
+        5s "zilla"                                  # group instance id
+        0s                                           # no error
+

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/initial.delay.config/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/initial.delay.config/server.rpt
@@ -1,0 +1,170 @@
+#
+# Copyright 2021-2023 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+
+
+accept "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+accepted
+
+connected
+
+read  22                                # size
+      10s                               # find coordinator
+      1s                                # v1
+      (int:newRequestId)
+      5s "zilla"                        # client id
+      4s "test"                         # "test" coordinator key
+      [0x00]                            # coordinator group type
+
+write 45                                 # size
+      ${newRequestId}
+      0                                  # throttle time
+      0s                                 # no error
+      4s "none"                          # error message none
+      0                                  # coordinator node
+      19s "broker1.example.com"          # host
+      9092                               # port
+
+accepted
+
+connected
+
+read 121                                                # size
+     32s                                                # describe configs
+     0s                                                 # v0
+     (int:requestId)
+     5s "zilla"                                         # client id
+     1                                                  # resources
+       [0x04]                                           # broker resource
+       1s "0"                                           # "node" topic
+       3                                                # configs
+         28s "group.min.session.timeout.ms"             # name
+         28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
+
+write 144                                                # size
+      ${requestId}
+      0
+      1                                                  # resources
+        0s                                               # no error
+        -1s                                              # error message
+        [0x04]                                           # broker resource
+        1s "0"                                           # "0" nodeId
+        3                                                # configs
+          28s "group.min.session.timeout.ms"             # name
+          4s "6000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          2s "23"                                         # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+
+read 64                                            # size
+     14s                                           # sync group
+     3s                                            # v3
+     (int:newRequestId)
+     5s "zilla"                                    # client id
+     4s "test"                                     # consumer group
+     0                                             # generation id
+     10s "memberId-1"                              # consumer member group id
+     5s "zilla"                                    # group instance id
+     1                                             # assignments
+       10s "memberId-1"                             # consumer member group id
+       0                                            # metadata
+
+write 14                                                # size
+      ${newRequestId}
+      0                                                 # throttle time
+      0s                                                # no error
+      0                                                 # assignment
+
+accepted
+
+connected
+
+read  82                                # size
+      11s                               # join group
+      5s                                # v5
+      (int:newRequestId)
+      5s "zilla"                        # client id
+      4s "test"                         # consumer group
+      30000                             # session timeout
+      4000                              # rebalance timeout
+      0s                                # consumer group member
+      5s "zilla"                        # group instance id
+      8s "consumer"                     # protocol type
+      1                                 # group protocol
+        10s "highlander"                     # protocol name
+        14                                   # metadata size
+        [0..14]                              # metadata
+
+
+write 34                                                # size
+      ${newRequestId}
+      0                                                 # throttle time
+      79s                                               # member id required
+      -1                                                # generated id
+      0s                                                # protocol name
+      0s                                                # leader id
+      10s "memberId-1"                                  # consumer member group id
+      0                                                 # members
+
+read  92                                # size
+      11s                               # join group
+      5s                                # v5
+      (int:newRequestId)
+      5s "zilla"                        # client id
+      4s "test"                         # consumer group
+      30000                             # session timeout
+      4000                              # rebalance timeout
+      10s "memberId-1"                  # consumer group member
+      5s "zilla"                        # group instance id
+      8s "consumer"                     # protocol type
+      1                                 # group protocol
+        10s "highlander"                    # protocol name
+        14                                   # metadata size
+        [0..14]                              # metadata
+
+write 91                                               # size
+      ${newRequestId}
+      0                                                 # throttle time
+      0s                                                # no error
+      0                                                 # generated id
+      10s "highlander"                                  # protocol name
+      10s "memberId-1"                                  # leader id
+      10s "memberId-1"                                  # consumer member group id
+      1                                                 # members
+         10s "memberId-1"                                  # consumer member group id
+         5s "zilla"                                        # group instance id
+         14                                                # metadata size
+         2s                                                # version
+         0                                                 # topics
+         0                                                 # userdata
+         0                                                 # partitions
+
+

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/invalid.describe.config/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/invalid.describe.config/client.rpt
@@ -73,7 +73,7 @@ connect await ROUTED_DESCRIBE_SERVER
 
 connected
 
-write 87                                                 # size
+write 121                                                 # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
@@ -81,9 +81,10 @@ write 87                                                 # size
       1                                                  # resources
         [0x04]                                           # broker resource
         1s "0"                                           # "node" topic
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
 
 read  24                                                # size
       (int:newRequestId)

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/invalid.describe.config/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/invalid.describe.config/server.rpt
@@ -63,7 +63,7 @@ accepted
 
 connected
 
-read 87                                                 # size
+read 121                                                 # size
      32s                                                # describe configs
      0s                                                 # v0
      (int:requestId)
@@ -71,9 +71,10 @@ read 87                                                 # size
      1                                                  # resources
        [0x04]                                           # broker resource
        1s "0"                                           # "node" topic
-       2                                                # configs
+       3                                                # configs
          28s "group.min.session.timeout.ms"             # name
          28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
 
 write 24                                                # size
       ${requestId}

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/invalid.session.timeout/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/invalid.session.timeout/client.rpt
@@ -73,7 +73,7 @@ connect await ROUTED_DESCRIBE_SERVER
 
 connected
 
-write 87                                                 # size
+write 121                                                # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
@@ -81,9 +81,10 @@ write 87                                                 # size
       1                                                  # resources
         [0x04]                                           # broker resource
         1s "0"                                           # "node" topic
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
 
 read 24                                                # size
       ${requestId}

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/invalid.session.timeout/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/invalid.session.timeout/server.rpt
@@ -63,7 +63,7 @@ accepted
 
 connected
 
-read 87                                                 # size
+read 121                                                # size
      32s                                                # describe configs
      0s                                                 # v0
      (int:requestId)
@@ -71,9 +71,10 @@ read 87                                                 # size
      1                                                  # resources
        [0x04]                                           # broker resource
        1s "0"                                           # "node" topic
-       2                                                # configs
+       3                                                # configs
          28s "group.min.session.timeout.ms"             # name
          28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
 
 write 24                                                # size
       ${requestId}
@@ -85,7 +86,7 @@ write 24                                                # size
         1s "0"                                           # "0" nodeId
         0                                                # configs
 
-read  82                               # size
+read  82                                # size
       11s                               # join group
       5s                                # v5
       (int:newRequestId)

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.multiple.members.with.same.group.id/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.multiple.members.with.same.group.id/client.rpt
@@ -73,7 +73,7 @@ connect await ROUTED_DESCRIBE_SERVER
 
 connected
 
-write 87                                                 # size
+write 121                                                # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
@@ -81,11 +81,12 @@ write 87                                                 # size
       1                                                  # resources
         [0x04]                                           # broker resource
         1s "0"                                           # "node" topic
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
 
-read 103                                                # size
+read 143                                                 # size
       (int:newRequestId)
       0
       1                                                  # resources
@@ -93,14 +94,19 @@ read 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
@@ -202,7 +208,7 @@ read  35                                           # size
         5s "zilla"                                  # group instance id
         0s                                           # no error
 
-write 87                                                 # size
+write 121                                                # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
@@ -210,11 +216,12 @@ write 87                                                 # size
       1                                                  # resources
         [0x04]                                           # broker resource
         1s "0"                                           # "node" topic
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
 
-read 103                                                # size
+read 143                                                 # size
       (int:newRequestId)
       0
       1                                                  # resources
@@ -222,14 +229,19 @@ read 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.multiple.members.with.same.group.id/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.multiple.members.with.same.group.id/server.rpt
@@ -63,7 +63,7 @@ accepted
 
 connected
 
-read 87                                                 # size
+read 121                                                 # size
      32s                                                # describe configs
      0s                                                 # v0
      (int:requestId)
@@ -71,11 +71,12 @@ read 87                                                 # size
      1                                                  # resources
        [0x04]                                           # broker resource
        1s "0"                                           # "node" topic
-       2                                                # configs
+       3                                                # configs
          28s "group.min.session.timeout.ms"             # name
          28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
 
-write 103                                                # size
+write 143                                                # size
       ${requestId}
       0
       1                                                  # resources
@@ -83,14 +84,19 @@ write 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
@@ -195,7 +201,7 @@ write 35                                           # size
 
 #Second try
 
-read 87                                                 # size
+read 121                                                # size
      32s                                                # describe configs
      0s                                                 # v0
      (int:requestId)
@@ -203,11 +209,12 @@ read 87                                                 # size
      1                                                  # resources
        [0x04]                                           # broker resource
        1s "0"                                           # "node" topic
-       2                                                # configs
+       3                                                # configs
          28s "group.min.session.timeout.ms"             # name
          28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
 
-write 103                                                # size
+write 143                                                # size
       ${requestId}
       0
       1                                                  # resources
@@ -215,14 +222,19 @@ write 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.heartbeat.unknown.member/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.heartbeat.unknown.member/client.rpt
@@ -56,7 +56,7 @@ connect await ROUTED_DESCRIBE_SERVER
 
 connected
 
-write 87                                                 # size
+write 121                                                # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
@@ -64,11 +64,12 @@ write 87                                                 # size
       1                                                  # resources
         [0x04]                                           # broker resource
         1s "0"                                           # "node" topic
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
 
-read 103                                                # size
+read 143                                                 # size
       (int:newRequestId)
       0
       1                                                  # resources
@@ -76,14 +77,19 @@ read 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.heartbeat.unknown.member/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.heartbeat.unknown.member/server.rpt
@@ -46,7 +46,7 @@ accepted
 
 connected
 
-read 87                                                 # size
+read 121                                                 # size
      32s                                                # describe configs
      0s                                                 # v0
      (int:requestId)
@@ -54,11 +54,12 @@ read 87                                                 # size
      1                                                  # resources
        [0x04]                                           # broker resource
        1s "0"                                           # "node" topic
-       2                                                # configs
+       3                                                # configs
          28s "group.min.session.timeout.ms"             # name
          28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
 
-write 103                                                # size
+write 143                                                # size
       ${requestId}
       0
       1                                                  # resources
@@ -66,14 +67,19 @@ write 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.migrate.leader.in.parallel/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.migrate.leader.in.parallel/client.rpt
@@ -56,7 +56,7 @@ connect await ROUTED_DESCRIBE_SERVER_FIRST
 
 connected
 
-write 87                                                 # size
+write 121                                                # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
@@ -64,11 +64,12 @@ write 87                                                 # size
       1                                                  # resources
         [0x04]                                           # broker resource
         1s "0"                                           # "node" topic
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
 
-read 103                                                # size
+read 143                                                 # size
       (int:newRequestId)
       0
       1                                                  # resources
@@ -76,14 +77,19 @@ read 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.migrate.leader.in.parallel/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.migrate.leader.in.parallel/server.rpt
@@ -46,34 +46,40 @@ accepted
 
 connected
 
-read 87                                                 # size
+read 121                                                 # size
      32s                                                # describe configs
      0s                                                 # v0
-     (int:newRequestId)
+     (int:requestId)
      5s "zilla"                                         # client id
      1                                                  # resources
        [0x04]                                           # broker resource
        1s "0"                                           # "node" topic
-       2                                                # configs
+       3                                                # configs
          28s "group.min.session.timeout.ms"             # name
          28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
 
-write 103                                                # size
-      ${newRequestId}
+write 143                                                # size
+      ${requestId}
       0
       1                                                  # resources
         0s                                               # no error
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.migrate.leader/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.migrate.leader/client.rpt
@@ -56,7 +56,7 @@ connect await ROUTED_DESCRIBE_SERVER_FIRST
 
 connected
 
-write 87                                                 # size
+write 121                                                # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
@@ -64,11 +64,12 @@ write 87                                                 # size
       1                                                  # resources
         [0x04]                                           # broker resource
         1s "0"                                           # "node" topic
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
 
-read 103                                                # size
+read 143                                                 # size
       (int:newRequestId)
       0
       1                                                  # resources
@@ -76,14 +77,19 @@ read 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.migrate.leader/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.migrate.leader/server.rpt
@@ -46,34 +46,40 @@ accepted
 
 connected
 
-read 87                                                 # size
+read 121                                                 # size
      32s                                                # describe configs
      0s                                                 # v0
-     (int:newRequestId)
+     (int:requestId)
      5s "zilla"                                         # client id
      1                                                  # resources
        [0x04]                                           # broker resource
        1s "0"                                           # "node" topic
-       2                                                # configs
+       3                                                # configs
          28s "group.min.session.timeout.ms"             # name
          28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
 
-write 103                                                # size
-      ${newRequestId}
+write 143                                                # size
+      ${requestId}
       0
       1                                                  # resources
         0s                                               # no error
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.unknown.member.id/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.unknown.member.id/client.rpt
@@ -56,7 +56,7 @@ connect await ROUTED_DESCRIBE_SERVER
 
 connected
 
-write 87                                                 # size
+write 121                                                # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
@@ -64,11 +64,12 @@ write 87                                                 # size
       1                                                  # resources
         [0x04]                                           # broker resource
         1s "0"                                           # "node" topic
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
 
-read 103                                                # size
+read 143                                                 # size
       (int:newRequestId)
       0
       1                                                  # resources
@@ -76,14 +77,19 @@ read 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.unknown.member.id/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.unknown.member.id/server.rpt
@@ -46,7 +46,7 @@ accepted
 
 connected
 
-read 87                                                 # size
+read 121                                                 # size
      32s                                                # describe configs
      0s                                                 # v0
      (int:requestId)
@@ -54,11 +54,12 @@ read 87                                                 # size
      1                                                  # resources
        [0x04]                                           # broker resource
        1s "0"                                           # "node" topic
-       2                                                # configs
+       3                                                # configs
          28s "group.min.session.timeout.ms"             # name
          28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
 
-write 103                                                # size
+write 143                                                # size
       ${requestId}
       0
       1                                                  # resources
@@ -66,7 +67,7 @@ write 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
@@ -74,6 +75,11 @@ write 103                                                # size
           [0x00]                                          # not sensitive
           28s "group.max.session.timeout.ms"              # name
           5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander/client.rpt
@@ -56,7 +56,7 @@ connect await ROUTED_DESCRIBE_SERVER
 
 connected
 
-write 87                                                 # size
+write 121                                                 # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
@@ -64,11 +64,12 @@ write 87                                                 # size
       1                                                  # resources
         [0x04]                                           # broker resource
         1s "0"                                           # "node" topic
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
 
-read 103                                                # size
+read 143                                                # size
       (int:newRequestId)
       0
       1                                                  # resources
@@ -76,7 +77,7 @@ read 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
@@ -84,6 +85,11 @@ read 103                                                # size
           [0x00]                                          # not sensitive
           28s "group.max.session.timeout.ms"             # name
           5s "30000"                                     # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander/client.rpt
@@ -56,7 +56,7 @@ connect await ROUTED_DESCRIBE_SERVER
 
 connected
 
-write 121                                                 # size
+write 121                                                # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
@@ -69,7 +69,7 @@ write 121                                                 # size
           28s "group.max.session.timeout.ms"             # name
           32s "group.initial.rebalance.delay.ms"         # name
 
-read 143                                                # size
+read 143                                                 # size
       (int:newRequestId)
       0
       1                                                  # resources
@@ -83,8 +83,8 @@ read 143                                                # size
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
@@ -103,7 +103,7 @@ write 82                                # size
       30000                             # session timeout
       4000                              # rebalance timeout
       0s                                # consumer group member
-      5s "zilla"                                # group instance id
+      5s "zilla"                        # group instance id
       8s "consumer"                     # protocol type
       1                                 # group protocol
         10s "highlander"                    # protocol name

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander/server.rpt
@@ -46,7 +46,7 @@ accepted
 
 connected
 
-read 87                                                 # size
+read 121                                                 # size
      32s                                                # describe configs
      0s                                                 # v0
      (int:requestId)
@@ -54,11 +54,12 @@ read 87                                                 # size
      1                                                  # resources
        [0x04]                                           # broker resource
        1s "0"                                           # "node" topic
-       2                                                # configs
+       3                                                # configs
          28s "group.min.session.timeout.ms"             # name
          28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
 
-write 103                                                # size
+write 143                                                # size
       ${requestId}
       0
       1                                                  # resources
@@ -66,19 +67,24 @@ write 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
 
-read  82                               # size
+read  82                                # size
       11s                               # join group
       5s                                # v5
       (int:newRequestId)
@@ -87,7 +93,7 @@ read  82                               # size
       30000                             # session timeout
       4000                              # rebalance timeout
       0s                                # consumer group member
-      5s "zilla"                       # group instance id
+      5s "zilla"                        # group instance id
       8s "consumer"                     # protocol type
       1                                 # group protocol
         10s "highlander"                     # protocol name
@@ -105,7 +111,7 @@ write 34                                                # size
       10s "memberId-1"                                  # consumer member group id
       0                                                 # members
 
-read  92                               # size
+read  92                                # size
       11s                               # join group
       5s                                # v5
       (int:newRequestId)
@@ -114,7 +120,7 @@ read  92                               # size
       30000                             # session timeout
       4000                              # rebalance timeout
       10s "memberId-1"                  # consumer group member
-      5s "zilla"                       # group instance id
+      5s "zilla"                        # group instance id
       8s "consumer"                     # protocol type
       1                                 # group protocol
         10s "highlander"                    # protocol name
@@ -131,14 +137,14 @@ write 91                                               # size
       10s "memberId-1"                                  # consumer member group id
       1                                                 # members
          10s "memberId-1"                                  # consumer member group id
-         5s "zilla"                                 # group instance id
+         5s "zilla"                                        # group instance id
          14                                                # metadata size
          2s                                                # version
          0                                                 # topics
          0                                                 # userdata
          0                                                 # partitions
 
-read 64                                           # size
+read 64                                            # size
      14s                                           # sync group
      3s                                            # v3
      (int:newRequestId)
@@ -146,7 +152,7 @@ read 64                                           # size
      4s "test"                                     # consumer group
      0                                             # generation id
      10s "memberId-1"                              # consumer member group id
-     5s "zilla"                                   # group instance id
+     5s "zilla"                                    # group instance id
      1                                             # assignments
        10s "memberId-1"                             # consumer member group id
        0                                            # metadata
@@ -165,14 +171,14 @@ read 44                                            # size
      4s "test"                                     # consumer group
      0                                             # generation id
      10s "memberId-1"                              # consumer member group id
-     5s "zilla"                                   # group instance id
+     5s "zilla"                                    # group instance id
 
 write 10                                                # size
       ${newRequestId}
       0                                                 # throttle time
       27s                                               # REBALANCE_IN_PROGRESS
 
-read  92                               # size
+read  92                                # size
       11s                               # join group
       5s                                # v5
       (int:newRequestId)
@@ -181,7 +187,7 @@ read  92                               # size
       30000                             # session timeout
       4000                              # rebalance timeout
       10s "memberId-1"                  # consumer member group id
-      5s "zilla"                       # group instance id
+      5s "zilla"                        # group instance id
       8s "consumer"                     # protocol type
       1                                 # group protocol
         10s "highlander"                    # protocol name
@@ -199,21 +205,21 @@ write 128                                               # size
       10s "memberId-1"                                  # consumer member group id
       2                                                 # members
          10s "memberId-1"                                  # consumer member group id
-         5s "zilla"                                 # group instance id
+         5s "zilla"                                        # group instance id
          14                                                # metadata size
          2s                                                # version
          0                                                 # topics
          0                                                 # userdata
          0                                                 # partitions
          10s "memberId-2"                                  # consumer member group id
-         5s "zilla"                                 # group instance id
+         5s "zilla"                                        # group instance id
          14                                                # metadata size
          2s                                                # version
          0                                                 # topics
          0                                                 # userdata
          0                                                 # partitions
 
-read 80                                           # size
+read 80                                            # size
      14s                                           # sync group
      3s                                            # v3
      (int:newRequestId)
@@ -221,7 +227,7 @@ read 80                                           # size
      4s "test"                                     # consumer group
      0                                             # generation id
      10s "memberId-1"                              # consumer member group id
-     5s "zilla"                                   # group instance id
+     5s "zilla"                                    # group instance id
      2                                             # assignments
        10s "memberId-1"                             # consumer member group id
        0                                            # metadata
@@ -241,8 +247,8 @@ read 44                                            # size
      5s "zilla"                                    # client id
      4s "test"                                     # consumer group
      1                                             # assignments
-       10s "memberId-1"                             # consumer member group id
-       5s "zilla"                                 # group instance id
+       10s "memberId-1"                            # consumer member group id
+       5s "zilla"                                  # group instance id
 
 write 35                                           # size
       ${newRequestId}
@@ -250,6 +256,6 @@ write 35                                           # size
       0s                                           # no error
       1                                            # assignments
         10s "memberId-1"                             # consumer member group id
-        5s "zilla"                            # group instance id
+        5s "zilla"                                   # group instance id
         0s                                           # no error
 

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.unknown/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.unknown/client.rpt
@@ -56,7 +56,7 @@ connect await ROUTED_DESCRIBE_SERVER
 
 connected
 
-write 87                                                 # size
+write 121                                                # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
@@ -64,11 +64,12 @@ write 87                                                 # size
       1                                                  # resources
         [0x04]                                           # broker resource
         1s "0"                                           # "node" topic
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
 
-read 103                                                # size
+read 143                                                 # size
       (int:newRequestId)
       0
       1                                                  # resources
@@ -76,14 +77,19 @@ read 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.unknown/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.unknown/server.rpt
@@ -44,7 +44,7 @@ accepted
 
 connected
 
-read 87                                                 # size
+read 121                                                 # size
      32s                                                # describe configs
      0s                                                 # v0
      (int:requestId)
@@ -52,11 +52,12 @@ read 87                                                 # size
      1                                                  # resources
        [0x04]                                           # broker resource
        1s "0"                                           # "node" topic
-       2                                                # configs
+       3                                                # configs
          28s "group.min.session.timeout.ms"             # name
          28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
 
-write 103                                                # size
+write 143                                                # size
       ${requestId}
       0
       1                                                  # resources
@@ -64,14 +65,19 @@ write 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.sync.group/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.sync.group/client.rpt
@@ -56,7 +56,7 @@ connect await ROUTED_DESCRIBE_SERVER
 
 connected
 
-write 87                                                 # size
+write 121                                                # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
@@ -64,11 +64,12 @@ write 87                                                 # size
       1                                                  # resources
         [0x04]                                           # broker resource
         1s "0"                                           # "node" topic
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
 
-read 103                                                # size
+read 143                                                 # size
       (int:newRequestId)
       0
       1                                                  # resources
@@ -76,14 +77,19 @@ read 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.sync.group/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.sync.group/server.rpt
@@ -46,7 +46,7 @@ accepted
 
 connected
 
-read 87                                                 # size
+read 121                                                 # size
      32s                                                # describe configs
      0s                                                 # v0
      (int:requestId)
@@ -54,11 +54,12 @@ read 87                                                 # size
      1                                                  # resources
        [0x04]                                           # broker resource
        1s "0"                                           # "node" topic
-       2                                                # configs
+       3                                                # configs
          28s "group.min.session.timeout.ms"             # name
          28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
 
-write 103                                                # size
+write 143                                                # size
       ${requestId}
       0
       1                                                  # resources
@@ -66,14 +67,19 @@ write 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/topics.partition.assignment/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/topics.partition.assignment/client.rpt
@@ -56,19 +56,20 @@ connect await ROUTED_CLUSTER_SERVER
 
 connected
 
-write 87                                                 # size
+write 121                                                # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
-      5s "zilla"                                         # no client id
+      5s "zilla"                                         # client id
       1                                                  # resources
         [0x04]                                           # broker resource
-        1s "0"                                           # "node"
-        2                                                # configs
+        1s "0"                                           # "node" topic
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
 
-read 103                                                # size
+read 143                                                 # size
       (int:newRequestId)
       0
       1                                                  # resources
@@ -76,14 +77,19 @@ read 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/topics.partition.assignment/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/topics.partition.assignment/server.rpt
@@ -46,19 +46,20 @@ accepted
 
 connected
 
-read 87                                                 # size
+read 121                                                 # size
      32s                                                # describe configs
      0s                                                 # v0
      (int:requestId)
-     5s "zilla"                                         # no client id
+     5s "zilla"                                         # client id
      1                                                  # resources
        [0x04]                                           # broker resource
-       1s "0"                                           # "node"
-       2                                                # configs
+       1s "0"                                           # "node" topic
+       3                                                # configs
          28s "group.min.session.timeout.ms"             # name
          28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
 
-write 103                                               # size
+write 143                                                # size
       ${requestId}
       0
       1                                                  # resources
@@ -66,7 +67,7 @@ write 103                                               # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
@@ -74,6 +75,11 @@ write 103                                               # size
           [0x00]                                          # not sensitive
           28s "group.max.session.timeout.ms"              # name
           5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/leader.assignment.with.sasl.plain/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/leader.assignment.with.sasl.plain/client.rpt
@@ -114,7 +114,7 @@ read 20                                 # size
      -1s                                # authentication bytes
      0L                                 # session lifetime
 
-write 87                                                 # size
+write 121                                                # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
@@ -122,11 +122,12 @@ write 87                                                 # size
       1                                                  # resources
         [0x04]                                           # broker resource
         1s "0"                                           # "node" topic
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
 
-read 103                                                # size
+read 143                                                 # size
       (int:newRequestId)
       0
       1                                                  # resources
@@ -134,14 +135,19 @@ read 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/leader.assignment.with.sasl.plain/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/leader.assignment.with.sasl.plain/server.rpt
@@ -104,7 +104,7 @@ write 20                                # size
       -1s                               # authentication bytes
       0L                                # session lifetime
 
-read 87                                                 # size
+read 121                                                 # size
      32s                                                # describe configs
      0s                                                 # v0
      (int:requestId)
@@ -112,11 +112,12 @@ read 87                                                 # size
      1                                                  # resources
        [0x04]                                           # broker resource
        1s "0"                                           # "node" topic
-       2                                                # configs
+       3                                                # configs
          28s "group.min.session.timeout.ms"             # name
          28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
 
-write 103                                                # size
+write 143                                                # size
       ${requestId}
       0
       1                                                  # resources
@@ -124,14 +125,19 @@ write 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/leader.assignment.with.sasl.scram/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/leader.assignment.with.sasl.scram/client.rpt
@@ -142,7 +142,7 @@ read 50                                 # size
      30 "v=rmF9pqV8S7suAoZWja4dJRkFsKQ="
      0L                                 # session lifetime
 
-write 87                                                 # size
+write 121                                                # size
       32s                                                # describe configs
       0s                                                 # v0
       ${newRequestId}
@@ -150,11 +150,12 @@ write 87                                                 # size
       1                                                  # resources
         [0x04]                                           # broker resource
         1s "0"                                           # "node" topic
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           28s "group.max.session.timeout.ms"             # name
+          32s "group.initial.rebalance.delay.ms"         # name
 
-read 103                                                # size
+read 143                                                 # size
       (int:newRequestId)
       0
       1                                                  # resources
@@ -162,14 +163,19 @@ read 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/leader.assignment.with.sasl.scram/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/leader.assignment.with.sasl.scram/server.rpt
@@ -132,7 +132,7 @@ write 50                                # size
       30 "v=rmF9pqV8S7suAoZWja4dJRkFsKQ="  # authentication bytes
       0L                                # session lifetime
 
-read 87                                                 # size
+read 121                                                 # size
      32s                                                # describe configs
      0s                                                 # v0
      (int:requestId)
@@ -140,11 +140,12 @@ read 87                                                 # size
      1                                                  # resources
        [0x04]                                           # broker resource
        1s "0"                                           # "node" topic
-       2                                                # configs
+       3                                                # configs
          28s "group.min.session.timeout.ms"             # name
          28s "group.max.session.timeout.ms"             # name
+         32s "group.initial.rebalance.delay.ms"         # name
 
-write 103                                                # size
+write 143                                                # size
       ${requestId}
       0
       1                                                  # resources
@@ -152,14 +153,19 @@ write 103                                                # size
         -1s                                              # error message
         [0x04]                                           # broker resource
         1s "0"                                           # "0" nodeId
-        2                                                # configs
+        3                                                # configs
           28s "group.min.session.timeout.ms"             # name
           4s "6000"                                      # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive
-          28s "group.max.session.timeout.ms"             # name
-          5s "30000"                                     # value
+          28s "group.max.session.timeout.ms"              # name
+          5s "30000"                                      # value
+          [0x00]                                          # not read only
+          [0x00]                                          # not default
+          [0x00]                                          # not sensitive
+          32s "group.initial.rebalance.delay.ms"          # name
+          1s "0"                                          # value
           [0x00]                                          # not read only
           [0x00]                                          # not default
           [0x00]                                          # not sensitive


### PR DESCRIPTION
## Description

Move join group request stream out of coordinator stream and use a separate connection if the group.initial.rebalance.delay.ms > 0 otherwise use the connection pool since there won't be any delay.

Fixes #719 
