### PR TITLE
Use flyweight fields instead of class fields for control

### DIFF
--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/streams/OpenapiClientFactory.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/streams/OpenapiClientFactory.java
@@ -379,9 +379,9 @@ public final class OpenapiClientFactory implements OpenapiStreamFactory
         }
 
         private void doOpenapiBegin(
-            long replySeq,
-            long replyAck,
-            int replyMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId,
             OctetsFW extension)
         {
@@ -394,14 +394,14 @@ public final class OpenapiClientFactory implements OpenapiStreamFactory
                 .extension(extension)
                 .build();
 
-            doBegin(sender, originId, routedId, replyId, replySeq, replyAck, replyMax,
+            doBegin(sender, originId, routedId, replyId, sequence, acknowledge, maximum,
                 traceId, authorization, affinity, openBeginEx);
         }
 
         private void doOpenapiData(
-            long replySeq,
-            long replyAck,
-            int replyMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId,
             long replyBudgetId,
             int flag,
@@ -409,35 +409,35 @@ public final class OpenapiClientFactory implements OpenapiStreamFactory
             OctetsFW payload,
             Flyweight extension)
         {
-            doData(sender, originId, routedId, replyId, replySeq, replyAck, replyMax,
-                    traceId, authorization, replyBudgetId, flag, reserved, payload, extension);
+            doData(sender, originId, routedId, replyId, sequence, acknowledge, maximum,
+                traceId, authorization, replyBudgetId, flag, reserved, payload, extension);
 
-            replySeq += reserved;
+            sequence += reserved;
         }
 
         private void doOpenapiFlush(
-            long replySeq,
-            long replyAck,
-            int replyMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId,
             long replyBudgetId,
             int reserved,
             OctetsFW extension)
         {
-            doFlush(sender, originId, routedId, replyId, replySeq, replyAck, replyMax,
+            doFlush(sender, originId, routedId, replyId, sequence, acknowledge, maximum,
                 traceId, authorization, replyBudgetId, reserved, extension);
         }
 
         private void doOpenapiEnd(
-            long replySeq,
-            long replyAck,
-            int replyMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId,
             OctetsFW extension)
         {
             if (OpenapiState.replyOpening(state) && !OpenapiState.replyClosed(state))
             {
-                doEnd(sender, originId, routedId, replyId, replySeq, replyAck, replyMax,
+                doEnd(sender, originId, routedId, replyId, sequence, acknowledge, maximum,
                     traceId, authorization, extension);
             }
 
@@ -445,14 +445,14 @@ public final class OpenapiClientFactory implements OpenapiStreamFactory
         }
 
         private void doOpenapiAbort(
-            long replySeq,
-            long replyAck,
-            int replyMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId)
         {
             if (OpenapiState.replyOpening(state) && !OpenapiState.replyClosed(state))
             {
-                doAbort(sender, originId, routedId, replyId, replySeq, replyAck, replyMax,
+                doAbort(sender, originId, routedId, replyId, sequence, acknowledge, maximum,
                     traceId, authorization, EMPTY_OCTETS);
             }
 
@@ -460,30 +460,30 @@ public final class OpenapiClientFactory implements OpenapiStreamFactory
         }
 
         private void doOpenapiReset(
-            long initialSeq,
-            long initialAck,
-            int initialMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId)
         {
             if (!OpenapiState.initialClosed(state))
             {
                 state = OpenapiState.closeInitial(state);
 
-                doReset(sender, originId, routedId, initialId, initialSeq, initialAck, initialMax,
+                doReset(sender, originId, routedId, initialId, sequence, acknowledge, maximum,
                     traceId, authorization, EMPTY_OCTETS);
             }
         }
 
         private void doOpenapiWindow(
-            long initialSeq,
-            long initialAck,
-            int initialMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long authorization,
             long traceId,
             long budgetId,
             int padding)
         {
-            doWindow(sender, originId, routedId, initialId, initialSeq, initialAck, initialMax,
+            doWindow(sender, originId, routedId, initialId, sequence, acknowledge, maximum,
                 traceId, authorization, budgetId, padding);
         }
     }
@@ -672,9 +672,9 @@ public final class OpenapiClientFactory implements OpenapiStreamFactory
         }
 
         private void doHttpBegin(
-            long initialSeq,
-            long initialAck,
-            int initialMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId,
             long affinity,
             OctetsFW extension)
@@ -683,16 +683,16 @@ public final class OpenapiClientFactory implements OpenapiStreamFactory
             {
                 assert state == 0;
 
-                this.receiver = newStream(this::onHttpMessage, originId, routedId, initialId, initialSeq,
-                    initialAck, initialMax, traceId, authorization, affinity, extension);
+                this.receiver = newStream(this::onHttpMessage, originId, routedId, initialId, sequence,
+                    acknowledge, maximum, traceId, authorization, affinity, extension);
                 state = OpenapiState.openingInitial(state);
             }
         }
 
         private void doHttpData(
-            long initialSeq,
-            long initialAck,
-            int initialMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId,
             long authorization,
             long budgetId,
@@ -701,37 +701,37 @@ public final class OpenapiClientFactory implements OpenapiStreamFactory
             OctetsFW payload,
             Flyweight extension)
         {
-            doData(receiver, originId, routedId, initialId, initialSeq, initialAck, initialMax,
+            doData(receiver, originId, routedId, initialId, sequence, acknowledge, maximum,
                 traceId, authorization, budgetId, flags, reserved, payload, extension);
         }
 
         private void doHttpFlush(
-            long initialSeq,
-            long initialAck,
-            int initialMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId,
             long initialBud,
             int reserved,
             OctetsFW extension)
         {
-            doFlush(receiver, originId, routedId, initialId, initialSeq, initialAck, initialMax,
+            doFlush(receiver, originId, routedId, initialId, sequence, acknowledge, maximum,
                 traceId, authorization, initialBud, reserved, extension);
 
-            initialSeq += reserved;
+            sequence += reserved;
 
-            assert initialSeq <= initialAck + initialMax;
+            assert sequence <= acknowledge + maximum;
         }
 
         private void doHttpEnd(
-            long initialSeq,
-            long initialAck,
-            int initialMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId,
             OctetsFW extension)
         {
             if (!OpenapiState.initialClosed(state))
             {
-                doEnd(receiver, originId, routedId, initialId, initialSeq, initialAck, initialMax,
+                doEnd(receiver, originId, routedId, initialId, sequence, acknowledge, maximum,
                     traceId, authorization, extension);
 
                 state = OpenapiState.closeInitial(state);
@@ -739,15 +739,15 @@ public final class OpenapiClientFactory implements OpenapiStreamFactory
         }
 
         private void doHttpAbort(
-            long initialSeq,
-            long initialAck,
-            int initialMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId,
             OctetsFW extension)
         {
             if (!OpenapiState.initialClosed(state))
             {
-                doAbort(receiver, originId, routedId, initialId, initialSeq, initialAck, initialMax,
+                doAbort(receiver, originId, routedId, initialId, sequence, acknowledge, maximum,
                     traceId, authorization, extension);
 
                 state = OpenapiState.closeInitial(state);
@@ -755,14 +755,14 @@ public final class OpenapiClientFactory implements OpenapiStreamFactory
         }
 
         private void doHttpReset(
-            long replySeq,
-            long replyAck,
-            int replyMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId)
         {
             if (!OpenapiState.replyClosed(state))
             {
-                doReset(receiver, originId, routedId, replyId, replySeq, replyAck, replyMax,
+                doReset(receiver, originId, routedId, replyId, sequence, acknowledge, maximum,
                     traceId, authorization, EMPTY_OCTETS);
 
                 state = OpenapiState.closeReply(state);
@@ -770,15 +770,15 @@ public final class OpenapiClientFactory implements OpenapiStreamFactory
         }
 
         private void doHttpWindow(
-            long replySeq,
-            long replyAck,
-            int replyMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId,
             long authorization,
             long budgetId,
             int padding)
         {
-            doWindow(receiver, originId, routedId, replyId, replySeq, replyAck, replyMax,
+            doWindow(receiver, originId, routedId, replyId, sequence, acknowledge, maximum,
                 traceId, authorization, budgetId, padding);
         }
     }

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/streams/OpenapiServerFactory.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/streams/OpenapiServerFactory.java
@@ -201,17 +201,6 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
 
         private int state;
 
-        private long replyBudgetId;
-
-        private long initialSeq;
-        private long initialAck;
-        private int initialMax;
-
-        private long replySeq;
-        private long replyAck;
-        private int replyMax;
-        private int replyPad;
-
         private HttpStream(
             MessageConsumer sender,
             long originId,
@@ -279,22 +268,16 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         {
             final long sequence = begin.sequence();
             final long acknowledge = begin.acknowledge();
+            final int maximum = begin.maximum();
             final long traceId = begin.traceId();
-            final long authorization = begin.authorization();
             final long affinity = begin.affinity();
             final OctetsFW extension = begin.extension();
 
             assert acknowledge <= sequence;
-            assert sequence >= initialSeq;
-            assert acknowledge >= initialAck;
 
-            initialSeq = sequence;
-            initialAck = acknowledge;
             state = OpenapiState.openingInitial(state);
 
-            assert initialAck <= initialSeq;
-
-            openapi.doOpenapiBegin(traceId, extension);
+            openapi.doOpenapiBegin(sequence, acknowledge, maximum, traceId, affinity, extension);
         }
 
         private void onHttpData(
@@ -302,6 +285,7 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         {
             final long sequence = data.sequence();
             final long acknowledge = data.acknowledge();
+            final int maximum = data.maximum();
             final long traceId = data.traceId();
             final long authorization = data.authorization();
             final long budgetId = data.budgetId();
@@ -311,13 +295,9 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
             final OctetsFW extension = data.extension();
 
             assert acknowledge <= sequence;
-            assert sequence >= initialSeq;
 
-            initialSeq = sequence + reserved;
-
-            assert initialAck <= initialSeq;
-
-            openapi.doOpenapiData(traceId, authorization, budgetId, reserved, flags, payload, extension);
+            openapi.doOpenapiData(sequence, acknowledge, maximum, traceId, authorization, budgetId,
+                reserved, flags, payload, extension);
         }
 
         private void onHttpEnd(
@@ -325,18 +305,15 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         {
             final long sequence = end.sequence();
             final long acknowledge = end.acknowledge();
+            final int maximum = end.maximum();
             final long traceId = end.traceId();
             final OctetsFW extension = end.extension();
 
             assert acknowledge <= sequence;
-            assert sequence >= initialSeq;
 
-            initialSeq = sequence;
             state = OpenapiState.closeInitial(state);
 
-            assert initialAck <= initialSeq;
-
-            openapi.doOpenapiEnd(traceId, extension);
+            openapi.doOpenapiEnd(sequence, acknowledge, maximum, traceId, extension);
         }
 
         private void onHttpFlush(
@@ -344,18 +321,15 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         {
             final long sequence = flush.sequence();
             final long acknowledge = flush.acknowledge();
+            final int maximum = flush.maximum();
             final long traceId = flush.traceId();
+            final long budgetId = flush.budgetId();
             final int reserved = flush.reserved();
             final OctetsFW extension = flush.extension();
 
             assert acknowledge <= sequence;
-            assert sequence >= initialSeq;
 
-            initialSeq = sequence + reserved;
-
-            assert initialAck <= initialSeq;
-
-            openapi.doOpenapiFlush(traceId, reserved, extension);
+            openapi.doOpenapiFlush(sequence, acknowledge, maximum, traceId, budgetId, reserved, extension);
         }
 
         private void onHttpAbort(
@@ -363,18 +337,15 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         {
             final long sequence = abort.sequence();
             final long acknowledge = abort.acknowledge();
+            final int maximum = abort.maximum();
             final long traceId = abort.traceId();
             final OctetsFW extension = abort.extension();
 
             assert acknowledge <= sequence;
-            assert sequence >= initialSeq;
 
-            initialSeq = sequence;
             state = OpenapiState.closeInitial(state);
 
-            assert initialAck <= initialSeq;
-
-            openapi.doOpenapiAbort(traceId, extension);
+            openapi.doOpenapiAbort(sequence, acknowledge, maximum, traceId, extension);
         }
 
         private void onHttpReset(
@@ -386,15 +357,10 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
             final long traceId = reset.traceId();
 
             assert acknowledge <= sequence;
-            assert acknowledge >= replyAck;
 
-            replyAck = acknowledge;
-            replyMax = maximum;
             state = OpenapiState.closeReply(state);
 
-            assert replyAck <= replySeq;
-
-            cleanup(traceId);
+            openapi.doOpenapiReset(sequence, acknowledge, maximum, traceId);
         }
 
         private void onHttpWindow(
@@ -404,26 +370,22 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
             final long acknowledge = window.acknowledge();
             final int maximum = window.maximum();
             final long traceId = window.traceId();
+            final long authorization = window.authorization();
             final long budgetId = window.budgetId();
             final int padding = window.padding();
 
             assert acknowledge <= sequence;
-            assert sequence <= replySeq;
-            assert acknowledge >= replyAck;
-            assert maximum >= replyMax;
 
-            replyAck = acknowledge;
-            replyMax = maximum;
-            replyPad = padding;
             state = OpenapiState.closingReply(state);
 
-            assert replyAck <= replySeq;
-
-            openapi.doOpenapiWindow(traceId, acknowledge, budgetId, padding);
+            openapi.doOpenapiWindow(sequence, acknowledge, maximum, traceId, authorization, budgetId, padding);
         }
 
         private void doHttpBegin(
             long traceId,
+            long replySeq,
+            long replyAck,
+            int replyMax,
             OctetsFW extension)
         {
             state = OpenapiState.openingReply(state);
@@ -433,30 +395,37 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         }
 
         private void doHttpData(
+            long replySeq,
+            long replyAck,
+            int replyMax,
             long traceId,
             int flag,
             int reserved,
+            long replyBudgetId,
             OctetsFW payload,
             Flyweight extension)
         {
             doData(sender, originId, routedId, replyId, replySeq, replyAck, replyMax,
                     traceId, authorization, replyBudgetId, flag, reserved, payload, extension);
-
-            replySeq += reserved;
         }
 
         private void doHttpFlush(
             long traceId,
+            long replyBudgetId,
+            long replySeq,
+            long replyAck,
+            int replyMax,
             int reserved,
             OctetsFW extension)
         {
             doFlush(sender, originId, routedId, replyId, replySeq, replyAck, replyMax,
                 traceId, authorization, replyBudgetId, reserved, extension);
-
-            replySeq += reserved;
         }
 
         private void doHttpEnd(
+            long replySeq,
+            long replyAck,
+            int replyMax,
             long traceId,
             OctetsFW extension)
         {
@@ -470,6 +439,9 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         }
 
         private void doHttpAbort(
+            long replySeq,
+            long replyAck,
+            int replyMax,
             long traceId)
         {
             if (OpenapiState.replyOpening(state) && !OpenapiState.replyClosed(state))
@@ -482,6 +454,9 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         }
 
         private void doHttpReset(
+            long initialSeq,
+            long initialAck,
+            int initialMax,
             long traceId)
         {
             if (!OpenapiState.initialClosed(state))
@@ -494,25 +469,16 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         }
 
         private void doHttpWindow(
+            long initialSeq,
+            long initialAck,
+            int initialMax,
             long authorization,
             long traceId,
             long budgetId,
             int padding)
         {
-            initialAck = openapi.initialAck;
-            initialMax = openapi.initialMax;
-
             doWindow(sender, originId, routedId, initialId, initialSeq, initialAck, initialMax,
                 traceId, authorization, budgetId, padding);
-        }
-
-        private void cleanup(
-            long traceId)
-        {
-            doHttpReset(traceId);
-            doHttpAbort(traceId);
-
-            openapi.cleanup(traceId);
         }
     }
 
@@ -530,16 +496,6 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         private MessageConsumer receiver;
 
         private int state;
-
-        private long initialSeq;
-        private long initialAck;
-        private int initialMax;
-        private long initialBud;
-
-        private long replySeq;
-        private long replyAck;
-        private int replyMax;
-        private int replyPad;
 
         private OpenapiStream(
             HttpStream delegate,
@@ -605,13 +561,16 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
             BeginFW begin)
         {
             final long traceId = begin.traceId();
+            final long sequence = begin.sequence();
+            final long acknowledge = begin.acknowledge();
+            final int maximum = begin.maximum();
             final OctetsFW extension = begin.extension();
 
             state = OpenapiState.openingReply(state);
 
             final OpenapiBeginExFW openapiBeginEx = extension.get(openapiBeginExRO::tryWrap);
 
-            delegate.doHttpBegin(traceId, openapiBeginEx.extension());
+            delegate.doHttpBegin(traceId, sequence, acknowledge, maximum, openapiBeginEx.extension());
         }
 
         private void onOpenapiData(
@@ -619,41 +578,33 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         {
             final long sequence = data.sequence();
             final long acknowledge = data.acknowledge();
+            final int maximum = data.maximum();
             final long traceId = data.traceId();
             final int flags = data.flags();
+            final long budgetId = data.budgetId();
             final int reserved = data.reserved();
             final OctetsFW payload = data.payload();
             final OctetsFW extension = data.extension();
 
             assert acknowledge <= sequence;
-            assert sequence >= replySeq;
 
-            replySeq = sequence + reserved;
-
-            assert replyAck <= replySeq;
-            assert replySeq <= replyAck + replyMax;
-
-            delegate.doHttpData(traceId, flags, reserved, payload, extension);
+            delegate.doHttpData(sequence, acknowledge, maximum, traceId, flags, reserved, budgetId, payload, extension);
         }
 
         private void onOpenapiFlush(
             FlushFW flush)
         {
+            final long budgetId = flush.budgetId();
             final long sequence = flush.sequence();
             final long acknowledge = flush.acknowledge();
+            final int maximum = flush.maximum();
             final long traceId = flush.traceId();
             final int reserved = flush.reserved();
             final OctetsFW extension = flush.extension();
 
             assert acknowledge <= sequence;
-            assert sequence >= replySeq;
 
-            replySeq = sequence + reserved;
-
-            assert replyAck <= replySeq;
-            assert replySeq <= replyAck + replyMax;
-
-            delegate.doHttpFlush(traceId, reserved, extension);
+            delegate.doHttpFlush(traceId, budgetId, sequence, acknowledge, maximum, reserved, extension);
         }
 
         private void onOpenapiEnd(
@@ -661,18 +612,15 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         {
             final long sequence = end.sequence();
             final long acknowledge = end.acknowledge();
+            final int maximum = end.maximum();
             final long traceId = end.traceId();
             final OctetsFW extension = end.extension();
 
             assert acknowledge <= sequence;
-            assert sequence >= replySeq;
 
-            replySeq = sequence;
             state = OpenapiState.closingReply(state);
 
-            assert replyAck <= replySeq;
-
-            delegate.doHttpEnd(traceId, extension);
+            delegate.doHttpEnd(sequence, acknowledge, maximum, traceId, extension);
         }
 
         private void onOpenapiAbort(
@@ -680,17 +628,14 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         {
             final long sequence = abort.sequence();
             final long acknowledge = abort.acknowledge();
+            final int maximum = abort.maximum();
             final long traceId = abort.traceId();
 
             assert acknowledge <= sequence;
-            assert sequence >= replySeq;
 
-            replySeq = sequence;
             state = OpenapiState.closingReply(state);
 
-            assert replyAck <= replySeq;
-
-            delegate.doHttpAbort(traceId);
+            delegate.doHttpAbort(sequence, acknowledge, maximum, traceId);
         }
 
         private void onOpenapiReset(
@@ -698,17 +643,14 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         {
             final long sequence = reset.sequence();
             final long acknowledge = reset.acknowledge();
+            final int maximum = reset.maximum();
             final long traceId = reset.traceId();
 
             assert acknowledge <= sequence;
-            assert acknowledge >= delegate.initialAck;
 
-            delegate.initialAck = acknowledge;
             state = OpenapiState.closeInitial(state);
 
-            assert delegate.initialAck <= delegate.initialSeq;
-
-            delegate.doHttpReset(traceId);
+            delegate.doHttpReset(sequence, acknowledge, maximum, traceId);
         }
 
 
@@ -724,21 +666,18 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
             final int padding = window.padding();
 
             assert acknowledge <= sequence;
-            assert acknowledge >= delegate.initialAck;
-            assert maximum >= delegate.initialMax;
 
-            initialAck = acknowledge;
-            initialMax = maximum;
-            initialBud = budgetId;
             state = OpenapiState.openInitial(state);
 
-            assert initialAck <= initialSeq;
-
-            delegate.doHttpWindow(authorization, traceId, budgetId, padding);
+            delegate.doHttpWindow(sequence, acknowledge, maximum, authorization, traceId, budgetId, padding);
         }
 
         private void doOpenapiBegin(
+            long initialSeq,
+            long initialAck,
+            int initialMax,
             long traceId,
+            long affinity,
             OctetsFW extension)
         {
             if (!OpenapiState.initialOpening(state))
@@ -754,12 +693,15 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
                     .build();
 
                 this.receiver = newStream(this::onOpenapiMessage, originId, routedId, initialId, initialSeq,
-                    initialAck, initialMax, traceId, authorization, 0L, openapiBeginEx);
+                    initialAck, initialMax, traceId, authorization, affinity, openapiBeginEx);
                 state = OpenapiState.openingInitial(state);
             }
         }
 
         private void doOpenapiData(
+            long initialSeq,
+            long initialAck,
+            int initialMax,
             long traceId,
             long authorization,
             long budgetId,
@@ -770,14 +712,14 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         {
             doData(receiver, originId, routedId, initialId, initialSeq, initialAck, initialMax,
                 traceId, authorization, budgetId, flags, reserved, payload, extension);
-
-            initialSeq += reserved;
-
-            assert initialSeq <= initialAck + initialMax;
         }
 
         private void doOpenapiFlush(
+            long initialSeq,
+            long initialAck,
+            int initialMax,
             long traceId,
+            long initialBud,
             int reserved,
             OctetsFW extension)
         {
@@ -790,6 +732,9 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         }
 
         private void doOpenapiEnd(
+            long initialSeq,
+            long initialAck,
+            int initialMax,
             long traceId,
             OctetsFW extension)
         {
@@ -803,6 +748,9 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         }
 
         private void doOpenapiAbort(
+            long initialSeq,
+            long initialAck,
+            int initialMax,
             long traceId,
             OctetsFW extension)
         {
@@ -816,6 +764,9 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         }
 
         private void doOpenapiReset(
+            long replySeq,
+            long replyAck,
+            int replyMax,
             long traceId)
         {
             if (!OpenapiState.replyClosed(state))
@@ -828,23 +779,16 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         }
 
         private void doOpenapiWindow(
+            long replySeq,
+            long replyAck,
+            int replyMax,
             long traceId,
             long authorization,
             long budgetId,
             int padding)
         {
-            replyAck = Math.max(delegate.replyAck - replyPad, 0);
-            replyMax = delegate.replyMax;
-
             doWindow(receiver, originId, routedId, replyId, replySeq, replyAck, replyMax,
-                traceId, authorization, budgetId, padding + replyPad);
-        }
-
-        private void cleanup(
-            long traceId)
-        {
-            doOpenapiAbort(traceId, EMPTY_OCTETS);
-            doOpenapiReset(traceId);
+                traceId, authorization, budgetId, padding);
         }
     }
 

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/streams/OpenapiServerFactory.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/streams/OpenapiServerFactory.java
@@ -383,21 +383,21 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
 
         private void doHttpBegin(
             long traceId,
-            long replySeq,
-            long replyAck,
-            int replyMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             OctetsFW extension)
         {
             state = OpenapiState.openingReply(state);
 
-            doBegin(sender, originId, routedId, replyId, replySeq, replyAck, replyMax,
+            doBegin(sender, originId, routedId, replyId, sequence, acknowledge, maximum,
                 traceId, authorization, affinity, extension);
         }
 
         private void doHttpData(
-            long replySeq,
-            long replyAck,
-            int replyMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId,
             int flag,
             int reserved,
@@ -405,33 +405,33 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
             OctetsFW payload,
             Flyweight extension)
         {
-            doData(sender, originId, routedId, replyId, replySeq, replyAck, replyMax,
+            doData(sender, originId, routedId, replyId, sequence, acknowledge, maximum,
                     traceId, authorization, replyBudgetId, flag, reserved, payload, extension);
         }
 
         private void doHttpFlush(
             long traceId,
             long replyBudgetId,
-            long replySeq,
-            long replyAck,
-            int replyMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             int reserved,
             OctetsFW extension)
         {
-            doFlush(sender, originId, routedId, replyId, replySeq, replyAck, replyMax,
+            doFlush(sender, originId, routedId, replyId, sequence, acknowledge, maximum,
                 traceId, authorization, replyBudgetId, reserved, extension);
         }
 
         private void doHttpEnd(
-            long replySeq,
-            long replyAck,
-            int replyMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId,
             OctetsFW extension)
         {
             if (OpenapiState.replyOpening(state) && !OpenapiState.replyClosed(state))
             {
-                doEnd(sender, originId, routedId, replyId, replySeq, replyAck, replyMax,
+                doEnd(sender, originId, routedId, replyId, sequence, acknowledge, maximum,
                     traceId, authorization, extension);
             }
 
@@ -439,14 +439,14 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         }
 
         private void doHttpAbort(
-            long replySeq,
-            long replyAck,
-            int replyMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId)
         {
             if (OpenapiState.replyOpening(state) && !OpenapiState.replyClosed(state))
             {
-                doAbort(sender, originId, routedId, replyId, replySeq, replyAck, replyMax,
+                doAbort(sender, originId, routedId, replyId, sequence, acknowledge, maximum,
                     traceId, authorization, EMPTY_OCTETS);
             }
 
@@ -454,30 +454,30 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         }
 
         private void doHttpReset(
-            long initialSeq,
-            long initialAck,
-            int initialMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId)
         {
             if (!OpenapiState.initialClosed(state))
             {
                 state = OpenapiState.closeInitial(state);
 
-                doReset(sender, originId, routedId, initialId, initialSeq, initialAck, initialMax,
+                doReset(sender, originId, routedId, initialId, sequence, acknowledge, maximum,
                     traceId, authorization, EMPTY_OCTETS);
             }
         }
 
         private void doHttpWindow(
-            long initialSeq,
-            long initialAck,
-            int initialMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long authorization,
             long traceId,
             long budgetId,
             int padding)
         {
-            doWindow(sender, originId, routedId, initialId, initialSeq, initialAck, initialMax,
+            doWindow(sender, originId, routedId, initialId, sequence, acknowledge, maximum,
                 traceId, authorization, budgetId, padding);
         }
     }
@@ -673,9 +673,9 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         }
 
         private void doOpenapiBegin(
-            long initialSeq,
-            long initialAck,
-            int initialMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId,
             long affinity,
             OctetsFW extension)
@@ -692,16 +692,16 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
                     .extension(extension)
                     .build();
 
-                this.receiver = newStream(this::onOpenapiMessage, originId, routedId, initialId, initialSeq,
-                    initialAck, initialMax, traceId, authorization, affinity, openapiBeginEx);
+                this.receiver = newStream(this::onOpenapiMessage, originId, routedId, initialId, sequence,
+                    acknowledge, maximum, traceId, authorization, affinity, openapiBeginEx);
                 state = OpenapiState.openingInitial(state);
             }
         }
 
         private void doOpenapiData(
-            long initialSeq,
-            long initialAck,
-            int initialMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId,
             long authorization,
             long budgetId,
@@ -710,37 +710,37 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
             OctetsFW payload,
             Flyweight extension)
         {
-            doData(receiver, originId, routedId, initialId, initialSeq, initialAck, initialMax,
+            doData(receiver, originId, routedId, initialId, sequence, acknowledge, maximum,
                 traceId, authorization, budgetId, flags, reserved, payload, extension);
         }
 
         private void doOpenapiFlush(
-            long initialSeq,
-            long initialAck,
-            int initialMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId,
             long initialBud,
             int reserved,
             OctetsFW extension)
         {
-            doFlush(receiver, originId, routedId, initialId, initialSeq, initialAck, initialMax,
+            doFlush(receiver, originId, routedId, initialId, sequence, acknowledge, maximum,
                 traceId, authorization, initialBud, reserved, extension);
 
-            initialSeq += reserved;
+            sequence += reserved;
 
-            assert initialSeq <= initialAck + initialMax;
+            assert sequence <= acknowledge + maximum;
         }
 
         private void doOpenapiEnd(
-            long initialSeq,
-            long initialAck,
-            int initialMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId,
             OctetsFW extension)
         {
             if (!OpenapiState.initialClosed(state))
             {
-                doEnd(receiver, originId, routedId, initialId, initialSeq, initialAck, initialMax,
+                doEnd(receiver, originId, routedId, initialId, sequence, acknowledge, maximum,
                     traceId, authorization, extension);
 
                 state = OpenapiState.closeInitial(state);
@@ -748,15 +748,15 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         }
 
         private void doOpenapiAbort(
-            long initialSeq,
-            long initialAck,
-            int initialMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId,
             OctetsFW extension)
         {
             if (!OpenapiState.initialClosed(state))
             {
-                doAbort(receiver, originId, routedId, initialId, initialSeq, initialAck, initialMax,
+                doAbort(receiver, originId, routedId, initialId, sequence, acknowledge, maximum,
                     traceId, authorization, extension);
 
                 state = OpenapiState.closeInitial(state);
@@ -764,14 +764,14 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         }
 
         private void doOpenapiReset(
-            long replySeq,
-            long replyAck,
-            int replyMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId)
         {
             if (!OpenapiState.replyClosed(state))
             {
-                doReset(receiver, originId, routedId, replyId, replySeq, replyAck, replyMax,
+                doReset(receiver, originId, routedId, replyId, sequence, acknowledge, maximum,
                     traceId, authorization, EMPTY_OCTETS);
 
                 state = OpenapiState.closeReply(state);
@@ -779,15 +779,15 @@ public final class OpenapiServerFactory implements OpenapiStreamFactory
         }
 
         private void doOpenapiWindow(
-            long replySeq,
-            long replyAck,
-            int replyMax,
+            long sequence,
+            long acknowledge,
+            int maximum,
             long traceId,
             long authorization,
             long budgetId,
             int padding)
         {
-            doWindow(receiver, originId, routedId, replyId, replySeq, replyAck, replyMax,
+            doWindow(receiver, originId, routedId, replyId, sequence, acknowledge, maximum,
                 traceId, authorization, budgetId, padding);
         }
     }


### PR DESCRIPTION
## Description

Use flyweight fields instead of class fields for control.

Fixes #1004 