### PR TITLE
Fix: Update helm-maven-plugin config for registry login

### DIFF
--- a/cloud/helm-chart/pom.xml
+++ b/cloud/helm-chart/pom.xml
@@ -68,6 +68,7 @@
           <execution>
             <goals>
               <goal>lint</goal>
+              <goal>registry-login</goal>
               <goal>push</goal>
             </goals>
           </execution>


### PR DESCRIPTION
### Description
Updates the `helm-maven-plugin` configuration to use the `registry-login` goal, resolving the deprecation warning: 'Registry login with helm:push is deprecated'.

### Related Issue
Fixes #630

### Verification
- Ran `./mvnw help:effective-pom` to verify configuration validity.