### PR TITLE
Fix tls handshake timeout description

### DIFF
--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsEventContext.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsEventContext.java
@@ -157,7 +157,7 @@ public class TlsEventContext
     {
         TlsEventExFW extension = tlsEventExRW
             .wrap(extensionBuffer, 0, extensionBuffer.capacity())
-            .tlsHandshakeFailed(e -> e
+            .tlsHandshakeTimeout(e -> e
                 .typeId(TLS_HANDSHAKE_TIMEOUT.value())
             )
             .build();

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsEventFormatter.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsEventFormatter.java
@@ -44,30 +44,23 @@ public final class TlsEventFormatter implements EventFormatterSpi
         switch (extension.kind())
         {
         case TLS_FAILED:
-        {
             result = "There was a generic error detected by an SSL subsystem.";
             break;
-        }
         case TLS_PROTOCOL_REJECTED:
-        {
             result = "There was an error in the operation of the SSL protocol.";
             break;
-        }
         case TLS_KEY_REJECTED:
-        {
             result = "Bad SSL key due to misconfiguration of the server or client SSL certificate and private key.";
             break;
-        }
         case TLS_PEER_NOT_VERIFIED:
-        {
             result = "The peer's identity could not be verified.";
             break;
-        }
         case TLS_HANDSHAKE_FAILED:
-        {
             result = "The client and server could not negotiate the desired level of security.";
             break;
-        }
+        case TLS_HANDSHAKE_TIMEOUT:
+            result = "The handshake did not complete before the timeout expired.";
+            break;
         }
         return result;
     }

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.event.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.event.yaml
@@ -29,7 +29,7 @@ telemetry:
                     - qname: test:app0
                       id: binding.tls.handshake.timeout
                       name: BINDING_TLS_HANDSHAKE_TIMEOUT
-                      message: The client and server could not negotiate the desired level of security.
+                      message: The handshake did not complete before the timeout expired.
 vaults:
     client:
         type: test

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.event.handshake.timeout.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.event.handshake.timeout.yaml
@@ -29,7 +29,7 @@ telemetry:
                     - qname: test:net0
                       id: binding.tls.handshake.timeout
                       name: BINDING_TLS_HANDSHAKE_TIMEOUT
-                      message: The client and server could not negotiate the desired level of security.
+                      message: The handshake did not complete before the timeout expired.
 vaults:
     server:
         type: test


### PR DESCRIPTION
Updates TLS handshake _timeout_ event descriptive text from

```
The client and server could not negotiate the desired level of security.
```

to

```
The handshake did not complete before the timeout expired.
```
