### PR TITLE
Fix HTTP 1.1 request flow control sequence

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpServerFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpServerFactory.java
@@ -2886,7 +2886,7 @@ public final class HttpServerFactory implements HttpStreamFactory
                 long traceId,
                 Flyweight extension)
             {
-                requestSeq = HttpServer.this.initialSeq;
+                requestSeq = 0;
                 requestAck = requestSeq;
 
                 application = newStream(this::onExchange, originId, routedId, requestId, requestSeq, requestAck, requestMax,


### PR DESCRIPTION
Handles a case where HTTP 1.1 request decode can sometimes stall when `GET` request is combined with `echo` service.