### PR TITLE
Support SKIP_MANY only kafka headers sequence filter

### DIFF
--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheCursorFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheCursorFactory.java
@@ -714,6 +714,11 @@ public final class KafkaCacheCursorFactory
                     matchItemOffset = matchItem.limit();
                 }
 
+                if (conditions.isEmpty())
+                {
+                    conditions.add(new KafkaFilterCondition.None());
+                }
+
                 this.name = headersCopy.name();
                 this.matches = headersCopy.values();
                 this.and = new And(mask, conditions);


### PR DESCRIPTION
## Description

Needed by mqtt-kafka for root multilevel wildcard `#` which is an automatic subscription used by [MQTT Explorer](https://mqtt-explorer.com/).

