### PR TITLE
zilla dump : bindings not found in /var/runtime/zilla directory

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -903,6 +903,8 @@ public class EngineWorker implements EngineContext, Agent
         taskQueue.offer(attachTask);
         signaler.signalNow(0L, 0L, 0L, supplyTraceId(), SIGNAL_TASK_QUEUED, 0);
 
+        writeBindingTypes(registry);
+
         return attachTask.future();
     }
 
@@ -914,6 +916,8 @@ public class EngineWorker implements EngineContext, Agent
         NamespaceTask detachTask = registry.detach(namespace);
         taskQueue.offer(detachTask);
         signaler.signalNow(0L, 0L, 0L, supplyTraceId(), SIGNAL_TASK_QUEUED, 0);
+
+        writeBindingTypes(registry);
 
         return detachTask.future();
     }


### PR DESCRIPTION
## Description

`zilla dump` was crashing due to `java.nio.file.NoSuchFileException`, as `bindings` was not found in /var/run/zilla directory. But it should have been generated on startup for worker-0.

