### PR TITLE
Support instrumentation via Java agent

### DIFF
--- a/cloud/docker-image/src/main/docker/Dockerfile
+++ b/cloud/docker-image/src/main/docker/Dockerfile
@@ -22,7 +22,7 @@ COPY zpm.json.template zpm.json.template
 
 RUN cat zpm.json.template | sed "s/\${VERSION}/${project.version}/g" | tee zpm.json
 
-RUN ./zpmw install --debug --exclude-remote-repositories
+RUN ./zpmw install --debug --instrument --exclude-remote-repositories
 RUN ./zpmw clean --keep-image
 
 FROM ubuntu:jammy-20240530

--- a/runtime/command/src/main/moditect/module-info.java
+++ b/runtime/command/src/main/moditect/module-info.java
@@ -20,5 +20,8 @@ module io.aklivity.zilla.runtime.command
 
     exports io.aklivity.zilla.runtime.command;
 
+    opens io.aklivity.zilla.runtime.command
+       to com.github.rvesse.airline;
+
     uses io.aklivity.zilla.runtime.command.ZillaCommandSpi;
 }


### PR DESCRIPTION
## Description
When attempting to use Java instrumentation agents, `zilla` gives the following error.

```
java.lang.module.FindException: Module java.instrument not found error.
```

This change includes `java.instrument` module in the `zilla` java linked runtime, and opens the main class package to allow the instrumentation to succeed on startup.
