### PR TITLE
Use GaugesLayout for engine worker capacity metric

### DIFF
--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpClientFactory.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpClientFactory.java
@@ -474,6 +474,7 @@ public class TcpClientFactory implements TcpStreamFactory
                 {
                     networkKey.clear(OP_CONNECT);
                     closeNet(net);
+                    doAppAbort(traceId);
                 }
                 else
                 {

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpClientRouter.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpClientRouter.java
@@ -90,7 +90,7 @@ public final class TcpClientRouter
         resolve:
         try
         {
-            if (capacity.get() <= 0)
+            if (capacity.available() <= 0)
             {
                 break resolve;
             }
@@ -180,7 +180,7 @@ public final class TcpClientRouter
 
         if (resolved != null)
         {
-            capacity.decrementAndGet();
+            capacity.onConnected();
         }
 
         return resolved;
@@ -194,7 +194,7 @@ public final class TcpClientRouter
 
     public void close()
     {
-        capacity.incrementAndGet();
+        capacity.onClosed();
     }
 
     @Override

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpClientRouter.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpClientRouter.java
@@ -20,6 +20,7 @@ import static io.aklivity.zilla.runtime.binding.tcp.internal.types.ProxyInfoType
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.nio.channels.SocketChannel;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -178,11 +179,6 @@ public final class TcpClientRouter
             event.dnsFailed(traceId, binding.id, ex.hostname);
         }
 
-        if (resolved != null)
-        {
-            capacity.claim();
-        }
-
         return resolved;
     }
 
@@ -192,7 +188,14 @@ public final class TcpClientRouter
         bindings.remove(bindingId);
     }
 
-    public void close()
+    public void opened(
+        SocketChannel network)
+    {
+        capacity.claim();
+    }
+
+    public void closed(
+        SocketChannel network)
     {
         capacity.released();
     }

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpClientRouter.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpClientRouter.java
@@ -180,7 +180,7 @@ public final class TcpClientRouter
 
         if (resolved != null)
         {
-            capacity.onConnected();
+            capacity.claim();
         }
 
         return resolved;
@@ -194,7 +194,7 @@ public final class TcpClientRouter
 
     public void close()
     {
-        capacity.onClosed();
+        capacity.released();
     }
 
     @Override

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpServerRouter.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpServerRouter.java
@@ -95,7 +95,7 @@ public final class TcpServerRouter
 
             if (channel != null)
             {
-                capacity.onConnected();
+                capacity.claim();
             }
         }
 
