### PR TITLE
Compute kafka produce checksum without staging headers

### DIFF
--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.header/client.rpt
@@ -73,7 +73,7 @@ read zilla:begin.ext ${kafka:beginEx()
 write zilla:data.ext ${kafka:dataEx()
                               .typeId(zilla:id("kafka"))
                               .produce()
-                                  .timestamp(newTimestamp)
+                                  .timestamp(1716424650323)
                                   .header("header1", "value1")
                                   .build()
                               .build()}

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.100k/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.100k/client.rpt
@@ -74,7 +74,7 @@ write zilla:data.ext ${kafka:dataEx()
                               .typeId(zilla:id("kafka"))
                               .produce()
                                   .deferred(102400 - 8192 + 512 + 512)
-                                  .timestamp(newTimestamp)
+                                  .timestamp(1716424650323)
                                   .build()
                               .build()}
 write zilla:data.ext ${kafka:dataEx()

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.header/client.rpt
@@ -98,11 +98,11 @@ write 140                               # size
       83                                # length
       -1
       [0x02]
-      0x4e8723aa
+      -1568090010
       0s
       0                                 # last offset delta
-      ${newTimestamp}                   # first timestamp
-      ${newTimestamp}                   # last timestamp
+      1716424650323L                    # first timestamp
+      1716424650323L                    # last timestamp
       -1L
       -1s
       -1

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.header/server.rpt
@@ -94,11 +94,11 @@ read 140
      83                                 # length
      -1
      [0x02]
-     [0..4]
+     -1568090010
      0s
      0                                  # last offset delta
-     (long:timestamp)                   # first timestamp
-     ${timestamp}                       # last timestamp
+     1716424650323L                     # first timestamp
+     1716424650323L                     # last timestamp
      -1L
      -1s
      -1

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.100k/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.100k/client.rpt
@@ -98,11 +98,11 @@ write 102517                             # size
       102460                            # length
       -1
       [0x02]
-      0x4e8723aa
+      0x46de7fe3
       0s
       0                                 # last offset delta
-      ${newTimestamp}                   # first timestamp
-      ${newTimestamp}                   # last timestamp
+      1716424650323L                    # first timestamp
+      1716424650323L                    # last timestamp
       -1L
       -1s
       -1

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.100k/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.100k/server.rpt
@@ -95,11 +95,11 @@ read 102517
      102460                             # length
      -1
      [0x02]
-     [0..4]
+     0x46de7fe3
      0s
      0                                  # last offset delta
-     (long:timestamp)                   # first timestamp
-     ${timestamp}                       # last timestamp
+     1716424650323L                     # first timestamp
+     1716424650323L                     # last timestamp
      -1L
      -1s
      -1


### PR DESCRIPTION
## Description

Kafka produce protocol requires crc32c checksum up front before the message value and headers. When messages are small, we have all the information at once, i.e. the complete value and the headers, so we can easily compute the checksum. When the message is fragmented, we have the headers with `init` fragment, and checksum of complete value, so we can compute the full checksum without staging the headers themselves temporarily. Then the headers are sent again with the `fin` fragment so we can include them after the message value, per the Kafka produce protocol format.

Fixes #1046 
