### PR TITLE
Support `engine.worker.capacity.unbounded` configuration

### DIFF
--- a/examples/tcp.echo/compose.yaml
+++ b/examples/tcp.echo/compose.yaml
@@ -15,7 +15,7 @@ services:
       ZILLA_INCUBATOR_ENABLED: "true"
     volumes:
       - ./etc:/etc/zilla
-    command: start -v -e
+    command: start -v -e -w 1 -Pzilla.engine.worker.capacity=32
 
 networks:
   default:

--- a/examples/tcp.echo/compose.yaml
+++ b/examples/tcp.echo/compose.yaml
@@ -15,7 +15,7 @@ services:
       ZILLA_INCUBATOR_ENABLED: "true"
     volumes:
       - ./etc:/etc/zilla
-    command: start -v -e -w 1 -Pzilla.engine.worker.capacity=32
+    command: start -v -e
 
 networks:
   default:

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpCapacityTracker.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpCapacityTracker.java
@@ -15,7 +15,7 @@
  */
 package io.aklivity.zilla.runtime.binding.tcp.internal;
 
-import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_WORKER_CAPACITY;
+import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_WORKER_CAPACITY_LIMIT;
 
 import java.util.function.LongConsumer;
 
@@ -32,7 +32,7 @@ public final class TcpCapacityTracker
         TcpConfiguration config,
         EngineContext context)
     {
-        this.capacity = ENGINE_WORKER_CAPACITY.getAsInt(config);
+        this.capacity = ENGINE_WORKER_CAPACITY_LIMIT.getAsInt(config);
         this.recordUsage = context.supplyUtilizationMetric();
     }
 

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineConfiguration.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineConfiguration.java
@@ -60,6 +60,8 @@ public class EngineConfiguration extends Configuration
     public static final PropertyDef<Path> ENGINE_CACHE_DIRECTORY;
     public static final PropertyDef<HostResolver> ENGINE_HOST_RESOLVER;
     public static final IntPropertyDef ENGINE_WORKER_CAPACITY;
+    public static final IntPropertyDef ENGINE_WORKER_CAPACITY_LIMIT;
+    public static final BooleanPropertyDef ENGINE_WORKER_CAPACITY_UNBOUNDED;
     public static final DoublePropertyDef ENGINE_MEMORY_PERCENTAGE;
     public static final DoublePropertyDef ENGINE_DISK_PERCENTAGE;
     public static final IntPropertyDef ENGINE_BUFFER_POOL_CAPACITY;
@@ -111,6 +113,8 @@ public class EngineConfiguration extends Configuration
         ENGINE_MEMORY_PERCENTAGE = config.property("memory.percentage", 0.25);
         ENGINE_DISK_PERCENTAGE = config.property("disk.percentage", 0.75);
         ENGINE_WORKER_CAPACITY = config.property("worker.capacity", EngineConfiguration::defaultWorkerCapacity);
+        ENGINE_WORKER_CAPACITY_UNBOUNDED = config.property("worker.capacity.unbounded", false);
+        ENGINE_WORKER_CAPACITY_LIMIT = config.property("worker.capacity.limit", EngineConfiguration::defaultWorkerCapacityLimit);
         ENGINE_BUFFER_POOL_CAPACITY = config.property("buffer.pool.capacity", EngineConfiguration::defaultBufferPoolCapacity);
         ENGINE_BUFFER_SLOT_CAPACITY = config.property("buffer.slot.capacity", 32 * 1024);
         ENGINE_STREAMS_BUFFER_CAPACITY = config.property("streams.buffer.capacity",
@@ -424,6 +428,14 @@ public class EngineConfiguration extends Configuration
         int newWorkersCapacity = Integer.highestOneBit(min(min(bufferPoolMaxCapacity, budgetsMaxCapacity), streamsMaxCapacity));
 
         return newWorkersCapacity;
+    }
+
+    private static int defaultWorkerCapacityLimit(
+        Configuration config)
+    {
+        return ENGINE_WORKER_CAPACITY_UNBOUNDED.get(config)
+            ? Integer.MAX_VALUE
+            : ENGINE_WORKER_CAPACITY.get(config);
     }
 
     private static URL configURL(

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -15,7 +15,7 @@
  */
 package io.aklivity.zilla.runtime.engine.internal.registry;
 
-import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_WORKER_CAPACITY;
+import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_WORKER_CAPACITY_LIMIT;
 import static io.aklivity.zilla.runtime.engine.budget.BudgetCreditor.NO_BUDGET_ID;
 import static io.aklivity.zilla.runtime.engine.concurrent.Signaler.NO_CANCEL_ID;
 import static io.aklivity.zilla.runtime.engine.internal.registry.MetricHandlerKind.ORIGIN;
@@ -895,7 +895,7 @@ public class EngineWorker implements EngineContext, Agent
             LongConsumer recordUtilization = supplyGaugeWriter(utilizationMetricId);
 
             recordCount.accept(1);
-            recordCapacity.accept(ENGINE_WORKER_CAPACITY.getAsInt(config));
+            recordCapacity.accept(ENGINE_WORKER_CAPACITY_LIMIT.getAsInt(config));
             recordUtilization.accept(0);
         }
     }


