### PR TITLE
Protobuf2 Model Support in Zilla

### DIFF
--- a/runtime/model-protobuf/src/main/antlr4/io/aklivity/zilla/runtime/model/protobuf/internal/parser/Protobuf2.g4
+++ b/runtime/model-protobuf/src/main/antlr4/io/aklivity/zilla/runtime/model/protobuf/internal/parser/Protobuf2.g4
@@ -1,0 +1,416 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+grammar Protobuf2;
+
+proto
+  : syntax
+    (
+        importStatement
+      | packageStatement
+      | optionStatement
+      | topLevelDef
+      | emptyStatement_
+    )* EOF
+  ;
+
+// Syntax
+
+syntax
+  : SYNTAX EQ (PROTO2_LIT_SINGLE | PROTO2_LIT_DOUBLE) SEMI
+  ;
+
+// Import Statement
+
+importStatement
+  : IMPORT ( WEAK | PUBLIC )? strLit SEMI
+  ;
+
+// Package
+
+packageStatement
+  : PACKAGE fullIdent SEMI
+  ;
+
+// Option
+
+optionStatement
+  : OPTION optionName EQ constant SEMI
+  ;
+
+optionName
+  : fullIdent
+  | LP fullIdent RP ( DOT fullIdent )?
+  ;
+
+// Normal Field - Proto2 includes required, optional, repeated
+fieldLabel
+  : REQUIRED | OPTIONAL | REPEATED
+  ;
+
+field
+  : fieldLabel type_ fieldName EQ fieldNumber ( LB fieldOptions RB )? SEMI
+  ;
+
+fieldOptions
+  : fieldOption ( COMMA  fieldOption )*
+  ;
+
+fieldOption
+  : optionName EQ constant
+  ;
+
+fieldNumber
+  : intLit
+  ;
+
+// Group field (deprecated but still supported in proto2)
+group
+  : fieldLabel GROUP groupName EQ fieldNumber LC ( field | emptyStatement_ )* RC
+  ;
+
+// Oneof and oneof field
+
+oneof
+  : ONEOF oneofName LC ( optionStatement | oneofField | emptyStatement_ )* RC
+  ;
+
+oneofField
+  : type_ fieldName EQ fieldNumber ( LB fieldOptions RB )? SEMI
+  ;
+
+// Map field
+
+mapField
+  : MAP LT keyType COMMA type_ GT mapName
+        EQ fieldNumber ( LB fieldOptions RB )? SEMI
+  ;
+keyType
+  : INT32
+  | INT64
+  | UINT32
+  | UINT64
+  | SINT32
+  | SINT64
+  | FIXED32
+  | FIXED64
+  | SFIXED32
+  | SFIXED64
+  | BOOL
+  | STRING
+  ;
+
+// field types
+
+type_
+  : DOUBLE
+  | FLOAT
+  | INT32
+  | INT64
+  | UINT32
+  | UINT64
+  | SINT32
+  | SINT64
+  | FIXED32
+  | FIXED64
+  | SFIXED32
+  | SFIXED64
+  | BOOL
+  | STRING
+  | BYTES
+  | messageType
+  | enumType
+  ;
+
+// Reserved
+
+reserved
+  : RESERVED ( ranges | reservedFieldNames ) SEMI
+  ;
+
+ranges
+  : range_ ( COMMA range_ )*
+  ;
+
+range_
+  : intLit ( TO ( intLit | MAX ) )?
+  ;
+
+reservedFieldNames
+  : strLit ( COMMA strLit )*
+  ;
+
+// Extensions (proto2 specific)
+
+extensions
+  : EXTENSIONS ranges SEMI
+  ;
+
+// Extend definition
+
+extendDef
+    :   EXTEND messageType LC ( field
+                                 | group
+                                 | emptyStatement_
+                                 )* RC
+    ;
+
+// Top Level definitions
+
+topLevelDef
+  : messageDef
+  | enumDef
+  | extendDef
+  | serviceDef
+  ;
+
+// enum
+
+enumDef
+  : ENUM enumName enumBody
+  ;
+
+enumBody
+  : LC enumElement* RC
+  ;
+
+enumElement
+  : optionStatement
+  | enumField
+  | emptyStatement_
+  ;
+
+enumField
+  : ident EQ ( MINUS )? intLit enumValueOptions?SEMI
+  ;
+
+enumValueOptions
+  : LB enumValueOption ( COMMA  enumValueOption )* RB
+  ;
+
+enumValueOption
+  : optionName EQ constant
+  ;
+
+// message
+
+messageDef
+  : MESSAGE messageName messageBody
+  ;
+
+messageBody
+  : LC messageElement* RC
+  ;
+
+messageElement
+  : field
+  | group
+  | enumDef
+  | messageDef
+  | extendDef
+  | extensions
+  | optionStatement
+  | oneof
+  | mapField
+  | reserved
+  | emptyStatement_
+  ;
+
+// service
+
+serviceDef
+  : SERVICE serviceName LC serviceElement* RC
+  ;
+
+serviceElement
+  : optionStatement
+  | rpc
+  | emptyStatement_
+  ;
+
+rpc
+  : RPC rpcName LP ( clientStreaming=STREAM )? messageType RP
+        RETURNS LP ( serverStreaming=STREAM )? messageType RP
+        (LC ( optionStatement | emptyStatement_ )* RC | SEMI)
+  ;
+
+// lexical
+
+constant
+  : fullIdent
+  | (MINUS | PLUS )? intLit
+  | ( MINUS | PLUS )? floatLit
+  | strLit
+  | boolLit
+  | blockLit
+  ;
+
+// not specified in specification but used in tests
+blockLit
+  : LC ( ident COLON constant )* RC
+  ;
+
+emptyStatement_: SEMI;
+
+// Lexical elements
+
+ident: IDENTIFIER | keywords;
+fullIdent: ident ( DOT ident )*;
+groupName: ident;
+messageName: ident;
+enumName: ident;
+fieldName: ident;
+oneofName: ident;
+mapName: ident;
+serviceName: ident;
+rpcName: ident;
+messageType: ( DOT )? ( ident DOT )* messageName;
+enumType: ( DOT )? ( ident DOT )* enumName;
+
+intLit: INT_LIT;
+strLit: STR_LIT | PROTO2_LIT_SINGLE | PROTO2_LIT_DOBULE;
+boolLit: BOOL_LIT;
+floatLit: FLOAT_LIT;
+
+// keywords
+SYNTAX: 'syntax';
+IMPORT: 'import';
+WEAK: 'weak';
+PUBLIC: 'public';
+PACKAGE: 'package';
+OPTION: 'option';
+REQUIRED: 'required';
+OPTIONAL: 'optional';
+REPEATED: 'repeated';
+ONEOF: 'oneof';
+MAP: 'map';
+GROUP: 'group';
+EXTENSIONS: 'extensions';
+INT32: 'int32';
+INT64: 'int64';
+UINT32: 'uint32';
+UINT64: 'uint64';
+SINT32: 'sint32';
+SINT64: 'sint64';
+FIXED32: 'fixed32';
+FIXED64: 'fixed64';
+SFIXED32: 'sfixed32';
+SFIXED64: 'sfixed64';
+BOOL: 'bool';
+STRING: 'string';
+DOUBLE: 'double';
+FLOAT: 'float';
+BYTES: 'bytes';
+RESERVED: 'reserved';
+TO: 'to';
+MAX: 'max';
+ENUM: 'enum';
+MESSAGE: 'message';
+SERVICE: 'service';
+EXTEND: 'extend';
+RPC: 'rpc';
+STREAM: 'stream';
+RETURNS: 'returns';
+
+PROTO2_LIT_SINGLE: '"proto2"';
+PROTO2_LIT_DOBULE: '\'proto2\'';
+
+// symbols
+
+SEMI: ';';
+EQ: '=';
+LP: '(';
+RP: ')';
+LB: '[';
+RB: ']';
+LC: '{';
+RC: '}';
+LT: '<';
+GT: '>';
+DOT: '.';
+COMMA: ',';
+COLON: ':';
+PLUS: '+';
+MINUS: '-';
+
+STR_LIT: ( '\'' ( CHAR_VALUE )*? '\'' ) |  ( '"' ( CHAR_VALUE )*? '"' );
+fragment CHAR_VALUE: HEX_ESCAPE | OCT_ESCAPE | CHAR_ESCAPE | ~[\u0000\n\\];
+fragment HEX_ESCAPE: '\\' ( 'x' | 'X' ) HEX_DIGIT HEX_DIGIT;
+fragment OCT_ESCAPE: '\\' OCTAL_DIGIT OCTAL_DIGIT OCTAL_DIGIT;
+fragment CHAR_ESCAPE: '\\' ( 'a' | 'b' | 'f' | 'n' | 'r' | 't' | 'v' | '\\' | '\'' | '"' );
+
+BOOL_LIT: 'true' | 'false';
+
+FLOAT_LIT : ( DECIMALS DOT DECIMALS? EXPONENT? | DECIMALS EXPONENT | DOT DECIMALS EXPONENT? ) | 'inf' | 'nan';
+fragment EXPONENT  : ( 'e' | 'E' ) (PLUS | MINUS)? DECIMALS;
+fragment DECIMALS  : DECIMAL_DIGIT+;
+
+INT_LIT     : DECIMAL_LIT | OCTAL_LIT | HEX_LIT;
+fragment DECIMAL_LIT : ( [1-9] ) DECIMAL_DIGIT*;
+fragment OCTAL_LIT   : '0' OCTAL_DIGIT*;
+fragment HEX_LIT     : '0' ( 'x' | 'X' ) HEX_DIGIT+ ;
+
+IDENTIFIER: LETTER ( LETTER | DECIMAL_DIGIT )*;
+
+fragment LETTER: [A-Za-z_];
+fragment DECIMAL_DIGIT: [0-9];
+fragment OCTAL_DIGIT: [0-7];
+fragment HEX_DIGIT: [0-9A-Fa-f];
+
+// comments
+WS  :   [ \t\r\n\u000C]+ -> skip;
+LINE_COMMENT: '//' ~[\r\n]* -> channel(HIDDEN);
+COMMENT: '/*' .*? '*/' -> channel(HIDDEN);
+
+keywords
+  : SYNTAX
+  | IMPORT
+  | WEAK
+  | PUBLIC
+  | PACKAGE
+  | OPTION
+  | REQUIRED
+  | OPTIONAL
+  | REPEATED
+  | ONEOF
+  | MAP
+  | GROUP
+  | EXTENSIONS
+  | INT32
+  | INT64
+  | UINT32
+  | UINT64
+  | SINT32
+  | SINT64
+  | FIXED32
+  | FIXED64
+  | SFIXED32
+  | SFIXED64
+  | BOOL
+  | STRING
+  | DOUBLE
+  | FLOAT
+  | BYTES
+  | RESERVED
+  | TO
+  | MAX
+  | ENUM
+  | MESSAGE
+  | SERVICE
+  | EXTEND
+  | RPC
+  | STREAM
+  | RETURNS
+  | BOOL_LIT
+  ;

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/config/ProtobufModelConfig.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/config/ProtobufModelConfig.java
@@ -24,15 +24,18 @@ public final class ProtobufModelConfig extends ModelConfig
 {
     public final String subject;
     public final String view;
+    public final String syntax;
 
     public ProtobufModelConfig(
         List<CatalogedConfig> cataloged,
         String subject,
-        String view)
+        String view,
+        String syntax)
     {
         super("protobuf", cataloged);
         this.subject = subject;
         this.view = view;
+        this.syntax = syntax;
     }
 
     public static <T> ProtobufModelConfigBuilder<T> builder(

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/config/ProtobufModelConfigBuilder.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/config/ProtobufModelConfigBuilder.java
@@ -29,6 +29,7 @@ public class ProtobufModelConfigBuilder<T> extends ConfigBuilder<T, ProtobufMode
     private List<CatalogedConfig> catalogs;
     private String subject;
     private String view;
+    private String syntax;
 
     ProtobufModelConfigBuilder(
         Function<ProtobufModelConfig, T> mapper)
@@ -73,9 +74,16 @@ public class ProtobufModelConfigBuilder<T> extends ConfigBuilder<T, ProtobufMode
         return this;
     }
 
