### PR TITLE
Allow content-length header with h2c upgrade

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpServerFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpServerFactory.java
@@ -1274,13 +1274,13 @@ public final class HttpServerFactory implements HttpStreamFactory
                 break;
 
             case "upgrade":
-                if (server.decoder != decodeHeadersOnly)
-                {
-                    error = ERROR_400_BAD_REQUEST;
-                }
-                else if ("h2c".equals(value))
+                if ("h2c".equals(value))
                 {
                     // TODO: h2c
+                }
+                else if (server.decoder != decodeHeadersOnly)
+                {
+                    error = ERROR_400_BAD_REQUEST;
                 }
                 else
                 {

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/StartingIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/StartingIT.java
@@ -79,6 +79,16 @@ public class StartingIT
         k3po.finish();
     }
 
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
+        "${net}/upgrade.h2c.with.no.settings/client",
+        "${app}/upgrade.http/server" })
+    public void shouldUpgradeViaCleartextWithNoSettings() throws Exception
+    {
+        k3po.finish();
+    }
+
     @Ignore("TODO")
     @Test
     @Configuration("server.yaml")

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.no.settings/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.no.settings/client.rpt
@@ -22,14 +22,16 @@ connected
 write "POST / HTTP/1.1\r\n"
       "Host: localhost:8080\r\n"
       "Connection: Upgrade, HTTP2-Settings\r\n"
-      "Upgrade: h2c\r\n"
       "Content-Type: text/plain;charset=UTF-8\r\n"
       "Content-Length: 12\r\n"
+      "Upgrade: h2c\r\n"
       "\r\n"
 
 write "Hello, world"
 
 read "HTTP/1.1 200 OK\r\n"
+     "Server: CERN/3.0 libwww/2.17\r\n"
+     "Date: Wed, 01 Feb 2017 19:12:46 GMT\r\n"
      "Content-Type: text/plain;charset=UTF-8\r\n"
      "Content-Length: 17\r\n"
      "\r\n"

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.no.settings/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.no.settings/server.rpt
@@ -23,14 +23,16 @@ connected
 read "POST / HTTP/1.1\r\n"
      "Host: localhost:8080\r\n"
      "Connection: Upgrade, HTTP2-Settings\r\n"
-     "Upgrade: h2c\r\n"
      "Content-Type: text/plain;charset=UTF-8\r\n"
      "Content-Length: 12\r\n"
+     "Upgrade: h2c\r\n"
      "\r\n"
 
 read "Hello, world"
 
 write "HTTP/1.1 200 OK\r\n"
+      "Server: CERN/3.0 libwww/2.17\r\n"
+      "Date: Wed, 01 Feb 2017 19:12:46 GMT\r\n"
       "Content-Type: text/plain;charset=UTF-8\r\n"
       "Content-Length: 17\r\n"
       "\r\n"


### PR DESCRIPTION
## Description

When `upgrade` is observed in the http 1.1 headers after `content-length`, it was enforcing that no body decoder is in place, just headers only before the upgrade. However, `content-length` is valid specifically for `h2c` upgrade.

Fixes #1192 
