### PR TITLE
Use long not int when calculating ack max

### DIFF
--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpServerFactory.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpServerFactory.java
@@ -4084,7 +4084,7 @@ public final class AmqpServerFactory implements AmqpStreamFactory
                         final int padding = PAYLOAD_HEADER_SIZE + (TRANSFER_HEADER_SIZE * maxFrameCount);
                         final int replyBudget = linkCredit * encodeMaxFrameSize;
                         final int replyPendingAck = Math.max(replyMax - replyBudget, 0);
-                        final long replyAckMax = (int)(replySeq - replyPendingAck);
+                        final long replyAckMax = replySeq - replyPendingAck;
                         final int replyBudgetMax = replyBudget + replyPendingAck;
 
                         if (replyAckMax > replyAck || replyBudgetMax != replyMax)

--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpServerFactory.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpServerFactory.java
@@ -4084,7 +4084,7 @@ public final class AmqpServerFactory implements AmqpStreamFactory
                         final int padding = PAYLOAD_HEADER_SIZE + (TRANSFER_HEADER_SIZE * maxFrameCount);
                         final int replyBudget = linkCredit * encodeMaxFrameSize;
                         final int replyPendingAck = Math.max(replyMax - replyBudget, 0);
-                        final int replyAckMax = (int)(replySeq - replyPendingAck);
+                        final long replyAckMax = (int)(replySeq - replyPendingAck);
                         final int replyBudgetMax = replyBudget + replyPendingAck;
 
                         if (replyAckMax > replyAck || replyBudgetMax != replyMax)

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsClientFactory.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsClientFactory.java
@@ -1279,8 +1279,7 @@ public final class TlsClientFactory implements TlsStreamFactory
         {
             assert TlsState.initialOpened(state);
 
-            // TODO: consider encodePool capacity
-            int initialAckMax = (int)(initialSeq - client.initialPendingAck());
+            long initialAckMax = initialSeq - client.initialPendingAck();
             if (initialAckMax > initialAck)
             {
                 initialAck = initialAckMax;

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsProxyFactory.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsProxyFactory.java
@@ -1685,8 +1685,7 @@ public final class TlsProxyFactory implements TlsStreamFactory
             private void flushAppWindow(
                 long traceId)
             {
-                // TODO: consider encodePool capacity
-                int replyAckMax = (int)(replySeq - TlsProxy.this.replyPendingAck());
+                long replyAckMax = replySeq - TlsProxy.this.replyPendingAck();
                 if (replyAckMax > replyAck)
                 {
                     replyAck = replyAckMax;

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsServerFactory.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsServerFactory.java
@@ -2353,8 +2353,7 @@ public final class TlsServerFactory implements TlsStreamFactory
             private void flushAppWindow(
                 long traceId)
             {
-                // TODO: consider encodePool capacity
-                int replyAckMax = (int)(replySeq - TlsServer.this.replyPendingAck());
+                long replyAckMax = replySeq - TlsServer.this.replyPendingAck();
                 if (replyAckMax > replyAck)
                 {
                     replyAck = replyAckMax;


### PR DESCRIPTION
## Description

Avoids issues with `int` when `long` data typed `ack` becomes greater than `Integer.MAX_VALUE`.