### PR TITLE
Lint helm chart on local builds and PR builds

### DIFF
--- a/cloud/helm-chart/pom.xml
+++ b/cloud/helm-chart/pom.xml
@@ -65,8 +65,8 @@
         </configuration>
         <executions>
           <execution>
-            <phase>deploy</phase>
             <goals>
+              <goal>lint</goal>
               <goal>push</goal>
             </goals>
           </execution>

--- a/cloud/pom.xml
+++ b/cloud/pom.xml
@@ -18,21 +18,6 @@
 
   <modules>
     <module>docker-image</module>
+    <module>helm-chart</module>
   </modules>
-
-  <profiles>
-    <profile>
-      <id>release</id>
-      <activation>
-        <property>
-          <name>release</name>
-          <value>true</value>
-        </property>
-      </activation>
-
-      <modules>
-        <module>helm-chart</module>
-      </modules>
-    </profile>
-  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -611,6 +611,8 @@
         <docker.skip.push>true</docker.skip.push>
         <docker.skip.tag>true</docker.skip.tag>
         <docker.latest.tag></docker.latest.tag>
+        <helm.push.skip>true</helm.push.skip>
+        <helm.package.skip>true</helm.package.skip>
       </properties>
 
       <build>


### PR DESCRIPTION
## Description

Includes `cloud/helm-chart` in non-release builds and adds explicit `lint` goal to check the helm chart during the build.