### PR TITLE
Fix http 1.1 client upgrade then close

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -2510,14 +2510,23 @@ public final class HttpClientFactory implements HttpStreamFactory
 
             state = HttpState.closingReply(state);
 
-            pool.exchanges.forEach((id, exchange) ->
+            if (decoder == decodeHttp11Upgraded &&
+                exchange != null)
             {
-                if (!HttpState.replyOpening(exchange.state) || decodeSlot == NO_SLOT)
+                exchange.doResponseEnd(traceId, authorization, EMPTY_OCTETS);
+                cleanupDecodeSlotIfNecessary();
+            }
+            else
+            {
+                pool.exchanges.forEach((id, exchange) ->
                 {
-                    exchange.cleanup(traceId, authorization);
-                    cleanupDecodeSlotIfNecessary();
-                }
-            });
+                    if (!HttpState.replyOpening(exchange.state) || decodeSlot == NO_SLOT)
+                    {
+                        exchange.cleanup(traceId, authorization);
+                        cleanupDecodeSlotIfNecessary();
+                    }
+                });
+            }
 
             if (decodeSlot == NO_SLOT)
             {

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/ConnectionManagementIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/ConnectionManagementIT.java
@@ -166,6 +166,15 @@ public class ConnectionManagementIT
         k3po.finish();
     }
 
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${app}/upgrade.request.and.response.then.server.sent.close/client",
+        "${net}/upgrade.request.and.response.then.server.sent.close/server" })
+    public void upgradeRequestAndResponseThenServerSentClose() throws Exception
+    {
+        k3po.finish();
+    }
 
     @Test
     @Configuration("client.yaml")

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.response.then.server.sent.close/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.response.then.server.sent.close/client.rpt
@@ -1,0 +1,39 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":scheme", "http")
+                              .header(":method", "GET")
+                              .header(":path", "/")
+                              .header(":authority", "localhost:8080")
+                              .header("upgrade", "WebSocket")
+                              .header("connection", "upgrade")
+                              .build()}
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":status", "101")
+                             .header("upgrade", "WebSocket")
+                             .build()}
+
+connected
+
+read closed

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.response.then.server.sent.close/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.response.then.server.sent.close/server.rpt
@@ -1,0 +1,40 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/app0"
+       option zilla:window 8192
+       option zilla:transmission "duplex"
+accepted
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":scheme", "http")
+                             .header(":method", "GET")
+                             .header(":path", "/")
+                             .header(":authority", "localhost:8080")
+                             .header("upgrade", "WebSocket")
+                             .header("connection", "upgrade")
+                             .build()}
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":status", "101")
+                              .header("upgrade", "WebSocket")
+                              .build()}
+
+connected
+
+write close

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.response.then.server.sent.close/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.response.then.server.sent.close/client.rpt
@@ -1,0 +1,34 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property clientInitialWindow 8192
+
+connect "http://localhost:8080/"
+  option http:transport "zilla://streams/net0"
+  option zilla:window ${clientInitialWindow}
+  option zilla:transmission "duplex"
+connected
+
+write http:method "GET"
+write http:header "Host" "localhost:8080"
+write http:header "Upgrade" "WebSocket"
+write http:header "Connection" "upgrade"
+write flush
+
+read http:status "101" /.*/
+read http:header "Upgrade" "WebSocket"
+
+read closed

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.response.then.server.sent.close/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.response.then.server.sent.close/server.rpt
@@ -1,0 +1,34 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property serverInitialWindow 8192
+
+accept "http://localhost:8080/"
+  option http:transport "zilla://streams/net0"
+  option zilla:window ${serverInitialWindow}
+  option zilla:transmission "duplex"
+accepted
+connected
+
+read http:method "GET"
+read http:header "Upgrade" /(?<upgradeHeader>.*)/
+read http:header "Connection" "upgrade" 
+
+write http:status "101" "Some Upgrade Protocol"
+write http:header "Upgrade" ${upgradeHeader}
+write flush
+
+write close

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/ConnectionManagementIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/ConnectionManagementIT.java
@@ -109,6 +109,15 @@ public class ConnectionManagementIT
 
     @Test
     @Specification({
+        "${app}/upgrade.request.and.response.then.server.sent.close/client",
+        "${app}/upgrade.request.and.response.then.server.sent.close/server" })
+    public void upgradeRequestAndResponseThenServerSentClose() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/request.and.503.response.with.retry/client",
         "${app}/request.and.503.response.with.retry/server" })
     public void requestAnd503ResponseWithRetry() throws Exception

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/ConnectionManagementIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/ConnectionManagementIT.java
@@ -161,6 +161,15 @@ public class ConnectionManagementIT
 
     @Test
     @Specification({
+        "${net}/upgrade.request.and.response.then.server.sent.close/client",
+        "${net}/upgrade.request.and.response.then.server.sent.close/server" })
+    public void shouldUpgradeThenServerSentClose() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${net}/request.incomplete.response.headers.and.abort/client",
         "${net}/request.incomplete.response.headers.and.abort/server" })
     public void shouldReportResponseAbortedBeforeResponseHeadersComplete() throws Exception


### PR DESCRIPTION
In certain conditions, `http` `client` binding would not clean close an `upgrade`'d connection, such as a `WebSocket`.