@@ -114,7 +114,7 @@ public final class TcpServerRouter
         SocketChannel channel)
     {
         CloseHelper.quietClose(channel);
-        capacity.onClosed();
+        capacity.released();
 
         if (unbound && capacity.available() > 0)
         {

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpServerRouter.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpServerRouter.java
@@ -89,17 +89,17 @@ public final class TcpServerRouter
     {
         SocketChannel channel = null;
 
-        if (capacity.get() > 0)
+        if (capacity.available() > 0)
         {
             channel = server.accept();
 
             if (channel != null)
             {
-                capacity.decrementAndGet();
+                capacity.onConnected();
             }
         }
 
-        if (!unbound && capacity.get() <= 0)
+        if (!unbound && capacity.available() <= 0)
         {
             bindings.values().stream()
                 .filter(b -> b.kind == SERVER)
@@ -114,9 +114,9 @@ public final class TcpServerRouter
         SocketChannel channel)
     {
         CloseHelper.quietClose(channel);
+        capacity.onClosed();
 
-        int newCapacity = capacity.incrementAndGet();
-        if (unbound && newCapacity > 0)
+        if (unbound && capacity.available() > 0)
         {
             bindings.values().stream()
                 .filter(b -> b.kind == SERVER)

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/SocketChannelHelper.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/SocketChannelHelper.java
@@ -83,6 +83,31 @@ public final class SocketChannelHelper
         }
     }
 
+    public static class DoConnectHelper extends Helper
+    {
+        private static boolean forcePending;
+
+        protected DoConnectHelper(org.jboss.byteman.rule.Rule rule)
+        {
+            super(rule);
+        }
+
+        public static void forcePending()
+        {
+            forcePending = true;
+        }
+
+        public boolean isConnectionPending(SocketChannel channel) throws IOException
+        {
+            return forcePending ? true : channel.isConnectionPending();
+        }
+
+        private static void reset()
+        {
+            forcePending = false;
+        }
+    }
+
     public static class CountDownHelper extends Helper
     {
         private static CountDownLatch latch;
@@ -130,6 +155,7 @@ public final class SocketChannelHelper
     {
         OnDataHelper.reset();
         HandleWriteHelper.reset();
+        DoConnectHelper.reset();
     }
 
     private static int write(

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientIT.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientIT.java
@@ -15,6 +15,7 @@
  */
 package io.aklivity.zilla.runtime.binding.tcp.internal.streams;
 
+import static io.aklivity.zilla.runtime.engine.test.EngineRule.ENGINE_WORKER_CAPACITY_NAME;
 import static java.net.StandardSocketOptions.SO_REUSEADDR;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -348,12 +349,10 @@ public class ClientIT
     @Specification({
         "${app}/max.connections.reset/client"
     })
-    @Configure(
-        name = "zilla.engine.worker.capacity",
-        value = "2")
+    @Configure(name = ENGINE_WORKER_CAPACITY_NAME, value = "2")
     public void shouldResetWhenConnectionsExceeded() throws Exception
     {
-        final LongSupplier utilization = engine.context().gauge(null, null, "engine.worker.utilization");
+        final LongSupplier utilization = engine.utilization();
 
         try (ServerSocketChannel server = ServerSocketChannel.open())
         {
@@ -398,8 +397,6 @@ public class ClientIT
             client4.close();
 
             k3po.finish();
-
-            assert utilization.getAsLong() == 0L;
         }
     }
 

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientIT.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientIT.java
@@ -21,15 +21,13 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.rules.RuleChain.outerRule;
 
-import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
-import java.nio.channels.SelectionKey;
-import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.util.function.LongSupplier;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -355,62 +353,53 @@ public class ClientIT
         value = "2")
     public void shouldResetWhenConnectionsExceeded() throws Exception
     {
-        try (ServerSocketChannel server = ServerSocketChannel.open();
-             Selector selector = Selector.open())
+        final LongSupplier utilization = engine.context().gauge(null, null, "engine.worker.utilization");
+
+        try (ServerSocketChannel server = ServerSocketChannel.open())
         {
-            server.configureBlocking(false);
             server.setOption(SO_REUSEADDR, true);
             server.bind(new InetSocketAddress("127.0.0.1", 12345));
-            server.register(selector, SelectionKey.OP_ACCEPT);
 
             k3po.start();
 
-            AcceptHandler handler = channel ->
-            {
-                channel.configureBlocking(true);
-                channel.close();
-            };
+            ByteBuffer buf = ByteBuffer.allocate(0);
 
-            int accepted = 0;
-            while (accepted < 2)
+            while (utilization.getAsLong() != 100L)
             {
-                selector.select();
-                for (SelectionKey key : selector.selectedKeys())
-                {
-                    if (key.isAcceptable())
-                    {
-                        SocketChannel client = server.accept();
-                        handler.handle(client);
-                        accepted++;
-                    }
-                }
-
-                if (accepted == 2)
-                {
-                    k3po.notifyBarrier("CONNECTION_ACCEPTED_1");
-                    k3po.notifyBarrier("CONNECTION_ACCEPTED_2");
-                }
+                Thread.onSpinWait();
             }
 
-            accepted = 0;
-            while (accepted < 2)
+            SocketChannel client1 = server.accept();
+            k3po.notifyBarrier("CONNECTION_ACCEPTED_1");
+            client1.read(buf);
+            client1.close();
+
+            while (utilization.getAsLong() != 50L)
             {
-                selector.select();
-                for (SelectionKey key : selector.selectedKeys())
-                {
-                    if (key.isAcceptable())
-                    {
-                        SocketChannel client = server.accept();
-                        handler.handle(client);
-                        accepted++;
-                    }
-                }
+                Thread.onSpinWait();
             }
 
-            assert accepted == 2;
+            SocketChannel client2 = server.accept();
+            k3po.notifyBarrier("CONNECTION_ACCEPTED_2");
+            client2.read(buf);
+            client2.close();
 
-            selector.selectedKeys().clear();
+            while (utilization.getAsLong() != 100L)
+            {
+                Thread.onSpinWait();
+            }
+
+            SocketChannel client3 = server.accept();
+            client3.read(buf);
+            client3.close();
+
+            SocketChannel client4 = server.accept();
+            client4.read(buf);
+            client4.close();
+
             k3po.finish();
+
+            assert utilization.getAsLong() == 0L;
         }
     }
 
@@ -418,11 +407,5 @@ public class ClientIT
         String host) throws UnknownHostException
     {
         throw new UnknownHostException();
-    }
-
-    @FunctionalInterface
-    interface AcceptHandler
-    {
-        void handle(SocketChannel channel) throws IOException;
     }
 }

--- a/runtime/binding-tcp/src/test/resources/SocketChannelHelper.btm
+++ b/runtime/binding-tcp/src/test/resources/SocketChannelHelper.btm
@@ -29,3 +29,11 @@ HELPER io.aklivity.zilla.runtime.binding.tcp.internal.SocketChannelHelper$Handle
 IF callerEquals("TcpServerFactory$TcpServer.onNetWritable", true, 2)
 DO return doWrite($0, $1);
 ENDRULE
+
+RULE doConnect
+CLASS ^java.nio.channels.SocketChannel
+METHOD isConnectionPending()
+HELPER io.aklivity.zilla.runtime.binding.tcp.internal.SocketChannelHelper$DoConnectHelper
+IF callerEquals("TcpClientFactory$TcpClient.doNetShutdownOutput", true, 2)
+DO return isConnectionPending($0);
+ENDRULE

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
@@ -16,6 +16,8 @@
 package io.aklivity.zilla.runtime.engine;
 
 import static io.aklivity.zilla.runtime.engine.internal.layouts.metrics.HistogramsLayout.BUCKETS;
+import static io.aklivity.zilla.runtime.engine.namespace.NamespacedId.NO_LOCAL_ID;
+import static io.aklivity.zilla.runtime.engine.namespace.NamespacedId.NO_NAMESPACE_ID;
 import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.stream.Collectors.toList;
 import static org.agrona.LangUtil.rethrowUnchecked;
@@ -568,12 +570,24 @@ public final class Engine implements Collector, AutoCloseable
             String binding,
             String metric)
         {
-            int namespaceId = supplyLabelId.applyAsInt(namespace);
-            int bindingId = supplyLabelId.applyAsInt(binding);
+            int namespaceId = namespace != null ? supplyLabelId.applyAsInt(namespace) : NO_NAMESPACE_ID;
+            int bindingId = binding != null ? supplyLabelId.applyAsInt(binding) : NO_LOCAL_ID;
             int metricId = supplyLabelId.applyAsInt(metric);
-            long namespacedBindingId = NamespacedId.id(namespaceId, bindingId);
-            long namespacedMetricId = NamespacedId.id(namespaceId, metricId);
-            return Engine.this.counter(namespacedBindingId, namespacedMetricId);
+            long namespacedId = NamespacedId.id(namespaceId, bindingId);
+            return Engine.this.counter(namespacedId, metricId);
+        }
+
+        @Override
+        public LongSupplier gauge(
+            String namespace,
+            String binding,
+            String metric)
+        {
+            int namespaceId = namespace != null ? supplyLabelId.applyAsInt(namespace) : NO_NAMESPACE_ID;
+            int bindingId = binding != null ? supplyLabelId.applyAsInt(binding) : NO_LOCAL_ID;
+            int metricId = supplyLabelId.applyAsInt(metric);
+            long namespacedId = NamespacedId.id(namespaceId, bindingId);
+            return Engine.this.gauge(namespacedId, metricId);
         }
 
         // required for testing
@@ -583,12 +597,11 @@ public final class Engine implements Collector, AutoCloseable
             String metric,
             int core)
         {
-            int namespaceId = supplyLabelId.applyAsInt(namespace);
-            int bindingId = supplyLabelId.applyAsInt(binding);
+            int namespaceId = namespace != null ? supplyLabelId.applyAsInt(namespace) : NO_NAMESPACE_ID;
+            int bindingId = binding != null ? supplyLabelId.applyAsInt(binding) : NO_LOCAL_ID;
             int metricId = supplyLabelId.applyAsInt(metric);
-            long namespacedBindingId = NamespacedId.id(namespaceId, bindingId);
-            long namespacedMetricId = NamespacedId.id(namespaceId, metricId);
-            return Engine.this.counterWriter(namespacedBindingId, namespacedMetricId, core);
+            long namespacedId = NamespacedId.id(namespaceId, bindingId);
+            return Engine.this.counterWriter(namespacedId, metricId, core);
         }
     }
 }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/ext/EngineExtContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/ext/EngineExtContext.java
