### PR TITLE
Eclipse IDE import maven projects

### DIFF
--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/AbstractMojo.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/AbstractMojo.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -65,11 +67,15 @@ public abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo
 
         try
         {
-            for (Object resourcePathEntry : project.getTestClasspathElements())
+            for (String classPathElement : project.getTestClasspathElements())
             {
-                File resourcePathFile = new File(resourcePathEntry.toString());
-                URI resourcePathURI = resourcePathFile.getAbsoluteFile().toURI();
-                resourcePath.add(URI.create(String.format("jar:%s!/META-INF/zilla/", resourcePathURI)).toURL());
+                Path classPathEntry = Path.of(classPathElement).toAbsolutePath();
+                URI classPathEntryURI = classPathEntry.toUri();
+                URI resourcePathEntryURI = Files.isDirectory(classPathEntry)
+                    ? classPathEntry.resolve("META-INF/zilla").toUri()
+                    : URI.create(String.format("jar:%s!/META-INF/zilla/", classPathEntryURI));
+                URL resourcePathEntry = resourcePathEntryURI.toURL();
+                resourcePath.add(resourcePathEntry);
             }
         }
         catch (DependencyResolutionRequiredException e)

--- a/conf/src/main/resources/io/aklivity/zilla/conf/checkstyle/configuration.xml
+++ b/conf/src/main/resources/io/aklivity/zilla/conf/checkstyle/configuration.xml
@@ -18,6 +18,10 @@
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
         "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="target/generated-.*sources/.*"/>
+    </module>
+
     <module name="SeverityMatchFilter">
         <property name="severity" value="info"/>
         <property name="acceptOnMatch" value="false"/>

--- a/conf/src/main/resources/io/aklivity/zilla/conf/checkstyle/suppressions.xml
+++ b/conf/src/main/resources/io/aklivity/zilla/conf/checkstyle/suppressions.xml
@@ -21,6 +21,4 @@
 <suppressions>
     <suppress checks="Javadoc.*" files=".+[\\/]internal[\\/].+" />
     <suppress checks="Javadoc.*" files=".+[\\/]src[\\/]test[\\/].+" />
-    <suppress checks=".*" files=".+[\\/]target[\\/]generated-sources[\\/].+" />
-    <suppress checks=".*" files=".+[\\/]target[\\/]generated-test-sources[\\/].+" />
 </suppressions>


### PR DESCRIPTION
Ignore checkstyle errors for generated sources and handle non-JAR project dependencies to resolve idl files when Eclipse M2E resolves Maven dependencies as peer Eclipse project instead.
