### PR TITLE
Fix http 1.1 client decode of response empty reason phrase

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -124,7 +124,7 @@ import io.aklivity.zilla.runtime.engine.model.function.ValueConsumer;
 public final class HttpClientFactory implements HttpStreamFactory
 {
     private static final Pattern RESPONSE_LINE_PATTERN =
-            Pattern.compile("(?<version>HTTP/\\d\\.\\d)\\s+(?<status>\\d+)\\s+(?<reason>[^\\r\\n]+)\r\n");
+            Pattern.compile("(?<version>HTTP/\\d\\.\\d)\\s+(?<status>\\d+)\\s+(?<reason>[^\\r\\n]*)\r\n");
     private static final Pattern VERSION_PATTERN = Pattern.compile("HTTP/1\\.\\d");
     private static final Pattern HEADER_LINE_PATTERN = Pattern.compile("(?<name>[^\\s:]+):\\s*(?<value>[^\r\n]*)\r\n");
     private static final Pattern CONNECTION_CLOSE_PATTERN = Pattern.compile("(^|\\s*,\\s*)close(\\s*,\\s*|$)");


### PR DESCRIPTION
HTTP 1.1 response of the following was failing to decode.

```
HTTP/1.1 200 \r\n
...
```

Notice empty reason phrase, such as `OK`, after space after status code and before `\r\n`.

This empty reason phrase is legitimate by [RFC 7230](https://datatracker.ietf.org/doc/html/rfc7230#section-3.1.2).
```
reason-phrase  = *( HTAB / SP / VCHAR / obs-text )
```

Given that `HTTP/2` eliminates the reason phrase entirely, this empty reason phrase seem increasingly likely to become the default behavior for systems that support `HTTP/1.1` and `HTTP/2`.