### PR TITLE
Fix http filesystem module-info

### DIFF
--- a/runtime/filesystem-http/src/main/moditect/module-info.java
+++ b/runtime/filesystem-http/src/main/moditect/module-info.java
@@ -17,6 +17,8 @@ module io.aklivity.zilla.runtime.filesystem.http
     requires java.net.http;
     requires org.agrona.core;
 
+    exports io.aklivity.zilla.runtime.filesystem.http;
+
     provides java.nio.file.spi.FileSystemProvider with
         io.aklivity.zilla.runtime.filesystem.http.internal.HttpFileSystemProvider,
         io.aklivity.zilla.runtime.filesystem.http.internal.HttpsFileSystemProvider;


### PR DESCRIPTION
Unable to reference `FileSystemEnvironment` constants outside the module unless the package is exported.