### PR TITLE
Support engine events and detect config watcher failed

### DIFF
--- a/runtime/engine/pom.xml
+++ b/runtime/engine/pom.xml
@@ -83,6 +83,26 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman-submit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman-install</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman-bmunit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jmock</groupId>
       <artifactId>jmock-junit4</artifactId>
       <scope>test</scope>
@@ -230,6 +250,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.jboss.byteman</groupId>
+        <artifactId>byteman-rulecheck-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineConfiguration.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineConfiguration.java
@@ -46,6 +46,7 @@ public class EngineConfiguration extends Configuration
 
     public static final PropertyDef<URL> ENGINE_CONFIG_URL;
     public static final PropertyDef<URI> ENGINE_CONFIG_URI;
+    public static final BooleanPropertyDef ENGINE_CONFIG_WATCH;
     public static final IntPropertyDef ENGINE_CONFIG_POLL_INTERVAL_SECONDS;
     public static final PropertyDef<String> ENGINE_NAME;
     public static final PropertyDef<String> ENGINE_DIRECTORY;
@@ -85,6 +86,7 @@ public class EngineConfiguration extends Configuration
         ENGINE_CONFIG_URL = config.property(URL.class, "config.url", EngineConfiguration::configURL, "file:zilla.yaml");
         ENGINE_CONFIG_URI = config.property(URI.class, "config.uri", EngineConfiguration::decodeConfigURI,
             EngineConfiguration::defaultConfigURI);
+        ENGINE_CONFIG_WATCH = config.property("config.watch", true);
         ENGINE_CONFIG_POLL_INTERVAL_SECONDS = config.property("config.poll.interval.seconds", 60);
         ENGINE_NAME = config.property("name", EngineConfiguration::defaultName);
         ENGINE_DIRECTORY = config.property("directory", EngineConfiguration::defaultDirectory);
