### PR TITLE
fix: add volume mounts into the deployment yaml

### DIFF
--- a/cloud/helm-chart/src/main/helm/zilla/templates/deployment.yaml
+++ b/cloud/helm-chart/src/main/helm/zilla/templates/deployment.yaml
@@ -97,6 +97,11 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+            { { - if .Values.volumeMounts } }
+              { { - with .Values.volumeMounts } }
+                { { - toYaml . | nindent 12 } }
+              { { - end } }
+            { { - end } }
             {{- if index .Values "zilla.yaml" }}
             - name: {{ include "zilla.fullname" . }}
               mountPath: {{ .Values.configPath }}
@@ -127,6 +132,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        { { - if .Values.volumes } }
+          { { - with .Values.volumes } }
+            { { - toYaml . | nindent 8 } }
+          { { - end } }
+        { { - end } }
         {{- if index .Values "zilla.yaml" }}
         - name: {{ include "zilla.fullname" . }}
           configMap:


### PR DESCRIPTION
## Description

This will use the values.yaml `volumes` and `volumeMounts` fields in the `deployment.yaml` to map existing resources to a zilla deployment.
