### PR TITLE
fix: locale-specific formatting due to `MessageFormat.format()`

### DIFF
--- a/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalogHandler.java
+++ b/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalogHandler.java
@@ -27,7 +27,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.ByteOrder;
-import java.text.MessageFormat;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -52,10 +51,10 @@ import io.aklivity.zilla.runtime.engine.model.function.ValueConsumer;
 
 public class ApicurioCatalogHandler implements CatalogHandler
 {
-    private static final String ARTIFACT_VERSION_PATH = "/apis/registry/v2/groups/{0}/artifacts/{1}/versions/{2}/meta";
-    private static final String ARTIFACT_BY_GLOBAL_ID_PATH = "/apis/registry/v2/ids/globalIds/{0}";
-    private static final String ARTIFACT_BY_CONTENT_ID_PATH = "/apis/registry/v2/ids/contentIds/{0}";
-    private static final String ARTIFACT_META_PATH = "/apis/registry/v2/groups/{0}/artifacts/{1}/meta";
+    private static final String ARTIFACT_VERSION_PATH = "/apis/registry/v2/groups/%s/artifacts/%s/versions/%s/meta";
+    private static final String ARTIFACT_BY_GLOBAL_ID_PATH = "/apis/registry/v2/ids/globalIds/%d";
+    private static final String ARTIFACT_BY_CONTENT_ID_PATH = "/apis/registry/v2/ids/contentIds/%d";
+    private static final String ARTIFACT_META_PATH = "/apis/registry/v2/groups/%s/artifacts/%s/meta";
     private static final String VERSION_LATEST = "latest";
     private static final int MAX_PADDING_LENGTH = SIZE_OF_BYTE + SIZE_OF_LONG;
     private static final byte MAGIC_BYTE = 0x0;
@@ -156,7 +155,7 @@ public class ApicurioCatalogHandler implements CatalogHandler
                 {
                     try
                     {
-                        artifact = sendHttpRequest(MessageFormat.format(artifactPath, artifactId));
+                        artifact = sendHttpRequest(artifactPath.formatted(artifactId));
                         if (artifact == null)
                         {
                             if (retryAttempts.getAndIncrement() == 0)
@@ -238,8 +237,8 @@ public class ApicurioCatalogHandler implements CatalogHandler
             {
                 try
                 {
-                    String path = VERSION_LATEST.equals(version) ? MessageFormat.format(ARTIFACT_META_PATH, groupId, artifact) :
-                        MessageFormat.format(ARTIFACT_VERSION_PATH, groupId, artifact, version);
+                    String path = VERSION_LATEST.equals(version) ? ARTIFACT_META_PATH.formatted(groupId, artifact) :
+                        ARTIFACT_VERSION_PATH.formatted(groupId, artifact, version);
 
                     String response = sendHttpRequest(path);
                     if (response == null)

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/handler/SchemaRegistryCatalogHandler.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/handler/SchemaRegistryCatalogHandler.java
@@ -24,7 +24,6 @@ import java.net.http.HttpResponse;
 import java.nio.ByteOrder;
 import java.security.KeyStore;
 import java.security.SecureRandom;
-import java.text.MessageFormat;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
@@ -59,10 +58,10 @@ import io.aklivity.zilla.runtime.engine.vault.VaultHandler;
 
 public class SchemaRegistryCatalogHandler implements CatalogHandler
 {
-    private static final String SUBJECT_VERSION_PATH = "/subjects/{0}/versions/{1}";
-    private static final String REGISTER_SUBJECT_PATH = "/subjects/{0}/versions";
-    private static final String UNREGISTER_SUBJECT_PATH = "/subjects/{0}";
-    private static final String SCHEMA_PATH = "/schemas/ids/{0}";
+    private static final String SUBJECT_VERSION_PATH = "/subjects/%s/versions/%s";
+    private static final String REGISTER_SUBJECT_PATH = "/subjects/%s/versions";
+    private static final String UNREGISTER_SUBJECT_PATH = "/subjects/%s";
+    private static final String SCHEMA_PATH = "/schemas/ids/%d";
     private static final String HTTPS = "https://";
 
     private static final int MAX_PADDING_LENGTH = 5;
@@ -154,7 +153,7 @@ public class SchemaRegistryCatalogHandler implements CatalogHandler
     {
         int versionId = NO_VERSION_ID;
 
-        String response = sendPostHttpRequest(MessageFormat.format(REGISTER_SUBJECT_PATH, subject), schema);
+        String response = sendPostHttpRequest(REGISTER_SUBJECT_PATH.formatted(subject), schema);
         if (response != null)
         {
             versionId = registerRequest.resolveResponse(response);
@@ -169,7 +168,7 @@ public class SchemaRegistryCatalogHandler implements CatalogHandler
     {
         int[] versions = NO_VERSIONS;
 
-        String response = sendDeleteHttpRequest(MessageFormat.format(UNREGISTER_SUBJECT_PATH, subject));
+        String response = sendDeleteHttpRequest(UNREGISTER_SUBJECT_PATH.formatted(subject));
         if (response != null)
         {
             versions = unregisterRequest.resolveResponse(response);
@@ -215,7 +214,7 @@ public class SchemaRegistryCatalogHandler implements CatalogHandler
                 {
                     try
                     {
-                        String response = sendHttpRequest(MessageFormat.format(SCHEMA_PATH, schemaId));
+                        String response = sendHttpRequest(SCHEMA_PATH.formatted(schemaId));
                         if (response == null)
                         {
                             if (retryAttempts.getAndIncrement() == 0)
@@ -297,7 +296,7 @@ public class SchemaRegistryCatalogHandler implements CatalogHandler
             {
                 try
                 {
-                    String response = sendHttpRequest(MessageFormat.format(SUBJECT_VERSION_PATH, subject, version));
+                    String response = sendHttpRequest(SUBJECT_VERSION_PATH.formatted(subject, version));
                     if (response == null)
                     {
                         if (retryAttempts.getAndIncrement() == 0)


### PR DESCRIPTION
When we have a schema ID (int), that's more than 3 digit, catalog handler unable to pull schema.

Cause: 
MessageFormat.format() treats numbers according to locale-specific formatting rules. By default, it inserts a thousands separator (comma in some locales) when formatting numbers larger than 999.

![Screenshot 2025-01-31 at 10 07 12 AM](https://github.com/user-attachments/assets/c0c6f08c-6c46-468f-936e-547594e3bce0)

Fixes #1391 