### PR TITLE
Exclude package-info.class from delegate module to avoid empty packages

### DIFF
--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
@@ -518,6 +518,7 @@ public final class ZpmInstall extends ZpmCommand
             Path moduleInfoPath = Paths.get(MODULE_INFO_CLASS_FILENAME);
             Path manifestPath = Paths.get("META-INF", "MANIFEST.MF");
             Path servicesPath = Paths.get("META-INF", "services");
+            String packageInfoName = "package-info.class";
             Path excludedPackage = Paths.get("org", "eclipse", "yasson", "internal", "components");
             String excludedClass = "BeanManagerInstanceCreator";
             Set<String> entryNames = new HashSet<>();
@@ -532,6 +533,7 @@ public final class ZpmInstall extends ZpmCommand
                         Path entryPath = Paths.get(entryName);
                         if (entryPath.equals(moduleInfoPath) ||
                             entryPath.equals(manifestPath) ||
+                            entryPath.endsWith(packageInfoName) ||
                             (entryPath.startsWith(excludedPackage)) &&
                              entryPath.getFileName().toString().startsWith(excludedClass))
                         {


### PR DESCRIPTION
## Description

`jdeps` generates a `module-info.java` that exports packages even if they have only `package-info.class`.
`jlink` complains that a package is empty, even if it includes `package-info.class`.

So, we need to exclude `package-info.class` from the delegate module to prevent `jdeps` from generating a `module-info.java` that is incompatible with `jlink`.
