### PR TITLE
Handle TLS Alert.USER_CANCELED then deferred Alert.CLOSE_NOTIFY

### DIFF
--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsClientFactory.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsClientFactory.java
@@ -1911,7 +1911,8 @@ public final class TlsClientFactory implements TlsStreamFactory
                 {
                     cleanupEncodeSlot();
 
-                    if (TlsState.initialClosing(state))
+                    if (TlsState.initialClosing(state) &&
+                        tlsEngine.isOutboundDone())
                     {
                         doNetEnd(traceId);
                     }
@@ -1964,7 +1965,11 @@ public final class TlsClientFactory implements TlsStreamFactory
                         if (!stream.isPresent())
                         {
                             doEncodeCloseOutbound(traceId, budgetId);
-                            doNetEnd(traceId);
+
+                            if (tlsEngine.isOutboundDone())
+                            {
+                                doNetEnd(traceId);
+                            }
                         }
 
                         decoder = decodeIgnoreAll;
@@ -2107,7 +2112,7 @@ public final class TlsClientFactory implements TlsStreamFactory
                             case CLOSED:
                                 assert bytesProduced > 0;
                                 doAppReset(traceId);
-                                state = TlsState.closingReply(state);
+                                state = TlsState.closingInitial(state);
                                 break loop;
                             case OK:
                                 assert bytesProduced > 0 || tlsEngine.isInboundDone();

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsServerFactory.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsServerFactory.java
@@ -1565,7 +1565,8 @@ public final class TlsServerFactory implements TlsStreamFactory
             {
                 cleanupEncodeSlot();
 
-                if (TlsState.replyClosing(state))
+                if (TlsState.replyClosing(state) &&
+                    tlsEngine.isOutboundDone())
                 {
                     doNetEnd(traceId);
                 }
@@ -1618,7 +1619,11 @@ public final class TlsServerFactory implements TlsStreamFactory
                     if (!stream.isPresent())
                     {
                         doEncodeCloseOutbound(traceId, budgetId);
-                        doNetEnd(traceId);
+
+                        if (tlsEngine.isOutboundDone())
+                        {
+                            doNetEnd(traceId);
+                        }
                     }
 
                     decoder = decodeIgnoreAll;


### PR DESCRIPTION
## Description

Current assumption is that `tlsEngine.closeOutbound()` should immediately end the stream, so `END` frame follows.
Instead we need to verify `tlsEngine.isOutboundDone()` before sending `END` frame.