### PR TITLE
Support sse server max idle time

### DIFF
--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/SseConfiguration.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/SseConfiguration.java
@@ -15,9 +15,6 @@
  */
 package io.aklivity.zilla.runtime.binding.sse.internal;
 
-import org.agrona.DirectBuffer;
-import org.agrona.concurrent.UnsafeBuffer;
-
 import io.aklivity.zilla.runtime.engine.Configuration;
 
 public class SseConfiguration extends Configuration
@@ -25,8 +22,7 @@ public class SseConfiguration extends Configuration
     public static final String CHALLENGE_EVENT_TYPE_NAME = "zilla.binding.sse.challenge.event.type";
 
     public static final BooleanPropertyDef INITIAL_COMMENT_ENABLED;
-
-    private static final DirectBuffer INITIAL_COMMENT_DEFAULT = new UnsafeBuffer(new byte[0]);
+    public static final IntPropertyDef MAXIMUM_IDLE_TIME;
 
     private static final ConfigurationDef SSE_CONFIG;
 
@@ -37,6 +33,7 @@ public class SseConfiguration extends Configuration
         final ConfigurationDef config = new ConfigurationDef("zilla.binding.sse");
         INITIAL_COMMENT_ENABLED = config.property("initial.comment.enabled", false);
         CHALLENGE_EVENT_TYPE = config.property("challenge.event.type", "challenge");
+        MAXIMUM_IDLE_TIME = config.property("maximum.idle.time", 0);
         SSE_CONFIG = config;
     }
 
@@ -46,14 +43,18 @@ public class SseConfiguration extends Configuration
         super(SSE_CONFIG, config);
     }
 
-    public DirectBuffer initialComment()
+    public boolean initialCommentEnabled()
     {
-        return INITIAL_COMMENT_ENABLED.getAsBoolean(this) ? INITIAL_COMMENT_DEFAULT : null;
+        return INITIAL_COMMENT_ENABLED.getAsBoolean(this);
     }
 
-    public String getChallengeEventType()
+    public String challengeEventType()
     {
         return CHALLENGE_EVENT_TYPE.get(this);
     }
 
+    public int maximumIdleTime()
+    {
+        return MAXIMUM_IDLE_TIME.getAsInt(this);
+    }
 }

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/SseConfigurationTest.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/SseConfigurationTest.java
@@ -18,6 +18,7 @@ package io.aklivity.zilla.runtime.binding.sse.internal;
 import static io.aklivity.zilla.runtime.binding.sse.internal.SseConfiguration.CHALLENGE_EVENT_TYPE;
 import static io.aklivity.zilla.runtime.binding.sse.internal.SseConfiguration.CHALLENGE_EVENT_TYPE_NAME;
 import static io.aklivity.zilla.runtime.binding.sse.internal.SseConfiguration.INITIAL_COMMENT_ENABLED;