@@ -154,6 +156,11 @@ public class EngineConfiguration extends Configuration
     public URI configURI()
     {
         return ENGINE_CONFIG_URI.get(this);
+    }
+
+    public boolean configWatch()
+    {
+        return ENGINE_CONFIG_WATCH.get(this);
     }
 
     public int configPollIntervalSeconds()

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/EngineEventContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/EngineEventContext.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021-2023 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.internal.event;
+
+import static io.aklivity.zilla.runtime.engine.internal.types.event.EngineEventType.CONFIG_WATCHER_FAILED;
+
+import java.nio.ByteBuffer;
+import java.time.Clock;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+import io.aklivity.zilla.runtime.engine.Engine;
+import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.internal.types.event.EngineEventExFW;
+import io.aklivity.zilla.runtime.engine.internal.types.event.EventFW;
+
+public final class EngineEventContext
+{
+    private static final int EVENT_BUFFER_CAPACITY = 1024;
+
+    private final MutableDirectBuffer eventBuffer = new UnsafeBuffer(ByteBuffer.allocate(EVENT_BUFFER_CAPACITY));
+    private final MutableDirectBuffer extensionBuffer = new UnsafeBuffer(ByteBuffer.allocate(EVENT_BUFFER_CAPACITY));
+
+    private final EventFW.Builder eventRW = new EventFW.Builder();
+    private final EngineEventExFW.Builder eventExRW = new EngineEventExFW.Builder();
+
+    private final long engineId;
+    private final int engineTypeId;
+    private final int configWatcherFailedEventId;
+    private final MessageConsumer eventWriter;
+    private final Clock clock;
+
+    public EngineEventContext(
+        Engine engine)
+    {
+        this.engineId = engine.supplyNamespacedId(Engine.NAME, "events");
+        this.engineTypeId = engine.supplyLabelId(Engine.NAME);
+        this.configWatcherFailedEventId = engine.supplyLabelId("engine.config.watcher.failed");
+        this.eventWriter = engine.supplyEventWriter();
+        this.clock = engine.clock();
+    }
+
+    public void configWatcherFailed(
+        long traceId,
+        String reason)
+    {
+        EngineEventExFW extension = eventExRW
+            .wrap(extensionBuffer, 0, extensionBuffer.capacity())
+            .configWatcherFailed(e -> e
+                .typeId(CONFIG_WATCHER_FAILED.value())
+                .reason(reason)
+            )
+            .build();
+
+        EventFW event = eventRW
+            .wrap(eventBuffer, 0, eventBuffer.capacity())
+            .id(configWatcherFailedEventId)
+            .timestamp(clock.millis())
+            .traceId(traceId)
+            .namespacedId(engineId)
+            .extension(extension.buffer(), extension.offset(), extension.limit())
+            .build();
+
+        eventWriter.accept(engineTypeId, event.buffer(), event.offset(), event.limit());
+    }
+
+}

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/EngineEventFormatter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/EngineEventFormatter.java
@@ -26,9 +26,9 @@ import io.aklivity.zilla.runtime.engine.internal.types.event.EventFW;
 public final class EngineEventFormatter implements EventFormatterSpi
 {
     private static final String CONFIG_WATCHER_FAILED_FORMAT =
-        "Please restart to apply any config changes.";
+        "Dynamic config reloading is disabled.";
     private static final String CONFIG_WATCHER_FAILED_WITH_REASON_FORMAT =
-        CONFIG_WATCHER_FAILED_FORMAT + " %s";
+        CONFIG_WATCHER_FAILED_FORMAT + " %s.";
 
     private final EventFW eventRO = new EventFW();
     private final EngineEventExFW eventExRO = new EngineEventExFW();

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/EngineEventFormatter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/EngineEventFormatter.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021-2023 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.internal.event;
+
+import org.agrona.DirectBuffer;
+
+import io.aklivity.zilla.runtime.engine.Configuration;
+import io.aklivity.zilla.runtime.engine.event.EventFormatterSpi;
+import io.aklivity.zilla.runtime.engine.internal.types.event.EngineConfigWatcherFailedExFW;
+import io.aklivity.zilla.runtime.engine.internal.types.event.EngineEventExFW;
+import io.aklivity.zilla.runtime.engine.internal.types.event.EventFW;
+
+public final class EngineEventFormatter implements EventFormatterSpi
+{
+    private static final String CONFIG_WATCHER_FAILED_FORMAT =
+        "Please restart to apply any config changes.";
+    private static final String CONFIG_WATCHER_FAILED_WITH_REASON_FORMAT =
+        CONFIG_WATCHER_FAILED_FORMAT + " %s";
+
+    private final EventFW eventRO = new EventFW();
+    private final EngineEventExFW eventExRO = new EngineEventExFW();
+
+    EngineEventFormatter(
+        Configuration config)
+    {
+    }
+
+    public String format(
+        DirectBuffer buffer,
+        int index,
+        int length)
+    {
+        final EventFW event = eventRO.wrap(buffer, index, index + length);
+        final EngineEventExFW extension = eventExRO
+            .wrap(event.extension().buffer(), event.extension().offset(), event.extension().limit());
+
+        String text = null;
+        switch (extension.kind())
+        {
+        case CONFIG_WATCHER_FAILED:
+            EngineConfigWatcherFailedExFW configWatcherFailed = extension.configWatcherFailed();
+            String reason = configWatcherFailed.reason().asString();
+            String format = reason != null
+                ? CONFIG_WATCHER_FAILED_WITH_REASON_FORMAT
+                : CONFIG_WATCHER_FAILED_FORMAT;
+            text = String.format(format, reason);
+            break;
+        }
+
+        return text;
+    }
+}

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/EngineEventFormatterFactory.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/EngineEventFormatterFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021-2023 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.internal.event;
+
+import io.aklivity.zilla.runtime.engine.Configuration;
+import io.aklivity.zilla.runtime.engine.Engine;
+import io.aklivity.zilla.runtime.engine.event.EventFormatterFactorySpi;
+
+public final class EngineEventFormatterFactory implements EventFormatterFactorySpi
+{
+    @Override
+    public EngineEventFormatter create(
+        Configuration config)
+    {
+        return new EngineEventFormatter(config);
+    }
+
+    @Override
+    public String type()
+    {
+        return Engine.NAME;
+    }
+}

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineManager.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineManager.java
@@ -65,6 +65,7 @@ import io.aklivity.zilla.runtime.engine.ext.EngineExtSpi;
 import io.aklivity.zilla.runtime.engine.guard.Guard;
 import io.aklivity.zilla.runtime.engine.internal.Tuning;
 import io.aklivity.zilla.runtime.engine.internal.config.NamespaceAdapter;
+import io.aklivity.zilla.runtime.engine.internal.event.EngineEventContext;
 import io.aklivity.zilla.runtime.engine.internal.watcher.EngineConfigWatchTask;
 import io.aklivity.zilla.runtime.engine.namespace.NamespacedId;
 import io.aklivity.zilla.runtime.engine.resolver.Resolver;
@@ -104,6 +105,7 @@ public class EngineManager
         Consumer<String> logger,
         EngineExtContext context,
         EngineConfiguration config,
+        EngineEventContext events,
         List<EngineExtSpi> extensions)
     {
         this.schemaTypes = schemaTypes;
@@ -120,7 +122,7 @@ public class EngineManager
         this.extensions = extensions;
         this.expressions = Resolver.instantiate(config);
         this.configPath = Path.of(config.configURI());
-        this.watchTask = new WatchTaskImpl(configPath);
+        this.watchTask = new WatchTaskImpl(config, events, configPath);
     }
 
     public void start() throws Exception
