### PR TITLE
Sort frames by timestamp in dump command

### DIFF
--- a/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/spy/OneToOneRingBufferSpy.java
+++ b/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/spy/OneToOneRingBufferSpy.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.AtomicBuffer;
 
+import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
 import io.aklivity.zilla.runtime.engine.binding.function.MessagePredicate;
 
 public class OneToOneRingBufferSpy implements RingBufferSpy
@@ -145,5 +146,27 @@ public class OneToOneRingBufferSpy implements RingBufferSpy
         }
 
         return messagesRead;
+    }
+
+    @Override
+    public int peek(
+        final MessageConsumer handler)
+    {
+        final AtomicBuffer buffer = this.buffer;
+        final long head = spyPosition.get();
+        final int capacity = this.capacity;
+        final int headIndex = (int)head & (capacity - 1);
+        final int recordLength = buffer.getIntVolatile(lengthOffset(headIndex));
+        int messagesPeeked = 0;
+        if (recordLength > 0)
+        {
+            final int messageTypeId = buffer.getInt(typeOffset(headIndex));
+            if (PADDING_MSG_TYPE_ID != messageTypeId)
+            {
+                handler.accept(messageTypeId, buffer, headIndex + HEADER_LENGTH, recordLength - HEADER_LENGTH);
+                messagesPeeked = 1;
+            }
+        }
+        return messagesPeeked;
     }
 }

--- a/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/spy/RingBufferSpy.java
+++ b/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/spy/RingBufferSpy.java
@@ -16,6 +16,7 @@ package io.aklivity.zilla.runtime.command.dump.internal.airline.spy;
 
 import org.agrona.DirectBuffer;
 
+import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
 import io.aklivity.zilla.runtime.engine.binding.function.MessagePredicate;
 
 public interface RingBufferSpy
@@ -31,6 +32,7 @@ public interface RingBufferSpy
 
     int spy(MessagePredicate handler);
     int spy(MessagePredicate handler, int messageCountLimit);
+    int peek(MessageConsumer handler);
 
     long producerPosition();
     long consumerPosition();


### PR DESCRIPTION
## Description

This change makes the `dump` command sort the packets by timestamp during generation such that packet number order and timestamp order are consistent.

Fixes #959 
