### PR TITLE
Handle slow TCP client handshake

### DIFF
--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpClientFactory.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpClientFactory.java
@@ -294,9 +294,11 @@ public class TcpClientFactory implements TcpStreamFactory
         {
             try
             {
-                key.clear(OP_CONNECT);
-                net.finishConnect();
-                onNetConnected();
+                if (net.finishConnect())
+                {
+                    key.clear(OP_CONNECT);
+                    onNetConnected();
+                }
             }
             catch (IOException ex)
             {


### PR DESCRIPTION
## Description

### Selector and `OP_CONNECT`
- In Selector, `OP_CONNECT` means “the socket is ready to finish the connection”, not necessarily that the handshake is complete.
- This readiness is based on low-level OS signals:
- On Linux/BSD/macOS: the kernel sets socket writable once the handshake progresses enough for `connect()` to be completed or fails immediately.
- The selector interprets a writable socket in non-blocking connect as `OP_CONNECT` ready.
- Key point: ready-to-finish does not guarantee `finishConnect()` will succeed immediately.

### Why `finishConnect()` can still return false
Even after the OS signals writable / `OP_CONNECT` ready:
- The TCP handshake may still be in progress (delays, packet loss, retransmission).
- The channel must call `finishConnect()` to:
    - Complete the handshake in Java’s `SocketChannel` API.
    - Update the internal channel state.
    - Assign local/remote addresses.
- If handshake is still incomplete, `finishConnect()` returns false — the Java API is just reporting the true channel state.