@@ -529,9 +531,11 @@ public class EngineManager
     private final class WatchTaskImpl extends EngineConfigWatchTask
     {
         WatchTaskImpl(
+            EngineConfiguration config,
+            EngineEventContext events,
             Path configPath)
         {
-            super(configPath);
+            super(config, events, configPath);
         }
 
         @Override

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -40,7 +40,6 @@ import static org.agrona.CloseHelper.quietClose;
 import static org.agrona.concurrent.AgentRunner.startOnThread;
 
 import java.net.InetAddress;
-import java.net.URI;
 import java.nio.channels.SelectableChannel;
 import java.nio.file.Path;
 import java.time.Clock;
@@ -746,7 +745,7 @@ public class EngineWorker implements EngineContext, Agent
     {
         return location.indexOf(':') == -1
             ? configPath.resolveSibling(location)
-            : Path.of(URI.create(location));
+            : Path.of(configPath.toUri().resolve(location));
     }
 
     @Override

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -1103,7 +1103,11 @@ public class EngineWorker implements EngineContext, Agent
         switch (signalId)
         {
         case SIGNAL_TASK_QUEUED:
-            taskQueue.poll().run();
+            final Runnable task = taskQueue.poll();
+            if (task != null)
+            {
+                task.run();
+            }
             break;
         }
     }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -308,9 +308,10 @@ public class EngineWorker implements EngineContext, Agent
                 .build();
 
         this.eventsLayout = new EventsLayout.Builder()
-            .path(config.directory().resolve(String.format("events%d", index)))
-            .capacity(config.eventsBufferCapacity())
-            .build();
+                .path(config.directory().resolve(String.format("events%d", index)))
+                .capacity(config.eventsBufferCapacity())
+                .build();
+
         this.eventNames = new Int2ObjectHashMap<>();
 
         this.agentName = String.format("engine/data#%d", index);

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/watcher/EngineConfigWatchTask.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/watcher/EngineConfigWatchTask.java
@@ -26,8 +26,6 @@ import java.nio.file.WatchKey;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import io.aklivity.zilla.runtime.engine.EngineConfiguration;
 import io.aklivity.zilla.runtime.engine.internal.event.EngineEventContext;
