### PR TITLE
fix: use integer for challenge type

### DIFF
--- a/specs/guard-jwt.spec/src/main/scripts/io/aklivity/zilla/specs/guard/jwt/schema/jwt.schema.patch.json
+++ b/specs/guard-jwt.spec/src/main/scripts/io/aklivity/zilla/specs/guard/jwt/schema/jwt.schema.patch.json
@@ -82,7 +82,7 @@
                             "challenge":
                             {
                                 "title": "Challenge",
-                                "type": "number"
+                                "type": "integer"
                             }
                         },
                         "additionalProperties": false


### PR DESCRIPTION
## Description

updates the type for the challenge options on the jwt guard.