### PR TITLE
update ingress values and implementation

### DIFF
--- a/cloud/helm-chart/src/main/helm/zilla/templates/NOTES.txt
+++ b/cloud/helm-chart/src/main/helm/zilla/templates/NOTES.txt
@@ -1,10 +1,12 @@
+{{- if not .Values.ingress.enabled }}
 Connect to Zilla by running these commands:
-{{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
-  {{- end }}
 {{- end }}
+{{- if .Values.ingress.enabled }}
+Zilla is available through an ingress controller at the base url(s):
+  {{- $host := or .Values.ingress.host "localhost" -}}
+  {{- range $path := .Values.ingress.paths }}
+    http{{ if $.Values.ingress.tls.enabled }}s{{ end }}://{{ $host }}{{ $path.path }}
+  {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "zilla.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/cloud/helm-chart/src/main/helm/zilla/templates/ingress.yaml
+++ b/cloud/helm-chart/src/main/helm/zilla/templates/ingress.yaml
@@ -22,39 +22,37 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- if .Values.ingress.tls.enabled }}
   tls:
-    {{- range .Values.ingress.tls }}
     - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+        - {{ tpl .Values.ingress.host . }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
+    - http:
         paths:
-          {{- range .paths }}
+        {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+          {{- range .Values.ingress.paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .pathType }}
-            {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ .port }}
-              {{- else }}
+          {{- end }}
+        {{- else -}}
+          {{- range .Values.ingress.paths }}
+          - path: {{ .path }}
+            backend:
               serviceName: {{ $fullName }}
               servicePort: {{ .port }}
-              {{- end }}
           {{- end }}
-    {{- end }}
+        {{- end }}
+      {{- if tpl .Values.ingress.host . }}
+      host: {{ tpl .Values.ingress.host . }}
+      {{- end }}
 {{- end }}

--- a/cloud/helm-chart/src/main/helm/zilla/values.yaml
+++ b/cloud/helm-chart/src/main/helm/zilla/values.yaml
@@ -96,22 +96,34 @@ service:
   type: ClusterIP
   ports: []
 
+# Ingress configuration
 ingress:
+  # Enable ingress resource
   enabled: false
-  className: ""
+
+  # Annotations for the Ingress
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          port: 7114
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+
+  # ingressClassName for the Ingress
+  ingressClassName: ""
+
+  # The hostname for the Ingress
+  host: ""
+
+  ## HTTP paths to add to the Ingress
+  ## e.g:
+  ## paths:
+  ##  - path: /api
+  ##    pathType: Prefix
+  ##    port: 7114
+  paths: []
+
+  # configs for Ingress TLS
+  tls:
+    # Enable TLS termination for the Ingress
+    enabled: false
+    # the name of a pre-created Secret containing a TLS private key and certificate
+    secretName: ""
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
## Description

This improves the ingress controller to allow for managing ingress without a host specified. It also enables defining paths that can map to different ports down to the K8s zilla service. Additionally, it supports backward-compatible K8s versions of ingress.

Notes output with multiple ingress paths defined:
```
Zilla is available through an ingress controller at the base url(s):
  http://localhost/api
  http://localhost/ui
```

Notes output when no ingress is configured, the command dynamically forwards any exposed Zilla service ports:

```
Connect to Zilla by running these commands:
  export SERVICE_PORTS=$(kubectl get svc --namespace $namespace $service_name --template "{{ range .spec.ports }}{{.port}} {{ end }}")
  eval "kubectl port-forward --namespace $namespace service/$service_name $SERVICE_PORTS"
```