@@ -30,4 +30,9 @@ public interface EngineExtContext
         String namespace,
         String binding,
         String metric);
+
+    LongSupplier gauge(
+        String namespace,
+        String binding,
+        String metric);
 }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/CountersLayout.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/CountersLayout.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.internal.layouts.metrics;
+
+import java.nio.file.Path;
+import java.util.function.LongConsumer;
+
+import org.agrona.concurrent.AtomicBuffer;
+
+public final class CountersLayout extends ScalarsLayout
+{
+    private CountersLayout(
+        AtomicBuffer buffer)
+    {
+        super(buffer);
+    }
+
+    @Override
+    public LongConsumer supplyWriter(
+        long bindingId,
+        long metricId)
+    {
+        int index = findOrSetPosition(bindingId, metricId);
+        return delta -> buffer.getAndAddLong(index + VALUE_OFFSET, delta);
+    }
+
+    public static final class Builder extends ScalarsLayout.Builder
+    {
+        @Override
+        public Builder capacity(
+            long capacity)
+        {
+            super.capacity(capacity);
+            return this;
+        }
+
+        @Override
+        public Builder path(
+            Path path)
+        {
+            super.path(path);
+            return this;
+        }
+
+        @Override
+        public Builder readonly(
+            boolean readonly)
+        {
+            super.readonly(readonly);
+            return this;
+        }
+
+        @Override
+        public Builder label(
+            String label)
+        {
+            super.label(label);
+            return this;
+        }
+
+        public CountersLayout build()
+        {
+            return build(CountersLayout::new);
+        }
+    }
+}

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/GaugesLayout.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/GaugesLayout.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.internal.layouts.metrics;
+
+import java.nio.file.Path;
+import java.util.function.LongConsumer;
+
+import org.agrona.concurrent.AtomicBuffer;
+
+public final class GaugesLayout extends ScalarsLayout
+{
+    private GaugesLayout(
+        AtomicBuffer buffer)
+    {
+        super(buffer);
+    }
+
+    @Override
+    public LongConsumer supplyWriter(
+        long bindingId,
+        long metricId)
+    {
+        int index = findOrSetPosition(bindingId, metricId);
+        return value -> buffer.getAndSetLong(index + VALUE_OFFSET, value);
+    }
+
+    public static final class Builder extends ScalarsLayout.Builder
+    {
+        @Override
+        public Builder capacity(
+            long capacity)
+        {
+            super.capacity(capacity);
+            return this;
+        }
+
+        @Override
+        public Builder path(
+            Path path)
+        {
+            super.path(path);
+            return this;
+        }
+
+        @Override
+        public Builder readonly(
+            boolean readonly)
+        {
+            super.readonly(readonly);
+            return this;
+        }
+
+        @Override
+        public Builder label(
+            String label)
+        {
+            super.label(label);
+            return this;
+        }
+
+        public GaugesLayout build()
+        {
+            return build(GaugesLayout::new);
+        }
+    }
+}

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/metrics/EngineMetricGroup.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/metrics/EngineMetricGroup.java
@@ -29,8 +29,8 @@ public class EngineMetricGroup implements MetricGroup
     public static final String NAME = "engine";
 
     private final Map<String, Supplier<Metric>> engineMetrics = Map.of(
-        "engine.worker.utilization", EngineWorkerUtilizationMetric::new,
-        "engine.worker.count", EngineWorkerCountMetric::new
+        EngineWorkerUtilizationMetric.NAME, EngineWorkerUtilizationMetric::new,
+        EngineWorkerCountMetric.NAME, EngineWorkerCountMetric::new
     );
 
     public EngineMetricGroup(

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/metrics/EngineWorkerCountMetric.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/metrics/EngineWorkerCountMetric.java
@@ -21,8 +21,8 @@ import io.aklivity.zilla.runtime.engine.metrics.MetricContext;
 
 public class EngineWorkerCountMetric implements Metric
 {
-    private static final String GROUP = EngineMetricGroup.NAME;
-    private static final String NAME = String.format("%s.%s", GROUP, "worker.count");
+    static final String NAME = String.format("%s.%s", EngineMetricGroup.NAME, "worker.count");
+
     private static final String DESCRIPTION = "Engine worker count";
 
     @Override

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/metrics/EngineWorkerUtilizationMetric.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/metrics/EngineWorkerUtilizationMetric.java
@@ -19,10 +19,10 @@ import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.metrics.Metric;
 import io.aklivity.zilla.runtime.engine.metrics.MetricContext;
 
-public class EngineWorkerUtilizationMetric implements Metric
+public final class EngineWorkerUtilizationMetric implements Metric
 {
-    private static final String GROUP = EngineMetricGroup.NAME;
-    private static final String NAME = String.format("%s.%s", GROUP, "worker.utilization");
+    public static final String NAME = String.format("%s.%s", EngineMetricGroup.NAME, "worker.utilization");
+
     private static final String DESCRIPTION = "Engine worker utilization";
 
     @Override

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -126,6 +126,7 @@ import io.aklivity.zilla.runtime.engine.internal.layouts.StreamsLayout;
 import io.aklivity.zilla.runtime.engine.internal.layouts.metrics.CountersLayout;
 import io.aklivity.zilla.runtime.engine.internal.layouts.metrics.GaugesLayout;
 import io.aklivity.zilla.runtime.engine.internal.layouts.metrics.HistogramsLayout;
+import io.aklivity.zilla.runtime.engine.internal.metrics.EngineWorkerUtilizationMetric;
 import io.aklivity.zilla.runtime.engine.internal.poller.Poller;
 import io.aklivity.zilla.runtime.engine.internal.stream.StreamId;
 import io.aklivity.zilla.runtime.engine.internal.stream.Target;
@@ -231,6 +232,7 @@ public class EngineWorker implements EngineContext, Agent
     private final Int2ObjectHashMap<String> eventNames;
     private final Supplier<MessageReader> supplyEventReader;
     private final EventFormatterFactory eventFormatterFactory;
+    private final LongSupplier utilizationMetric;
 
     private long initialId;
     private long promiseId;
@@ -465,6 +467,7 @@ public class EngineWorker implements EngineContext, Agent
         this.exportersById = new Long2ObjectHashMap<>();
         this.supplyEventReader = supplyEventReader;
         this.eventFormatterFactory = eventFormatterFactory;
+        this.utilizationMetric = supplyGauge(NO_NAMESPACED_ID, labels.supplyLabelId(EngineWorkerUtilizationMetric.NAME));
     }
 
     public static int indexOfId(
@@ -777,7 +780,7 @@ public class EngineWorker implements EngineContext, Agent
     @Override
     public LongConsumer supplyUtilizationMetric()
     {
-        final int metricId = labels.supplyLabelId("engine.worker.utilization");
+        final int metricId = labels.supplyLabelId(EngineWorkerUtilizationMetric.NAME);
 
         return supplyMetricWriter(GAUGE, NO_NAMESPACED_ID, metricId);
     }
@@ -922,6 +925,12 @@ public class EngineWorker implements EngineContext, Agent
             throw new IllegalStateException(
                     String.format("Some resources not released: %d buffers, %d creditors, %d debitors",
                                   acquiredBuffers, acquiredCreditors, acquiredDebitors));
+        }
+
+        long utilization = utilizationMetric.getAsLong();
+        if (utilization != 0L)
+        {
+            throw new IllegalStateException("Engine worker utilization is non-zero: %d".formatted(utilization));
         }
     }
 

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -123,6 +123,8 @@ import io.aklivity.zilla.runtime.engine.internal.layouts.BudgetsLayout;
 import io.aklivity.zilla.runtime.engine.internal.layouts.BufferPoolLayout;
 import io.aklivity.zilla.runtime.engine.internal.layouts.EventsLayout;
 import io.aklivity.zilla.runtime.engine.internal.layouts.StreamsLayout;
+import io.aklivity.zilla.runtime.engine.internal.layouts.metrics.CountersLayout;
+import io.aklivity.zilla.runtime.engine.internal.layouts.metrics.GaugesLayout;
 import io.aklivity.zilla.runtime.engine.internal.layouts.metrics.HistogramsLayout;
 import io.aklivity.zilla.runtime.engine.internal.layouts.metrics.ScalarsLayout;
 import io.aklivity.zilla.runtime.engine.internal.poller.Poller;
@@ -273,14 +275,14 @@ public class EngineWorker implements EngineContext, Agent
                 config.minParkNanos(),
                 config.maxParkNanos());
 
