### PR TITLE
Support configuration of timestamps in zilla transport for k3po

### DIFF
--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/DuplexIT.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/DuplexIT.java
@@ -200,6 +200,16 @@ public class DuplexIT
 
     @Test
     @Specification({
+        "timestamps.false/client",
+        "timestamps.false/server"
+    })
+    public void shouldConnectWithoutTimestamps() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "client.sent.data/client",
         "client.sent.data/server"
     })

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/DefaultZillaChannelConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/DefaultZillaChannelConfig.java
@@ -56,6 +56,7 @@ public class DefaultZillaChannelConfig extends DefaultChannelConfig implements Z
     {
         super();
         setBufferFactory(NATIVE_BUFFER_FACTORY);
+        setTimestamps(true);
     }
 
     @Override

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/DefaultZillaChannelConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/DefaultZillaChannelConfig.java
@@ -26,6 +26,7 @@ import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.Zill
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_SHARED_WINDOW;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_STREAM_ID;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_THROTTLE;
+import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_TIMESTAMPS;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_TRANSMISSION;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_UPDATE;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_WINDOW;
@@ -49,6 +50,7 @@ public class DefaultZillaChannelConfig extends DefaultChannelConfig implements Z
     private ZillaUpdateMode update = ZillaUpdateMode.STREAM;
     private long affinity;
     private byte capabilities;
+    private boolean timestamps;
 
     public DefaultZillaChannelConfig()
     {
@@ -190,6 +192,19 @@ public class DefaultZillaChannelConfig extends DefaultChannelConfig implements Z
     }
 
     @Override
+    public void setTimestamps(
+        boolean timestamps)
+    {
+        this.timestamps = timestamps;
+    }
+
+    @Override
+    public boolean hasTimestamps()
+    {
+        return timestamps;
+    }
+
+    @Override
     protected boolean setOption0(
         String key,
         Object value)
