### PR TITLE
Simplify TLS decode loop by inlining decodeHandshakeNeedTask

### DIFF
--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsClientFactory.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsClientFactory.java
@@ -1520,7 +1520,6 @@ public final class TlsClientFactory implements TlsStreamFactory
                 {
                     cleanupDecodeSlot();
 
-                    cancelHandshakeTask();
                     cancelHandshakeTimeout();
 
                     doAppAbort(traceId);
@@ -1560,7 +1559,6 @@ public final class TlsClientFactory implements TlsStreamFactory
 
                 cleanupDecodeSlot();
 
-                cancelHandshakeTask();
                 cancelHandshakeTimeout();
 
                 doAppAbort(traceId);
@@ -1586,8 +1584,6 @@ public final class TlsClientFactory implements TlsStreamFactory
                 assert initialAck <= initialSeq;
 
                 cleanupEncodeSlot();
-
-                cancelHandshakeTask();
 
                 doAppReset(traceId);
                 doAppAbort(traceId);
@@ -1780,8 +1776,6 @@ public final class TlsClientFactory implements TlsStreamFactory
                 }
 
                 cleanupEncodeSlot();
-
-                cancelHandshakeTask();
             }
 
             private void doNetAbort(
@@ -1795,8 +1789,6 @@ public final class TlsClientFactory implements TlsStreamFactory
                 }
 
                 cleanupEncodeSlot();
-
-                cancelHandshakeTask();
             }
 
             private void doNetFlush(
@@ -1820,7 +1812,6 @@ public final class TlsClientFactory implements TlsStreamFactory
 
                 cleanupDecodeSlot();
 
-                cancelHandshakeTask();
                 cancelHandshakeTimeout();
             }
 
@@ -2207,16 +2198,6 @@ public final class TlsClientFactory implements TlsStreamFactory
                 {
                     signaler.cancel(handshakeTimeoutFutureId);
                     handshakeTimeoutFutureId = NO_CANCEL_ID;
-                }
-            }
-
-            private void cancelHandshakeTask()
-            {
-                if (TlsState.closed(state) &&
-                    handshakeTaskFutureId != NO_CANCEL_ID)
-                {
-                    signaler.cancel(handshakeTaskFutureId);
-                    handshakeTaskFutureId = NO_CANCEL_ID;
                 }
             }
         }

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsClientFactory.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsClientFactory.java
@@ -114,7 +114,6 @@ public final class TlsClientFactory implements TlsStreamFactory
 
     private final TlsClientDecoder decodeHandshake = this::decodeHandshake;
     private final TlsClientDecoder decodeHandshakeFinished = this::decodeHandshakeFinished;
-    private final TlsClientDecoder decodeHandshakeNeedTask = this::decodeHandshakeNeedTask;
     private final TlsClientDecoder decodeHandshakeNeedUnwrap = this::decodeHandshakeNeedUnwrap;
     private final TlsClientDecoder decodeHandshakeNeedWrap = this::decodeHandshakeNeedWrap;
     private final TlsClientDecoder decodeNotHandshaking = this::decodeNotHandshaking;
@@ -524,7 +523,7 @@ public final class TlsClientFactory implements TlsStreamFactory
             client.decoder = decodeHandshakeFinished;
             break;
         case NEED_TASK:
-            client.decoder = decodeHandshakeNeedTask;
+            client.onDecodeHandshakeNeedTask(traceId);
             break;
         case NEED_WRAP:
             client.decoder = decodeHandshakeNeedWrap;
@@ -746,21 +745,6 @@ public final class TlsClientFactory implements TlsStreamFactory
         int limit)
     {
         client.onDecodeHandshakeFinished(traceId, budgetId);
-        client.decoder = decodeHandshake;
-        return progress;
-    }
-
-    private int decodeHandshakeNeedTask(
-        TlsStream.TlsClient client,
-        long traceId,
-        long budgetId,
-        int reserved,
-        DirectBuffer buffer,
-        int offset,
-        int progress,
-        int limit)
-    {
-        client.onDecodeHandshakeNeedTask(traceId);
         client.decoder = decodeHandshake;
         return progress;
     }