-        this.countersLayout = new ScalarsLayout.Builder()
+        this.countersLayout = new CountersLayout.Builder()
                 .path(config.directory().resolve(String.format("metrics/counters%d", index)))
                 .capacity(config.countersBufferCapacity())
                 .readonly(readonly)
                 .label("counters")
                 .build();
 
-        this.gaugesLayout = new ScalarsLayout.Builder()
+        this.gaugesLayout = new GaugesLayout.Builder()
                 .path(config.directory().resolve(String.format("metrics/gauges%d", index)))
                 .capacity(config.countersBufferCapacity())
                 .readonly(readonly)

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -126,7 +126,6 @@ import io.aklivity.zilla.runtime.engine.internal.layouts.StreamsLayout;
 import io.aklivity.zilla.runtime.engine.internal.layouts.metrics.CountersLayout;
 import io.aklivity.zilla.runtime.engine.internal.layouts.metrics.GaugesLayout;
 import io.aklivity.zilla.runtime.engine.internal.layouts.metrics.HistogramsLayout;
-import io.aklivity.zilla.runtime.engine.internal.layouts.metrics.ScalarsLayout;
 import io.aklivity.zilla.runtime.engine.internal.poller.Poller;
 import io.aklivity.zilla.runtime.engine.internal.stream.StreamId;
 import io.aklivity.zilla.runtime.engine.internal.stream.Target;
