### PR TITLE
Use default kafka client id for kafka client instance id

### DIFF
--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/KafkaConfiguration.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/KafkaConfiguration.java
@@ -443,6 +443,13 @@ public class KafkaConfiguration extends Configuration
     private static InstanceIdSupplier defaultInstanceId(
         Configuration config)
     {
-        return () -> String.format("%s-%s", KAFKA_CLIENT_ID.get(config), UUID.randomUUID());
+        return () -> String.format("%s-%s", clientIdWithDefault(config), UUID.randomUUID());
+    }
+
+    private static String clientIdWithDefault(
+        Configuration config)
+    {
+        String clientId = KAFKA_CLIENT_ID.get(config);
+        return clientId != null ? clientId : KAFKA_CLIENT_ID_DEFAULT;
     }
 }


### PR DESCRIPTION
## Description

When `zilla.binding.kafka.client.id` property is not specified, we default to `zilla` but not when using the client id as part of the default kafka instance id.

This change allows kafka instance id to use the default kafka client id `zilla`.