+    public ProtobufModelConfigBuilder<T> syntax(
+        String syntax)
+    {
+        this.syntax = syntax;
+        return this;
+    }
+
     @Override
     public T build()
     {
-        return mapper.apply(new ProtobufModelConfig(catalogs, subject, view));
+        return mapper.apply(new ProtobufModelConfig(catalogs, subject, view, syntax));
     }
 }

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/Proto2Listener.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/Proto2Listener.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.protobuf.internal;
+
+import static java.util.Map.entry;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Label;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+
+import io.aklivity.zilla.runtime.model.protobuf.internal.parser.Protobuf2BaseListener;
+import io.aklivity.zilla.runtime.model.protobuf.internal.parser.Protobuf2Parser;
+
+public class Proto2Listener extends Protobuf2BaseListener
+{
+    private static final Map<String, Type> TYPES = Map.ofEntries(
+        entry("double", Type.TYPE_DOUBLE),
+        entry("float", Type.TYPE_FLOAT),
+        entry("int32", Type.TYPE_INT32),
+        entry("int64", Type.TYPE_INT64),
+        entry("uint32", Type.TYPE_UINT32),
+        entry("uint64", Type.TYPE_UINT64),
+        entry("sint32", Type.TYPE_SINT32),
+        entry("sint64", Type.TYPE_SINT64),
+        entry("fixed32", Type.TYPE_FIXED32),
+        entry("fixed64", Type.TYPE_FIXED64),
+        entry("sfixed32", Type.TYPE_SFIXED32),
+        entry("sfixed64", Type.TYPE_SFIXED64),
+        entry("bool", Type.TYPE_BOOL),
+        entry("string", Type.TYPE_STRING),
+        entry("bytes", Type.TYPE_BYTES)
+    );
+
+    private static final Map<String, Label> LABELS = Map.ofEntries(
+        entry("optional", Label.LABEL_OPTIONAL),
+        entry("required", Label.LABEL_REQUIRED),
+        entry("repeated", Label.LABEL_REPEATED)
+    );
+
+    private String packageName;
+    private List<String> imports;
+    private final FileDescriptorProto.Builder builder;
+    private Stack<String> messageHierarchy = new Stack<>();
+
+    public Proto2Listener()
+    {
+        this.imports = new ArrayList<>();
+        this.builder = FileDescriptorProto.newBuilder();
+    }
+
+    @Override
+    public void enterSyntax(
+        Protobuf2Parser.SyntaxContext ctx)
+    {
+        builder.setSyntax(ctx.getChild(2).getText());
+    }
+
+    @Override
+    public void enterPackageStatement(
+        Protobuf2Parser.PackageStatementContext ctx)
+    {
+        packageName = ctx.fullIdent().getText();
+        builder.setPackage(packageName);
+    }
+
+    @Override
+    public void enterImportStatement(
+        Protobuf2Parser.ImportStatementContext ctx)
+    {
+        String importStatement = ctx.strLit().getText();
+        imports.add(importStatement);
+        System.out.println("Import statements are currently not supported");
+    }
+
+    @Override
+    public void enterMessageDef(
+        Protobuf2Parser.MessageDefContext ctx)
+    {
+        DescriptorProto.Builder builder = DescriptorProto.newBuilder();
+        String name = ctx.messageName().getText();
+        builder.setName(name);
+        messageHierarchy.push(name);
+
+        for (Protobuf2Parser.MessageElementContext element : ctx.messageBody().messageElement())
+        {
+            if (element.field() != null)
+            {
+                builder.addField(processFieldElement(element.field()));
+            }
+            if (element.messageDef() != null)
+            {
+                builder.addNestedType(processNestedMessage(element.messageDef()));
+            }
+            if (element.group() != null)
+            {
+                // Handle group fields (proto2 specific)
+                builder.addField(processGroupElement(element.group()));
+            }
+        }
+        if (messageHierarchy.size() == 1)
+        {
+            this.builder.addMessageType(builder.build());
+            builder.clear();
+        }
+    }
+
+    @Override
+    public void exitMessageDef(
+        Protobuf2Parser.MessageDefContext ctx)
+    {
+        messageHierarchy.pop();
+    }
+
+    public DescriptorProtos.FileDescriptorProto build()
+    {
+        return builder.build();
+    }
+
+    private DescriptorProto processNestedMessage(
+        Protobuf2Parser.MessageDefContext ctx)
+    {
+        DescriptorProto.Builder builder = DescriptorProto.newBuilder();
+        String name = ctx.messageName().getText();
+        builder.setName(name);
+
+        for (Protobuf2Parser.MessageElementContext element : ctx.messageBody().messageElement())
+        {
+            if (element.field() != null)
+            {
+                builder.addField(processFieldElement(element.field()));
+            }
+            if (element.messageDef() != null)
+            {
+                builder.addNestedType(processNestedMessage(element.messageDef()));
+            }
+            if (element.group() != null)
+            {
+                builder.addField(processGroupElement(element.group()));
+            }
+        }
+        return builder.build();
+    }
+
+    private FieldDescriptorProto processFieldElement(
+        Protobuf2Parser.FieldContext ctx)
+    {
+        FieldDescriptorProto.Builder builder = FieldDescriptorProto.newBuilder();
+        String type = ctx.type_().getText();
+        String name = ctx.fieldName().getText();
+        String label = ctx.fieldLabel().getText();
+        int number = Integer.parseInt(ctx.fieldNumber().getText());
+
+        builder.setName(name);
+        builder.setNumber(number);
+        builder.setLabel(LABELS.get(label));
+        
+        if (TYPES.containsKey(type))
+        {
+            builder.setType(TYPES.get(type));
+        }
+        else
+        {
+            builder.setTypeName(type);
+        }
+        
+        // Handle default values if present in field options
+        if (ctx.fieldOptions() != null)
+        {
+            for (Protobuf2Parser.FieldOptionContext option : ctx.fieldOptions().fieldOption())
+            {
+                String optionName = option.optionName().getText();
+                if ("default".equals(optionName))
+                {
+                    String defaultValue = option.constant().getText();
+                    // Remove quotes from string literals
+                    if (defaultValue.startsWith("\"") && defaultValue.endsWith("\""))
+                    {
+                        defaultValue = defaultValue.substring(1, defaultValue.length() - 1);
+                    }
+                    builder.setDefaultValue(defaultValue);
+                }
+            }
+        }
+        
+        return builder.build();
+    }
+
+    private FieldDescriptorProto processGroupElement(
+        Protobuf2Parser.GroupContext ctx)
+    {
+        FieldDescriptorProto.Builder builder = FieldDescriptorProto.newBuilder();
+        String name = ctx.groupName().getText();
+        String label = ctx.fieldLabel().getText();
+        int number = Integer.parseInt(ctx.fieldNumber().getText());
+
+        builder.setName(name.toLowerCase());
+        builder.setNumber(number);
+        builder.setLabel(LABELS.get(label));
+        builder.setType(Type.TYPE_GROUP);
+        builder.setTypeName(name);
+        
+        return builder.build();
+    }
+}

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/Proto3Listener.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/Proto3Listener.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.protobuf.internal;
+
+import static java.util.Map.entry;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Label;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+
+import io.aklivity.zilla.runtime.model.protobuf.internal.parser.Protobuf3BaseListener;
+import io.aklivity.zilla.runtime.model.protobuf.internal.parser.Protobuf3Parser;
+
+public class Proto3Listener extends Protobuf3BaseListener
+{
+    private static final Map<String, Type> TYPES = Map.ofEntries(
+        entry("double", Type.TYPE_DOUBLE),
+        entry("float", Type.TYPE_FLOAT),
+        entry("int32", Type.TYPE_INT32),
+        entry("int64", Type.TYPE_INT64),
+        entry("uint32", Type.TYPE_UINT32),
+        entry("uint64", Type.TYPE_UINT64),
+        entry("sint32", Type.TYPE_SINT32),
+        entry("sint64", Type.TYPE_SINT64),
+        entry("fixed32", Type.TYPE_FIXED32),
+        entry("fixed64", Type.TYPE_FIXED64),
+        entry("sfixed32", Type.TYPE_SFIXED32),
+        entry("sfixed64", Type.TYPE_SFIXED64),
+        entry("bool", Type.TYPE_BOOL),
+        entry("string", Type.TYPE_STRING),
+        entry("bytes", Type.TYPE_BYTES)
+    );
+
+    private static final Map<String, Label> LABELS = Map.ofEntries(
+        entry("optional", Label.LABEL_OPTIONAL),
+        entry("required", Label.LABEL_REQUIRED),
+        entry("repeated", Label.LABEL_REPEATED)
+    );
+
+    private String packageName;
+    private List<String> imports;
+    private final FileDescriptorProto.Builder builder;
+    private Stack<String> messageHierarchy = new Stack<>();
+
+    public Proto3Listener()
+    {
+        this.imports = new ArrayList<>();
+        this.builder = FileDescriptorProto.newBuilder();
+    }
+
+    @Override
+    public void enterSyntax(
+        Protobuf3Parser.SyntaxContext ctx)
+    {
+        builder.setSyntax(ctx.getChild(2).getText());
+    }
+
+    @Override
+    public void enterPackageStatement(
+        Protobuf3Parser.PackageStatementContext ctx)
+    {
+        packageName = ctx.fullIdent().getText();
+        builder.setPackage(packageName);
+    }
+
+    @Override
+    public void enterImportStatement(
+        Protobuf3Parser.ImportStatementContext ctx)
+    {
+        String importStatement = ctx.strLit().getText();
+        imports.add(importStatement);
+        System.out.println("Import statements are currently not supported");
+    }
+
+    @Override
+    public void enterMessageDef(
+        Protobuf3Parser.MessageDefContext ctx)
+    {
+        DescriptorProto.Builder builder = DescriptorProto.newBuilder();
+        String name = ctx.messageName().getText();
+        builder.setName(name);
+        messageHierarchy.push(name);
+
+        for (Protobuf3Parser.MessageElementContext element : ctx.messageBody().messageElement())
+        {
+            if (element.field() != null)
+            {
+                builder.addField(processFieldElement(element.field()));
+            }
+            if (element.messageDef() != null)
+            {
+                builder.addNestedType(processNestedMessage(element.messageDef()));
+            }
+        }
+        if (messageHierarchy.size() == 1)
+        {
+            this.builder.addMessageType(builder.build());
+            builder.clear();
+        }
+    }
+
+    @Override
+    public void exitMessageDef(
+        Protobuf3Parser.MessageDefContext ctx)
+    {
+        messageHierarchy.pop();
+    }
+
+    public DescriptorProtos.FileDescriptorProto build()
+    {
+        return builder.build();
+    }
+
+    private DescriptorProto processNestedMessage(
+        Protobuf3Parser.MessageDefContext ctx)
+    {
+        DescriptorProto.Builder builder = DescriptorProto.newBuilder();
+        String name = ctx.messageName().getText();
+        builder.setName(name);
+
+        for (Protobuf3Parser.MessageElementContext element : ctx.messageBody().messageElement())
+        {
+            if (element.field() != null)
+            {
+                builder.addField(processFieldElement(element.field()));
+            }
+            if (element.messageDef() != null)
+            {
+                builder.addNestedType(processNestedMessage(element.messageDef()));
+            }
+        }
+        return builder.build();
+    }
+
+    private FieldDescriptorProto processFieldElement(
+        Protobuf3Parser.FieldContext ctx)
+    {
+        FieldDescriptorProto.Builder builder = FieldDescriptorProto.newBuilder();
+        String type = ctx.type_().getText();
+        String name = ctx.fieldName().getText();
+        String label = ctx.fieldLabel() != null ? ctx.fieldLabel().getText() : null;
+        int number = Integer.parseInt(ctx.fieldNumber().getText());
+
+        builder.setName(name);
+        builder.setNumber(number);
+        if (label != null)
+        {
+            builder.setLabel(LABELS.get(label));
+        }
+        if (TYPES.containsKey(type))
+        {
+            builder.setType(TYPES.get(type));
+        }
+        else
+        {
+            builder.setTypeName(type);
+        }
+        return builder.build();
+    }
+}

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufSyntaxDetector.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufSyntaxDetector.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.protobuf.internal;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class ProtobufSyntaxDetector
+{
+    private static final Pattern SYNTAX_PATTERN = Pattern.compile(
+        "^\\s*syntax\\s*=\\s*[\"'](proto2|proto3)[\"']\\s*;", 
+        Pattern.MULTILINE | Pattern.CASE_INSENSITIVE
+    );
+    
+    private static final String PROTO2_SYNTAX = "proto2";
+    private static final String PROTO3_SYNTAX = "proto3";
+    
+    public enum ProtoSyntax
+    {
+        PROTO2,
+        PROTO3,
+        UNKNOWN
+    }
+    
+    private ProtobufSyntaxDetector()
+    {
+        // Utility class
+    }
+    
+    /**
+     * Detects the protobuf syntax version from the schema text.
+     * 
+     * @param schemaText the protobuf schema text
+     * @return the detected syntax version
+     */
+    public static ProtoSyntax detectSyntax(String schemaText)
+    {
+        if (schemaText == null || schemaText.isEmpty())
+        {
+            return ProtoSyntax.UNKNOWN;
+        }
+        
+        Matcher matcher = SYNTAX_PATTERN.matcher(schemaText);
+        if (matcher.find())
+        {
+            String syntax = matcher.group(1).toLowerCase();
+            if (PROTO2_SYNTAX.equals(syntax))
+            {
+                return ProtoSyntax.PROTO2;
+            }
+            else if (PROTO3_SYNTAX.equals(syntax))
+            {
+                return ProtoSyntax.PROTO3;
+            }
+        }
+        
+        // If no syntax is specified, return UNKNOWN
+        return ProtoSyntax.UNKNOWN;
+    }
+    
+    /**
+     * Converts a string representation to ProtoSyntax enum.
+     * 
+     * @param syntax the syntax string ("proto2", "proto3")
+     * @return the corresponding ProtoSyntax enum value
+     */
+    public static ProtoSyntax fromString(String syntax)
+    {
+        if (syntax == null)
+        {
+            return ProtoSyntax.UNKNOWN;
+        }
+        
+        String lowerSyntax = syntax.toLowerCase();
+        if (PROTO2_SYNTAX.equals(lowerSyntax))
+        {
+            return ProtoSyntax.PROTO2;
+        }
+        else if (PROTO3_SYNTAX.equals(lowerSyntax))
+        {
+            return ProtoSyntax.PROTO3;
+        }
+        
+        return ProtoSyntax.UNKNOWN;
+    }
+}

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/config/ProtobufModelConfigAdapter.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/config/ProtobufModelConfigAdapter.java
@@ -39,6 +39,7 @@ public final class ProtobufModelConfigAdapter implements ModelConfigAdapterSpi, 
     private static final String CATALOG_NAME = "catalog";
     private static final String SUBJECT_NAME = "subject";
     private static final String VIEW = "view";
