### PR TITLE
Use piped input and output stream

### DIFF
--- a/runtime/exporter-stdout/src/test/java/io/aklivity/zilla/runtime/exporter/stdout/internal/events/EventIT.java
+++ b/runtime/exporter-stdout/src/test/java/io/aklivity/zilla/runtime/exporter/stdout/internal/events/EventIT.java
@@ -63,6 +63,6 @@ public class EventIT
     public void shouldLogEvents() throws Exception
     {
         k3po.finish();
-        output.expect(Pattern.compile("test.net0 \\[[^\\]]+\\] \\[[^\\]]+\\] BINDING_TEST_CONNECTED test event message\n"));
+        output.expect(Pattern.compile("test.net0 \\[[^\\]]+\\] \\[[^\\]]+\\] BINDING_TEST_CONNECTED test event message"));
     }
 }


### PR DESCRIPTION
Plus read full line to verify expected output.

This prevents non-deterministic failures for `stdout` exporter when only partial output is being verified.