### PR TITLE
fix: Add custom pod labels and fix notes for connection instructions

### DIFF
--- a/cloud/helm-chart/src/main/helm/zilla/templates/NOTES.txt
+++ b/cloud/helm-chart/src/main/helm/zilla/templates/NOTES.txt
@@ -1,4 +1,4 @@
-1. Get the application URL by running these commands:
+Connect to Zilla by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
@@ -17,8 +17,6 @@
   echo http://$SERVICE_IP:{{ $port.port }}
   {{- end }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "zilla.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+  export SERVICE_PORTS=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "zilla.fullname" . }} --template "{{"{{ range .spec.ports }}{{.port}} {{ end }}"}}")
+  eval "kubectl port-forward --namespace {{ .Release.Namespace }} service/{{ include "zilla.fullname" . }} $SERVICE_PORTS"
 {{- end }}

--- a/cloud/helm-chart/src/main/helm/zilla/templates/deployment.yaml
+++ b/cloud/helm-chart/src/main/helm/zilla/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       {{- end }}
       labels:
         {{- include "zilla.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/cloud/helm-chart/src/main/helm/zilla/templates/deployment.yaml
+++ b/cloud/helm-chart/src/main/helm/zilla/templates/deployment.yaml
@@ -96,6 +96,7 @@ spec:
           readinessProbe:
             tcpSocket:
               port: {{ .Values.readinessProbePort }}
+            initialDelaySeconds: 3
           {{- end}}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
## Description

This is a simple fix in the helm chat to allow the `podLabels` field in the value.yaml to work. 
A change in the install output to correct the notes printed on install to correctly show how to port forward all of the configured service ports. 
Add an initial delay to the readiness check so the pod doesn't fail the first check when zilla hasn't started yet.
