### PR TITLE
Fix exporter-otlp schema

### DIFF
--- a/incubator/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/config/event.yaml
+++ b/incubator/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/config/event.yaml
@@ -27,6 +27,8 @@ telemetry:
                     - logs
                 endpoint:
                     location: http://localhost:4318
+                    overrides:
+                        logs: /v1/logs
 bindings:
     net0:
         type: test

--- a/incubator/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/config/metrics.yaml
+++ b/incubator/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/config/metrics.yaml
@@ -31,6 +31,8 @@ telemetry:
                     - metrics
                 endpoint:
                     location: http://localhost:4318
+                    overrides:
+                        metrics: /v1/metrics
 bindings:
     net0:
         type: test

--- a/incubator/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/schema/otlp.schema.patch.json
+++ b/incubator/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/schema/otlp.schema.patch.json
@@ -64,6 +64,21 @@
                                     "location":
                                     {
                                         "type": "string"
+                                    },
+                                    "overrides":
+                                    {
+                                        "type": "object",
+                                        "properties":
+                                        {
+                                            "metrics":
+                                            {
+                                                "type": "string"
+                                            },
+                                            "logs":
+                                            {
+                                                "type": "string"
+                                            }
+                                        }
                                     }
                                 },
                                 "required":

--- a/incubator/exporter-otlp/src/test/java/io/aklivity/zilla/runtime/exporter/otlp/internal/config/SchemaTest.java
+++ b/incubator/exporter-otlp/src/test/java/io/aklivity/zilla/runtime/exporter/otlp/internal/config/SchemaTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021-2023 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.exporter.otlp.internal.config;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import jakarta.json.JsonObject;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.aklivity.zilla.specs.engine.config.ConfigSchemaRule;
+
+public class SchemaTest
+{
+    @Rule
+    public final ConfigSchemaRule schema = new ConfigSchemaRule()
+        .schemaPatch("io/aklivity/zilla/specs/exporter/otlp/schema/otlp.schema.patch.json")
+        .schemaPatch("io/aklivity/zilla/specs/engine/schema/binding/test.schema.patch.json")
+        .schemaPatch("io/aklivity/zilla/specs/engine/schema/metrics/test.schema.patch.json")
+        .configurationRoot("io/aklivity/zilla/specs/exporter/otlp/config");
+
+    @Test
+    public void shouldValidateEvent()
+    {
+        JsonObject config = schema.validate("event.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
+    @Test
+    public void shouldValidateMetrics()
+    {
+        JsonObject config = schema.validate("metrics.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+}


### PR DESCRIPTION
## Description

This adds back the missing schema for overrides in the `exporter-otlp` module.