### PR TITLE
Include prefer wait in watch request even after initial 404 read request

### DIFF
--- a/runtime/filesystem-http/src/main/java/io/aklivity/zilla/runtime/filesystem/http/internal/HttpPath.java
+++ b/runtime/filesystem-http/src/main/java/io/aklivity/zilla/runtime/filesystem/http/internal/HttpPath.java
@@ -358,11 +358,12 @@ public final class HttpPath implements Path
     {
         HttpRequest.Builder request = HttpRequest.newBuilder()
             .GET()
-            .uri(location);
+            .uri(location)
+            .header("Prefer", "wait=86400");
 
         if (etag != null)
         {
-            request = request.headers("If-None-Match", etag, "Prefer", "wait=86400");
+            request = request.header("If-None-Match", etag);
         }
 
         return request.build();


### PR DESCRIPTION
## Description

Before this change, if the initial request for `zilla.yaml` receives `404` not found, then the next watch request would not include `prefer: wait=N` so it can return immediately with `404` also, causing the next watch request to be sent only after a poll interval, which is `60s` by default.

After this change, even if the initial request for `zilla.yaml` receives `404`, then the next watch request now includes `prefer: wait=N` and responds immediately when the response becomes available, with no need for polling.