### PR TITLE
Disable tcp.reflect example

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,7 @@ jobs:
             ^\.assets$
             ^\.git$
             ^\.vscode$
+            ^tcp.reflect$
             ^ws.reflect$
 
   testing:


### PR DESCRIPTION
`tcp.reflect` example is non-deterministic.