### PR TITLE
Implement millisecond conversion to metrics

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/reader/HistogramRecord.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/reader/HistogramRecord.java
@@ -23,8 +23,12 @@ import java.util.Objects;
 import java.util.function.LongFunction;
 import java.util.function.LongSupplier;
 
+import org.agrona.collections.Int2IntHashMap;
+
 public class HistogramRecord implements MetricRecord
 {
+    private static final Int2IntHashMap MS_BUCKET_MAP = generateMillisecondsBucketMap();
+
     private final long bindingId;
     private final long metricId;
     private final int namespaceId;
@@ -32,6 +36,7 @@ public class HistogramRecord implements MetricRecord
     private final LongFunction<String> labelResolver;
 
     private long[] bucketValues = new long[BUCKETS];
+    private long[] millisecondBucketValues = null;
 
     public HistogramRecord(
         long bindingId,
@@ -87,6 +92,7 @@ public class HistogramRecord implements MetricRecord
         {
             bucketValues[i] = readers[i].getAsLong();
         }
+        millisecondBucketValues = null;
     }
 
     public long[] bucketValues()
@@ -94,7 +100,36 @@ public class HistogramRecord implements MetricRecord
         return bucketValues;
     }
 
+    public long[] millisecondBucketValues()
+    {
+        if (millisecondBucketValues == null)
+        {
+            millisecondBucketValues = new long[BUCKETS];
+            for (int i = 0; i < BUCKETS; i++)
+            {
+                int msIndex = MS_BUCKET_MAP.get(i);
+                millisecondBucketValues[msIndex] += bucketValues[i];
+            }
+        }
+        return millisecondBucketValues;
+    }
+
     public long[] stats()
+    {
+        return stats(bucketValues);
+    }
+
+    public long[] millisecondStats()
+    {
+        if (millisecondBucketValues == null)
+        {
+            millisecondBucketValues();
+        }
+        return stats(millisecondBucketValues);
+    }
+
+    private long[] stats(
+        long[] bucketValues)
     {
         long count = 0L;
         long sum = 0L;
@@ -120,7 +155,6 @@ public class HistogramRecord implements MetricRecord
         long average = count == 0L ? 0L : sum / count;
         return new long[]{minimum, maximum, sum, count, average};
     }
-
 
     private long getValue(
         int index)
