### PR TITLE
Fix failing test when JVM default locale is not US

### DIFF
--- a/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/printer/PrometheusMetricsPrinter.java
+++ b/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/printer/PrometheusMetricsPrinter.java
@@ -84,7 +84,7 @@ public class PrometheusMetricsPrinter
         String msFormat =
             "# HELP %s %s\n" +
             "# TYPE %s %s\n" +
-            "%s{namespace=\"%s\",binding=\"%s\"} %f";
+            "%s{namespace=\"%s\",binding=\"%s\"} %s";
         return milliseconds ?
             String.format(msFormat, extName, description, extName, kind, extName,
                 record.namespace(), record.binding(), record.millisecondsValueReader().getAsDouble()) :

--- a/runtime/exporter-prometheus/src/test/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/printer/PrometheusMetricsPrinterTest.java
+++ b/runtime/exporter-prometheus/src/test/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/printer/PrometheusMetricsPrinterTest.java
@@ -106,11 +106,11 @@ public class PrometheusMetricsPrinterTest
         String expectedOutput =
             "# HELP counter1_total description for counter1\n" +
                 "# TYPE counter1_total counter\n" +
-                "counter1_total{namespace=\"ns1\",binding=\"binding1\"} 42.000000\n" +
+                "counter1_total{namespace=\"ns1\",binding=\"binding1\"} 42.0\n" +
                 "\n" +
                 "# HELP gauge1 description for gauge1\n" +
                 "# TYPE gauge1 gauge\n" +
-                "gauge1{namespace=\"ns1\",binding=\"binding1\"} 77.000000\n" +
+                "gauge1{namespace=\"ns1\",binding=\"binding1\"} 77.0\n" +
                 "\n" +
                 "# HELP histogram1 description for histogram1\n" +
                 "# TYPE histogram1 histogram\n" +


### PR DESCRIPTION
## Description
The test [PrometheusMetricsPrinterTest.shouldWorkWithMilliseconds()](https://github.com/aklivity/zilla/blob/b3f686c8d6646a3affeba4c2668da0a7801dd3cd/runtime/exporter-prometheus/src/test/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/printer/PrometheusMetricsPrinterTest.java#L104) fails when the default JVM locale does not use  dot (`.`) as the decimal separator, because floating point numbers are formatted differently and the string comparison does not match.

**Solution**: explicitly set the locale to `Locale.US` when formatting decimal numbers. This makes the test pass regardless of the JVM locale settings and generally ensures more consistent behaviour because the output is independent from the JVM local configuration.