@@ -1928,7 +1912,7 @@ public final class TlsClientFactory implements TlsStreamFactory
             {
                 TlsClientDecoder previous = null;
                 int progress = offset;
-                while (progress <= limit && previous != decoder && handshakeTaskFutureId == NO_CANCEL_ID)
+                while (progress <= limit && previous != decoder)
                 {
                     previous = decoder;
                     progress = decoder.decode(this, traceId, budgetId, reserved, buffer, offset, progress, limit);

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsClientFactory.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsClientFactory.java
@@ -2212,7 +2212,8 @@ public final class TlsClientFactory implements TlsStreamFactory
 
             private void cancelHandshakeTask()
             {
-                if (handshakeTaskFutureId != NO_CANCEL_ID)
+                if (TlsState.closed(state) &&
+                    handshakeTaskFutureId != NO_CANCEL_ID)
                 {
                     signaler.cancel(handshakeTaskFutureId);
                     handshakeTaskFutureId = NO_CANCEL_ID;

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsClientFactory.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsClientFactory.java
@@ -1214,8 +1214,13 @@ public final class TlsClientFactory implements TlsStreamFactory
         private void doAppAbort(
             long traceId)
         {
-            if (TlsState.replyOpening(state) &&
+            if (!TlsState.replyOpening(state) &&
                 !TlsState.replyClosed(state))
+            {
+                doAppBegin(traceId, 0L, null, null);
+            }
+
+            if (!TlsState.replyClosed(state))
             {
                 state = TlsState.closeReply(state);
                 client.stream = nullIfClosed(state, client.stream);

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsServerFactory.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsServerFactory.java
@@ -1860,7 +1860,8 @@ public final class TlsServerFactory implements TlsStreamFactory
 
         private void cancelHandshakeTask()
         {
-            if (handshakeTaskFutureId != NO_CANCEL_ID)
+            if (TlsState.closed(state) &&
+                handshakeTaskFutureId != NO_CANCEL_ID)
             {
                 signaler.cancel(handshakeTaskFutureId);
                 handshakeTaskFutureId = NO_CANCEL_ID;

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsServerFactory.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsServerFactory.java
@@ -1225,7 +1225,6 @@ public final class TlsServerFactory implements TlsStreamFactory
             {
                 cleanupDecodeSlot();
 
-                cancelHandshakeTask();
                 cancelHandshakeTimeout();
 
                 stream.ifPresent(s -> s.doAppAbort(traceId));
@@ -1263,7 +1262,6 @@ public final class TlsServerFactory implements TlsStreamFactory
 
             cleanupDecodeSlot();
 
-            cancelHandshakeTask();
             cancelHandshakeTimeout();
 
             stream.ifPresent(s -> s.doAppAbort(traceId));
@@ -1289,8 +1287,6 @@ public final class TlsServerFactory implements TlsStreamFactory
             assert replyAck <= replySeq;
 
             cleanupEncodeSlot();
-
-            cancelHandshakeTask();
 
             stream.ifPresent(s -> s.doAppReset(traceId));
             stream.ifPresent(s -> s.doAppAbort(traceId));
@@ -1429,8 +1425,6 @@ public final class TlsServerFactory implements TlsStreamFactory
             }
 
             cleanupEncodeSlot();
-
-            cancelHandshakeTask();
         }
 
         private void doNetAbort(
@@ -1443,8 +1437,6 @@ public final class TlsServerFactory implements TlsStreamFactory
             }
 
             cleanupEncodeSlot();
-
-            cancelHandshakeTask();
         }
 
         private void doNetFlush(
@@ -1469,7 +1461,6 @@ public final class TlsServerFactory implements TlsStreamFactory
 
             cleanupDecodeSlot();
 
-            cancelHandshakeTask();
             cancelHandshakeTimeout();
         }
 
@@ -1855,16 +1846,6 @@ public final class TlsServerFactory implements TlsStreamFactory
             {
                 signaler.cancel(handshakeTimeoutFutureId);
                 handshakeTimeoutFutureId = NO_CANCEL_ID;
-            }
-        }
-
-        private void cancelHandshakeTask()
-        {
-            if (TlsState.closed(state) &&
-                handshakeTaskFutureId != NO_CANCEL_ID)
-            {
-                signaler.cancel(handshakeTaskFutureId);
-                handshakeTaskFutureId = NO_CANCEL_ID;
             }
         }
 

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsServerFactory.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsServerFactory.java
@@ -127,7 +127,6 @@ public final class TlsServerFactory implements TlsStreamFactory
     private final TlsServerDecoder decodeHandshake = this::decodeHandshake;
     private final TlsServerDecoder decodeBeforeHandshake = this::decodeBeforeHandshake;
     private final TlsServerDecoder decodeHandshakeFinished = this::decodeHandshakeFinished;
-    private final TlsServerDecoder decodeHandshakeNeedTask = this::decodeHandshakeNeedTask;
     private final TlsServerDecoder decodeHandshakeNeedUnwrap = this::decodeHandshakeNeedUnwrap;
     private final TlsServerDecoder decodeHandshakeNeedWrap = this::decodeHandshakeNeedWrap;
     private final TlsServerDecoder decodeNotHandshaking = this::decodeNotHandshaking;
@@ -589,7 +588,7 @@ public final class TlsServerFactory implements TlsStreamFactory
             server.decoder = decodeHandshakeFinished;
             break;
         case NEED_TASK:
-            server.decoder = decodeHandshakeNeedTask;
+            server.onDecodeHandshakeNeedTask(traceId);
             break;
         case NEED_WRAP:
             server.decoder = decodeHandshakeNeedWrap;
@@ -803,21 +802,6 @@ public final class TlsServerFactory implements TlsStreamFactory
         int limit)
     {
         server.onDecodeHandshakeFinished(traceId, budgetId);
-        server.decoder = decodeHandshake;
-        return progress;
-    }
-
-    private int decodeHandshakeNeedTask(
-        TlsServer server,
-        long traceId,
-        long budgetId,
-        int reserved,
-        DirectBuffer buffer,
-        int offset,
-        int progress,
-        int limit)
-    {
-        server.onDecodeHandshakeNeedTask(traceId);
         server.decoder = decodeHandshake;
         return progress;
     }
@@ -1583,7 +1567,7 @@ public final class TlsServerFactory implements TlsStreamFactory
         {
             TlsServerDecoder previous = null;
             int progress = offset;
-            while (progress <= limit && previous != decoder && handshakeTaskFutureId == NO_CANCEL_ID)
+            while (progress <= limit && previous != decoder)
             {
                 previous = decoder;
                 progress = decoder.decode(this, traceId, budgetId, reserved, buffer, offset, progress, limit);


### PR DESCRIPTION
Handle case where TLS client handshake task is pending but has been canceled by closing the network initial stream.

Apply same simplification to TLS server.