### PR TITLE
Include blocking select with timeout in doWork loops

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/poller/Poller.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/poller/Poller.java
@@ -51,6 +51,23 @@ public final class Poller extends TransportPoller
         return workDone;
     }
 
+    public int doWork(
+        int timeout)
+    {
+        int workDone = 0;
+
+        try
+        {
+            workDone += selector.select(selectHandler, timeout);
+        }
+        catch (Throwable ex)
+        {
+            LangUtil.rethrowUnchecked(ex);
+        }
+
+        return workDone;
+    }
+
     public void onClose()
     {
         for (SelectionKey key : selector.keys())


### PR DESCRIPTION
Optimize doWork loops to incorporate a blocking select with timeout to proactively detect new work from the network while idle after completing all other internal work.