### PR TITLE
fix null binding during connection accept

### DIFF
--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpServerFactory.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpServerFactory.java
@@ -171,7 +171,7 @@ public class TcpServerFactory implements TcpStreamFactory
         final TcpBindingConfig binding = bindings.get(bindingId);
         assert binding != null;
 
-        final TcpRouteConfig route = binding.resolve(local);
+        final TcpRouteConfig route = binding != null ? binding.resolve(local) : null;
 
         if (route != null)
         {


### PR DESCRIPTION
Error stack:
```
Caused by: java.lang.NullPointerException: Cannot invoke "io.aklivity.zilla.runtime.binding.tcp.internal.config.TcpBindingConfig.resolve(java.net.InetSocketAddress)" because "binding" is null
at io.aklivity.zilla.runtime.binding.tcp@1.0.1/io.aklivity.zilla.runtime.binding.tcp.internal.stream.TcpServerFactory.onAccepted(TcpServerFactory.java:174)
org.agrona.concurrent.AgentTerminationException: java.lang.NullPointerException: Cannot invoke "io.aklivity.zilla.runtime.binding.tcp.internal.config.TcpBindingConfig.resolve(java.net.InetSocketAddress)" 
```