### PR TITLE
Fix: Using `asyncapi client` binding trigger NPE & crashes Zilla

### DIFF
--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/composite/AsyncapiClientGenerator.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/composite/AsyncapiClientGenerator.java
@@ -336,14 +336,17 @@ public final class AsyncapiClientGenerator extends AsyncapiCompositeGenerator
                 AsyncapiChannelView channel,
                 List<KafkaTopicConfig> topics)
             {
-                Optional<KafkaTopicConfig> topicConfig = topics.stream()
-                    .filter(t -> t.name.equals(channel.address))
-                    .findFirst();
-                topicConfig.ifPresent(kafkaTopicConfig -> topic
-                            .transforms()
-                                .extractKey(kafkaTopicConfig.transforms.extractKey)
-                                .extractHeaders(kafkaTopicConfig.transforms.extractHeaders)
-                                .build());
+                if (topics != null)
+                {
+                    Optional<KafkaTopicConfig> topicConfig = topics.stream()
+                        .filter(t -> t.name.equals(channel.address))
+                        .findFirst();
+                    topicConfig.ifPresent(kafkaTopicConfig -> topic
+                        .transforms()
+                        .extractKey(kafkaTopicConfig.transforms.extractKey)
+                        .extractHeaders(kafkaTopicConfig.transforms.extractHeaders)
+                        .build());
+                }
                 return topic;
             }
 


### PR DESCRIPTION
## Description

Using `asyncapi client` binding trigger NPE & crashes Zilla 

**To Reproduce**
Steps to reproduce the behavior:
1. Pull latest zilla changes & create a local build.  
2. Update [asyncapi example](https://github.com/aklivity/zilla-examples/tree/main/asyncapi.http.kafka.proxy ) to use develop-SNAPSHOT version of zilla
3. On start, zilla crashes with mentioned error:
```
java.util.concurrent.CompletionException: java.lang.NullPointerException: Cannot invoke "java.util.List.stream()" because "topics" is null
        at java.base/java.util.concurrent.CompletableFuture.reportJoin(CompletableFuture.java:413)
        ...
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.List.stream()" because "topics" is null
        at io.aklivity.zilla.runtime.binding.asyncapi@0.9.92/io.aklivity.zilla.runtime.binding.asyncapi.internal.config.composite.AsyncapiClientGenerator$ClientNamespaceHelper$ClientBindingsHelper.injectKafkaTopicTransforms(AsyncapiClientGenerator.java:339)
        ...
        at org.agrona.core/org.agrona.concurrent.AgentRunner.run(AgentRunner.java:162)
        ... 1 more
stopped
```
