### PR TITLE
Support multiple requests with single window ack on shared connection

### DIFF
--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientGroupFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientGroupFactory.java
@@ -1238,6 +1238,7 @@ public final class KafkaClientGroupFactory extends KafkaClientSaslHandshaker imp
                 progress = leaveGroupResponse.limit();
 
                 final short errorCode = leaveGroupResponse.errorCode();
+
                 if (errorCode == ERROR_NONE)
                 {
                     members:
@@ -5198,7 +5199,7 @@ public final class KafkaClientGroupFactory extends KafkaClientSaslHandshaker imp
             switch (errorCode)
             {
             case ERROR_NONE:
-                encoders.add(encodeSaslAuthenticateRequest);
+                encoders.addFirst(encodeSaslAuthenticateRequest);
                 decoder = decodeCoordinatorSaslAuthenticateResponse;
                 break;
             default:
@@ -5240,7 +5241,12 @@ public final class KafkaClientGroupFactory extends KafkaClientSaslHandshaker imp
         {
             nextResponseId++;
 
-            delegate.groupMembership.memberIds.put(delegate.groupId, memberId);
+            String removedId = delegate.groupMembership.memberIds.put(delegate.groupId, memberId);
+            if (removedId != null)
+            {
+                // TODO: log event
+                System.out.printf("[%s] consumer group member id error %s, heartbeat too late?\n", delegate.groupId, removedId);
+            }
 
             delegate.client = joinGroup;
             joinGroup.doJoinGroupRequest(traceId);


### PR DESCRIPTION
## Description

We are using flow control budget to manage multiple requests on shared connection from pool, so multiple small requests can successfully claim non-fragmented budget and send both requests.

They could arrive in any order in practice. When sent via TLS, there is potential for batching at encryption layer so a single window can be received to ack both requests in the aggregate.

When we distribute the flow control credit to each stream, we need to make sure not to over credit beyond the amount actually sent by each stream. Otherwise, we would not hit the condition to precisely ack the data sent by the first stream, and therefore it is not removed from the queue, blocking ack for all subsequent streams.

When this occurs, subsequent streams on the shared connection in the pool will eventually reach zero window and stall.

Also, when connection pool is disabled, `SASL` needs multiple requests to complete, so if a flush arrives on the group stream, queuing the `SyncGroupRequest`, we need to make sure it is processed _after_ `SaslAuthenticateRequest` etc.