@@ -241,6 +256,10 @@ public class DefaultZillaChannelConfig extends DefaultChannelConfig implements Z
         else if (OPTION_CAPABILITIES.getName().equals(key))
         {
             setCapabilities(convertToByte(value));
+        }
+        else if (OPTION_TIMESTAMPS.getName().equals(key))
+        {
+            setTimestamps(Boolean.parseBoolean(Objects.toString(value, "false")));
         }
         else
         {

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/DefaultZillaServerChannelConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/DefaultZillaServerChannelConfig.java
@@ -55,6 +55,7 @@ public class DefaultZillaServerChannelConfig extends DefaultServerChannelConfig 
     {
         super();
         setBufferFactory(NATIVE_BUFFER_FACTORY);
+        setTimestamps(true);
     }
 
     @Override

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/DefaultZillaServerChannelConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/DefaultZillaServerChannelConfig.java
@@ -25,6 +25,7 @@ import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.Zill
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_SHARED_WINDOW;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_STREAM_ID;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_THROTTLE;
+import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_TIMESTAMPS;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_TRANSMISSION;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_UPDATE;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_WINDOW;
@@ -48,6 +49,7 @@ public class DefaultZillaServerChannelConfig extends DefaultServerChannelConfig 
     private ZillaUpdateMode update = ZillaUpdateMode.STREAM;
     private long affinity;
     private byte capabilities;
+    private boolean timestamps;
 
     public DefaultZillaServerChannelConfig()
     {
@@ -190,6 +192,19 @@ public class DefaultZillaServerChannelConfig extends DefaultServerChannelConfig 
     }
 
     @Override
+    public void setTimestamps(
+        boolean timestamps)
+    {
+        this.timestamps = timestamps;
+    }
+
+    @Override
+    public boolean hasTimestamps()
+    {
+        return timestamps;
+    }
+
+    @Override
     protected boolean setOption0(
         String key,
         Object value)
@@ -238,6 +253,10 @@ public class DefaultZillaServerChannelConfig extends DefaultServerChannelConfig 
         else if (OPTION_CAPABILITIES.getName().equals(key))
         {
             setCapabilities(convertToByte(value));
+        }
+        else if (OPTION_TIMESTAMPS.getName().equals(key))
+        {
+            setTimestamps(Boolean.parseBoolean(Objects.toString(value, "false")));
         }
         else
         {

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChannel.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChannel.java
@@ -213,6 +213,11 @@ public abstract class ZillaChannel extends AbstractChannel<ZillaChannelConfig>
         return String.format("%s [sourceId=%d, targetId=%d]", description, sourceId, targetId);
     }
 
+    public long timestamp()
+    {
+        return getConfig().hasTimestamps() ? System.nanoTime() : 0L;
+    }
+
     public void acknowledgeBytes(
         int reserved)
     {

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChannelAddressFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChannelAddressFactory.java
@@ -23,6 +23,7 @@ import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.Zill
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_REPLY_TO;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_STREAM_ID;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_THROTTLE;
+import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_TIMESTAMPS;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_TRANSMISSION;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_UPDATE;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_WINDOW;
@@ -75,7 +76,7 @@ public class ZillaChannelAddressFactory extends ChannelAddressFactorySpi
 
         Collection<TypeInfo<?>> allOptionTypes = asList(OPTION_EPHEMERAL, OPTION_REPLY_TO, OPTION_WINDOW, OPTION_BUDGET_ID,
                 OPTION_STREAM_ID, OPTION_PADDING, OPTION_UPDATE, OPTION_AUTHORIZATION, OPTION_THROTTLE,
-                OPTION_TRANSMISSION, OPTION_BYTE_ORDER);
+                OPTION_TRANSMISSION, OPTION_BYTE_ORDER, OPTION_TIMESTAMPS);
         for (TypeInfo<?> optionType : allOptionTypes)
         {
             if (options != null && options.containsKey(optionType.getName()))

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChannelConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChannelConfig.java
@@ -60,4 +60,8 @@ public interface ZillaChannelConfig extends ChannelConfig
     void setCapabilities(byte capabilities);
 
     byte getCapabilities();
+
+    void setTimestamps(boolean timestamps);
+
+    boolean hasTimestamps();
 }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaEngine.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaEngine.java
@@ -285,7 +285,7 @@ public final class ZillaEngine implements Runnable, ExternalResourceReleasable
         int scopeIndex)
     {
         ZillaScope scope = new ZillaScope(config, labels, scopeIndex, this::lookupTargetIndex,
-                System::nanoTime, traceIds::incrementAndGet);
+                traceIds::incrementAndGet);
         this.scopes = ArrayUtil.add(this.scopes, scope);
         return scope;
     }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaPartition.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaPartition.java
@@ -416,6 +416,7 @@ final class ZillaPartition implements AutoCloseable
             childConfig.setPadding(serverConfig.getPadding());
             childConfig.setAlignment(serverConfig.getAlignment());
             childConfig.setCapabilities(serverConfig.getCapabilities());