@@ -148,5 +182,75 @@ public class HistogramRecord implements MetricRecord
     public int hashCode()
     {
         return Objects.hash(namespaceId, bindingId, metricId);
+    }
+
+    private static Int2IntHashMap generateMillisecondsBucketMap()
+    {
+        Int2IntHashMap map = new Int2IntHashMap(-1);
+        // source bucket index -> dividing source bucket limit by 1 million -> destination bucket index
+        map.put(0, 0); // 2 -> 2
+        map.put(1, 0); // 4 -> 2
+        map.put(2, 0); // 8 -> 2
+        map.put(3, 0); // 16 -> 2
+        map.put(4, 0); // 32 -> 2
+        map.put(5, 0); // 64 -> 2
+        map.put(6, 0); // 128 -> 2
+        map.put(7, 0); // 256 -> 2
+        map.put(8, 0); // 512 -> 2
+        map.put(9, 0); // 1024 -> 2
+        map.put(10, 0); // 2048 -> 2
+        map.put(11, 0); // 4096 -> 2
+        map.put(12, 0); // 8192 -> 2
+        map.put(13, 0); // 16384 -> 2
+        map.put(14, 0); // 32768 -> 2
+        map.put(15, 0); // 65536 -> 2
+        map.put(16, 0); // 131072 -> 2
+        map.put(17, 0); // 262144 -> 2
+        map.put(18, 0); // 524288 -> 2
+        map.put(19, 0); // 1048576 -> 2
+        map.put(20, 1); // 2097152 -> 4
+        map.put(21, 2); // 4194304 -> 4
+        map.put(22, 3); // 8388608 -> 8
+        map.put(23, 4); // 16777216 -> 16
+        map.put(24, 5); // 33554432 -> 33
+        map.put(25, 6); // 67108864 -> 67
+        map.put(26, 7); // 134217728 -> 134
+        map.put(27, 8); // 268435456 -> 268
+        map.put(28, 9); // 536870912 -> 536
+        map.put(29, 10); // 1073741824 -> 1073
+        map.put(30, 11); // 2147483648 -> 2147
+        map.put(31, 12); // 4294967296 -> 4294
+        map.put(32, 13); // 8589934592 -> 8589
+        map.put(33, 14); // 17179869184 -> 17179
+        map.put(34, 15); // 34359738368 -> 34359
+        map.put(35, 16); // 68719476736 -> 68719
+        map.put(36, 17); // 137438953472 -> 137438
+        map.put(37, 18); // 274877906944 -> 274877
+        map.put(38, 19); // 549755813888 -> 549755
+        map.put(39, 20); // 1099511627776 -> 1099511
+        map.put(40, 21); // 2199023255552 -> 2199023
+        map.put(41, 22); // 4398046511104 -> 4398046
+        map.put(42, 23); // 8796093022208 -> 8796093
+        map.put(43, 24); // 17592186044416 -> 17592186
+        map.put(44, 25); // 35184372088832 -> 35184372
+        map.put(45, 26); // 70368744177664 -> 70368744
+        map.put(46, 27); // 140737488355328 -> 140737488
+        map.put(47, 28); // 281474976710656 -> 281474976
+        map.put(48, 29); // 562949953421312 -> 562949953
+        map.put(49, 30); // 1125899906842624 -> 1125899906
+        map.put(50, 31); // 2251799813685248 -> 2251799813
+        map.put(51, 32); // 4503599627370496 -> 4503599627
+        map.put(52, 33); // 9007199254740992 -> 9007199254
+        map.put(53, 34); // 18014398509481984 -> 18014398509
+        map.put(54, 35); // 36028797018963968 -> 36028797018
+        map.put(55, 36); // 72057594037927936 -> 72057594037
+        map.put(56, 37); // 144115188075855872 -> 144115188075
+        map.put(57, 38); // 288230376151711744 -> 288230376151
+        map.put(58, 39); // 576460752303423488 -> 576460752303
+        map.put(59, 40); // 1152921504606846976 -> 1152921504606
+        map.put(60, 41); // 2305843009213693952 -> 2305843009213
+        map.put(61, 42); // 4611686018427387904 -> 4611686018427
+        map.put(62, 43);
+        return map;
     }
 }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/reader/ScalarRecord.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/reader/ScalarRecord.java
@@ -18,6 +18,7 @@ package io.aklivity.zilla.runtime.engine.metrics.reader;
 import static io.aklivity.zilla.runtime.engine.namespace.NamespacedId.namespaceId;
 
 import java.util.Objects;
+import java.util.function.DoubleSupplier;
 import java.util.function.LongFunction;
 import java.util.function.LongSupplier;
 
@@ -70,6 +71,11 @@ public class ScalarRecord implements MetricRecord
     public LongSupplier valueReader()
     {
         return this.reader;
+    }
+
+    public DoubleSupplier millisecondsValueReader()
+    {
+        return () -> (double) this.valueReader().getAsLong() / 1_000_000L;
     }
 
     @Override

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/metrics/reader/HistogramRecordTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/metrics/reader/HistogramRecordTest.java
@@ -15,8 +15,8 @@
  */
 package io.aklivity.zilla.runtime.engine.metrics.reader;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -39,6 +39,17 @@ public class HistogramRecordTest
         () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L,
         () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L,
         () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L
+    };
+    public static final LongSupplier[] READER_HISTOGRAM_MS = new LongSupplier[]
+    {
+        () -> 0L, () -> 1L, () -> 2L, () -> 0L, () -> 3L, () -> 0L, () -> 0L, () -> 0L,
+        () -> 0L, () -> 0L, () -> 4L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L,
+        () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L,
+        () -> 0L, () -> 4L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L,
+        () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 2L, () -> 0L, () -> 0L,
+        () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L,
+        () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L, () -> 0L,
+        () -> 0L, () -> 3L, () -> 0L, () -> 0L, () -> 1L, () -> 0L, () -> 0L
     };
 
     @Test
@@ -73,6 +84,34 @@ public class HistogramRecordTest
         assertThat(stats[2], equalTo(5_051_808L)); // sum
         assertThat(stats[3], equalTo(100L)); // cnt
         assertThat(stats[4], equalTo(50_518L)); // avg
