### PR TITLE
Disable `ws.reflect` example

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
             ^\.assets$
             ^\.git$
             ^\.vscode$
-            ^examples/ws.reflect$
+            ^ws.reflect$
 
   testing:
     strategy:


### PR DESCRIPTION
`ws.reflect` example is non-deterministic.