+            childConfig.setTimestamps(serverConfig.hasTimestamps());
 
             if (childConfig.getTransmission() == SIMPLEX)
             {

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaScope.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaScope.java
@@ -57,7 +57,6 @@ public final class ZillaScope implements AutoCloseable
     private final Long2ObjectHashMap<MessageHandler> throttlesById;
     private final Long2ObjectHashMap<ZillaCorrelation> correlations;
     private final ToIntFunction<Long> lookupTargetIndex;
-    private final LongSupplier supplyTimestamp;
     private final LongSupplier supplyTraceId;
     private final ZillaSource source;
 
@@ -68,7 +67,6 @@ public final class ZillaScope implements AutoCloseable
         LabelManager labels,
         int scopeIndex,
         ToIntFunction<Long> lookupTargetIndex,
-        LongSupplier supplyTimestamp,
         LongSupplier supplyTraceId)
     {
         this.config = config;
@@ -81,7 +79,6 @@ public final class ZillaScope implements AutoCloseable
         this.targetsByIndex = new Int2ObjectHashMap<>();
         this.debitorsByIndex = new Int2ObjectHashMap<>();
         this.lookupTargetIndex = lookupTargetIndex;
-        this.supplyTimestamp = supplyTimestamp;
         this.supplyTraceId = supplyTraceId;
         this.source = new ZillaSource(config, scopeIndex, supplyTraceId,
                 correlations::remove, this::supplySender, this::supplyTarget,
@@ -365,7 +362,7 @@ public final class ZillaScope implements AutoCloseable
 
         final ZillaTarget target = new ZillaTarget(source.scopeIndex(), targetPath, layout, writeBuffer,
                 throttlesById::put, throttlesById::remove, correlations::put,
-                supplyTimestamp, supplyTraceId);
+                supplyTraceId);
 
         this.targets = ArrayUtil.add(this.targets, target);
 

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaStreamFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaStreamFactory.java
@@ -105,7 +105,7 @@ public final class ZillaStreamFactory
         final int maximum = channel.sourceMax();
 
         final ZillaTarget sender = supplySender.apply(streamId);
-        sender.doChallenge(originId, routedId, streamId, sequence, acknowledge, traceId, maximum, challengeExt);
+        sender.doChallenge(channel, originId, routedId, streamId, sequence, acknowledge, traceId, maximum, challengeExt);
     }
 
     public MessageHandler newStream(

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaTarget.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaTarget.java
@@ -104,7 +104,6 @@ final class ZillaTarget implements AutoCloseable
     private final LongConsumer unregisterThrottle;
     private final MutableDirectBuffer writeBuffer;
     private final LongObjectBiConsumer<ZillaCorrelation> correlateNew;
-    private final LongSupplier supplyTimestamp;
     private final LongSupplier supplyTraceId;
 
     ZillaTarget(
@@ -115,7 +114,6 @@ final class ZillaTarget implements AutoCloseable
         LongObjectBiConsumer<MessageHandler> registerThrottle,
         LongConsumer unregisterThrottle,
         LongObjectBiConsumer<ZillaCorrelation> correlateNew,
-        LongSupplier supplyTimestamp,
         LongSupplier supplyTraceId)
     {
         this.scopeIndex = scopeIndex;
@@ -127,7 +125,6 @@ final class ZillaTarget implements AutoCloseable
         this.registerThrottle = registerThrottle;
         this.unregisterThrottle = unregisterThrottle;
         this.correlateNew = correlateNew;
-        this.supplyTimestamp = supplyTimestamp;
         this.supplyTraceId = supplyTraceId;
     }
 
@@ -270,7 +267,7 @@ final class ZillaTarget implements AutoCloseable
                 .sequence(sequence)
                 .acknowledge(acknowledge)
                 .maximum(maximum)
-                .timestamp(supplyTimestamp.getAsLong())
+                .timestamp(client.timestamp())
                 .traceId(supplyTraceId.getAsLong())
                 .authorization(authorization)
                 .affinity(affinity)
@@ -334,14 +331,14 @@ final class ZillaTarget implements AutoCloseable
     }
 
     public void doConnectAbort(
-        ZillaClientChannel clientChannel)
+        ZillaClientChannel client)
     {
-        final long originId = clientChannel.originId();
-        final long routedId = clientChannel.routedId();
-        final long initialId = clientChannel.targetId();
-        final long sequence = clientChannel.targetSeq();
-        final long acknowledge = clientChannel.targetAck();
-        final int maximum = clientChannel.targetMax();
+        final long originId = client.originId();
+        final long routedId = client.routedId();
+        final long initialId = client.targetId();
+        final long sequence = client.targetSeq();
+        final long acknowledge = client.targetAck();
+        final int maximum = client.targetMax();
 
         final AbortFW abort = abortRW.wrap(writeBuffer, 0, writeBuffer.capacity())
                 .originId(originId)
@@ -350,7 +347,7 @@ final class ZillaTarget implements AutoCloseable
                 .sequence(sequence)
                 .acknowledge(acknowledge)
                 .maximum(maximum)
-                .timestamp(supplyTimestamp.getAsLong())
+                .timestamp(client.timestamp())
                 .traceId(supplyTraceId.getAsLong())
                 .build();
 
@@ -390,7 +387,7 @@ final class ZillaTarget implements AutoCloseable
                 .sequence(sequence)
                 .acknowledge(acknowledge)
                 .maximum(maximum)
-                .timestamp(supplyTimestamp.getAsLong())
+                .timestamp(channel.timestamp())
                 .traceId(supplyTraceId.getAsLong())
                 .affinity(affinity)
                 .extension(p -> p.set(beginExtCopy))
@@ -495,7 +492,7 @@ final class ZillaTarget implements AutoCloseable
                 .sequence(sequence)
                 .acknowledge(acknowledge)
                 .maximum(maximum)
-                .timestamp(supplyTimestamp.getAsLong())
+                .timestamp(channel.timestamp())
                 .traceId(supplyTraceId.getAsLong())
                 .authorization(authorization)
                 .budgetId(budgetId)
@@ -535,7 +532,7 @@ final class ZillaTarget implements AutoCloseable
                 .sequence(sequence)
                 .acknowledge(acknowledge)
                 .maximum(maximum)
-                .timestamp(supplyTimestamp.getAsLong())
+                .timestamp(channel.timestamp())
                 .traceId(supplyTraceId.getAsLong())
                 .authorization(authorization)
                 .extension(p -> p.set(abortExtCopy))
@@ -585,7 +582,7 @@ final class ZillaTarget implements AutoCloseable
                 .sequence(sequence)
                 .acknowledge(acknowledge)
                 .maximum(maximum)
-                .timestamp(supplyTimestamp.getAsLong())
+                .timestamp(channel.timestamp())
                 .traceId(supplyTraceId.getAsLong())
                 .authorization(authorization)
                 .extension(p -> p.set(endExtCopy))
@@ -631,7 +628,7 @@ final class ZillaTarget implements AutoCloseable
                 .sequence(sequence)
                 .acknowledge(acknowledge)
                 .maximum(channel.targetMax())
-                .timestamp(supplyTimestamp.getAsLong())
+                .timestamp(channel.timestamp())
                 .traceId(supplyTraceId.getAsLong())
                 .authorization(channel.targetAuth())
                 .extension(p -> p.set(endExtCopy))
@@ -767,7 +764,7 @@ final class ZillaTarget implements AutoCloseable
                     .sequence(sequence)
                     .acknowledge(acknowledge)
                     .maximum(maximum)
-                    .timestamp(supplyTimestamp.getAsLong())
+                    .timestamp(channel.timestamp())
                     .traceId(supplyTraceId.getAsLong())
                     .authorization(authorization)
                     .flags(flags)
@@ -839,7 +836,7 @@ final class ZillaTarget implements AutoCloseable
                 .sequence(sequence)
                 .acknowledge(acknowledge)
                 .maximum(maximum)
-                .timestamp(supplyTimestamp.getAsLong())
+                .timestamp(channel.timestamp())
                 .traceId(supplyTraceId.getAsLong())
                 .budgetId(budgetId)
                 .padding(padding)
@@ -880,7 +877,6 @@ final class ZillaTarget implements AutoCloseable
                 .sequence(sequence)
                 .acknowledge(acknowledge)
                 .maximum(maximum)
-                .timestamp(supplyTimestamp.getAsLong())
                 .traceId(traceId)
                 .build();
 
@@ -908,7 +904,7 @@ final class ZillaTarget implements AutoCloseable
                 .sequence(sequence)
                 .acknowledge(acknowledge)
                 .maximum(maximum)
-                .timestamp(supplyTimestamp.getAsLong())
+                .timestamp(channel.timestamp())
                 .traceId(traceId)
                 .extension(p -> p.set(extensionCopy))
                 .build();
@@ -917,6 +913,7 @@ final class ZillaTarget implements AutoCloseable
     }
 
     void doChallenge(
+        final ZillaChannel channel,
         final long originId,
         final long routedId,
         final long streamId,
@@ -935,7 +932,7 @@ final class ZillaTarget implements AutoCloseable
                 .sequence(sequence)
                 .acknowledge(acknowledge)
                 .maximum(maximum)
-                .timestamp(supplyTimestamp.getAsLong())
+                .timestamp(channel.timestamp())
                 .traceId(traceId)
                 .extension(p -> p.set(extensionCopy))
                 .build();
@@ -1128,7 +1125,7 @@ final class ZillaTarget implements AutoCloseable
                         .sequence(sequence)
                         .acknowledge(acknowledge)
                         .maximum(maximum)
-                        .timestamp(supplyTimestamp.getAsLong())
+                        .timestamp(channel.timestamp())
                         .traceId(supplyTraceId.getAsLong())
                         .build();
 

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/types/ZillaTypeSystem.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/types/ZillaTypeSystem.java
@@ -45,6 +45,7 @@ public final class ZillaTypeSystem implements TypeSystemSpi
     public static final TypeInfo<String> OPTION_ALIGNMENT = new TypeInfo<>("alignment", String.class);
     public static final TypeInfo<Long> OPTION_AFFINITY = new TypeInfo<>("affinity", Long.class);
     public static final TypeInfo<Byte> OPTION_CAPABILITIES = new TypeInfo<>("capabilities", Byte.class);
+    public static final TypeInfo<String> OPTION_TIMESTAMPS = new TypeInfo<>("timestamps", String.class);
     public static final TypeInfo<Integer> OPTION_FLAGS = new TypeInfo<>("flags", Integer.class);
     public static final TypeInfo<Integer> OPTION_ACK = new TypeInfo<>("ack", Integer.class);
 
@@ -93,6 +94,7 @@ public final class ZillaTypeSystem implements TypeSystemSpi
         acceptOptions.add(OPTION_BYTE_ORDER);
         acceptOptions.add(OPTION_ALIGNMENT);
         acceptOptions.add(OPTION_CAPABILITIES);
+        acceptOptions.add(OPTION_TIMESTAMPS);
         this.acceptOptions = unmodifiableSet(acceptOptions);
 
         Set<TypeInfo<?>> connectOptions = new LinkedHashSet<>();
@@ -111,6 +113,7 @@ public final class ZillaTypeSystem implements TypeSystemSpi
         connectOptions.add(OPTION_ALIGNMENT);
         connectOptions.add(OPTION_AFFINITY);
         connectOptions.add(OPTION_CAPABILITIES);
+        connectOptions.add(OPTION_TIMESTAMPS);
         this.connectOptions = unmodifiableSet(connectOptions);
 
         Set<TypeInfo<?>> readOptions = new LinkedHashSet<>();

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/timestamps.false/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/timestamps.false/client.rpt
@@ -1,0 +1,21 @@
+#
+# Copyright 2021-2023 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/server#0"
+        option zilla:transmission "duplex"
+        option zilla:window 8192
+        option zilla:timestamps "false"
+connected

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/timestamps.false/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/timestamps.false/server.rpt
@@ -1,0 +1,23 @@
+#
+# Copyright 2021-2023 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/server#0"
+       option zilla:transmission "duplex"
+       option zilla:window 8192
+       option zilla:timestamps "false"
+
+accepted
+connected


### PR DESCRIPTION
## Description

Allows timestamps to be disabled via script options in k3po zilla transport.

Needed by command-dump for ITs to produce predictable output for comparison to expected output.