@@ -225,8 +224,8 @@ public class EngineWorker implements EngineContext, Agent
     private final Supplier<IdleStrategy> supplyIdleStrategy;
     private final Consumer<Throwable> reporter;
     private final ErrorHandler errorHandler;
-    private final ScalarsLayout countersLayout;
-    private final ScalarsLayout gaugesLayout;
+    private final CountersLayout countersLayout;
+    private final GaugesLayout gaugesLayout;
     private final HistogramsLayout histogramsLayout;
     private final EventsLayout eventsLayout;
     private final Int2ObjectHashMap<String> eventNames;

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineConfigurationTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineConfigurationTest.java
@@ -21,12 +21,14 @@ import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_CACERT
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_CACERTS_STORE_PASS;
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_CACERTS_STORE_TYPE;
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_CONFIG_URL;
+import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_WORKER_CAPACITY;
 import static io.aklivity.zilla.runtime.engine.test.EngineRule.ENGINE_BUFFER_POOL_CAPACITY_NAME;
 import static io.aklivity.zilla.runtime.engine.test.EngineRule.ENGINE_BUFFER_SLOT_CAPACITY_NAME;
 import static io.aklivity.zilla.runtime.engine.test.EngineRule.ENGINE_CACERTS_STORE_NAME;
 import static io.aklivity.zilla.runtime.engine.test.EngineRule.ENGINE_CACERTS_STORE_PASS_NAME;
 import static io.aklivity.zilla.runtime.engine.test.EngineRule.ENGINE_CACERTS_STORE_TYPE_NAME;
 import static io.aklivity.zilla.runtime.engine.test.EngineRule.ENGINE_CONFIG_URL_NAME;