+import static io.aklivity.zilla.runtime.binding.sse.internal.SseConfiguration.MAXIMUM_IDLE_TIME;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -26,16 +27,13 @@ public class SseConfigurationTest
 {
     // needed by test annotations
     public static final String SSE_INITIAL_COMMENT_ENABLED_NAME = "zilla.binding.sse.initial.comment.enabled";
+    public static final String SSE_MAXIMUM_IDLE_TIME_NAME = "zilla.binding.sse.maximum.idle.time";
 
     @Test
     public void shouldVerifyConstants() throws Exception
     {
+        assertEquals(CHALLENGE_EVENT_TYPE.name(), CHALLENGE_EVENT_TYPE_NAME);
         assertEquals(INITIAL_COMMENT_ENABLED.name(), SSE_INITIAL_COMMENT_ENABLED_NAME);
-    }
-
-    @Test
-    public void shouldMatchChallengeEventTypeConfigName()
-    {
-        assertEquals(CHALLENGE_EVENT_TYPE_NAME, CHALLENGE_EVENT_TYPE.name());
+        assertEquals(MAXIMUM_IDLE_TIME.name(), SSE_MAXIMUM_IDLE_TIME_NAME);
     }
 }

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/IdleIT.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/IdleIT.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.binding.sse.internal.streams.server;
+
+import static io.aklivity.zilla.runtime.binding.sse.internal.SseConfigurationTest.SSE_MAXIMUM_IDLE_TIME_NAME;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.rules.RuleChain.outerRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+
+import io.aklivity.k3po.runtime.junit.annotation.Specification;
+import io.aklivity.k3po.runtime.junit.rules.K3poRule;
+import io.aklivity.zilla.runtime.engine.test.EngineRule;
+import io.aklivity.zilla.runtime.engine.test.annotation.Configuration;
+import io.aklivity.zilla.runtime.engine.test.annotation.Configure;
+
+public class IdleIT
+{
+    private final K3poRule k3po = new K3poRule()
+        .addScriptRoot("net", "io/aklivity/zilla/specs/binding/sse/streams/network/idle")
+        .addScriptRoot("app", "io/aklivity/zilla/specs/binding/sse/streams/application/idle");
+
+    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
+
+    private final EngineRule engine = new EngineRule()
+        .directory("target/zilla-itests")
+        .countersBufferCapacity(4096)
+        .configurationRoot("io/aklivity/zilla/specs/binding/sse/config")
+        .external("app0")
+        .clean();
+
+    @Rule
+    public final TestRule chain = outerRule(engine).around(k3po).around(timeout);
+
+    @Test
+    @Configuration("server.when.yaml")
+    @Specification({
+        "${net}/comment/request",
+        "${app}/comment/server" })
+    @Configure(name = SSE_MAXIMUM_IDLE_TIME_NAME, value = "1")
+    public void shouldSendCommentOnMaxIdleTime() throws Exception
+    {
+        k3po.finish();
+    }
+}

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/idle/comment/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/idle/comment/client.rpt
@@ -1,0 +1,29 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "duplex"
+
+write zilla:begin.ext ${sse:beginEx()
+                           .typeId(zilla:id("sse"))
+                           .scheme("http")
+                           .authority("localhost:8080")
+                           .path("/events/a8b7c6d5")
+                           .lastId(null)
+                           .build()}
+
+connected

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/idle/comment/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/idle/comment/server.rpt
@@ -1,0 +1,30 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/app0"
+       option zilla:window 8192
+       option zilla:transmission "duplex"
+accepted
+
+read zilla:begin.ext ${sse:beginEx()
+                          .typeId(zilla:id("sse"))
+                          .scheme("http")
+                          .authority("localhost:8080")
+                          .path("/events/a8b7c6d5")
+                          .lastId(null)
+                          .build()}
+
+connected

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/idle/comment/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/idle/comment/request.rpt
@@ -1,0 +1,41 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":scheme", "http")
+                              .header(":method", "GET")
+                              .header(":path", "/events/a8b7c6d5")
+                              .header(":authority", "localhost:8080")
+                              .header("accept", "text/event-stream")
+                              .build()}
+
+connected
+
+write close
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":status", "200")
+                             .header("content-type", "text/event-stream")
+                             .build()}
+
+read ":\n\n"
+read ":\n\n"

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/idle/comment/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/idle/comment/response.rpt
@@ -1,0 +1,46 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "half-duplex"
+accepted
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":scheme", "http")
+                             .header(":method", "GET")
+                             .header(":path", "/events/a8b7c6d5")
+                             .header(":authority", "localhost:8080")
+                             .header("accept", "text/event-stream")
+                             .build()}
+
+connected
+
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":status", "200")
+                              .header("content-type", "text/event-stream")
+                              .build()}
+write flush
+
+write ":\n\n"
+write flush
+
+write ":\n\n"
+write flush

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/IdleIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/IdleIT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.specs.binding.sse.streams.application;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.rules.RuleChain.outerRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+
+import io.aklivity.k3po.runtime.junit.annotation.Specification;
+import io.aklivity.k3po.runtime.junit.rules.K3poRule;
+
+public class IdleIT
+{
+    private final K3poRule k3po = new K3poRule()
+        .addScriptRoot("app", "io/aklivity/zilla/specs/binding/sse/streams/application/idle");
+
+    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
+
+    @Rule
+    public final TestRule chain = outerRule(k3po).around(timeout);
+
+    @Test
+    @Specification({
+        "${app}/comment/client",
+        "${app}/comment/server" })
+    public void shouldSendCommentOnMaxIdleTime() throws Exception
+    {
+        k3po.finish();
+    }
+}

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/IdleIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/IdleIT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.specs.binding.sse.streams.network;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.rules.RuleChain.outerRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+
+import io.aklivity.k3po.runtime.junit.annotation.Specification;
+import io.aklivity.k3po.runtime.junit.rules.K3poRule;
+
+public class IdleIT
+{
+    private final K3poRule k3po = new K3poRule()
+        .addScriptRoot("net", "io/aklivity/zilla/specs/binding/sse/streams/network/idle");
+
+    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
+
+    @Rule
+    public final TestRule chain = outerRule(k3po).around(timeout);
+
+    @Test
+    @Specification({
+        "${net}/comment/request",
+        "${net}/comment/response" })
+    public void shouldSendCommentOnMaxIdleTime() throws Exception
+    {
+        k3po.finish();
+    }
+}


### PR DESCRIPTION
## Description

Add configuration property such as `zilla start -Pzilla.binding.sse.maximum.idle.time=55` to send an empty SSE comment on any SSE response that is idle for 55 seconds.

Fixes #1638 