+    private static final String SYNTAX = "syntax";
 
     private final SchemaConfigAdapter schema = new SchemaConfigAdapter();
 
@@ -59,6 +60,11 @@ public final class ProtobufModelConfigAdapter implements ModelConfigAdapterSpi, 
         if (protobufConfig.view != null)
         {
             converter.add(VIEW, protobufConfig.view);
+        }
+
+        if (protobufConfig.syntax != null)
+        {
+            converter.add(SYNTAX, protobufConfig.syntax);
         }
 
         if (protobufConfig.cataloged != null && !protobufConfig.cataloged.isEmpty())
@@ -109,6 +115,10 @@ public final class ProtobufModelConfigAdapter implements ModelConfigAdapterSpi, 
                 ? object.getString(VIEW)
                 : null;
 
-        return new ProtobufModelConfig(catalogs, subject, view);
+        String syntax = object.containsKey(SYNTAX)
+                ? object.getString(SYNTAX)
+                : null;
+
+        return new ProtobufModelConfig(catalogs, subject, view, syntax);
     }
 }

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/Proto2ModelTest.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/Proto2ModelTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.protobuf.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Descriptors.DescriptorValidationException;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Label;
+
+import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.config.ModelConfig;
+import io.aklivity.zilla.runtime.model.protobuf.config.ProtobufModelConfig;
+import io.aklivity.zilla.runtime.model.protobuf.internal.ProtobufModelContext;
+
+public class Proto2ModelTest
+{
+    @Test
+    public void shouldParseProto2WithRequiredFields() throws Exception
+    {
+        String proto2Schema = """
+            syntax = "proto2";
+            
+            package test;
+            
+            message Person {
+              required string name = 1;
+              required int32 id = 2;
+              optional string email = 3;
+              repeated string phone = 4;
+            }
+            """;
+
+        FileDescriptor descriptor = parseProto2Schema(proto2Schema);
+        
+        assertNotNull(descriptor);
+        assertEquals("proto2", descriptor.getSyntax());
+        assertEquals("test", descriptor.getPackage());
+        
+        Descriptors.Descriptor personMessage = descriptor.findMessageTypeByName("Person");
+        assertNotNull(personMessage);
+        
+        // Verify field labels
+        FieldDescriptor nameField = personMessage.findFieldByName("name");
+        assertNotNull(nameField);
+        assertEquals(Label.LABEL_REQUIRED, nameField.toProto().getLabel());
+        
+        FieldDescriptor idField = personMessage.findFieldByName("id");
+        assertNotNull(idField);
+        assertEquals(Label.LABEL_REQUIRED, idField.toProto().getLabel());
+        
+        FieldDescriptor emailField = personMessage.findFieldByName("email");
+        assertNotNull(emailField);
+        assertEquals(Label.LABEL_OPTIONAL, emailField.toProto().getLabel());
+        
+        FieldDescriptor phoneField = personMessage.findFieldByName("phone");
+        assertNotNull(phoneField);
+        assertEquals(Label.LABEL_REPEATED, phoneField.toProto().getLabel());
+    }
+    
+    @Test
+    public void shouldParseProto2WithDefaultValues() throws Exception
+    {
+        String proto2Schema = """
+            syntax = "proto2";
+            
+            message Settings {
+              optional int32 port = 1 [default = 8080];
+              optional string host = 2 [default = "localhost"];
+              optional bool enabled = 3 [default = true];
+              optional float timeout = 4 [default = 30.5];
+            }
+            """;
+
+        FileDescriptor descriptor = parseProto2Schema(proto2Schema);
+        
+        assertNotNull(descriptor);
+        
+        Descriptors.Descriptor settingsMessage = descriptor.findMessageTypeByName("Settings");
+        assertNotNull(settingsMessage);
+        
+        // Verify default values
+        FieldDescriptor portField = settingsMessage.findFieldByName("port");
+        assertNotNull(portField);
+        assertEquals("8080", portField.toProto().getDefaultValue());
+        
+        FieldDescriptor hostField = settingsMessage.findFieldByName("host");
+        assertNotNull(hostField);
+        assertEquals("localhost", hostField.toProto().getDefaultValue());
+        
+        FieldDescriptor enabledField = settingsMessage.findFieldByName("enabled");
+        assertNotNull(enabledField);
+        assertEquals("true", enabledField.toProto().getDefaultValue());
+        
+        FieldDescriptor timeoutField = settingsMessage.findFieldByName("timeout");
+        assertNotNull(timeoutField);
+        assertEquals("30.5", timeoutField.toProto().getDefaultValue());
+    }
+    
+    @Test
+    public void shouldParseProto2WithGroups() throws Exception
+    {
+        String proto2Schema = """
+            syntax = "proto2";
+            
+            message Result {
+              required int32 id = 1;
+              optional group Data = 2 {
+                optional string value = 3;
+                optional int32 count = 4;
+              }
+            }
+            """;
+
+        FileDescriptor descriptor = parseProto2Schema(proto2Schema);
+        
+        assertNotNull(descriptor);
+        
+        Descriptors.Descriptor resultMessage = descriptor.findMessageTypeByName("Result");
+        assertNotNull(resultMessage);
+        
+        // Verify group field
+        FieldDescriptor dataField = resultMessage.findFieldByName("data");
+        assertNotNull(dataField);
+        assertEquals(FieldDescriptor.Type.GROUP, dataField.getType());
+        assertEquals("Data", dataField.toProto().getTypeName());
+    }
+    
+    @Test
+    public void shouldParseProto2WithExtensions() throws Exception
+    {
+        String proto2Schema = """
+            syntax = "proto2";
+            
+            message Base {
+              required int32 id = 1;
+              extensions 100 to 199;
+            }
+            
+            extend Base {
+              optional string extra_field = 100;
+            }
+            """;
+
+        FileDescriptor descriptor = parseProto2Schema(proto2Schema);
+        
+        assertNotNull(descriptor);
+        
+        Descriptors.Descriptor baseMessage = descriptor.findMessageTypeByName("Base");
+        assertNotNull(baseMessage);
+        assertEquals(1, baseMessage.getExtensionRanges().size());
+        
+        // Verify extension range
+        Descriptors.Descriptor.ExtensionRange range = baseMessage.getExtensionRanges().get(0);
+        assertEquals(100, range.getStart());
+        assertEquals(200, range.getEnd()); // End is exclusive
+    }
+    
+
+    
+    private FileDescriptor parseProto2Schema(String schemaText) throws DescriptorValidationException
+    {
+        org.antlr.v4.runtime.CharStream input = org.antlr.v4.runtime.CharStreams.fromString(schemaText);
+        io.aklivity.zilla.runtime.model.protobuf.internal.parser.Protobuf2Lexer lexer = 
+            new io.aklivity.zilla.runtime.model.protobuf.internal.parser.Protobuf2Lexer(input);
+        org.antlr.v4.runtime.CommonTokenStream tokens = new org.antlr.v4.runtime.CommonTokenStream(lexer);
+
+        io.aklivity.zilla.runtime.model.protobuf.internal.parser.Protobuf2Parser parser = 
+            new io.aklivity.zilla.runtime.model.protobuf.internal.parser.Protobuf2Parser(tokens);
+        parser.setErrorHandler(new org.antlr.v4.runtime.BailErrorStrategy());
+        org.antlr.v4.runtime.tree.ParseTreeWalker walker = new org.antlr.v4.runtime.tree.ParseTreeWalker();
+
+        Proto2Listener listener = new Proto2Listener();
+        walker.walk(listener, parser.proto());
+
+        return FileDescriptor.buildFrom(listener.build(), new FileDescriptor[0]);
+    }
+}

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/Proto3ModelTest.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/Proto3ModelTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.protobuf.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Descriptors.DescriptorValidationException;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Label;
+
+public class Proto3ModelTest
+{
+    @Test
+    public void shouldParseProto3WithImplicitOptionalFields() throws Exception
+    {
+        String proto3Schema = """
+            syntax = "proto3";
+            
+            package test;
+            
+            message Person {
+              string name = 1;
+              int32 id = 2;
+              string email = 3;
+              repeated string phone = 4;
+            }
+            """;
+
+        FileDescriptor descriptor = parseProto3Schema(proto3Schema);
+        
+        assertNotNull(descriptor);
+        assertEquals("proto3", descriptor.getSyntax());
+        assertEquals("test", descriptor.getPackage());
+        
+        Descriptors.Descriptor personMessage = descriptor.findMessageTypeByName("Person");
+        assertNotNull(personMessage);
+        
+        // In proto3, all fields are implicitly optional (except repeated)
+        FieldDescriptor nameField = personMessage.findFieldByName("name");
+        assertNotNull(nameField);
+        // Proto3 doesn't use LABEL_OPTIONAL for regular fields
+        
+        FieldDescriptor phoneField = personMessage.findFieldByName("phone");
+        assertNotNull(phoneField);
+        assertEquals(Label.LABEL_REPEATED, phoneField.toProto().getLabel());
+    }
+    
+    @Test
+    public void shouldParseProto3WithOneOf() throws Exception
+    {
+        String proto3Schema = """
+            syntax = "proto3";
+            
+            message TestMessage {
+              oneof test_oneof {
+                string name = 1;
+                int32 id = 2;
+              }
+              string common_field = 3;
+            }
+            """;
+
+        FileDescriptor descriptor = parseProto3Schema(proto3Schema);
+        
+        assertNotNull(descriptor);
+        
+        Descriptors.Descriptor testMessage = descriptor.findMessageTypeByName("TestMessage");
+        assertNotNull(testMessage);
+        
+        // Verify oneof fields
+        FieldDescriptor nameField = testMessage.findFieldByName("name");
+        assertNotNull(nameField);
+        assertNotNull(nameField.getContainingOneof());
+        assertEquals("test_oneof", nameField.getContainingOneof().getName());
+        
+        FieldDescriptor idField = testMessage.findFieldByName("id");
+        assertNotNull(idField);
+        assertNotNull(idField.getContainingOneof());
+        assertEquals("test_oneof", idField.getContainingOneof().getName());
+        
+        FieldDescriptor commonField = testMessage.findFieldByName("common_field");
+        assertNotNull(commonField);
+        assertNull(commonField.getContainingOneof());
+    }
+    
+    @Test
+    public void shouldParseProto3WithMaps() throws Exception
+    {
+        String proto3Schema = """
+            syntax = "proto3";
+            
+            message MapMessage {
+              map<string, string> string_map = 1;
+              map<int32, string> int_string_map = 2;
+              map<string, Person> person_map = 3;
+            }
+            
+            message Person {
+              string name = 1;
+              int32 age = 2;
+            }
+            """;
+
+        FileDescriptor descriptor = parseProto3Schema(proto3Schema);
+        
+        assertNotNull(descriptor);
+        
+        Descriptors.Descriptor mapMessage = descriptor.findMessageTypeByName("MapMessage");
+        assertNotNull(mapMessage);
+        
+        // Verify map fields
+        FieldDescriptor stringMapField = mapMessage.findFieldByName("string_map");
+        assertNotNull(stringMapField);
+        assertEquals(FieldDescriptor.Type.MESSAGE, stringMapField.getType());
+        assertTrue(stringMapField.isMapField());
+        
+        FieldDescriptor intStringMapField = mapMessage.findFieldByName("int_string_map");
+        assertNotNull(intStringMapField);
+        assertTrue(intStringMapField.isMapField());
+        
+        FieldDescriptor personMapField = mapMessage.findFieldByName("person_map");
+        assertNotNull(personMapField);
+        assertTrue(personMapField.isMapField());
+    }
+    
+    @Test
+    public void shouldParseProto3WithEnums() throws Exception
+    {
+        String proto3Schema = """
+            syntax = "proto3";
+            
+            message Settings {
+              enum Theme {
+                THEME_UNSPECIFIED = 0;  // Proto3 requires first enum value to be 0
+                LIGHT = 1;
+                DARK = 2;
+                AUTO = 3;
+              }
+              
+              Theme theme = 1;
+              repeated Theme available_themes = 2;
+            }
+            """;
+
+        FileDescriptor descriptor = parseProto3Schema(proto3Schema);
+        
+        assertNotNull(descriptor);
+        
+        Descriptors.Descriptor settingsMessage = descriptor.findMessageTypeByName("Settings");
+        assertNotNull(settingsMessage);
+        
+        // Verify enum
+        Descriptors.EnumDescriptor themeEnum = settingsMessage.findEnumTypeByName("Theme");
+        assertNotNull(themeEnum);
+        assertEquals(4, themeEnum.getValues().size());
+        
+        // Proto3 requires first enum value to be 0
+        assertEquals(0, themeEnum.getValues().get(0).getNumber());
+        assertEquals("THEME_UNSPECIFIED", themeEnum.getValues().get(0).getName());
+    }
+    
+    @Test
+    public void shouldParseProto3WithNestedMessages() throws Exception
+    {
+        String proto3Schema = """
+            syntax = "proto3";
+            
+            message Outer {
+              message Middle {
+                message Inner {
+                  string value = 1;
+                }
+                Inner inner = 1;
+              }
+              Middle middle = 1;
+              string name = 2;
+            }
+            """;
+
+        FileDescriptor descriptor = parseProto3Schema(proto3Schema);
+        
+        assertNotNull(descriptor);
+        
+        Descriptors.Descriptor outerMessage = descriptor.findMessageTypeByName("Outer");
+        assertNotNull(outerMessage);
+        
+        Descriptors.Descriptor middleMessage = outerMessage.findNestedTypeByName("Middle");
+        assertNotNull(middleMessage);
+        
+        Descriptors.Descriptor innerMessage = middleMessage.findNestedTypeByName("Inner");
+        assertNotNull(innerMessage);
+        
+        FieldDescriptor valueField = innerMessage.findFieldByName("value");
+        assertNotNull(valueField);
+    }
+    
+    private FileDescriptor parseProto3Schema(String schemaText) throws DescriptorValidationException
+    {
+        org.antlr.v4.runtime.CharStream input = org.antlr.v4.runtime.CharStreams.fromString(schemaText);
+        io.aklivity.zilla.runtime.model.protobuf.internal.parser.Protobuf3Lexer lexer = 
+            new io.aklivity.zilla.runtime.model.protobuf.internal.parser.Protobuf3Lexer(input);
+        org.antlr.v4.runtime.CommonTokenStream tokens = new org.antlr.v4.runtime.CommonTokenStream(lexer);
+
+        io.aklivity.zilla.runtime.model.protobuf.internal.parser.Protobuf3Parser parser = 
+            new io.aklivity.zilla.runtime.model.protobuf.internal.parser.Protobuf3Parser(tokens);
+        parser.setErrorHandler(new org.antlr.v4.runtime.BailErrorStrategy());
+        org.antlr.v4.runtime.tree.ParseTreeWalker walker = new org.antlr.v4.runtime.tree.ParseTreeWalker();
+
+        Proto3Listener listener = new Proto3Listener();
+        walker.walk(listener, parser.proto());
+
+        return FileDescriptor.buildFrom(listener.build(), new FileDescriptor[0]);
+    }
+}

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandlerTest.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandlerTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.protobuf.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
+import io.aklivity.zilla.runtime.engine.config.CatalogedConfig;
+import io.aklivity.zilla.runtime.model.protobuf.config.ProtobufModelConfig;
+
+public class ProtobufModelHandlerTest
+{
+    private ProtobufModelHandler handler;
+    private CatalogHandler mockCatalogHandler;
+    private EngineContext mockContext;
+
+    @Before
+    public void setup()
+    {
+        mockContext = mock(EngineContext.class);
+        mockCatalogHandler = mock(CatalogHandler.class);
+        
+        CatalogedConfig cataloged = new CatalogedConfig("test-catalog", List.of());
+        ProtobufModelConfig config = new ProtobufModelConfig(
+            List.of(cataloged),
+            "test-subject",
+            null,
+            null  // No explicit syntax
+        );
+        
+        when(mockContext.supplyCatalog(0L)).thenReturn(mockCatalogHandler);
+        
+        handler = new ProtobufModelHandler(config, mockContext);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenNoSyntaxDeclared()
+    {
+        // Schema without syntax declaration
+        String schemaWithoutSyntax = """
+            message TestMessage {
+              required string name = 1;
+              optional int32 value = 2;
+            }
+            """;
+        
+        when(mockCatalogHandler.resolve(1)).thenReturn(schemaWithoutSyntax);
+        
+        // This should return null because createDescriptors catches the exception
+        assertNull(handler.supplyDescriptor(1));
+    }
+
+    @Test
+    public void shouldParseProto2WithExplicitSyntax()
+    {
+        String proto2Schema = """
+            syntax = "proto2";
+            
+            message TestMessage {
+              required string name = 1;
+              optional int32 value = 2;
+            }
+            """;
+        
+        when(mockCatalogHandler.resolve(1)).thenReturn(proto2Schema);
+        
+        assertNotNull(handler.supplyDescriptor(1));
+    }
+
+    @Test
+    public void shouldParseProto3WithExplicitSyntax()
+    {
+        String proto3Schema = """
+            syntax = "proto3";
+            
+            message TestMessage {
+              string name = 1;
+              int32 value = 2;
+            }
+            """;
+        
+        when(mockCatalogHandler.resolve(1)).thenReturn(proto3Schema);
+        
+        assertNotNull(handler.supplyDescriptor(1));
+    }
+
+    @Test
+    public void shouldUseConfiguredSyntaxOverDetected()
+    {
+        // Create handler with explicit proto2 syntax
+        CatalogedConfig cataloged = new CatalogedConfig("test-catalog", List.of());
+        ProtobufModelConfig config = new ProtobufModelConfig(
+            List.of(cataloged),
+            "test-subject",
+            null,
+            "proto2"  // Explicit proto2
+        );
+        
+        when(mockContext.supplyCatalog(0L)).thenReturn(mockCatalogHandler);
+        
+        ProtobufModelHandler handlerWithProto2 = new ProtobufModelHandler(config, mockContext);
+        
+        // Schema that says proto3 but config says proto2
+        String proto3Schema = """
+            syntax = "proto3";
+            
+            message TestMessage {
+              string name = 1;
+              int32 value = 2;
+            }
+            """;
+        
+        when(mockCatalogHandler.resolve(1)).thenReturn(proto3Schema);
+        
+        // This should parse as proto2 due to config
+        assertNotNull(handlerWithProto2.supplyDescriptor(1));
+    }
+}

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufSyntaxDetectorTest.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufSyntaxDetectorTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.protobuf.internal;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.model.protobuf.internal.ProtobufSyntaxDetector.ProtoSyntax;
+
+public class ProtobufSyntaxDetectorTest
+{
+    @Test
+    public void shouldDetectProto2Syntax()
+    {
+        String proto2Schema = """
+            syntax = "proto2";
+            
+            message Person {
+              required string name = 1;
+              optional int32 id = 2;
+              repeated string email = 3;
+            }
+            """;
+        
+        ProtoSyntax syntax = ProtobufSyntaxDetector.detectSyntax(proto2Schema);
+        assertEquals(ProtoSyntax.PROTO2, syntax);
+    }
+    
+    @Test
+    public void shouldDetectProto3Syntax()
+    {
+        String proto3Schema = """
+            syntax = "proto3";
+            
+            message Person {
+              string name = 1;
+              int32 id = 2;
+              repeated string email = 3;
+            }
+            """;
+        
+        ProtoSyntax syntax = ProtobufSyntaxDetector.detectSyntax(proto3Schema);
+        assertEquals(ProtoSyntax.PROTO3, syntax);
+    }
+    
+    @Test
+    public void shouldDetectProto2WithSingleQuotes()
+    {
+        String proto2Schema = "syntax = 'proto2';\nmessage Test {}";
+        
+        ProtoSyntax syntax = ProtobufSyntaxDetector.detectSyntax(proto2Schema);
+        assertEquals(ProtoSyntax.PROTO2, syntax);
+    }
+    
+    @Test
+    public void shouldDetectProto3WithSingleQuotes()
+    {
+        String proto3Schema = "syntax = 'proto3';\nmessage Test {}";
+        
+        ProtoSyntax syntax = ProtobufSyntaxDetector.detectSyntax(proto3Schema);
+        assertEquals(ProtoSyntax.PROTO3, syntax);
+    }
+    
+    @Test
+    public void shouldReturnUnknownWhenNoSyntax()
+    {
+        String noSyntaxSchema = """
+            message Person {
+              required string name = 1;
+              optional int32 id = 2;
+            }
+            """;
+        
+        ProtoSyntax syntax = ProtobufSyntaxDetector.detectSyntax(noSyntaxSchema);
+        assertEquals(ProtoSyntax.UNKNOWN, syntax);
+    }
+    
+    @Test
+    public void shouldReturnUnknownForNull()
+    {
+        ProtoSyntax syntax = ProtobufSyntaxDetector.detectSyntax(null);
+        assertEquals(ProtoSyntax.UNKNOWN, syntax);
+    }
+    
+    @Test
+    public void shouldReturnUnknownForEmptyString()
+    {
+        ProtoSyntax syntax = ProtobufSyntaxDetector.detectSyntax("");
+        assertEquals(ProtoSyntax.UNKNOWN, syntax);
+    }
+    
+    @Test
+    public void shouldConvertStringToProto2()
+    {
+        assertEquals(ProtoSyntax.PROTO2, ProtobufSyntaxDetector.fromString("proto2"));
+        assertEquals(ProtoSyntax.PROTO2, ProtobufSyntaxDetector.fromString("Proto2"));
+        assertEquals(ProtoSyntax.PROTO2, ProtobufSyntaxDetector.fromString("PROTO2"));
+    }
+    
+    @Test
+    public void shouldConvertStringToProto3()
+    {
+        assertEquals(ProtoSyntax.PROTO3, ProtobufSyntaxDetector.fromString("proto3"));
+        assertEquals(ProtoSyntax.PROTO3, ProtobufSyntaxDetector.fromString("Proto3"));
+        assertEquals(ProtoSyntax.PROTO3, ProtobufSyntaxDetector.fromString("PROTO3"));
+    }
+    
+    @Test
+    public void shouldReturnUnknownForInvalidString()
+    {
+        assertEquals(ProtoSyntax.UNKNOWN, ProtobufSyntaxDetector.fromString("proto4"));
+        assertEquals(ProtoSyntax.UNKNOWN, ProtobufSyntaxDetector.fromString("invalid"));
+        assertEquals(ProtoSyntax.UNKNOWN, ProtobufSyntaxDetector.fromString(null));
+    }
+}

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/config/ProtobufModelConfigAdapterTest.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/config/ProtobufModelConfigAdapterTest.java
@@ -16,6 +16,7 @@ package io.aklivity.zilla.runtime.model.protobuf.internal.config;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -27,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.aklivity.zilla.runtime.model.protobuf.config.ProtobufModelConfig;
+import io.aklivity.zilla.runtime.engine.config.ModelConfig;
 
 public class ProtobufModelConfigAdapterTest
 {
@@ -134,5 +136,73 @@ public class ProtobufModelConfigAdapterTest
         // THEN
         assertThat(json, not(nullValue()));
         assertThat(json, equalTo(expectedJson));
+    }
+
+    @Test
+    public void shouldWriteProtobufWithProto2Syntax()
+    {
+        // GIVEN
+        String expectedJson =
+            "{" +
+                "\"model\":\"protobuf\"," +
+                "\"syntax\":\"proto2\"," +
+                "\"catalog\":" +
+                "{" +
+                    "\"test0\":" +
+                    "[" +
+                        "{" +
+                            "\"subject\":\"user\"," +
+                            "\"version\":\"latest\"" +
+                        "}" +
+                    "]" +
+                "}" +
+            "}";
+        ProtobufModelConfig converter = ProtobufModelConfig.builder()
+            .syntax("proto2")
+            .catalog()
+                .name("test0")
+                    .schema()
+                        .subject("user")
+                        .version("latest")
+                        .build()
+                    .build()
+            .build();
+
+        // WHEN
+        String json = jsonb.toJson(converter);
+
+        // THEN
+        assertThat(json, not(nullValue()));
+        assertThat(json, equalTo(expectedJson));
+    }
+
+    @Test
+    public void shouldReadProtobufWithProto2Syntax()
+    {
+        // GIVEN
+        String json =
+            "{" +
+                "\"model\":\"protobuf\"," +
+                "\"syntax\":\"proto2\"," +
+                "\"catalog\":" +
+                "{" +
+                    "\"test0\":" +
+                    "[" +
+                        "{" +
+                            "\"subject\":\"user\"," +
+                            "\"version\":\"latest\"" +
+                        "}" +
+                    "]" +
+                "}" +
+            "}";
+
+        // WHEN
+        ProtobufModelConfig converter = (ProtobufModelConfig) jsonb.fromJson(json, ModelConfig.class);
+
+        // THEN
+        assertThat(converter.model, equalTo("protobuf"));
+        assertThat(converter.syntax, equalTo("proto2"));
+        assertThat(converter.cataloged, hasSize(1));
+        assertThat(converter.cataloged.get(0).name, equalTo("test0"));
     }
 }


### PR DESCRIPTION
Fixes # (issue)

Enhance Model Protobuf to support both Protobuf 2 and Protobuf 3 using ANTLR grammar.
This update ensures compatibility with both versions of the Protobuf specification, enabling broader schema parsing and validation within Zilla. By leveraging ANTLR grammar, the implementation remains consistent, maintainable, and extendable for future improvements.