+import static io.aklivity.zilla.runtime.engine.test.EngineRule.ENGINE_WORKER_CAPACITY_NAME;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -38,9 +40,10 @@ public class EngineConfigurationTest
     {
         assertEquals(ENGINE_BUFFER_POOL_CAPACITY.name(), ENGINE_BUFFER_POOL_CAPACITY_NAME);
         assertEquals(ENGINE_BUFFER_SLOT_CAPACITY.name(), ENGINE_BUFFER_SLOT_CAPACITY_NAME);
-        assertEquals(ENGINE_CONFIG_URL.name(), ENGINE_CONFIG_URL_NAME);
         assertEquals(ENGINE_CACERTS_STORE_TYPE.name(), ENGINE_CACERTS_STORE_TYPE_NAME);
         assertEquals(ENGINE_CACERTS_STORE.name(), ENGINE_CACERTS_STORE_NAME);
         assertEquals(ENGINE_CACERTS_STORE_PASS.name(), ENGINE_CACERTS_STORE_PASS_NAME);
+        assertEquals(ENGINE_CONFIG_URL.name(), ENGINE_CONFIG_URL_NAME);
+        assertEquals(ENGINE_WORKER_CAPACITY.name(), ENGINE_WORKER_CAPACITY_NAME);
     }
 }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/CountersLayoutTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/CountersLayoutTest.java
@@ -28,27 +28,27 @@ import java.util.function.LongSupplier;
 
 import org.junit.Test;
 
