### PR TITLE
Support configurable TLS client SNI validation and handle FQDNs …

### DIFF
--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsConfiguration.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsConfiguration.java
@@ -28,6 +28,7 @@ public class TlsConfiguration extends Configuration
     public static final LongPropertyDef TLS_AWAIT_SYNC_CLOSE_MILLIS;
     public static final BooleanPropertyDef TLS_PROACTIVE_CLIENT_REPLY_BEGIN;
     public static final BooleanPropertyDef TLS_CLIENT_HTTPS_IDENTIFICATION;
+    public static final BooleanPropertyDef TLS_CLIENT_SERVER_NAME_INDICATION;
     public static final BooleanPropertyDef TLS_VERBOSE;
     public static final BooleanPropertyDef TLS_DEBUG;
 
@@ -42,6 +43,7 @@ public class TlsConfiguration extends Configuration
         TLS_AWAIT_SYNC_CLOSE_MILLIS = config.property("await.sync.close.millis", 3000L);
         TLS_PROACTIVE_CLIENT_REPLY_BEGIN = config.property("proactive.client.reply.begin", false);
         TLS_CLIENT_HTTPS_IDENTIFICATION = config.property("client.https.identification", true);
+        TLS_CLIENT_SERVER_NAME_INDICATION = config.property("client.server.name.indication", true);
         TLS_VERBOSE = config.property("verbose", TlsConfiguration::verboseDefault);
         TLS_DEBUG = config.property("debug", TlsConfiguration::debugDefault);
         TLS_CONFIG = config;
@@ -81,6 +83,11 @@ public class TlsConfiguration extends Configuration
     public boolean clientHttpsIdentification()
     {
         return TLS_CLIENT_HTTPS_IDENTIFICATION.getAsBoolean(this);
+    }
+
+    public boolean clientServerNameIndication()
+    {
+        return TLS_CLIENT_SERVER_NAME_INDICATION.getAsBoolean(this);
     }
 
     public boolean verbose()

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsBindingConfig.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsBindingConfig.java
@@ -73,6 +73,7 @@ public final class TlsBindingConfig
     private SSLContext context;
 
     private boolean clientHttpsIdentification;
+    private boolean clientServerNameIndication;
 
     public TlsBindingConfig(
         BindingConfig binding)
@@ -126,6 +127,7 @@ public final class TlsBindingConfig
 
             this.context = context;
             this.clientHttpsIdentification = config.clientHttpsIdentification();
+            this.clientServerNameIndication = config.clientServerNameIndication();
         }
         catch (Exception ex)
         {
@@ -240,9 +242,10 @@ public final class TlsBindingConfig
                 parameters.setEndpointIdentificationAlgorithm("HTTPS");
             }
 
-            if (sni != null)
+            if (clientServerNameIndication && sni != null)
             {
                 List<SNIServerName> serverNames = sni.stream()
+                        .map(TlsBindingConfig::trimHostnameTrailingDot)
                         .map(SNIHostName::new)
                         .collect(toList());
                 parameters.setServerNames(serverNames);
@@ -495,5 +498,11 @@ public final class TlsBindingConfig
         }
 
         return names;
+    }
+
+    private static String trimHostnameTrailingDot(
+        String hostname)
+    {
+        return hostname.endsWith(".") ? hostname.substring(0, hostname.length() - 1) : hostname;
     }
 }


### PR DESCRIPTION
…with trailing dot

When a Kafka server hostname has a trailing dot, such as `server.dev.local.` then we implicitly pick this up as both the remote DNS name (for TCP) and the remote SNI Hostname (for TLS).

However, SNI Hostname does not support a trailing dot, and parts of the Java SSLEngine API remove it implicitly. Therefore, we need to also remove this implicitly when necessary in TLS client.

Note that DNS resolution considers `server.dev.local.` (absolute) and `server.dev.local` (relatve to . = root) as equivalent.

For example:
```
openssl s_client \
  -connect www.google.com.:443 \
  -servername www.google.com
```
and
```
openssl s_client \
  -connect www.google.com:443 \
  -servername www.google.com
```
both work correctly as expected.

This is because the server certificate has a `CommonName` of `www.google.com` in both cases.

If the server certifciate presents a `CommonName` with trailing dot, then TLS Hostname Verification must also be disabled by passing `-Pzilla.binding.tls.client.https.identification=false` to `zilla start`.