+    }
+
+    @Test
+    public void shouldResolveTimeInMilliseconds()
+    {
+        // GIVEN
+        LongFunction<String> labelResolver = mock(LongFunction.class);
+        long bindingId = NamespacedId.id(77, 7);
+        long metricId = NamespacedId.id(77, 8);
+        HistogramRecord histogram = new HistogramRecord(bindingId, metricId, READER_HISTOGRAM_MS, labelResolver);
+
+        // WHEN
+        histogram.update();
+        int buckets = histogram.buckets();
+        long[] value = histogram.millisecondBucketValues();
+        long[] stats = histogram.millisecondStats();
+
+        // THEN
+        assertThat(buckets, equalTo(63));
+        assertThat(value[0], equalTo(10L));
+        assertThat(value[18], equalTo(2L));
+        assertThat(value[38], equalTo(3L));
+        assertThat(value[41], equalTo(1L));
+        assertThat(stats[0], equalTo(1L)); // min
+        assertThat(stats[1], equalTo(4_398_046_511_103L)); // max
+        assertThat(stats[2], equalTo(6_047_315_001_856L)); // sum
+        assertThat(stats[3], equalTo(20L)); // cnt
+        assertThat(stats[4], equalTo(302_365_750_092L)); // avg
     }
 
     @Test

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/metrics/reader/ScalarRecordTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/metrics/reader/ScalarRecordTest.java
@@ -15,8 +15,8 @@
  */
 package io.aklivity.zilla.runtime.engine.metrics.reader;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -30,6 +30,7 @@ import io.aklivity.zilla.runtime.engine.namespace.NamespacedId;
 public class ScalarRecordTest
 {
     private static final LongSupplier READER_42 = () -> 42L;
+    private static final LongSupplier READER_42_M = () -> 42_005_000L;
 
     @Test
     public void shouldResolveFields()
@@ -54,5 +55,21 @@ public class ScalarRecordTest
         assertThat(bindingName, equalTo("binding1"));
         assertThat(metricName, equalTo("metric1"));
         assertThat(value, equalTo(42L));
+    }
+
+    @Test
+    public void shouldResolveTimeInMilliseconds()
+    {
+        // GIVEN
+        LongFunction<String> labelResolver = mock(LongFunction.class);
+        long bindingId = NamespacedId.id(77, 7);
+        long metricId = NamespacedId.id(77, 8);
+        ScalarRecord scalar = new ScalarRecord(bindingId, metricId, READER_42_M, labelResolver);
+
+        // WHEN
+        double millisecondsValue = scalar.millisecondsValueReader().getAsDouble();
+
+        // THEN
+        assertThat(millisecondsValue, equalTo(42.005));
     }
 }

--- a/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/PrometheusExporterHandler.java
+++ b/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/PrometheusExporterHandler.java
@@ -70,7 +70,8 @@ public class PrometheusExporterHandler implements ExporterHandler
         MetricsReader metrics = new MetricsReader(collector, context::supplyLocalName);
         List<MetricRecord> records = metrics.records();
         PrometheusMetricDescriptor descriptor = new PrometheusMetricDescriptor(context::resolveMetric);
-        printer = new PrometheusMetricsPrinter(records, descriptor::kind, descriptor::name, descriptor::description);
+        printer = new PrometheusMetricsPrinter(records, descriptor::kind, descriptor::name, descriptor::description,
+            descriptor::milliseconds);
 
         for (PrometheusEndpointConfig endpoint : endpoints)
         {

--- a/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/printer/PrometheusMetricDescriptor.java
+++ b/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/printer/PrometheusMetricDescriptor.java
@@ -72,13 +72,22 @@ public class PrometheusMetricDescriptor
         }
         else if (metric.unit() == NANOSECONDS)
         {
-            result += "_nanoseconds";
+            // we are converting nanoseconds values to milliseconds
+            result += "_milliseconds";
         }
         if (metric.kind() == COUNTER)
         {
             result += "_total";
         }
         return result;
+    }
+
+    public boolean milliseconds(
+        String internalName)
+    {
+        // we are converting nanoseconds values to milliseconds
+        Metric metric = metricResolver.apply(internalName);
+        return metric.unit() == NANOSECONDS;
     }
 
     public String description(


### PR DESCRIPTION
## Description

This change exports time based metrics in milliseconds that are accurate down to the nanosecond decimal place.

Fixes #1069 
