### PR TITLE
Fix config watcher to skip unregistered watch keys

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/watcher/EngineConfigWatchTask.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/watcher/EngineConfigWatchTask.java
@@ -88,8 +88,11 @@ public abstract class EngineConfigWatchTask implements AutoCloseable, Callable<V
             try
             {
                 final WatchKey key = watcher.take();
-                final Path watchable = (Path) key.watchable();
-                onPathChanged(watchable);
+                if (key != null)
+                {
+                    final Path watchable = (Path) key.watchable();
+                    onPathChanged(watchable);
+                }
             }
             catch (InterruptedException ex)
             {

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/watcher/EngineConfigWatcher.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/watcher/EngineConfigWatcher.java
@@ -146,9 +146,7 @@ public final class EngineConfigWatcher implements AutoCloseable
     private WatchKey takeImpl() throws InterruptedException
     {
         WatchKey watchKey = watcher.take();
-        CompoundWatchKey compoundKey = compoundKeys.get(watchKey);
-
-        return compoundKey;
+        return compoundKeys.get(watchKey);
     }
 
     private final class CompoundWatchKey implements WatchKey


### PR DESCRIPTION
 When TLS vault files signaled changes, their watch keys were not registered in compoundKeys, causing take() to return null and crash the config watch loop. The gateway would then stop detecting config changes until  restarted.