-public class ScalarsLayoutTest
+public class CountersLayoutTest
 {
     @Test
     public void shouldWorkInGenericCase() throws Exception
     {
         String fileName = "target/zilla-itests/counters0";
         Path path = Paths.get(fileName);
-        ScalarsLayout scalarsLayout = new ScalarsLayout.Builder()
+        CountersLayout layout = new CountersLayout.Builder()
                 .path(path)
                 .capacity(8192)
                 .readonly(false)
                 .label("counters")
                 .build();
 
-        LongConsumer writer1 = scalarsLayout.supplyWriter(11L, 42L);
-        LongConsumer writer2 = scalarsLayout.supplyWriter(22L, 77L);
-        LongConsumer writer3 = scalarsLayout.supplyWriter(33L, 88L);
+        LongConsumer writer1 = layout.supplyWriter(11L, 42L);
+        LongConsumer writer2 = layout.supplyWriter(22L, 77L);
+        LongConsumer writer3 = layout.supplyWriter(33L, 88L);
 
-        LongSupplier reader1 = scalarsLayout.supplyReader(11L, 42L);
-        LongSupplier reader2 = scalarsLayout.supplyReader(22L, 77L);
-        LongSupplier reader3 = scalarsLayout.supplyReader(33L, 88L);
+        LongSupplier reader1 = layout.supplyReader(11L, 42L);
+        LongSupplier reader2 = layout.supplyReader(22L, 77L);
+        LongSupplier reader3 = layout.supplyReader(33L, 88L);
 
         assertThat(reader1.getAsLong(), equalTo(0L)); // should be 0L initially
         writer1.accept(1L);
@@ -67,7 +67,7 @@ public class ScalarsLayoutTest
         assertThat(reader2.getAsLong(), equalTo(130L)); // 100 + 10 + 20
         assertThat(reader3.getAsLong(), equalTo(80L)); // 77 + 1 + 1 + 1
 
-        scalarsLayout.close();
+        layout.close();
         assertTrue(Files.exists(path));
         Files.delete(path);
     }
@@ -77,21 +77,21 @@ public class ScalarsLayoutTest
     {
         String fileName = "target/zilla-itests/counters1";
         Path path = Paths.get(fileName);
-        ScalarsLayout scalarsLayout = new ScalarsLayout.Builder()
+        CountersLayout layout = new CountersLayout.Builder()
                 .path(path)
                 .capacity(71) // we'd need 72 bytes here for the 3 records
                 .readonly(false)
                 .label("counters")
                 .build();
 
-        scalarsLayout.supplyWriter(11L, 42L);
-        scalarsLayout.supplyWriter(22L, 77L);
+        layout.supplyWriter(11L, 42L);
+        layout.supplyWriter(22L, 77L);
         assertThrows(IndexOutOfBoundsException.class, () ->
         {
-            scalarsLayout.supplyWriter(33L, 88L);
+            layout.supplyWriter(33L, 88L);
         });
 
-        scalarsLayout.close();
+        layout.close();
         assertTrue(Files.exists(path));
         Files.delete(path);
     }
@@ -101,18 +101,18 @@ public class ScalarsLayoutTest
     {
         String fileName = "target/zilla-itests/counters2";
         Path path = Paths.get(fileName);
-        ScalarsLayout scalarsLayout = new ScalarsLayout.Builder()
+        CountersLayout layout = new CountersLayout.Builder()
                 .path(path)
                 .capacity(8192)
                 .readonly(false)
                 .label("counters")
                 .build();
 
-        scalarsLayout.supplyWriter(11L, 42L);
-        scalarsLayout.supplyWriter(22L, 77L);
-        scalarsLayout.supplyWriter(33L, 88L);
+        layout.supplyWriter(11L, 42L);
+        layout.supplyWriter(22L, 77L);
+        layout.supplyWriter(33L, 88L);
         long[][] expectedIds = new long[][]{{11L, 42L}, {22L, 77L}, {33L, 88L}};
 
-        assertThat(scalarsLayout.getIds(), equalTo(expectedIds));
+        assertThat(layout.getIds(), equalTo(expectedIds));
     }
 }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/GaugesLayoutTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/GaugesLayoutTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.internal.layouts.metrics;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.function.LongConsumer;
