### PR TITLE
`zilla` build fix

### DIFF
--- a/cloud/docker-image/pom.xml
+++ b/cloud/docker-image/pom.xml
@@ -141,6 +141,12 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>binding-pgsql-kafka</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>binding-proxy</artifactId>
       <version>${project.version}</version>
       <scope>runtime</scope>


### PR DESCRIPTION
## Description

`zilla` build fails with mentioned error:

```
[INFO] DOCKER> #13 3.399 :: problems summary ::
[INFO] DOCKER> #13 3.399 :::: WARNINGS
[INFO] DOCKER> #13 3.399 		module not found: io.aklivity.zilla#binding-pgsql-kafka;develop-SNAPSHOT
```
![Screenshot 2024-09-12 at 12 36 01 PM](https://github.com/user-attachments/assets/45a4b49c-ef7d-46fc-ad9b-36dd03a72ff2)