@@ -36,7 +34,6 @@ public abstract class EngineConfigWatchTask implements AutoCloseable, Callable<V
 {
     private final Path configPath;
     private final EngineConfigWatcher watcher;
-    private final ExecutorService executor;
     private Map<String, WatchKey> resourceKeys;
 
     protected EngineConfigWatchTask(
@@ -46,14 +43,13 @@ public abstract class EngineConfigWatchTask implements AutoCloseable, Callable<V
     {
         this.configPath = configPath;
         this.watcher = new EngineConfigWatcher(config, events, configPath.getFileSystem());
-        this.executor = Executors.newScheduledThreadPool(2);
         this.resourceKeys = new HashMap<>();
     }
 
     public void submit()
     {
         onPathChanged(configPath);
-        executor.submit(this);
+        watcher.submit(this);
     }
 
     public void watch(
@@ -108,7 +104,7 @@ public abstract class EngineConfigWatchTask implements AutoCloseable, Callable<V
     @Override
     public final void close()
     {
-        executor.shutdownNow();
+        watcher.close();
     }
 
     protected abstract void onPathChanged(

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/watcher/EngineConfigWatchTask.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/watcher/EngineConfigWatchTask.java
@@ -29,6 +29,9 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import io.aklivity.zilla.runtime.engine.EngineConfiguration;
+import io.aklivity.zilla.runtime.engine.internal.event.EngineEventContext;
+
 public abstract class EngineConfigWatchTask implements AutoCloseable, Callable<Void>
 {
     private final Path configPath;
@@ -37,10 +40,12 @@ public abstract class EngineConfigWatchTask implements AutoCloseable, Callable<V
     private Map<String, WatchKey> resourceKeys;
 
     protected EngineConfigWatchTask(
+        EngineConfiguration config,
+        EngineEventContext events,
         Path configPath)
     {
         this.configPath = configPath;
-        this.watcher = new EngineConfigWatcher(configPath.getFileSystem());
+        this.watcher = new EngineConfigWatcher(config, events, configPath.getFileSystem());
         this.executor = Executors.newScheduledThreadPool(2);
         this.resourceKeys = new HashMap<>();
     }

--- a/runtime/engine/src/main/moditect/module-info.java
+++ b/runtime/engine/src/main/moditect/module-info.java
@@ -53,6 +53,9 @@ module io.aklivity.zilla.runtime.engine
     requires org.slf4j;
     requires io.aklivity.zilla.runtime.common;
 
+    provides io.aklivity.zilla.runtime.engine.event.EventFormatterFactorySpi
+        with io.aklivity.zilla.runtime.engine.internal.event.EngineEventFormatterFactory;
+
     uses io.aklivity.zilla.runtime.engine.config.ConditionConfigAdapterSpi;
     uses io.aklivity.zilla.runtime.engine.config.CompositeBindingAdapterSpi;
     uses io.aklivity.zilla.runtime.engine.config.OptionsConfigAdapterSpi;

--- a/runtime/engine/src/main/resources/META-INF/services/io.aklivity.zilla.runtime.engine.event.EventFormatterFactorySpi
+++ b/runtime/engine/src/main/resources/META-INF/services/io.aklivity.zilla.runtime.engine.event.EventFormatterFactorySpi
@@ -1,0 +1,1 @@
+io.aklivity.zilla.runtime.engine.internal.event.EngineEventFormatterFactory

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/event/EngineEventIT.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/event/EngineEventIT.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021-2023 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.internal.event;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.rules.RuleChain.outerRule;
+
+import org.jboss.byteman.contrib.bmunit.BMScript;
+import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+
+import io.aklivity.k3po.runtime.junit.annotation.Specification;
+import io.aklivity.k3po.runtime.junit.rules.K3poRule;
+import io.aklivity.zilla.runtime.engine.test.EngineRule;
+import io.aklivity.zilla.runtime.engine.test.annotation.Configuration;
+
+@RunWith(org.jboss.byteman.contrib.bmunit.BMUnitRunner.class)
+@BMUnitConfig(loadDirectory = "src/test/resources")
+@BMScript(value = "FileSystemHelper.btm")
+public class EngineEventIT
+{
+    private final K3poRule k3po = new K3poRule()
+        .addScriptRoot("net", "io/aklivity/zilla/specs/engine/streams/network")
+        .addScriptRoot("app", "io/aklivity/zilla/specs/engine/streams/application");
+
+    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
+
+    private final EngineRule engine = new EngineRule()
+        .directory("target/zilla-itests")
+        .countersBufferCapacity(4096)
+        .configurationRoot("io/aklivity/zilla/specs/engine/config")
+        .external("app0")
+        .clean();
+
+    @Rule
+    public final TestRule chain = outerRule(engine).around(k3po).around(timeout);
+
+    @Test
+    @Configuration("engine.events.yaml")
+    @Specification({
+        "${net}/handshake/client",
+        "${app}/handshake/server"
+    })
+    public void shouldLogEvents() throws Exception
+    {
+        k3po.finish();
+    }
+}

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/exporter/TestExporterHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/exporter/TestExporterHandler.java
@@ -68,16 +68,18 @@ class TestExporterHandler implements ExporterHandler
         int length)
     {
         final EventFW event = eventRO.wrap(buffer, index, index + length);
+
         String qname = context.supplyQName(event.namespacedId());
         String id = context.supplyLocalName(event.id());
         String name = context.supplyEventName(event.id());
         String message = formatter.format(msgTypeId, buffer, index, length);
+
         if (options.events != null && eventIndex < options.events.size())
         {
             TestExporterOptionsConfig.Event e = options.events.get(eventIndex);
             if (!qname.equals(e.qName) || !id.equals(e.id) || !name.equals(e.name) || !message.equals(e.message))
             {
-                throw new IllegalStateException(String.format("event mismatch, expected: %s %s %s %s, got: %s %s %s %s",
+                throw new IllegalStateException(String.format("event mismatch, expected: %s %s %s %s, actual: %s %s %s %s",
                     e.qName, e.id, e.name, e.message, qname, id, name, message));
             }
             eventIndex++;

--- a/runtime/engine/src/test/resources/FileSystemHelper.btm
+++ b/runtime/engine/src/test/resources/FileSystemHelper.btm
@@ -1,0 +1,6 @@
+RULE watcher service failed
+CLASS ^java.nio.file.FileSystem
+METHOD newWatchService
+IF TRUE
+DO throw new java.io.IOException("[failed]")
+ENDRULE

--- a/specs/engine.spec/src/main/resources/META-INF/zilla/core.idl
+++ b/specs/engine.spec/src/main/resources/META-INF/zilla/core.idl
@@ -111,5 +111,20 @@ scope core
             int64 namespacedId;
             octets extension;
         }
+
+        enum EngineEventType (uint8)
+        {
+            CONFIG_WATCHER_FAILED (1)
+        }
+
+        struct EngineConfigWatcherFailedEx extends core::stream::Extension
+        {
+            string16 reason;
+        }
+
+        union EngineEventEx switch (EngineEventType)
+        {
+            case CONFIG_WATCHER_FAILED: EngineConfigWatcherFailedEx configWatcherFailed;
+        }
     }
 }

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/engine.events.yaml
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/engine.events.yaml
@@ -25,7 +25,7 @@ telemetry:
           - qname: engine.events
             id: engine.config.watcher.failed
             name: ENGINE_CONFIG_WATCHER_FAILED
-            message: Please restart to apply any config changes. [failed]
+            message: Dynamic config reloading is disabled. [failed].
 bindings:
   net0:
     type: test

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/engine.events.yaml
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/engine.events.yaml
@@ -1,0 +1,33 @@
+#
+# Copyright 2021-2023 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+name: test
+telemetry:
+  exporters:
+    exporter0:
+      type: test
+      options:
+        events:
+          - qname: engine.events
+            id: engine.config.watcher.failed
+            name: ENGINE_CONFIG_WATCHER_FAILED
+            message: Please restart to apply any config changes. [failed]
+bindings:
+  net0:
+    type: test
+    kind: server
+    exit: app0


### PR DESCRIPTION
## Description

Creates a new `events` file for events at engine scope, in addition to per-core engine workers. Updates event reader to include these events as well so they are all picked up automatically by telemetry exporters.

Detect when `FileSystem.newWatchService()` fails, and record engine event, then still continue startup with observed `zilla.yaml` configuration.

Fixes #1081 