+import java.util.function.LongSupplier;
+
+import org.junit.Test;
+
+public class GaugesLayoutTest
+{
+    @Test
+    public void shouldWorkInGenericCase() throws Exception
+    {
+        String fileName = "target/zilla-itests/gauges0";
+        Path path = Paths.get(fileName);
+        GaugesLayout layout = new GaugesLayout.Builder()
+                .path(path)
+                .capacity(8192)
+                .readonly(false)
+                .label("counters")
+                .build();
+
+        LongConsumer writer1 = layout.supplyWriter(11L, 42L);
+        LongConsumer writer2 = layout.supplyWriter(22L, 77L);
+        LongConsumer writer3 = layout.supplyWriter(33L, 88L);
+
+        LongSupplier reader1 = layout.supplyReader(11L, 42L);
+        LongSupplier reader2 = layout.supplyReader(22L, 77L);
+        LongSupplier reader3 = layout.supplyReader(33L, 88L);
+
+        assertThat(reader1.getAsLong(), equalTo(0L)); // should be 0L initially
+        writer1.accept(1L);
+        assertThat(reader1.getAsLong(), equalTo(1L));
+        writer1.accept(1L);
+        writer2.accept(100L);
+        writer3.accept(77L);
+        assertThat(reader1.getAsLong(), equalTo(1L));
+        assertThat(reader2.getAsLong(), equalTo(100L));
+        assertThat(reader3.getAsLong(), equalTo(77L));
+        writer2.accept(10L);
+        writer3.accept(1L);
+        writer2.accept(20L);
+        writer3.accept(1L);
+        writer3.accept(1L);
+        assertThat(reader2.getAsLong(), equalTo(20L));
+        assertThat(reader3.getAsLong(), equalTo(1L));
+
+        layout.close();
+        assertTrue(Files.exists(path));
+        Files.delete(path);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfBufferIsTooSmall() throws Exception
+    {
+        String fileName = "target/zilla-itests/gauges1";
+        Path path = Paths.get(fileName);
+        GaugesLayout layout = new GaugesLayout.Builder()
+                .path(path)
+                .capacity(71) // we'd need 72 bytes here for the 3 records
+                .readonly(false)
+                .label("counters")
+                .build();
+
+        layout.supplyWriter(11L, 42L);
+        layout.supplyWriter(22L, 77L);
+        assertThrows(IndexOutOfBoundsException.class, () ->
+        {
+            layout.supplyWriter(33L, 88L);
+        });
+
+        layout.close();
+        assertTrue(Files.exists(path));
+        Files.delete(path);
+    }
+
+    @Test
+    public void shouldGetIds()
+    {
+        String fileName = "target/zilla-itests/gauges2";
+        Path path = Paths.get(fileName);
+        GaugesLayout layout = new GaugesLayout.Builder()
+                .path(path)
+                .capacity(8192)
+                .readonly(false)
+                .label("counters")
+                .build();
+
+        layout.supplyWriter(11L, 42L);
+        layout.supplyWriter(22L, 77L);
+        layout.supplyWriter(33L, 88L);
+        long[][] expectedIds = new long[][]{{11L, 42L}, {22L, 77L}, {33L, 88L}};
+
+        assertThat(layout.getIds(), equalTo(expectedIds));
+    }
+}

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/EngineRule.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/EngineRule.java
@@ -23,6 +23,7 @@ import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_ROUTED
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_SYNTHETIC_ABORT;
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_WORKERS;
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_WORKER_CAPACITY;
+import static io.aklivity.zilla.runtime.engine.namespace.NamespacedId.NO_NAMESPACED_ID;
 import static java.nio.file.FileVisitOption.FOLLOW_LINKS;
 import static java.nio.file.Files.exists;
 import static java.util.Collections.synchronizedList;
@@ -59,6 +60,7 @@ import io.aklivity.zilla.runtime.engine.EngineBuilder;
 import io.aklivity.zilla.runtime.engine.EngineConfiguration;
 import io.aklivity.zilla.runtime.engine.binding.Binding;
 import io.aklivity.zilla.runtime.engine.ext.EngineExtContext;
+import io.aklivity.zilla.runtime.engine.internal.metrics.EngineWorkerUtilizationMetric;
 import io.aklivity.zilla.runtime.engine.test.annotation.Configuration;
 import io.aklivity.zilla.runtime.engine.test.annotation.Configure;
 
@@ -67,10 +69,11 @@ public final class EngineRule implements TestRule
     // needed by test annotations
     public static final String ENGINE_BUFFER_POOL_CAPACITY_NAME = "zilla.engine.buffer.pool.capacity";
     public static final String ENGINE_BUFFER_SLOT_CAPACITY_NAME = "zilla.engine.buffer.slot.capacity";
-    public static final String ENGINE_CONFIG_URL_NAME = "zilla.engine.config.url";
     public static final String ENGINE_CACERTS_STORE_TYPE_NAME = "zilla.engine.cacerts.store.type";
     public static final String ENGINE_CACERTS_STORE_NAME = "zilla.engine.cacerts.store";
     public static final String ENGINE_CACERTS_STORE_PASS_NAME = "zilla.engine.cacerts.store.pass";
+    public static final String ENGINE_CONFIG_URL_NAME = "zilla.engine.config.url";
+    public static final String ENGINE_WORKER_CAPACITY_NAME = "zilla.engine.worker.capacity";
 
     private static final long EXTERNAL_AFFINITY_MASK = 1L << (Long.SIZE - 1);
     private static final Pattern DATA_FILENAME_PATTERN = Pattern.compile("data\\d+");
@@ -251,6 +254,11 @@ public final class EngineRule implements TestRule
         int core)
     {
         return engine.context().counterWriter(namespace, binding, metric, core);
+    }
+
+    public LongSupplier utilization()
+    {
+        return gauge(NO_NAMESPACED_ID, supplyLabelId(EngineWorkerUtilizationMetric.NAME));
     }
 
     public int supplyLabelId(

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.close.immediately/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.close.immediately/client.rpt
@@ -1,0 +1,24 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "duplex"
+
+connected
+
+write close
+read aborted

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.close.immediately/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.close.immediately/server.rpt
@@ -1,0 +1,25 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/app0"
+       option zilla:window 8192
+       option zilla:transmission "duplex"
+accepted
+
+connected
+
+read closed
+write abort

--- a/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/streams/ApplicationIT.java
+++ b/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/streams/ApplicationIT.java
@@ -70,6 +70,15 @@ public class ApplicationIT
 
     @Test
     @Specification({
+        "${app}/client.close.immediately/client",
+        "${app}/client.close.immediately/server" })
+    public void shouldInitiateClientCloseImmediately() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/client.received.abort.sent.end/client",
         "${app}/client.received.abort.sent.end/server" })
     public void clientShouldReceiveResetAndAbortAndNoAdditionalResetWhensendEnd() throws Exception


### PR DESCRIPTION
## Description

Engine metric for worker utilization is an absolute value, so should be recorded via Gauge semantics rather than specifying delta to accumulating Counter semantics.