### PR DESCRIPTION
`-w 1`
```
root@zilla:/# ls -l /var/run/zilla/
total 1050284
-rw-r--r-- 1 root root        80 Jun 15 01:12 bindings
-rw-r--r-- 1 root root   1048576 Jun 15 01:12 budgets0
-rw-r--r-- 1 root root 537001988 Jun 15 01:12 buffers0
-rw-r--r-- 1 root root 536871680 Jun 15 01:12 data0
-rw-r--r-- 1 root root    262912 Jun 15 01:12 events
-rw-r--r-- 1 root root    262912 Jun 15 01:12 events0
-rw-r--r-- 1 root root        12 Jun 15 01:12 info
-rw-r--r-- 1 root root       749 Jun 15 01:12 labels
drwxr-xr-x 2 root root      4096 Jun 15 01:12 metrics
-rw-r--r-- 1 root root        32 Jun 15 01:12 tuning

root@zilla:/opt/zilla# ./zilla metrics
namespace    binding    metric                        value
                        engine.workers.utilization        0
                        engine.workers.count              1
                        engine.workers.capacity       16384
```

`-w 1 -Pzilla.engine.worker.capacity.limit=8192`
```
root@zilla:/# ls -l /var/run/zilla/
total 1050284
-rw-r--r-- 1 root root        80 Jun 15 01:14 bindings
-rw-r--r-- 1 root root   1048576 Jun 15 01:14 budgets0
-rw-r--r-- 1 root root 537001988 Jun 15 01:14 buffers0
-rw-r--r-- 1 root root 536871680 Jun 15 01:14 data0
-rw-r--r-- 1 root root    262912 Jun 15 01:14 events
-rw-r--r-- 1 root root    262912 Jun 15 01:14 events0
-rw-r--r-- 1 root root        12 Jun 15 01:14 info
-rw-r--r-- 1 root root       749 Jun 15 01:14 labels
drwxr-xr-x 2 root root      4096 Jun 15 01:14 metrics
-rw-r--r-- 1 root root        32 Jun 15 01:14 tuning

root@zilla:/opt/zilla# ./zilla metrics
namespace    binding    metric                        value
                        engine.workers.utilization        0
                        engine.workers.count              1
                        engine.workers.capacity        8192
```

`-w 1 -Pzilla.engine.worker.capacity.unbounded=true`
```
root@zilla:/# ls -l /var/run/zilla/
total 1050284
-rw-r--r-- 1 root root        80 Jun 15 01:15 bindings
-rw-r--r-- 1 root root   1048576 Jun 15 01:15 budgets0
-rw-r--r-- 1 root root 537001988 Jun 15 01:15 buffers0
-rw-r--r-- 1 root root 536871680 Jun 15 01:16 data0
-rw-r--r-- 1 root root    262912 Jun 15 01:15 events
-rw-r--r-- 1 root root    262912 Jun 15 01:15 events0
-rw-r--r-- 1 root root        12 Jun 15 01:15 info
-rw-r--r-- 1 root root       749 Jun 15 01:15 labels
drwxr-xr-x 2 root root      4096 Jun 15 01:15 metrics
-rw-r--r-- 1 root root        32 Jun 15 01:15 tuning

root@zilla:/opt/zilla# ./zilla metrics
namespace    binding    metric                             value
                        engine.workers.utilization             0
                        engine.workers.count                   1
                        engine.workers.capacity       2147483647
```