### PR TITLE
Cancel pending TLS handshake task when streams closed in both directions

### DIFF
--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsClientFactory.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsClientFactory.java
@@ -1529,6 +1529,8 @@ public final class TlsClientFactory implements TlsStreamFactory
                         doAppReset(traceId);
                         doEncodeCloseOutbound(traceId, budgetId);
                         doNetEnd(traceId);
+
+                        cancelHandshakeTask();
                     }
 
                     decoder = decodeIgnoreAll;
@@ -1565,6 +1567,8 @@ public final class TlsClientFactory implements TlsStreamFactory
                 doAppReset(traceId);
 
                 doNetAbort(traceId);
+
+                cancelHandshakeTask();
             }
 
             private void onNetReset(
@@ -1589,6 +1593,8 @@ public final class TlsClientFactory implements TlsStreamFactory
                 doAppAbort(traceId);
 
                 doNetReset(traceId);
+
+                cancelHandshakeTask();
             }
 
             private void onNetWindow(
@@ -2191,6 +2197,17 @@ public final class TlsClientFactory implements TlsStreamFactory
                     encodeSlot = NO_SLOT;
                     encodeSlotOffset = 0;
                     encodeSlotTraceId = 0;
+                }
+            }
+
+            private void cancelHandshakeTask()
+            {
+                assert TlsState.closed(state);
+
+                if (handshakeTaskFutureId != NO_CANCEL_ID)
+                {
+                    signaler.cancel(handshakeTaskFutureId);
+                    handshakeTaskFutureId = NO_CANCEL_ID;
                 }
             }
 

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsServerFactory.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsServerFactory.java
@@ -1233,6 +1233,8 @@ public final class TlsServerFactory implements TlsStreamFactory
                 {
                     doEncodeCloseOutbound(traceId, budgetId);
                     doNetEnd(traceId);
+
+                    cancelHandshakeTask();
                 }
 
                 decoder = decodeIgnoreAll;
@@ -1268,6 +1270,8 @@ public final class TlsServerFactory implements TlsStreamFactory
             stream.ifPresent(s -> s.doAppReset(traceId));
 
             doNetAbort(traceId);
+
+            cancelHandshakeTask();
         }
 
         private void onNetReset(
@@ -1292,6 +1296,8 @@ public final class TlsServerFactory implements TlsStreamFactory
             stream.ifPresent(s -> s.doAppAbort(traceId));
 
             doNetReset(traceId);
+
+            cancelHandshakeTask();
         }
 
         private void onNetWindow(
@@ -1838,6 +1844,17 @@ public final class TlsServerFactory implements TlsStreamFactory
                 encodeSlot = NO_SLOT;
                 encodeSlotOffset = 0;
                 encodeSlotTraceId = 0;
+            }
+        }
+
+        private void cancelHandshakeTask()
+        {
+            assert TlsState.closed(state);
+
+            if (handshakeTaskFutureId != NO_CANCEL_ID)
+            {
+                signaler.cancel(handshakeTaskFutureId);
+                handshakeTaskFutureId = NO_CANCEL_ID;
             }
         }
 


### PR DESCRIPTION
TLS clients sending `ClientHello` then closing the TCP connection before receiving `ServerHello` should not consume further CPU for TLS handshake tasks.