### PR TITLE
Enables `bindings:asyncapi` to use `catalog::apicurio`

### DIFF
--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/composite/AsyncapiCompositeGenerator.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/composite/AsyncapiCompositeGenerator.java
@@ -49,7 +49,7 @@ import io.aklivity.zilla.runtime.binding.asyncapi.internal.view.AsyncapiSchemaIt
 import io.aklivity.zilla.runtime.binding.asyncapi.internal.view.AsyncapiSchemaView;
 import io.aklivity.zilla.runtime.binding.asyncapi.internal.view.AsyncapiServerView;
 import io.aklivity.zilla.runtime.binding.asyncapi.internal.view.AsyncapiView;
-import io.aklivity.zilla.runtime.catalog.apicurio.internal.config.ApicurioOptionsConfig;
+import io.aklivity.zilla.runtime.catalog.apicurio.config.ApicurioOptionsConfig;
 import io.aklivity.zilla.runtime.catalog.inline.config.InlineOptionsConfig;
 import io.aklivity.zilla.runtime.catalog.inline.config.InlineOptionsConfigBuilder;
 import io.aklivity.zilla.runtime.catalog.karapace.config.KarapaceOptionsConfig;

--- a/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/config/ApicurioOptionsConfig.java
+++ b/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/config/ApicurioOptionsConfig.java
@@ -12,7 +12,7 @@
  * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package io.aklivity.zilla.runtime.catalog.apicurio.internal.config;
+package io.aklivity.zilla.runtime.catalog.apicurio.config;
 
 import java.time.Duration;
 import java.util.function.Function;

--- a/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/config/ApicurioOptionsConfigBuilder.java
+++ b/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/config/ApicurioOptionsConfigBuilder.java
@@ -12,7 +12,7 @@
  * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package io.aklivity.zilla.runtime.catalog.apicurio.internal.config;
+package io.aklivity.zilla.runtime.catalog.apicurio.config;
 
 import java.time.Duration;
 import java.util.function.Function;

--- a/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalogContext.java
+++ b/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalogContext.java
@@ -16,7 +16,7 @@ package io.aklivity.zilla.runtime.catalog.apicurio.internal;
 
 import java.util.concurrent.ConcurrentMap;
 
-import io.aklivity.zilla.runtime.catalog.apicurio.internal.config.ApicurioOptionsConfig;
+import io.aklivity.zilla.runtime.catalog.apicurio.config.ApicurioOptionsConfig;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogContext;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;

--- a/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalogHandler.java
+++ b/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalogHandler.java
@@ -14,9 +14,9 @@
  */
 package io.aklivity.zilla.runtime.catalog.apicurio.internal;
 
+import static io.aklivity.zilla.runtime.catalog.apicurio.config.ApicurioOptionsConfigBuilder.CONTENT_ID;
+import static io.aklivity.zilla.runtime.catalog.apicurio.config.ApicurioOptionsConfigBuilder.LEGACY_ID_ENCODING;
 import static io.aklivity.zilla.runtime.catalog.apicurio.internal.CachedArtifactId.IN_PROGRESS;
-import static io.aklivity.zilla.runtime.catalog.apicurio.internal.config.ApicurioOptionsConfigBuilder.CONTENT_ID;
-import static io.aklivity.zilla.runtime.catalog.apicurio.internal.config.ApicurioOptionsConfigBuilder.LEGACY_ID_ENCODING;
 import static org.agrona.BitUtil.SIZE_OF_BYTE;
 import static org.agrona.BitUtil.SIZE_OF_INT;
 import static org.agrona.BitUtil.SIZE_OF_LONG;
@@ -42,7 +42,7 @@ import org.agrona.DirectBuffer;
 import org.agrona.collections.Int2ObjectCache;
 import org.agrona.concurrent.UnsafeBuffer;
 
-import io.aklivity.zilla.runtime.catalog.apicurio.internal.config.ApicurioOptionsConfig;
+import io.aklivity.zilla.runtime.catalog.apicurio.config.ApicurioOptionsConfig;
 import io.aklivity.zilla.runtime.catalog.apicurio.internal.types.ApicurioPrefixFW;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;

--- a/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/config/ApicurioOptionsConfigAdapter.java
+++ b/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/config/ApicurioOptionsConfigAdapter.java
@@ -21,6 +21,8 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.bind.adapter.JsonbAdapter;
 
+import io.aklivity.zilla.runtime.catalog.apicurio.config.ApicurioOptionsConfig;
+import io.aklivity.zilla.runtime.catalog.apicurio.config.ApicurioOptionsConfigBuilder;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfig;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfigAdapterSpi;
 

--- a/runtime/catalog-apicurio/src/main/moditect/module-info.java
+++ b/runtime/catalog-apicurio/src/main/moditect/module-info.java
@@ -17,6 +17,8 @@ module io.aklivity.zilla.runtime.catalog.apicurio
     requires java.net.http;
     requires io.aklivity.zilla.runtime.engine;
 
+    exports io.aklivity.zilla.runtime.catalog.apicurio.internal.config;
+
     provides io.aklivity.zilla.runtime.engine.catalog.CatalogFactorySpi
         with io.aklivity.zilla.runtime.catalog.apicurio.internal.ApicurioCatalogFactorySpi;
 

--- a/runtime/catalog-apicurio/src/main/moditect/module-info.java
+++ b/runtime/catalog-apicurio/src/main/moditect/module-info.java
@@ -17,7 +17,7 @@ module io.aklivity.zilla.runtime.catalog.apicurio
     requires java.net.http;
     requires io.aklivity.zilla.runtime.engine;
 
-    exports io.aklivity.zilla.runtime.catalog.apicurio.internal.config;
+    exports io.aklivity.zilla.runtime.catalog.apicurio.config;
 
     provides io.aklivity.zilla.runtime.engine.catalog.CatalogFactorySpi
         with io.aklivity.zilla.runtime.catalog.apicurio.internal.ApicurioCatalogFactorySpi;

--- a/runtime/catalog-apicurio/src/test/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalogIT.java
+++ b/runtime/catalog-apicurio/src/test/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalogIT.java
@@ -32,7 +32,7 @@ import org.junit.rules.Timeout;
 
 import io.aklivity.k3po.runtime.junit.annotation.Specification;
 import io.aklivity.k3po.runtime.junit.rules.K3poRule;
-import io.aklivity.zilla.runtime.catalog.apicurio.internal.config.ApicurioOptionsConfig;
+import io.aklivity.zilla.runtime.catalog.apicurio.config.ApicurioOptionsConfig;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
 import io.aklivity.zilla.runtime.engine.model.function.ValueConsumer;

--- a/runtime/catalog-apicurio/src/test/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/config/ApicurioOptionsConfigAdapterTest.java
+++ b/runtime/catalog-apicurio/src/test/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/config/ApicurioOptionsConfigAdapterTest.java
@@ -28,6 +28,8 @@ import jakarta.json.bind.JsonbConfig;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.aklivity.zilla.runtime.catalog.apicurio.config.ApicurioOptionsConfig;
+
 public class ApicurioOptionsConfigAdapterTest
 {
     private Jsonb jsonb;


### PR DESCRIPTION
Fixes #1185 
