### PR TITLE
feat(binding-mcp): implement mcp proxy binding

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpConditionConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpConditionConfig.java
@@ -14,6 +14,7 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.config;
 
+import java.util.List;
 import java.util.function.Function;
 
 import io.aklivity.zilla.runtime.engine.config.ConditionConfig;
@@ -21,11 +22,11 @@ import io.aklivity.zilla.runtime.engine.config.ConditionConfig;
 public final class McpConditionConfig extends ConditionConfig
 {
     public final String toolkit;
-    public final String capability;
+    public final List<String> capability;
 
     McpConditionConfig(
         String toolkit,
-        String capability)
+        List<String> capability)
     {
         this.toolkit = toolkit;
         this.capability = capability;

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpConditionConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpConditionConfig.java
@@ -20,12 +20,15 @@ import io.aklivity.zilla.runtime.engine.config.ConditionConfig;
 
 public final class McpConditionConfig extends ConditionConfig
 {
-    public final String kind;
+    public final String toolkit;
+    public final String capability;
 
-    public McpConditionConfig(
-        String kind)
+    McpConditionConfig(
+        String toolkit,
+        String capability)
     {
-        this.kind = kind;
+        this.toolkit = toolkit;
+        this.capability = capability;
     }
 
     public static McpConditionConfigBuilder<McpConditionConfig> builder()

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpConditionConfigBuilder.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpConditionConfigBuilder.java
@@ -23,7 +23,8 @@ public final class McpConditionConfigBuilder<T> extends ConfigBuilder<T, McpCond
 {
     private final Function<ConditionConfig, T> mapper;
 
-    private String kind;
+    private String toolkit;
+    private String capability;
 
     public McpConditionConfigBuilder(
         Function<ConditionConfig, T> mapper)
@@ -31,10 +32,17 @@ public final class McpConditionConfigBuilder<T> extends ConfigBuilder<T, McpCond
         this.mapper = mapper;
     }
 
-    public McpConditionConfigBuilder<T> kind(
-        String kind)
+    public McpConditionConfigBuilder<T> toolkit(
+        String toolkit)
     {
-        this.kind = kind;
+        this.toolkit = toolkit;
+        return this;
+    }
+
+    public McpConditionConfigBuilder<T> capability(
+        String capability)
+    {
+        this.capability = capability;
         return this;
     }
 
@@ -48,6 +56,6 @@ public final class McpConditionConfigBuilder<T> extends ConfigBuilder<T, McpCond
     @Override
     public T build()
     {
-        return mapper.apply(new McpConditionConfig(kind));
+        return mapper.apply(new McpConditionConfig(toolkit, capability));
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpConditionConfigBuilder.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpConditionConfigBuilder.java
@@ -14,6 +14,7 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.config;
 
+import java.util.List;
 import java.util.function.Function;
 
 import io.aklivity.zilla.runtime.engine.config.ConditionConfig;
@@ -24,7 +25,7 @@ public final class McpConditionConfigBuilder<T> extends ConfigBuilder<T, McpCond
     private final Function<ConditionConfig, T> mapper;
 
     private String toolkit;
-    private String capability;
+    private List<String> capability;
 
     public McpConditionConfigBuilder(
         Function<ConditionConfig, T> mapper)
@@ -40,7 +41,7 @@ public final class McpConditionConfigBuilder<T> extends ConfigBuilder<T, McpCond
     }
 
     public McpConditionConfigBuilder<T> capability(
-        String capability)
+        List<String> capability)
     {
         this.capability = capability;
         return this;

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpBindingContext.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpBindingContext.java
@@ -15,12 +15,14 @@
 package io.aklivity.zilla.runtime.binding.mcp.internal;
 
 import static io.aklivity.zilla.runtime.engine.config.KindConfig.CLIENT;
+import static io.aklivity.zilla.runtime.engine.config.KindConfig.PROXY;
 import static io.aklivity.zilla.runtime.engine.config.KindConfig.SERVER;
 
 import java.util.EnumMap;
 import java.util.Map;
 
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpClientFactory;
+import io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyFactory;
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpServerFactory;
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpStreamFactory;
 import io.aklivity.zilla.runtime.engine.EngineContext;
@@ -40,6 +42,7 @@ final class McpBindingContext implements BindingContext
         final Map<KindConfig, McpStreamFactory> factories = new EnumMap<>(KindConfig.class);
         factories.put(SERVER, new McpServerFactory(config, context));
         factories.put(CLIENT, new McpClientFactory(config, context));
+        factories.put(PROXY, new McpProxyFactory(config, context));
         this.factories = factories;
     }
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
@@ -14,6 +14,7 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.config;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -98,5 +99,27 @@ public final class McpBindingConfig
         }
 
         return resolved;
+    }
+
+    public List<McpRouteConfig> resolveAll(
+        McpBeginExFW beginEx,
+        long authorization)
+    {
+        final String capability = McpRouteConfig.capabilityOf(beginEx);
+        final String identifier = McpRouteConfig.identifierOf(beginEx);
+        final List<McpRouteConfig> result = new ArrayList<>();
+
+        if (capability != null && identifier == null)
+        {
+            for (McpRouteConfig route : routes)
+            {
+                if (route.authorized(authorization) && route.serves(capability))
+                {
+                    result.add(route);
+                }
+            }
+        }
+
+        return result;
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
@@ -14,13 +14,6 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.config;
 
-import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_GET;
-import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
-import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
-import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_READ;
-import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_CALL;
-import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
-
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -30,13 +23,6 @@ import io.aklivity.zilla.runtime.engine.config.BindingConfig;
 
 public final class McpBindingConfig
 {
-    private static final String CAPABILITY_TOOLS = "tools";
-    private static final String CAPABILITY_PROMPTS = "prompts";
-    private static final String CAPABILITY_RESOURCES = "resources";
-
-    private static final String TOOLKIT_NAME_DELIMITER = "__";
-    private static final String TOOLKIT_URI_DELIMITER = "+";
-
     public final long id;
     public final McpOptionsConfig options;
 
@@ -65,44 +51,27 @@ public final class McpBindingConfig
         McpBeginExFW beginEx,
         long authorization)
     {
-        final String capability = capability(beginEx);
-        final String toolkit = toolkit(beginEx);
+        final String capability = McpRouteConfig.capabilityOf(beginEx);
+        final String identifier = McpRouteConfig.identifierOf(beginEx);
 
-        return routes.stream()
-            .filter(r -> r.authorized(authorization) && r.matches(toolkit, capability))
-            .findFirst()
-            .orElse(null);
-    }
+        McpRouteConfig resolved = null;
 
-    private static String capability(
-        McpBeginExFW beginEx)
-    {
-        return switch (beginEx.kind())
+        if (capability == null)
         {
-        case KIND_TOOLS_LIST, KIND_TOOLS_CALL -> CAPABILITY_TOOLS;
-        case KIND_PROMPTS_LIST, KIND_PROMPTS_GET -> CAPABILITY_PROMPTS;
-        case KIND_RESOURCES_LIST, KIND_RESOURCES_READ -> CAPABILITY_RESOURCES;
-        default -> null;
-        };
-    }
-
-    private static String toolkit(
-        McpBeginExFW beginEx)
-    {
-        return switch (beginEx.kind())
+            resolved = resolve(authorization);
+        }
+        else if (identifier != null)
         {
-        case KIND_TOOLS_CALL -> prefix(beginEx.toolsCall().name().asString(), TOOLKIT_NAME_DELIMITER);
-        case KIND_PROMPTS_GET -> prefix(beginEx.promptsGet().name().asString(), TOOLKIT_NAME_DELIMITER);
-        case KIND_RESOURCES_READ -> prefix(beginEx.resourcesRead().uri().asString(), TOOLKIT_URI_DELIMITER);
-        default -> null;
-        };
-    }
+            for (McpRouteConfig route : routes)
+            {
+                if (route.authorized(authorization) && route.matches(capability, identifier))
+                {
+                    resolved = route;
+                    break;
+                }
+            }
+        }
 
-    private static String prefix(
-        String value,
-        String delimiter)
-    {
-        final int index = value != null ? value.indexOf(delimiter) : -1;
-        return index > 0 ? value.substring(0, index) : null;
+        return resolved;
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
@@ -14,14 +14,29 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.config;
 
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_GET;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_READ;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_CALL;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
 import io.aklivity.zilla.runtime.binding.mcp.config.McpOptionsConfig;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW;
 import io.aklivity.zilla.runtime.engine.config.BindingConfig;
 
 public final class McpBindingConfig
 {
+    private static final String CAPABILITY_TOOLS = "tools";
+    private static final String CAPABILITY_PROMPTS = "prompts";
+    private static final String CAPABILITY_RESOURCES = "resources";
+
+    private static final String TOOLKIT_NAME_DELIMITER = "__";
+    private static final String TOOLKIT_URI_DELIMITER = "+";
+
     public final long id;
     public final McpOptionsConfig options;
 
@@ -41,8 +56,53 @@ public final class McpBindingConfig
         long authorization)
     {
         return routes.stream()
-            .filter(r -> r.authorized(authorization) && r.matches(""))
+            .filter(r -> r.authorized(authorization))
             .findFirst()
             .orElse(null);
+    }
+
+    public McpRouteConfig resolve(
+        McpBeginExFW beginEx,
+        long authorization)
+    {
+        final String capability = capability(beginEx);
+        final String toolkit = toolkit(beginEx);
+
+        return routes.stream()
+            .filter(r -> r.authorized(authorization) && r.matches(toolkit, capability))
+            .findFirst()
+            .orElse(null);
+    }
+
+    private static String capability(
+        McpBeginExFW beginEx)
+    {
+        return switch (beginEx.kind())
+        {
+        case KIND_TOOLS_LIST, KIND_TOOLS_CALL -> CAPABILITY_TOOLS;
+        case KIND_PROMPTS_LIST, KIND_PROMPTS_GET -> CAPABILITY_PROMPTS;
+        case KIND_RESOURCES_LIST, KIND_RESOURCES_READ -> CAPABILITY_RESOURCES;
+        default -> null;
+        };
+    }
+
+    private static String toolkit(
+        McpBeginExFW beginEx)
+    {
+        return switch (beginEx.kind())
+        {
+        case KIND_TOOLS_CALL -> prefix(beginEx.toolsCall().name().asString(), TOOLKIT_NAME_DELIMITER);
+        case KIND_PROMPTS_GET -> prefix(beginEx.promptsGet().name().asString(), TOOLKIT_NAME_DELIMITER);
+        case KIND_RESOURCES_READ -> prefix(beginEx.resourcesRead().uri().asString(), TOOLKIT_URI_DELIMITER);
+        default -> null;
+        };
+    }
+
+    private static String prefix(
+        String value,
+        String delimiter)
+    {
+        final int index = value != null ? value.indexOf(delimiter) : -1;
+        return index > 0 ? value.substring(0, index) : null;
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
@@ -47,6 +47,20 @@ public final class McpBindingConfig
             .orElse(null);
     }
 
+    public int serverCapabilities(
+        long authorization)
+    {
+        int bits = 0;
+        for (McpRouteConfig route : routes)
+        {
+            if (route.authorized(authorization))
+            {
+                bits |= route.serverCapabilities();
+            }
+        }
+        return bits;
+    }
+
     public McpRouteConfig resolve(
         McpBeginExFW beginEx,
         long authorization)

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
@@ -85,6 +85,17 @@ public final class McpBindingConfig
                 }
             }
         }
+        else
+        {
+            for (McpRouteConfig route : routes)
+            {
+                if (route.authorized(authorization) && route.serves(capability))
+                {
+                    resolved = route;
+                    break;
+                }
+            }
+        }
 
         return resolved;
     }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpConditionConfigAdapter.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpConditionConfigAdapter.java
@@ -14,9 +14,16 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.config;
 
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+
 import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonString;
 import jakarta.json.bind.adapter.JsonbAdapter;
 
 import io.aklivity.zilla.runtime.binding.mcp.config.McpConditionConfig;
@@ -50,7 +57,9 @@ public final class McpConditionConfigAdapter implements ConditionConfigAdapterSp
 
         if (mcpCondition.capability != null)
         {
-            object.add(CAPABILITY_NAME, mcpCondition.capability);
+            JsonArrayBuilder array = Json.createArrayBuilder();
+            mcpCondition.capability.forEach(array::add);
+            object.add(CAPABILITY_NAME, array);
         }
 
         return object.build();
@@ -64,9 +73,15 @@ public final class McpConditionConfigAdapter implements ConditionConfigAdapterSp
             ? object.getString(TOOLKIT_NAME)
             : null;
 
-        String capability = object.containsKey(CAPABILITY_NAME)
-            ? object.getString(CAPABILITY_NAME)
-            : null;
+        List<String> capability = null;
+        if (object.containsKey(CAPABILITY_NAME))
+        {
+            JsonArray array = object.getJsonArray(CAPABILITY_NAME);
+            capability = array.stream()
+                .map(JsonString.class::cast)
+                .map(JsonString::getString)
+                .collect(toList());
+        }
 
         return McpConditionConfig.builder()
             .toolkit(toolkit)

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpConditionConfigAdapter.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpConditionConfigAdapter.java
@@ -26,7 +26,8 @@ import io.aklivity.zilla.runtime.engine.config.ConditionConfigAdapterSpi;
 
 public final class McpConditionConfigAdapter implements ConditionConfigAdapterSpi, JsonbAdapter<ConditionConfig, JsonObject>
 {
-    private static final String KIND_NAME = "kind";
+    private static final String TOOLKIT_NAME = "toolkit";
+    private static final String CAPABILITY_NAME = "capability";
 
     @Override
     public String type()
@@ -42,9 +43,14 @@ public final class McpConditionConfigAdapter implements ConditionConfigAdapterSp
 
         JsonObjectBuilder object = Json.createObjectBuilder();
 
-        if (mcpCondition.kind != null)
+        if (mcpCondition.toolkit != null)
         {
-            object.add(KIND_NAME, mcpCondition.kind);
+            object.add(TOOLKIT_NAME, mcpCondition.toolkit);
+        }
+
+        if (mcpCondition.capability != null)
+        {
+            object.add(CAPABILITY_NAME, mcpCondition.capability);
         }
 
         return object.build();
@@ -54,12 +60,17 @@ public final class McpConditionConfigAdapter implements ConditionConfigAdapterSp
     public ConditionConfig adaptFromJson(
         JsonObject object)
     {
-        String kind = object.containsKey(KIND_NAME)
-            ? object.getString(KIND_NAME)
+        String toolkit = object.containsKey(TOOLKIT_NAME)
+            ? object.getString(TOOLKIT_NAME)
+            : null;
+
+        String capability = object.containsKey(CAPABILITY_NAME)
+            ? object.getString(CAPABILITY_NAME)
             : null;
 
         return McpConditionConfig.builder()
-            .kind(kind)
+            .toolkit(toolkit)
+            .capability(capability)
             .build();
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRouteConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRouteConfig.java
@@ -110,6 +110,28 @@ public final class McpRouteConfig
         return result;
     }
 
+    public String prefix(
+        McpBeginExFW beginEx)
+    {
+        final String capability = capabilityOf(beginEx);
+        String result = "";
+
+        if (capability != null && !matchers.isEmpty())
+        {
+            for (ConditionMatcher matcher : matchers)
+            {
+                final String prefix = matcher.prefix(capability);
+                if (prefix != null)
+                {
+                    result = prefix;
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+
     boolean matches(
         String capability,
         String identifier)

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRouteConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRouteConfig.java
@@ -131,6 +131,26 @@ public final class McpRouteConfig
         return result;
     }
 
+    boolean serves(
+        String capability)
+    {
+        boolean result = matchers.isEmpty();
+
+        if (!result)
+        {
+            for (ConditionMatcher matcher : matchers)
+            {
+                if (matcher.serves(capability))
+                {
+                    result = true;
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+
     static String capabilityOf(
         McpBeginExFW beginEx)
     {
@@ -208,6 +228,12 @@ public final class McpRouteConfig
             }
 
             return result;
+        }
+
+        private boolean serves(
+            String capability)
+        {
+            return prefix(capability) != null;
         }
 
         private String prefix(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRouteConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRouteConfig.java
@@ -14,6 +14,9 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.config;
 
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabilities.SERVER_PROMPTS;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabilities.SERVER_RESOURCES;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabilities.SERVER_TOOLS;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_GET;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
@@ -63,6 +66,24 @@ public final class McpRouteConfig
         long authorization)
     {
         return authorized.test(authorization, identity());
+    }
+
+    public int serverCapabilities()
+    {
+        int bits;
+        if (matchers.isEmpty())
+        {
+            bits = SERVER_TOOLS.value() | SERVER_PROMPTS.value() | SERVER_RESOURCES.value();
+        }
+        else
+        {
+            bits = 0;
+            for (ConditionMatcher matcher : matchers)
+            {
+                bits |= matcher.serverCapabilities();
+            }
+        }
+        return bits;
     }
 
     public String strip(
@@ -154,6 +175,24 @@ public final class McpRouteConfig
             this.toolsPrefix = tools ? (toolkit != null ? toolkit + DELIMITER_NAME : "") : null;
             this.promptsPrefix = prompts ? (toolkit != null ? toolkit + DELIMITER_NAME : "") : null;
             this.resourcesPrefix = resources ? (toolkit != null ? toolkit + DELIMITER_URI : "") : null;
+        }
+
+        private int serverCapabilities()
+        {
+            int bits = 0;
+            if (toolsPrefix != null)
+            {
+                bits |= SERVER_TOOLS.value();
+            }
+            if (promptsPrefix != null)
+            {
+                bits |= SERVER_PROMPTS.value();
+            }
+            if (resourcesPrefix != null)
+            {
+                bits |= SERVER_RESOURCES.value();
+            }
+            return bits;
         }
 
         private String match(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRouteConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRouteConfig.java
@@ -14,23 +14,37 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.config;
 
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_GET;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_READ;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_CALL;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 import static java.util.function.UnaryOperator.identity;
+import static java.util.stream.Collectors.toList;
 
 import java.util.List;
 import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
 
 import io.aklivity.zilla.runtime.binding.mcp.config.McpConditionConfig;
 import io.aklivity.zilla.runtime.binding.mcp.config.McpWithConfig;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW;
 import io.aklivity.zilla.runtime.engine.config.RouteConfig;
 import io.aklivity.zilla.runtime.engine.util.function.LongObjectPredicate;
 
 public final class McpRouteConfig
 {
+    static final String CAPABILITY_TOOLS = "tools";
+    static final String CAPABILITY_PROMPTS = "prompts";
+    static final String CAPABILITY_RESOURCES = "resources";
+
+    private static final String DELIMITER_NAME = "__";
+    private static final String DELIMITER_URI = "+";
+
     public final long id;
     public final McpWithConfig with;
 
-    private final List<McpConditionConfig> when;
+    private final List<ConditionMatcher> matchers;
     private final LongObjectPredicate<UnaryOperator<String>> authorized;
 
     public McpRouteConfig(
@@ -38,9 +52,10 @@ public final class McpRouteConfig
     {
         this.id = route.id;
         this.with = McpWithConfig.class.cast(route.with);
-        this.when = route.when.stream()
+        this.matchers = route.when.stream()
             .map(McpConditionConfig.class::cast)
-            .collect(Collectors.toList());
+            .map(ConditionMatcher::new)
+            .collect(toList());
         this.authorized = route.authorized;
     }
 
@@ -50,13 +65,122 @@ public final class McpRouteConfig
         return authorized.test(authorization, identity());
     }
 
-    public boolean matches(
-        String toolkit,
-        String capability)
+    public String strip(
+        McpBeginExFW beginEx)
     {
-        return when.isEmpty() ||
-            when.stream().anyMatch(c ->
-                (c.toolkit == null || c.toolkit.equals(toolkit)) &&
-                (c.capability == null || c.capability.equals(capability)));
+        final String capability = capabilityOf(beginEx);
+        final String identifier = identifierOf(beginEx);
+
+        String result = identifier;
+
+        if (capability != null && identifier != null && !matchers.isEmpty())
+        {
+            for (ConditionMatcher matcher : matchers)
+            {
+                final String stripped = matcher.match(capability, identifier);
+                if (stripped != null)
+                {
+                    result = stripped;
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    boolean matches(
+        String capability,
+        String identifier)
+    {
+        boolean result = matchers.isEmpty();
+
+        if (!result)
+        {
+            for (ConditionMatcher matcher : matchers)
+            {
+                if (matcher.match(capability, identifier) != null)
+                {
+                    result = true;
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    static String capabilityOf(
+        McpBeginExFW beginEx)
+    {
+        return switch (beginEx.kind())
+        {
+        case KIND_TOOLS_LIST, KIND_TOOLS_CALL -> CAPABILITY_TOOLS;
+        case KIND_PROMPTS_LIST, KIND_PROMPTS_GET -> CAPABILITY_PROMPTS;
+        case KIND_RESOURCES_LIST, KIND_RESOURCES_READ -> CAPABILITY_RESOURCES;
+        default -> null;
+        };
+    }
+
+    static String identifierOf(
+        McpBeginExFW beginEx)
+    {
+        return switch (beginEx.kind())
+        {
+        case KIND_TOOLS_CALL -> beginEx.toolsCall().name().asString();
+        case KIND_PROMPTS_GET -> beginEx.promptsGet().name().asString();
+        case KIND_RESOURCES_READ -> beginEx.resourcesRead().uri().asString();
+        default -> null;
+        };
+    }
+
+    private static final class ConditionMatcher
+    {
+        private final String toolsPrefix;
+        private final String promptsPrefix;
+        private final String resourcesPrefix;
+
+        private ConditionMatcher(
+            McpConditionConfig condition)
+        {
+            final List<String> capabilities = condition.capability;
+            final String toolkit = condition.toolkit;
+
+            final boolean anyCapability = capabilities == null;
+            final boolean tools = anyCapability || capabilities.contains(CAPABILITY_TOOLS);
+            final boolean prompts = anyCapability || capabilities.contains(CAPABILITY_PROMPTS);
+            final boolean resources = anyCapability || capabilities.contains(CAPABILITY_RESOURCES);
+
+            this.toolsPrefix = tools ? (toolkit != null ? toolkit + DELIMITER_NAME : "") : null;
+            this.promptsPrefix = prompts ? (toolkit != null ? toolkit + DELIMITER_NAME : "") : null;
+            this.resourcesPrefix = resources ? (toolkit != null ? toolkit + DELIMITER_URI : "") : null;
+        }
+
+        private String match(
+            String capability,
+            String identifier)
+        {
+            final String prefix = prefix(capability);
+            String result = null;
+
+            if (prefix != null && identifier != null && identifier.startsWith(prefix))
+            {
+                result = identifier.substring(prefix.length());
+            }
+
+            return result;
+        }
+
+        private String prefix(
+            String capability)
+        {
+            return switch (capability)
+            {
+            case CAPABILITY_TOOLS -> toolsPrefix;
+            case CAPABILITY_PROMPTS -> promptsPrefix;
+            case CAPABILITY_RESOURCES -> resourcesPrefix;
+            default -> null;
+            };
+        }
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRouteConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRouteConfig.java
@@ -14,18 +14,24 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.config;
 
+import static java.util.function.UnaryOperator.identity;
+
 import java.util.List;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import io.aklivity.zilla.runtime.binding.mcp.config.McpConditionConfig;
 import io.aklivity.zilla.runtime.binding.mcp.config.McpWithConfig;
 import io.aklivity.zilla.runtime.engine.config.RouteConfig;
+import io.aklivity.zilla.runtime.engine.util.function.LongObjectPredicate;
 
 public final class McpRouteConfig
 {
     public final long id;
     public final McpWithConfig with;
+
     private final List<McpConditionConfig> when;
+    private final LongObjectPredicate<UnaryOperator<String>> authorized;
 
     public McpRouteConfig(
         RouteConfig route)
@@ -35,18 +41,22 @@ public final class McpRouteConfig
         this.when = route.when.stream()
             .map(McpConditionConfig.class::cast)
             .collect(Collectors.toList());
+        this.authorized = route.authorized;
     }
 
     public boolean authorized(
         long authorization)
     {
-        return true;
+        return authorized.test(authorization, identity());
     }
 
     public boolean matches(
-        String kind)
+        String toolkit,
+        String capability)
     {
         return when.isEmpty() ||
-            when.stream().anyMatch(c -> c.kind == null || c.kind.equals(kind));
+            when.stream().anyMatch(c ->
+                (c.toolkit == null || c.toolkit.equals(toolkit)) &&
+                (c.capability == null || c.capability.equals(capability)));
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRouteConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRouteConfig.java
@@ -113,7 +113,18 @@ public final class McpRouteConfig
     public String prefix(
         McpBeginExFW beginEx)
     {
-        final String capability = capabilityOf(beginEx);
+        return prefix(capabilityOf(beginEx));
+    }
+
+    public String prefix(
+        int kind)
+    {
+        return prefix(capabilityOf(kind));
+    }
+
+    private String prefix(
+        String capability)
+    {
         String result = "";
 
         if (capability != null && !matchers.isEmpty())
@@ -176,7 +187,13 @@ public final class McpRouteConfig
     static String capabilityOf(
         McpBeginExFW beginEx)
     {
-        return switch (beginEx.kind())
+        return capabilityOf(beginEx.kind());
+    }
+
+    static String capabilityOf(
+        int kind)
+    {
+        return switch (kind)
         {
         case KIND_TOOLS_LIST, KIND_TOOLS_CALL -> CAPABILITY_TOOLS;
         case KIND_PROMPTS_LIST, KIND_PROMPTS_GET -> CAPABILITY_PROMPTS;

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRoutePrefix.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRoutePrefix.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.config;
+
+public record McpRoutePrefix(
+    long resolvedId,
+    String prefix)
+{
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -14,6 +14,9 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
 
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabilities.SERVER_PROMPTS;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabilities.SERVER_RESOURCES;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabilities.SERVER_TOOLS;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_LIFECYCLE;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_GET;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
@@ -65,6 +68,9 @@ import io.aklivity.zilla.runtime.engine.config.BindingConfig;
 
 public final class McpClientFactory implements McpStreamFactory
 {
+    private static final int SERVER_CAPABILITIES =
+        SERVER_TOOLS.value() | SERVER_PROMPTS.value() | SERVER_RESOURCES.value();
+
     private static final String HTTP_TYPE_NAME = "http";
     private static final String MCP_TYPE_NAME = "mcp";
 
@@ -1179,7 +1185,9 @@ public final class McpClientFactory implements McpStreamFactory
                 doAppBegin(traceId, authorization, mcpBeginExRW
                     .wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(mcpTypeId)
-                    .lifecycle(b -> b.sessionId(sid))
+                    .lifecycle(b -> b
+                        .sessionId(sid)
+                        .capabilities(SERVER_CAPABILITIES))
                     .build());
                 touch();
                 scheduleKeepalive(traceId);

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -896,16 +896,18 @@ public final class McpClientFactory implements McpStreamFactory
             final long acknowledge = window.acknowledge();
             final int maximum = window.maximum();
             final long budgetId = window.budgetId();
+            final int padding = window.padding();
 
             assert acknowledge <= sequence;
+            assert sequence <= replySeq;
             assert acknowledge >= replyAck;
-            assert maximum >= replyMax;
+            assert maximum + acknowledge >= replyMax + replyAck;
 
             state = McpState.openedReply(state);
             replyAck = acknowledge;
             replyMax = maximum;
-            replyBud = window.budgetId();
-            replyPad = window.padding();
+            replyBud = budgetId;
+            replyPad = padding;
 
             assert replyAck <= replySeq;
 
@@ -1512,6 +1514,7 @@ public final class McpClientFactory implements McpStreamFactory
         private long initialSeq;
         private long initialAck;
         private int initialMax;
+        private int initialPad;
 
         private long replySeq;
         private long replyAck;
@@ -1818,12 +1821,19 @@ public final class McpClientFactory implements McpStreamFactory
             final long sequence = window.sequence();
             final long acknowledge = window.acknowledge();
             final int maximum = window.maximum();
+            final int padding = window.padding();
 
             assert acknowledge <= sequence;
+            assert sequence <= initialSeq;
+            assert acknowledge >= initialAck;
+            assert maximum + acknowledge >= initialMax + initialAck;
 
             state = McpState.openedInitial(state);
             initialAck = acknowledge;
             initialMax = maximum;
+            initialPad = padding;
+
+            assert initialAck <= initialSeq;
 
             if (encodeSlot != NO_SLOT)
             {

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -27,10 +27,13 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeg
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.LongUnaryOperator;
 
+import jakarta.json.Json;
+import jakarta.json.JsonPointer;
 import jakarta.json.stream.JsonParser;
 
 import org.agrona.DirectBuffer;
@@ -127,6 +130,15 @@ public final class McpClientFactory implements McpStreamFactory
     private final String clientName;
     private final String clientVersion;
 
+    // JSON paths whose values McpClientFactory reads via getString(). Configured on the
+    // StreamingJson parser so non-included values (notably /result subtree contents which
+    // pass through verbatim) scan without scratch accumulation. KEY_NAME tokens are
+    // always readable.
+    private static final List<JsonPointer> CLIENT_JSON_PATH_INCLUDES = List.of(
+        Json.createPointer("/jsonrpc"),
+        Json.createPointer("/id"));
+    private final Map<String, ?> clientJsonConfig;
+
     private final Long2ObjectHashMap<McpBindingConfig> bindings;
     private final Map<String, McpStream> sessions = new Object2ObjectHashMap<>();
     private final Int2ObjectHashMap<McpSessionIdResolver> resolvers;
@@ -154,6 +166,9 @@ public final class McpClientFactory implements McpStreamFactory
         this.signaler = context.signaler();
         this.clientName = config.clientName();
         this.clientVersion = config.clientVersion();
+        this.clientJsonConfig = Map.of(
+            StreamingJson.PATH_INCLUDES, CLIENT_JSON_PATH_INCLUDES,
+            StreamingJson.TOKEN_MAX_BYTES, decodeMax);
 
         final Int2ObjectHashMap<McpSessionIdResolver> resolvers = new Int2ObjectHashMap<>();
         resolvers.put(KIND_TOOLS_LIST, ex -> ex.toolsList().sessionId().asString());
@@ -246,7 +261,7 @@ public final class McpClientFactory implements McpStreamFactory
         DirectBufferInputStreamEx input = inputRO;
         input.wrap(buffer, offset, limit - offset);
 
-        http.decodableJson = StreamingJson.createParser(input);
+        http.decodableJson = StreamingJson.createParser(input, clientJsonConfig);
         http.decoder = decodeJsonRpcStart;
 
         progress = limit - input.available();

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -32,9 +32,8 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.function.LongUnaryOperator;
 
-import jakarta.json.Json;
-import jakarta.json.JsonPointer;
 import jakarta.json.stream.JsonParser;
+import jakarta.json.stream.JsonParserFactory;
 
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -72,7 +71,9 @@ import io.aklivity.zilla.runtime.engine.config.BindingConfig;
 public final class McpClientFactory implements McpStreamFactory
 {
     private static final int SERVER_CAPABILITIES =
-        SERVER_TOOLS.value() | SERVER_PROMPTS.value() | SERVER_RESOURCES.value();
+        SERVER_TOOLS.value() |
+        SERVER_PROMPTS.value() |
+        SERVER_RESOURCES.value();
 
     private static final String HTTP_TYPE_NAME = "http";
     private static final String MCP_TYPE_NAME = "mcp";
@@ -130,14 +131,10 @@ public final class McpClientFactory implements McpStreamFactory
     private final String clientName;
     private final String clientVersion;
 
-    // JSON paths whose values McpClientFactory reads via getString(). Configured on the
-    // StreamingJson parser so non-included values (notably /result subtree contents which
-    // pass through verbatim) scan without scratch accumulation. KEY_NAME tokens are
-    // always readable.
-    private static final List<JsonPointer> CLIENT_JSON_PATH_INCLUDES = List.of(
-        Json.createPointer("/jsonrpc"),
-        Json.createPointer("/id"));
-    private final Map<String, ?> clientJsonConfig;
+    private static final List<String> CLIENT_JSON_PATH_INCLUDES = List.of(
+        "/jsonrpc",
+        "/id");
+    private final JsonParserFactory jsonParserFactory;
 
     private final Long2ObjectHashMap<McpBindingConfig> bindings;
     private final Map<String, McpStream> sessions = new Object2ObjectHashMap<>();
@@ -166,9 +163,9 @@ public final class McpClientFactory implements McpStreamFactory
         this.signaler = context.signaler();
         this.clientName = config.clientName();
         this.clientVersion = config.clientVersion();
-        this.clientJsonConfig = Map.of(
+        this.jsonParserFactory = StreamingJson.createParserFactory(Map.of(
             StreamingJson.PATH_INCLUDES, CLIENT_JSON_PATH_INCLUDES,
-            StreamingJson.TOKEN_MAX_BYTES, decodeMax);
+            StreamingJson.TOKEN_MAX_BYTES, decodeMax));
 
         final Int2ObjectHashMap<McpSessionIdResolver> resolvers = new Int2ObjectHashMap<>();
         resolvers.put(KIND_TOOLS_LIST, ex -> ex.toolsList().sessionId().asString());
@@ -261,7 +258,7 @@ public final class McpClientFactory implements McpStreamFactory
         DirectBufferInputStreamEx input = inputRO;
         input.wrap(buffer, offset, limit - offset);
 
-        http.decodableJson = StreamingJson.createParser(input, clientJsonConfig);
+        http.decodableJson = jsonParserFactory.createParser(input);
         http.decoder = decodeJsonRpcStart;
 
         progress = limit - input.available();

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -134,7 +134,7 @@ public final class McpClientFactory implements McpStreamFactory
     private static final List<String> CLIENT_JSON_PATH_INCLUDES = List.of(
         "/jsonrpc",
         "/id");
-    private final JsonParserFactory jsonParserFactory;
+    private final JsonParserFactory parserFactory;
 
     private final Long2ObjectHashMap<McpBindingConfig> bindings;
     private final Map<String, McpStream> sessions = new Object2ObjectHashMap<>();
@@ -163,7 +163,7 @@ public final class McpClientFactory implements McpStreamFactory
         this.signaler = context.signaler();
         this.clientName = config.clientName();
         this.clientVersion = config.clientVersion();
-        this.jsonParserFactory = StreamingJson.createParserFactory(Map.of(
+        this.parserFactory = StreamingJson.createParserFactory(Map.of(
             StreamingJson.PATH_INCLUDES, CLIENT_JSON_PATH_INCLUDES,
             StreamingJson.TOKEN_MAX_BYTES, decodeMax));
 
@@ -258,7 +258,7 @@ public final class McpClientFactory implements McpStreamFactory
         DirectBufferInputStreamEx input = inputRO;
         input.wrap(buffer, offset, limit - offset);
 
-        http.decodableJson = jsonParserFactory.createParser(input);
+        http.decodableJson = parserFactory.createParser(input);
         http.decoder = decodeJsonRpcStart;
 
         progress = limit - input.available();

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -81,6 +81,16 @@ public final class McpProxyFactory implements McpStreamFactory
     private final OctetsFW emptyRO = new OctetsFW().wrap(new UnsafeBuffer(), 0, 0);
     private final UnsafeBuffer itemRO = new UnsafeBuffer(0, 0);
     private final DirectBufferInputStreamEx inputRO = new DirectBufferInputStreamEx();
+    private final DirectBuffer listReplyToolsOpenRO =
+        new UnsafeBuffer("{\"tools\":[".getBytes(StandardCharsets.UTF_8));
+    private final DirectBuffer listReplyPromptsOpenRO =
+        new UnsafeBuffer("{\"prompts\":[".getBytes(StandardCharsets.UTF_8));
+    private final DirectBuffer listReplyResourcesOpenRO =
+        new UnsafeBuffer("{\"resources\":[".getBytes(StandardCharsets.UTF_8));
+    private final DirectBuffer listReplyCloseRO =
+        new UnsafeBuffer("]}".getBytes(StandardCharsets.UTF_8));
+    private final DirectBuffer listReplySeparatorRO =
+        new UnsafeBuffer(",".getBytes(StandardCharsets.UTF_8));
 
     private final BeginFW.Builder beginRW = new BeginFW.Builder();
     private final DataFW.Builder dataRW = new DataFW.Builder();
@@ -2076,17 +2086,6 @@ public final class McpProxyFactory implements McpStreamFactory
         return limit;
     }
 
-    private static final DirectBuffer LIST_REPLY_TOOLS_OPEN_RO =
-        new UnsafeBuffer("{\"tools\":[".getBytes(StandardCharsets.UTF_8));
-    private static final DirectBuffer LIST_REPLY_PROMPTS_OPEN_RO =
-        new UnsafeBuffer("{\"prompts\":[".getBytes(StandardCharsets.UTF_8));
-    private static final DirectBuffer LIST_REPLY_RESOURCES_OPEN_RO =
-        new UnsafeBuffer("{\"resources\":[".getBytes(StandardCharsets.UTF_8));
-    private static final DirectBuffer LIST_REPLY_CLOSE_RO =
-        new UnsafeBuffer("]}".getBytes(StandardCharsets.UTF_8));
-    private static final DirectBuffer LIST_REPLY_SEPARATOR_RO =
-        new UnsafeBuffer(",".getBytes(StandardCharsets.UTF_8));
-
     private final class McpListServer
     {
         private final McpLifecycleServer lifecycle;
@@ -2311,8 +2310,8 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (itemsEmitted > 0)
             {
-                doServerData(traceId, 0L, 0x03, LIST_REPLY_SEPARATOR_RO.capacity(),
-                    LIST_REPLY_SEPARATOR_RO, 0, LIST_REPLY_SEPARATOR_RO.capacity());
+                doServerData(traceId, 0L, 0x03, listReplySeparatorRO.capacity(),
+                    listReplySeparatorRO, 0, listReplySeparatorRO.capacity());
             }
             itemRO.wrap(item, offset, length);
             doServerData(traceId, 0L, 0x03, length, itemRO, 0, length);
@@ -2324,9 +2323,9 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final DirectBuffer prelude = switch (kind)
             {
-            case KIND_TOOLS_LIST -> LIST_REPLY_TOOLS_OPEN_RO;
-            case KIND_PROMPTS_LIST -> LIST_REPLY_PROMPTS_OPEN_RO;
-            case KIND_RESOURCES_LIST -> LIST_REPLY_RESOURCES_OPEN_RO;
+            case KIND_TOOLS_LIST -> listReplyToolsOpenRO;
+            case KIND_PROMPTS_LIST -> listReplyPromptsOpenRO;
+            case KIND_RESOURCES_LIST -> listReplyResourcesOpenRO;
             default -> throw new IllegalStateException("unexpected list kind: " + kind);
             };
             doServerData(traceId, 0L, 0x03, prelude.capacity(), prelude, 0, prelude.capacity());
@@ -2335,8 +2334,8 @@ public final class McpProxyFactory implements McpStreamFactory
         private void doEncodeEndItems(
             long traceId)
         {
-            doServerData(traceId, 0L, 0x03, LIST_REPLY_CLOSE_RO.capacity(),
-                LIST_REPLY_CLOSE_RO, 0, LIST_REPLY_CLOSE_RO.capacity());
+            doServerData(traceId, 0L, 0x03, listReplyCloseRO.capacity(),
+                listReplyCloseRO, 0, listReplyCloseRO.capacity());
             doServerEnd(traceId);
         }
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -29,7 +29,6 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
-import java.util.function.LongConsumer;
 import java.util.function.LongUnaryOperator;
 
 import jakarta.json.stream.JsonParser;
@@ -222,12 +221,6 @@ public final class McpProxyFactory implements McpStreamFactory
         return newStream;
     }
 
-    private record PendingAction(
-        LongConsumer onProceed,
-        LongConsumer onReset)
-    {
-    }
-
     private final class McpServer
     {
         private final MessageConsumer sender;
@@ -329,14 +322,8 @@ public final class McpProxyFactory implements McpStreamFactory
 
             state = McpState.openingInitial(state);
 
-            lifecycle.proceedOrQueue(resolvedId, traceId,
-                new PendingAction(this::proceed, this::doServerReset));
-        }
-
-        private void proceed(
-            long traceId)
-        {
-            this.client = new McpClient(this, resolvedId, traceId);
+            this.client = new McpClient(this, resolvedId);
+            client.doClientBegin(traceId);
 
             doWindow(sender, originId, routedId, initialId, traceId, authorization, 0,
                 writeBuffer.capacity(), 0);
@@ -477,29 +464,35 @@ public final class McpProxyFactory implements McpStreamFactory
     {
         private final McpServer server;
         private final long resolvedId;
+        private final McpLifecycleClient lifecycle;
 
         private final long initialId;
         private final long replyId;
-        private final MessageConsumer sender;
 
+        private MessageConsumer sender;
         private int state;
 
         private McpClient(
             McpServer server,
-            long resolvedId,
-            long traceId)
+            long resolvedId)
         {
             this.server = server;
             this.resolvedId = resolvedId;
+            this.lifecycle = server.lifecycle.supplyClient(resolvedId);
             this.initialId = supplyInitialId.applyAsLong(resolvedId);
             this.replyId = supplyReplyId.applyAsLong(initialId);
+        }
+
+        private void doClientBegin(
+            long traceId)
+        {
+            lifecycle.doClientBegin(traceId);
 
             final String identifier = server.identifier;
             final int capabilities = server.capabilities;
-            final boolean lifecycle = server.kind == KIND_LIFECYCLE;
-            final McpLifecycleClient upstream = server.lifecycle.exits.get(server.resolvedId);
-            final String upstreamSessionId = upstream != null ? upstream.sessionId : null;
-            final String outboundSessionId = lifecycle || upstreamSessionId == null
+            final boolean lifecycleKind = server.kind == KIND_LIFECYCLE;
+            final String upstreamSessionId = lifecycle.sessionId;
+            final String outboundSessionId = lifecycleKind || upstreamSessionId == null
                 ? server.sessionId()
                 : upstreamSessionId;
             final McpBeginExFW.Builder builder = mcpBeginExRW
@@ -525,9 +518,9 @@ public final class McpProxyFactory implements McpStreamFactory
             }
             final McpBeginExFW beginEx = builder.build();
 
-            this.sender = newStream(this::onClientMessage, server.originId, resolvedId, initialId,
+            sender = newStream(this::onClientMessage, server.originId, resolvedId, initialId,
                 traceId, server.authorization, server.affinity, beginEx);
-            this.state = McpState.openingInitial(0);
+            state = McpState.openingInitial(state);
         }
 
         private void doClientData(
@@ -745,7 +738,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private final long authorization;
         private final int clientCapabilities;
         private final String sessionId;
-        private final Long2ObjectHashMap<McpLifecycleClient> exits;
+        private final Long2ObjectHashMap<McpLifecycleClient> clients;
 
         private int state;
 
@@ -768,29 +761,13 @@ public final class McpProxyFactory implements McpStreamFactory
             this.authorization = authorization;
             this.clientCapabilities = clientCapabilities;
             this.sessionId = sessionId;
-            this.exits = new Long2ObjectHashMap<>();
+            this.clients = new Long2ObjectHashMap<>();
         }
 
-        private void proceedOrQueue(
-            long exitId,
-            long traceId,
-            PendingAction action)
+        private McpLifecycleClient supplyClient(
+            long routedId)
         {
-            McpLifecycleClient upstream = exits.get(exitId);
-            if (upstream != null && McpState.replyOpened(upstream.state))
-            {
-                action.onProceed().accept(traceId);
-            }
-            else
-            {
-                if (upstream == null)
-                {
-                    upstream = new McpLifecycleClient(this, exitId);
-                    exits.put(exitId, upstream);
-                    upstream.doClientBegin(traceId);
-                }
-                upstream.pending.add(action);
-            }
+            return clients.computeIfAbsent(routedId, id -> new McpLifecycleClient(this, id));
         }
 
         private void onServerMessage(
@@ -898,14 +875,9 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             sessions.remove(sessionId);
 
-            for (McpLifecycleClient upstream : exits.values())
+            for (McpLifecycleClient upstream : clients.values())
             {
                 upstream.doClientEnd(traceId);
-                for (PendingAction pending : upstream.pending)
-                {
-                    pending.onReset().accept(traceId);
-                }
-                upstream.pending.clear();
             }
         }
     }
@@ -916,7 +888,6 @@ public final class McpProxyFactory implements McpStreamFactory
         private final long exitId;
         private final long initialId;
         private final long replyId;
-        private final Deque<PendingAction> pending;
 
         private MessageConsumer sender;
         private int state;
@@ -930,23 +901,25 @@ public final class McpProxyFactory implements McpStreamFactory
             this.exitId = exitId;
             this.initialId = supplyInitialId.applyAsLong(exitId);
             this.replyId = supplyReplyId.applyAsLong(initialId);
-            this.pending = new ArrayDeque<>();
         }
 
         private void doClientBegin(
             long traceId)
         {
-            final String sid = server.sessionId;
-            final int clientCapabilities = server.clientCapabilities;
-            final McpBeginExFW beginEx = mcpBeginExRW
-                .wrap(codecBuffer, 0, codecBuffer.capacity())
-                .typeId(mcpTypeId)
-                .lifecycle(l -> l.sessionId(sid).capabilities(clientCapabilities))
-                .build();
+            if (!McpState.initialOpening(state))
+            {
+                final String sid = server.sessionId;
+                final int clientCapabilities = server.clientCapabilities;
+                final McpBeginExFW beginEx = mcpBeginExRW
+                    .wrap(codecBuffer, 0, codecBuffer.capacity())
+                    .typeId(mcpTypeId)
+                    .lifecycle(l -> l.sessionId(sid).capabilities(clientCapabilities))
+                    .build();
 
-            sender = newStream(this::onClientMessage, server.originId, exitId, initialId,
-                traceId, server.authorization, server.affinity, beginEx);
-            state = McpState.openingInitial(state);
+                sender = newStream(this::onClientMessage, server.originId, exitId, initialId,
+                    traceId, server.authorization, server.affinity, beginEx);
+                state = McpState.openingInitial(state);
+            }
         }
 
         private void doClientEnd(
@@ -1016,49 +989,24 @@ public final class McpProxyFactory implements McpStreamFactory
                 writeBuffer.capacity(), 0);
 
             state = McpState.openedReply(state);
-            while (!pending.isEmpty())
-            {
-                pending.poll().onProceed().accept(traceId);
-            }
         }
 
         private void onClientEnd(
             EndFW end)
         {
-            final long traceId = end.traceId();
-
             state = McpState.closedReply(state);
-
-            failPending(traceId);
         }
 
         private void onClientAbort(
             AbortFW abort)
         {
-            final long traceId = abort.traceId();
-
             state = McpState.closedReply(state);
-
-            failPending(traceId);
         }
 
         private void onClientReset(
             ResetFW reset)
         {
-            final long traceId = reset.traceId();
-
             state = McpState.closedInitial(state);
-
-            failPending(traceId);
-        }
-
-        private void failPending(
-            long traceId)
-        {
-            while (!pending.isEmpty())
-            {
-                pending.poll().onReset().accept(traceId);
-            }
         }
     }
 
@@ -1068,9 +1016,10 @@ public final class McpProxyFactory implements McpStreamFactory
         private final long resolvedId;
         private final String prefix;
         private final byte[] prefixBytes;
+        private final McpLifecycleClient lifecycle;
+        private final long initialId;
+        private final long replyId;
 
-        private long initialId;
-        private long replyId;
         private MessageConsumer sender;
         private int state;
         private int replySlot = NO_SLOT;
@@ -1101,36 +1050,17 @@ public final class McpProxyFactory implements McpStreamFactory
             this.resolvedId = resolvedId;
             this.prefix = prefix;
             this.prefixBytes = prefix.getBytes(StandardCharsets.UTF_8);
-        }
-
-        private void proceed(
-            long traceId)
-        {
-            doClientBegin(traceId);
-            if (McpState.initialClosed(server.state))
-            {
-                doClientEnd(traceId);
-            }
-        }
-
-        private void doServerReset(
-            long traceId)
-        {
-            if (!McpState.replyClosed(state))
-            {
-                state = McpState.closedReply(state);
-                server.clientFailed(this, traceId);
-            }
+            this.lifecycle = server.lifecycle.supplyClient(resolvedId);
+            this.initialId = supplyInitialId.applyAsLong(resolvedId);
+            this.replyId = supplyReplyId.applyAsLong(initialId);
         }
 
         private void doClientBegin(
             long traceId)
         {
-            initialId = supplyInitialId.applyAsLong(resolvedId);
-            replyId = supplyReplyId.applyAsLong(initialId);
+            lifecycle.doClientBegin(traceId);
 
-            final McpLifecycleClient upstream = server.lifecycle.exits.get(resolvedId);
-            final String upstreamSessionId = upstream != null ? upstream.sessionId : null;
+            final String upstreamSessionId = lifecycle.sessionId;
             final String sid = upstreamSessionId != null ? upstreamSessionId : server.lifecycle.sessionId;
             final McpBeginExFW.Builder builder = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
@@ -1235,7 +1165,7 @@ public final class McpProxyFactory implements McpStreamFactory
             if (!appended)
             {
                 state = McpState.closedReply(state);
-                server.clientFailed(this, traceId);
+                server.onClientError(this, traceId);
                 return;
             }
             streamItems(traceId);
@@ -1249,7 +1179,7 @@ public final class McpProxyFactory implements McpStreamFactory
             {
                 state = McpState.closedReply(state);
                 cleanupClientSlot();
-                server.clientDone(this, traceId);
+                server.onClientClosed(this, traceId);
             }
         }
 
@@ -1261,7 +1191,7 @@ public final class McpProxyFactory implements McpStreamFactory
             {
                 state = McpState.closedReply(state);
                 cleanupClientSlot();
-                server.clientFailed(this, traceId);
+                server.onClientError(this, traceId);
             }
         }
 
@@ -1273,7 +1203,7 @@ public final class McpProxyFactory implements McpStreamFactory
             if (!McpState.replyClosed(state))
             {
                 state = McpState.closedReply(state);
-                server.clientFailed(this, traceId);
+                server.onClientError(this, traceId);
             }
         }
 
@@ -1517,6 +1447,12 @@ public final class McpProxyFactory implements McpStreamFactory
     private static final byte[] LIST_REPLY_CLOSE = "]}".getBytes(StandardCharsets.UTF_8);
     private static final byte[] LIST_REPLY_SEPARATOR = ",".getBytes(StandardCharsets.UTF_8);
 
+    private record PendingRoute(
+        long resolvedId,
+        String prefix)
+    {
+    }
+
     private final class McpListServer
     {
         private final MessageConsumer sender;
@@ -1528,7 +1464,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private final long authorization;
         private final int kind;
         private final McpLifecycleServer lifecycle;
-        private final Deque<McpListClient> remaining;
+        private final Deque<PendingRoute> remaining;
 
         private int state;
         private int itemsEmitted;
@@ -1558,8 +1494,7 @@ public final class McpProxyFactory implements McpStreamFactory
             this.remaining = new ArrayDeque<>(routes.size());
             for (final McpRouteConfig route : routes)
             {
-                final String prefix = route.prefix(beginEx);
-                remaining.add(new McpListClient(this, route.id, prefix));
+                remaining.add(new PendingRoute(route.id, route.prefix(beginEx)));
             }
         }
 
@@ -1605,7 +1540,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
             doServerBegin(traceId);
             emitPrelude(traceId);
-            startNextRoute(traceId);
+            onNextClient(traceId);
         }
 
         private void onServerEnd(
@@ -1614,7 +1549,7 @@ public final class McpProxyFactory implements McpStreamFactory
             final long traceId = end.traceId();
             state = McpState.closedInitial(state);
 
-            if (currentClient != null && McpState.initialOpened(currentClient.state))
+            if (currentClient != null)
             {
                 currentClient.doClientEnd(traceId);
             }
@@ -1630,7 +1565,6 @@ public final class McpProxyFactory implements McpStreamFactory
             {
                 currentClient.doClientAbort(traceId);
             }
-            // queued clients have not opened an upstream stream — drop them
             remaining.clear();
         }
 
@@ -1644,42 +1578,41 @@ public final class McpProxyFactory implements McpStreamFactory
             {
                 currentClient.doClientReset(traceId);
             }
-            // queued clients have not opened an upstream stream — drop them
             remaining.clear();
         }
 
-        private void clientDone(
+        private void onClientClosed(
             McpListClient client,
             long traceId)
         {
             currentClient = null;
-            startNextRoute(traceId);
+            onNextClient(traceId);
         }
 
-        private void clientFailed(
+        private void onClientError(
             McpListClient client,
             long traceId)
         {
             currentClient = null;
-            for (final McpListClient queued : remaining)
-            {
-                queued.doClientAbort(traceId);
-            }
             remaining.clear();
             doServerAbort(traceId);
         }
 
-        private void startNextRoute(
+        private void onNextClient(
             long traceId)
         {
-            if (remaining.isEmpty())
+            final PendingRoute route = remaining.poll();
+            if (route == null)
             {
                 closeReply(traceId);
                 return;
             }
-            currentClient = remaining.poll();
-            lifecycle.proceedOrQueue(currentClient.resolvedId, traceId,
-                new PendingAction(currentClient::proceed, currentClient::doServerReset));
+            currentClient = new McpListClient(this, route.resolvedId(), route.prefix());
+            currentClient.doClientBegin(traceId);
+            if (McpState.initialClosed(state))
+            {
+                currentClient.doClientEnd(traceId);
+            }
         }
 
         private void streamItem(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -22,6 +22,8 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeg
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_CALL;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Map;
 import java.util.function.LongUnaryOperator;
 
@@ -146,33 +148,44 @@ public final class McpProxyFactory implements McpStreamFactory
             {
                 final int beginKind = beginEx.kind();
                 final String sessionId = sessionId(beginEx);
-                final boolean lifecycle = beginKind == KIND_LIFECYCLE;
-                final McpSession session = lifecycle
-                    ? sessions.computeIfAbsent(sessionId, McpSession::new)
-                    : sessions.get(sessionId);
-                final McpExit exit = session != null
-                    ? (lifecycle ? session.supplyExit(route.id) : session.exits.get(route.id))
-                    : null;
 
-                if (exit != null)
+                if (beginKind == KIND_LIFECYCLE)
                 {
-                    final String identifier = route.strip(beginEx);
-                    final int capabilities = lifecycle ? beginEx.lifecycle().capabilities() : 0;
+                    final McpSession session = sessions.computeIfAbsent(sessionId, McpSession::new);
+                    session.originId = originId;
+                    session.routedId = routedId;
+                    session.authorization = authorization;
+                    session.affinity = affinity;
+                    session.clientCapabilities = beginEx.lifecycle().capabilities();
 
-                    newStream = new McpServer(
-                        sender,
-                        originId,
-                        routedId,
-                        initialId,
-                        route.id,
-                        affinity,
-                        authorization,
-                        beginKind,
-                        sessionId,
-                        identifier,
-                        capabilities,
-                        session,
-                        exit)::onServerMessage;
+                    final McpInboundLifecycle inboundLifecycle = new McpInboundLifecycle(
+                        sender, originId, routedId, initialId, affinity, authorization, session, binding);
+                    session.lifecycle = inboundLifecycle;
+                    newStream = inboundLifecycle::onServerMessage;
+                }
+                else
+                {
+                    final McpSession session = sessions.get(sessionId);
+                    if (session != null)
+                    {
+                        final McpExit exit = session.supplyExit(route.id);
+                        final String identifier = route.strip(beginEx);
+
+                        newStream = new McpServer(
+                            sender,
+                            originId,
+                            routedId,
+                            initialId,
+                            route.id,
+                            affinity,
+                            authorization,
+                            beginKind,
+                            sessionId,
+                            identifier,
+                            0,
+                            session,
+                            exit)::onServerMessage;
+                    }
                 }
             }
         }
@@ -184,6 +197,13 @@ public final class McpProxyFactory implements McpStreamFactory
     {
         private final String sessionId;
         private final Long2ObjectHashMap<McpExit> exits;
+
+        private long originId;
+        private long routedId;
+        private long authorization;
+        private long affinity;
+        private int clientCapabilities;
+        private McpInboundLifecycle lifecycle;
 
         private McpSession(
             String sessionId)
@@ -199,15 +219,24 @@ public final class McpProxyFactory implements McpStreamFactory
         }
     }
 
-    private static final class McpExit
+    private final class McpExit
     {
+        private static final int UNINITIALIZED = 0;
+        private static final int OPENING = 1;
+        private static final int OPENED = 2;
+
         private final long exitId;
+        private final Deque<McpServer> pending;
+
+        private int state;
         private String exitSessionId;
+        private McpOutboundLifecycle lifecycle;
 
         private McpExit(
             long exitId)
         {
             this.exitId = exitId;
+            this.pending = new ArrayDeque<>();
         }
     }
 
@@ -309,6 +338,25 @@ public final class McpProxyFactory implements McpStreamFactory
 
             state = McpState.openingInitial(state);
 
+            if (exit.state == McpExit.OPENED)
+            {
+                proceed(traceId);
+            }
+            else
+            {
+                exit.pending.add(this);
+                if (exit.state == McpExit.UNINITIALIZED)
+                {
+                    exit.state = McpExit.OPENING;
+                    exit.lifecycle = new McpOutboundLifecycle(exit, session);
+                    exit.lifecycle.doClientBegin(traceId);
+                }
+            }
+        }
+
+        private void proceed(
+            long traceId)
+        {
             client.doClientBegin(traceId);
 
             doWindow(sender, originId, routedId, replyId, traceId, authorization, 0,
@@ -620,16 +668,6 @@ public final class McpProxyFactory implements McpStreamFactory
 
             state = McpState.openedInitial(state);
 
-            if (server.beginKind == KIND_LIFECYCLE && extension.sizeof() > 0)
-            {
-                final McpBeginExFW beginEx = mcpBeginExRO.wrap(
-                    extension.buffer(), extension.offset(), extension.limit());
-                if (beginEx.kind() == KIND_LIFECYCLE)
-                {
-                    server.exit.exitSessionId = beginEx.lifecycle().sessionId().asString();
-                }
-            }
-
             server.doServerBegin(traceId, extension);
         }
 
@@ -688,6 +726,312 @@ public final class McpProxyFactory implements McpStreamFactory
             state = McpState.closedInitial(state);
 
             server.doServerReset(traceId);
+        }
+    }
+
+    private final class McpInboundLifecycle
+    {
+        private final MessageConsumer sender;
+        private final long originId;
+        private final long routedId;
+        private final long initialId;
+        private final long replyId;
+        private final long affinity;
+        private final long authorization;
+        private final McpSession session;
+        private final McpBindingConfig binding;
+
+        private int state;
+
+        private McpInboundLifecycle(
+            MessageConsumer sender,
+            long originId,
+            long routedId,
+            long initialId,
+            long affinity,
+            long authorization,
+            McpSession session,
+            McpBindingConfig binding)
+        {
+            this.sender = sender;
+            this.originId = originId;
+            this.routedId = routedId;
+            this.initialId = initialId;
+            this.replyId = supplyReplyId.applyAsLong(initialId);
+            this.affinity = affinity;
+            this.authorization = authorization;
+            this.session = session;
+            this.binding = binding;
+        }
+
+        private void onServerMessage(
+            int msgTypeId,
+            DirectBuffer buffer,
+            int index,
+            int length)
+        {
+            switch (msgTypeId)
+            {
+            case BeginFW.TYPE_ID:
+                final BeginFW begin = beginRO.wrap(buffer, index, index + length);
+                onServerBegin(begin);
+                break;
+            case DataFW.TYPE_ID:
+                // no-op: proxy terminates lifecycle locally, no DATA is forwarded
+                break;
+            case EndFW.TYPE_ID:
+                final EndFW end = endRO.wrap(buffer, index, index + length);
+                onServerEnd(end);
+                break;
+            case AbortFW.TYPE_ID:
+                final AbortFW abort = abortRO.wrap(buffer, index, index + length);
+                onServerAbort(abort);
+                break;
+            case WindowFW.TYPE_ID:
+                // reply direction window from upstream; no DATA to send so ignore
+                break;
+            case ResetFW.TYPE_ID:
+                final ResetFW reset = resetRO.wrap(buffer, index, index + length);
+                onServerReset(reset);
+                break;
+            default:
+                break;
+            }
+        }
+
+        private void onServerBegin(
+            BeginFW begin)
+        {
+            final long traceId = begin.traceId();
+
+            state = McpState.openingInitial(state);
+
+            final int serverCapabilities = binding.serverCapabilities(authorization);
+            final String sid = session.sessionId;
+            final McpBeginExFW beginEx = mcpBeginExRW
+                .wrap(codecBuffer, 0, codecBuffer.capacity())
+                .typeId(mcpTypeId)
+                .lifecycle(l -> l.sessionId(sid).capabilities(serverCapabilities))
+                .build();
+
+            doBegin(sender, originId, routedId, replyId, traceId, authorization, affinity, beginEx);
+            state = McpState.openedReply(state);
+
+            doWindow(sender, originId, routedId, replyId, traceId, authorization, 0,
+                writeBuffer.capacity(), 0);
+        }
+
+        private void onServerEnd(
+            EndFW end)
+        {
+            final long traceId = end.traceId();
+
+            state = McpState.closedInitial(state);
+
+            cleanup(traceId);
+
+            if (!McpState.replyClosed(state))
+            {
+                doEnd(sender, originId, routedId, replyId, traceId, authorization);
+                state = McpState.closedReply(state);
+            }
+        }
+
+        private void onServerAbort(
+            AbortFW abort)
+        {
+            final long traceId = abort.traceId();
+
+            state = McpState.closedInitial(state);
+
+            cleanup(traceId);
+
+            if (!McpState.replyClosed(state))
+            {
+                doAbort(sender, originId, routedId, replyId, traceId, authorization);
+                state = McpState.closedReply(state);
+            }
+        }
+
+        private void onServerReset(
+            ResetFW reset)
+        {
+            final long traceId = reset.traceId();
+
+            state = McpState.closedReply(state);
+
+            cleanup(traceId);
+        }
+
+        private void cleanup(
+            long traceId)
+        {
+            sessions.remove(session.sessionId);
+
+            for (McpExit exit : session.exits.values())
+            {
+                if (exit.lifecycle != null)
+                {
+                    exit.lifecycle.doClientEnd(traceId);
+                }
+                for (McpServer pending : exit.pending)
+                {
+                    pending.doServerReset(traceId);
+                }
+                exit.pending.clear();
+            }
+        }
+    }
+
+    private final class McpOutboundLifecycle
+    {
+        private final McpExit exit;
+        private final McpSession session;
+        private final long initialId;
+        private final long replyId;
+        private MessageConsumer sender;
+
+        private int state;
+
+        private McpOutboundLifecycle(
+            McpExit exit,
+            McpSession session)
+        {
+            this.exit = exit;
+            this.session = session;
+            this.initialId = supplyInitialId.applyAsLong(exit.exitId);
+            this.replyId = supplyReplyId.applyAsLong(initialId);
+        }
+
+        private void doClientBegin(
+            long traceId)
+        {
+            sender = streamFactory.newStream(BeginFW.TYPE_ID, writeBuffer, 0, 0, this::onClientMessage);
+            assert sender != null;
+
+            final String sid = session.sessionId;
+            final int clientCapabilities = session.clientCapabilities;
+            final McpBeginExFW beginEx = mcpBeginExRW
+                .wrap(codecBuffer, 0, codecBuffer.capacity())
+                .typeId(mcpTypeId)
+                .lifecycle(l -> l.sessionId(sid).capabilities(clientCapabilities))
+                .build();
+
+            doBegin(sender, session.originId, exit.exitId, initialId, traceId,
+                session.authorization, session.affinity, beginEx);
+            state = McpState.openingInitial(state);
+        }
+
+        private void doClientEnd(
+            long traceId)
+        {
+            if (sender != null && !McpState.initialClosed(state))
+            {
+                doEnd(sender, session.originId, exit.exitId, initialId, traceId, session.authorization);
+                state = McpState.closedInitial(state);
+            }
+        }
+
+        private void onClientMessage(
+            int msgTypeId,
+            DirectBuffer buffer,
+            int index,
+            int length)
+        {
+            switch (msgTypeId)
+            {
+            case BeginFW.TYPE_ID:
+                final BeginFW begin = beginRO.wrap(buffer, index, index + length);
+                onClientBegin(begin);
+                break;
+            case DataFW.TYPE_ID:
+                // lifecycle does not carry DATA in this proxy model
+                break;
+            case EndFW.TYPE_ID:
+                final EndFW end = endRO.wrap(buffer, index, index + length);
+                onClientEnd(end);
+                break;
+            case AbortFW.TYPE_ID:
+                final AbortFW abort = abortRO.wrap(buffer, index, index + length);
+                onClientAbort(abort);
+                break;
+            case WindowFW.TYPE_ID:
+                // we do not send DATA on this stream; nothing to do
+                break;
+            case ResetFW.TYPE_ID:
+                final ResetFW reset = resetRO.wrap(buffer, index, index + length);
+                onClientReset(reset);
+                break;
+            default:
+                break;
+            }
+        }
+
+        private void onClientBegin(
+            BeginFW begin)
+        {
+            final long traceId = begin.traceId();
+            final OctetsFW extension = begin.extension();
+
+            state = McpState.openedInitial(state);
+
+            if (extension.sizeof() > 0)
+            {
+                final McpBeginExFW beginEx = mcpBeginExRO.wrap(
+                    extension.buffer(), extension.offset(), extension.limit());
+                if (beginEx.kind() == KIND_LIFECYCLE)
+                {
+                    exit.exitSessionId = beginEx.lifecycle().sessionId().asString();
+                }
+            }
+
+            doWindow(sender, session.originId, exit.exitId, replyId, traceId, session.authorization, 0,
+                writeBuffer.capacity(), 0);
+
+            exit.state = McpExit.OPENED;
+            while (!exit.pending.isEmpty())
+            {
+                exit.pending.poll().proceed(traceId);
+            }
+        }
+
+        private void onClientEnd(
+            EndFW end)
+        {
+            final long traceId = end.traceId();
+
+            state = McpState.closedReply(state);
+
+            failPending(traceId);
+        }
+
+        private void onClientAbort(
+            AbortFW abort)
+        {
+            final long traceId = abort.traceId();
+
+            state = McpState.closedReply(state);
+
+            failPending(traceId);
+        }
+
+        private void onClientReset(
+            ResetFW reset)
+        {
+            final long traceId = reset.traceId();
+
+            state = McpState.closedInitial(state);
+
+            failPending(traceId);
+        }
+
+        private void failPending(
+            long traceId)
+        {
+            while (!exit.pending.isEmpty())
+            {
+                exit.pending.poll().doServerReset(traceId);
+            }
         }
     }
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -1412,8 +1412,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private int decodeDepth;                  // JSON nesting depth in the reply envelope
         private int decodeItemDepth;              // JSON nesting depth within the current item
         private int decodeSkipDepth;              // JSON nesting depth within a skipped value
-        private long itemStartStreamOffset = -1;
-        private long itemEmittedStreamOffset = -1;
+        private long decodedItemProgress = -1;    // streamOffset of last byte emitted within the current item, -1 between items
         private McpListClientDecoder decoder = decodeInit;
         private String arrayKey;
         private String idKey;
@@ -1734,9 +1733,9 @@ public final class McpProxyFactory implements McpStreamFactory
             }
 
             final int compactBoundaryInBuf;
-            if (itemStartStreamOffset >= 0)
+            if (decodedItemProgress >= 0)
             {
-                compactBoundaryInBuf = offset + (int) (itemEmittedStreamOffset - decodedParserProgress);
+                compactBoundaryInBuf = offset + (int) (decodedItemProgress - decodedParserProgress);
             }
             else
             {
@@ -2035,13 +2034,12 @@ public final class McpProxyFactory implements McpStreamFactory
         decode:
         while (parser.hasNext())
         {
-            final long afterStreamOffset = parser.getLocation().getStreamOffset();
+            final long decodedItemProgress = parser.getLocation().getStreamOffset();
             final JsonParser.Event event = parser.next();
             switch (event)
             {
             case START_OBJECT:
-                client.itemStartStreamOffset = afterStreamOffset - 1;
-                client.itemEmittedStreamOffset = client.itemStartStreamOffset;
+                client.decodedItemProgress = decodedItemProgress - 1;
                 client.server.streamItemBegin(traceId);
                 client.decodeItemDepth = 1;
                 client.decoder = decodeItemBody;
@@ -2074,16 +2072,16 @@ public final class McpProxyFactory implements McpStreamFactory
         decode:
         while (true)
         {
-            final long parserStreamOffset = parser.getLocation().getStreamOffset();
-            if (client.itemEmittedStreamOffset < parserStreamOffset)
+            final long decodedItemProgress = parser.getLocation().getStreamOffset();
+            if (client.decodedItemProgress < decodedItemProgress)
             {
-                final int emittedInBuf =
-                    offset + (int) (client.itemEmittedStreamOffset - client.decodedParserProgress);
-                final int parserInBuf = offset + (int) (parserStreamOffset - client.decodedParserProgress);
-                final int chunkLen = parserInBuf - emittedInBuf;
-                final int emitted = client.server.streamItemChunk(buffer, emittedInBuf, chunkLen, traceId);
-                client.itemEmittedStreamOffset += emitted;
-                if (emitted < chunkLen)
+                final int decodedOffset =
+                    offset + (int) (client.decodedItemProgress - client.decodedParserProgress);
+                final int decodedLimit = offset + (int) (decodedItemProgress - client.decodedParserProgress);
+                final int chunkLen = decodedLimit - decodedOffset;
+                final int decodedProgress = client.server.streamItemChunk(buffer, decodedOffset, chunkLen, traceId);
+                client.decodedItemProgress += decodedProgress;
+                if (decodedProgress < chunkLen)
                 {
                     break decode;
                 }
@@ -2093,7 +2091,7 @@ public final class McpProxyFactory implements McpStreamFactory
             {
                 break decode;
             }
-            final long afterStreamOffset = parser.getLocation().getStreamOffset();
+            final long decodedEventProgress = parser.getLocation().getStreamOffset();
             final JsonParser.Event event = parser.next();
             switch (event)
             {
@@ -2105,20 +2103,19 @@ public final class McpProxyFactory implements McpStreamFactory
                 client.decodeItemDepth--;
                 if (client.decodeItemDepth == 0)
                 {
-                    final int afterInBuf = offset + (int) (afterStreamOffset - client.decodedParserProgress);
-                    final int emittedInBuf =
-                        offset + (int) (client.itemEmittedStreamOffset - client.decodedParserProgress);
-                    final int chunkLen = afterInBuf - emittedInBuf;
-                    final int emitted = client.server.streamItemChunk(buffer, emittedInBuf, chunkLen, traceId);
-                    client.itemEmittedStreamOffset += emitted;
-                    if (emitted < chunkLen)
+                    final int decodedLimit = offset + (int) (decodedEventProgress - client.decodedParserProgress);
+                    final int decodedOffset =
+                        offset + (int) (client.decodedItemProgress - client.decodedParserProgress);
+                    final int chunkLen = decodedLimit - decodedOffset;
+                    final int decodedProgress = client.server.streamItemChunk(buffer, decodedOffset, chunkLen, traceId);
+                    client.decodedItemProgress += decodedProgress;
+                    if (decodedProgress < chunkLen)
                     {
                         client.decoder = decodeItemFinalize;
                         break decode;
                     }
                     client.server.streamItemEnd(traceId);
-                    client.itemStartStreamOffset = -1;
-                    client.itemEmittedStreamOffset = -1;
+                    client.decodedItemProgress = -1;
                     client.decoder = decodeItemStart;
                     break decode;
                 }
@@ -2156,42 +2153,41 @@ public final class McpProxyFactory implements McpStreamFactory
     {
         final JsonParser parser = client.decodableJson;
 
-        final long parserStreamOffset = parser.getLocation().getStreamOffset();
-        if (client.itemEmittedStreamOffset < parserStreamOffset)
+        final long decodedKeyProgress = parser.getLocation().getStreamOffset();
+        if (client.decodedItemProgress < decodedKeyProgress)
         {
-            final int emittedInBuf =
-                offset + (int) (client.itemEmittedStreamOffset - client.decodedParserProgress);
-            final int parserInBuf = offset + (int) (parserStreamOffset - client.decodedParserProgress);
-            final int chunkLen = parserInBuf - emittedInBuf;
-            final int emitted = client.server.streamItemChunk(buffer, emittedInBuf, chunkLen, traceId);
-            client.itemEmittedStreamOffset += emitted;
-            if (emitted < chunkLen)
+            final int decodedOffset =
+                offset + (int) (client.decodedItemProgress - client.decodedParserProgress);
+            final int decodedLimit = offset + (int) (decodedKeyProgress - client.decodedParserProgress);
+            final int chunkLen = decodedLimit - decodedOffset;
+            final int decodedProgress = client.server.streamItemChunk(buffer, decodedOffset, chunkLen, traceId);
+            client.decodedItemProgress += decodedProgress;
+            if (decodedProgress < chunkLen)
             {
-                return offset + (int) (client.itemEmittedStreamOffset - client.decodedParserProgress);
+                return offset + (int) (client.decodedItemProgress - client.decodedParserProgress);
             }
         }
 
-        final long beforeStreamOffset = parser.getLocation().getStreamOffset();
         if (parser.hasNext())
         {
-            final long afterStreamOffset = parser.getLocation().getStreamOffset();
+            final long decodedValueProgress = parser.getLocation().getStreamOffset();
             final JsonParser.Event event = parser.next();
             if (event == JsonParser.Event.VALUE_STRING)
             {
-                final int beforeInBuf = offset + (int) (beforeStreamOffset - client.decodedParserProgress);
-                final int afterInBuf = offset + (int) (afterStreamOffset - client.decodedParserProgress);
-                int openingQuote = beforeInBuf;
-                while (openingQuote < afterInBuf && buffer.getByte(openingQuote) != (byte) '"')
+                final int decodedKeyOffset = offset + (int) (decodedKeyProgress - client.decodedParserProgress);
+                final int decodedValueOffset = offset + (int) (decodedValueProgress - client.decodedParserProgress);
+                int openingQuote = decodedKeyOffset;
+                while (openingQuote < decodedValueOffset && buffer.getByte(openingQuote) != (byte) '"')
                 {
                     openingQuote++;
                 }
-                final int contentStart = openingQuote + 1;
-                final int emittedInBuf =
-                    offset + (int) (client.itemEmittedStreamOffset - client.decodedParserProgress);
-                client.server.streamItemChunk(buffer, emittedInBuf, contentStart - emittedInBuf, traceId);
+                final int decodedContent = openingQuote + 1;
+                final int decodedOffset =
+                    offset + (int) (client.decodedItemProgress - client.decodedParserProgress);
+                client.server.streamItemChunk(buffer, decodedOffset, decodedContent - decodedOffset, traceId);
                 client.server.streamItemChunk(client.prefixBufferRO, 0, client.prefixBytes.length, traceId);
-                client.itemEmittedStreamOffset =
-                    client.decodedParserProgress + (long) (contentStart - offset);
+                client.decodedItemProgress =
+                    client.decodedParserProgress + (long) (decodedContent - offset);
             }
             client.decoder = decodeItemBody;
         }
@@ -2211,28 +2207,27 @@ public final class McpProxyFactory implements McpStreamFactory
         int limit)
     {
         final JsonParser parser = client.decodableJson;
-        final long parserStreamOffset = parser.getLocation().getStreamOffset();
+        final long decodedItemProgress = parser.getLocation().getStreamOffset();
 
-        if (client.itemEmittedStreamOffset < parserStreamOffset)
+        if (client.decodedItemProgress < decodedItemProgress)
         {
-            final int emittedInBuf =
-                offset + (int) (client.itemEmittedStreamOffset - client.decodedParserProgress);
-            final int parserInBuf = offset + (int) (parserStreamOffset - client.decodedParserProgress);
-            final int chunkLen = parserInBuf - emittedInBuf;
-            final int emitted = client.server.streamItemChunk(buffer, emittedInBuf, chunkLen, traceId);
-            client.itemEmittedStreamOffset += emitted;
-            if (emitted < chunkLen)
+            final int decodedOffset =
+                offset + (int) (client.decodedItemProgress - client.decodedParserProgress);
+            final int decodedLimit = offset + (int) (decodedItemProgress - client.decodedParserProgress);
+            final int chunkLen = decodedLimit - decodedOffset;
+            final int decodedProgress = client.server.streamItemChunk(buffer, decodedOffset, chunkLen, traceId);
+            client.decodedItemProgress += decodedProgress;
+            if (decodedProgress < chunkLen)
             {
-                return offset + (int) (client.itemEmittedStreamOffset - client.decodedParserProgress);
+                return offset + (int) (client.decodedItemProgress - client.decodedParserProgress);
             }
         }
 
         client.server.streamItemEnd(traceId);
-        client.itemStartStreamOffset = -1;
-        client.itemEmittedStreamOffset = -1;
+        client.decodedItemProgress = -1;
         client.decoder = decodeItemStart;
 
-        return offset + (int) (parserStreamOffset - client.decodedParserProgress);
+        return offset + (int) (decodedItemProgress - client.decodedParserProgress);
     }
 
     private int decodeIgnore(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -1084,11 +1084,13 @@ public final class McpProxyFactory implements McpStreamFactory
         private long parserBaseOffset;       // absolute streamOffset of slot[0]
         private int depth;
         private int itemDepth = -1;          // depth at which target items live, set on START_ARRAY
-        private boolean inTargetArray;
         private boolean awaitingArrayValue;
         private boolean awaitingIdValue;
         private long itemStartStreamOffset = -1;
         private long itemLastEmittedStreamOffset = -1;
+        private McpListClientDecoder decoder;
+        private String arrayKey;
+        private String idKey;
 
         private McpListClient(
             McpListServer server,
@@ -1316,22 +1318,21 @@ public final class McpProxyFactory implements McpStreamFactory
                 parser = parserFactory.createParser(jsonInput);
                 itemOut = new ByteArrayOutputStream(256);
                 itemTransferBuffer = new byte[bufferPool.slotCapacity()];
+                arrayKey = switch (server.kind)
+                {
+                case KIND_TOOLS_LIST -> "tools";
+                case KIND_PROMPTS_LIST -> "prompts";
+                case KIND_RESOURCES_LIST -> "resources";
+                default -> null;
+                };
+                idKey = server.kind == KIND_RESOURCES_LIST ? "uri" : "name";
+                decoder = decodeListBeforeItems;
             }
 
             final MutableDirectBuffer slotBuffer = bufferPool.buffer(replySlot);
             final int parserPosInSlot = (int) (parser.getLocation().getStreamOffset() - parserBaseOffset);
             jsonInput.wrap(slotBuffer, parserPosInSlot, replySlotOffset - parserPosInSlot);
 
-            final String idKey = server.kind == KIND_RESOURCES_LIST ? "uri" : "name";
-            final String arrayKey = switch (server.kind)
-            {
-            case KIND_TOOLS_LIST -> "tools";
-            case KIND_PROMPTS_LIST -> "prompts";
-            case KIND_RESOURCES_LIST -> "resources";
-            default -> null;
-            };
-
-            walk:
             while (true)
             {
                 final long beforeStreamOffset = parser.getLocation().getStreamOffset();
@@ -1341,88 +1342,7 @@ public final class McpProxyFactory implements McpStreamFactory
                 }
                 final long afterStreamOffset = parser.getLocation().getStreamOffset();
                 final JsonParser.Event ev = parser.next();
-                final int afterInSlot = (int) (afterStreamOffset - parserBaseOffset);
-                final int beforeInSlot = (int) (beforeStreamOffset - parserBaseOffset);
-                switch (ev)
-                {
-                case START_OBJECT:
-                    depth++;
-                    if (inTargetArray && depth == itemDepth)
-                    {
-                        itemStartStreamOffset = afterStreamOffset - 1;
-                        itemLastEmittedStreamOffset = itemStartStreamOffset;
-                        itemOut.reset();
-                    }
-                    break;
-                case START_ARRAY:
-                    depth++;
-                    if (awaitingArrayValue)
-                    {
-                        awaitingArrayValue = false;
-                        inTargetArray = true;
-                        itemDepth = depth + 1;
-                    }
-                    break;
-                case END_OBJECT:
-                    if (depth == itemDepth && itemStartStreamOffset >= 0)
-                    {
-                        final int itemLastEmittedInSlot = (int) (itemLastEmittedStreamOffset - parserBaseOffset);
-                        slotBuffer.getBytes(itemLastEmittedInSlot, itemTransferBuffer,
-                            0, afterInSlot - itemLastEmittedInSlot);
-                        itemOut.write(itemTransferBuffer, 0, afterInSlot - itemLastEmittedInSlot);
-                        server.streamItem(itemOut.toByteArray(), 0, itemOut.size(), traceId);
-                        itemStartStreamOffset = -1;
-                        itemLastEmittedStreamOffset = -1;
-                    }
-                    depth--;
-                    break;
-                case END_ARRAY:
-                    depth--;
-                    if (inTargetArray && depth + 1 == itemDepth - 1)
-                    {
-                        inTargetArray = false;
-                        itemDepth = -1;
-                    }
-                    break;
-                case KEY_NAME:
-                    final String key = parser.getString();
-                    if (depth == 1 && arrayKey.equals(key))
-                    {
-                        awaitingArrayValue = true;
-                    }
-                    else if (inTargetArray && depth == itemDepth && idKey.equals(key))
-                    {
-                        awaitingIdValue = true;
-                    }
-                    break;
-                case VALUE_STRING:
-                    if (awaitingIdValue && itemStartStreamOffset >= 0 && prefixBytes.length > 0)
-                    {
-                        awaitingIdValue = false;
-                        // bytes [beforeInSlot..afterInSlot) span ":<ws>\"<content>\"" — find opening quote
-                        int openingQuote = beforeInSlot;
-                        while (openingQuote < afterInSlot && slotBuffer.getByte(openingQuote) != (byte) '"')
-                        {
-                            openingQuote++;
-                        }
-                        final int contentStart = openingQuote + 1;
-                        final int itemLastEmittedInSlot = (int) (itemLastEmittedStreamOffset - parserBaseOffset);
-                        // emit verbatim up to and including opening quote
-                        slotBuffer.getBytes(itemLastEmittedInSlot, itemTransferBuffer,
-                            0, contentStart - itemLastEmittedInSlot);
-                        itemOut.write(itemTransferBuffer, 0, contentStart - itemLastEmittedInSlot);
-                        // splice in the prefix
-                        itemOut.write(prefixBytes, 0, prefixBytes.length);
-                        itemLastEmittedStreamOffset = parserBaseOffset + contentStart;
-                    }
-                    else if (awaitingIdValue)
-                    {
-                        awaitingIdValue = false;
-                    }
-                    break;
-                default:
-                    break;
-                }
+                decoder.decode(this, ev, traceId, beforeStreamOffset, afterStreamOffset, slotBuffer);
             }
 
             // Compact slot: drop bytes that are no longer needed (consumed and not part of an in-progress item)
@@ -1451,6 +1371,136 @@ public final class McpProxyFactory implements McpStreamFactory
                 replySlot = NO_SLOT;
                 replySlotOffset = 0;
             }
+        }
+    }
+
+    @FunctionalInterface
+    private interface McpListClientDecoder
+    {
+        void decode(
+            McpListClient client,
+            JsonParser.Event event,
+            long traceId,
+            long beforeOffset,
+            long afterOffset,
+            MutableDirectBuffer slotBuffer);
+    }
+
+    private final McpListClientDecoder decodeListBeforeItems = this::decodeListBeforeItems;
+    private final McpListClientDecoder decodeListWithinItems = this::decodeListWithinItems;
+
+    private void decodeListBeforeItems(
+        McpListClient client,
+        JsonParser.Event event,
+        long traceId,
+        long beforeOffset,
+        long afterOffset,
+        MutableDirectBuffer slotBuffer)
+    {
+        switch (event)
+        {
+        case START_OBJECT:
+        case START_ARRAY:
+            client.depth++;
+            if (event == JsonParser.Event.START_ARRAY && client.awaitingArrayValue)
+            {
+                client.awaitingArrayValue = false;
+                client.itemDepth = client.depth + 1;
+                client.decoder = decodeListWithinItems;
+            }
+            break;
+        case END_OBJECT:
+        case END_ARRAY:
+            client.depth--;
+            break;
+        case KEY_NAME:
+            if (client.depth == 1 && client.arrayKey.equals(client.parser.getString()))
+            {
+                client.awaitingArrayValue = true;
+            }
+            break;
+        default:
+            break;
+        }
+    }
+
+    private void decodeListWithinItems(
+        McpListClient client,
+        JsonParser.Event event,
+        long traceId,
+        long beforeOffset,
+        long afterOffset,
+        MutableDirectBuffer slotBuffer)
+    {
+        final int afterInSlot = (int) (afterOffset - client.parserBaseOffset);
+        final int beforeInSlot = (int) (beforeOffset - client.parserBaseOffset);
+        switch (event)
+        {
+        case START_OBJECT:
+            client.depth++;
+            if (client.depth == client.itemDepth)
+            {
+                client.itemStartStreamOffset = afterOffset - 1;
+                client.itemLastEmittedStreamOffset = client.itemStartStreamOffset;
+                client.itemOut.reset();
+            }
+            break;
+        case START_ARRAY:
+            client.depth++;
+            break;
+        case END_OBJECT:
+            if (client.depth == client.itemDepth && client.itemStartStreamOffset >= 0)
+            {
+                final int itemLastEmittedInSlot =
+                    (int) (client.itemLastEmittedStreamOffset - client.parserBaseOffset);
+                slotBuffer.getBytes(itemLastEmittedInSlot, client.itemTransferBuffer,
+                    0, afterInSlot - itemLastEmittedInSlot);
+                client.itemOut.write(client.itemTransferBuffer, 0, afterInSlot - itemLastEmittedInSlot);
+                client.server.streamItem(client.itemOut.toByteArray(), 0, client.itemOut.size(), traceId);
+                client.itemStartStreamOffset = -1;
+                client.itemLastEmittedStreamOffset = -1;
+            }
+            client.depth--;
+            break;
+        case END_ARRAY:
+            client.depth--;
+            if (client.depth + 1 == client.itemDepth - 1)
+            {
+                client.itemDepth = -1;
+                client.decoder = decodeListBeforeItems;
+            }
+            break;
+        case KEY_NAME:
+            if (client.depth == client.itemDepth && client.idKey.equals(client.parser.getString()))
+            {
+                client.awaitingIdValue = true;
+            }
+            break;
+        case VALUE_STRING:
+            if (client.awaitingIdValue && client.itemStartStreamOffset >= 0 && client.prefixBytes.length > 0)
+            {
+                client.awaitingIdValue = false;
+                int openingQuote = beforeInSlot;
+                while (openingQuote < afterInSlot && slotBuffer.getByte(openingQuote) != (byte) '"')
+                {
+                    openingQuote++;
+                }
+                final int contentStart = openingQuote + 1;
+                final int itemLastEmittedInSlot =
+                    (int) (client.itemLastEmittedStreamOffset - client.parserBaseOffset);
+                slotBuffer.getBytes(itemLastEmittedInSlot, client.itemTransferBuffer,
+                    0, contentStart - itemLastEmittedInSlot);
+                client.itemOut.write(client.itemTransferBuffer, 0, contentStart - itemLastEmittedInSlot);
+                client.itemOut.write(client.prefixBytes, 0, client.prefixBytes.length);
+                client.itemLastEmittedStreamOffset = client.parserBaseOffset + contentStart;
+            }
+            else if (client.awaitingIdValue)
+            {
+                client.awaitingIdValue = false;
+            }
+            break;
+        default:
+            break;
         }
     }
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -1499,8 +1499,27 @@ public final class McpProxyFactory implements McpStreamFactory
             long budgetId,
             int padding)
         {
+            state = McpState.openedReply(state);
             doWindow(sender, server.lifecycle.originId, resolvedId, replyId,
                 replySeq, replyAck, replyMax, traceId, server.authorization, budgetId, padding);
+        }
+
+        private void flushClientWindow(
+            long traceId,
+            long budgetId,
+            int padding,
+            long minReplyNoAck,
+            int minReplyMax)
+        {
+            final long newReplyAck = Math.max(replyAck, replySeq - minReplyNoAck);
+            final int newReplyMax = Math.max(replyMax, minReplyMax);
+
+            if (newReplyAck > replyAck || newReplyMax > replyMax || !McpState.replyOpened(state))
+            {
+                replyAck = newReplyAck;
+                replyMax = newReplyMax;
+                doClientWindow(traceId, budgetId, padding);
+            }
         }
 
         private void onClientMessage(
@@ -1552,8 +1571,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
             state = McpState.openedInitial(state);
 
-            replyMax = writeBuffer.capacity();
-            doClientWindow(traceId, 0L, 0);
+            flushClientWindow(traceId, 0L, 0, 0L, 0);
         }
 
         private void onClientData(
@@ -1650,6 +1668,8 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = window.sequence();
             final long acknowledge = window.acknowledge();
+            final long traceId = window.traceId();
+            final long budgetId = window.budgetId();
             final int maximum = window.maximum();
             final int padding = window.padding();
 
@@ -1663,6 +1683,8 @@ public final class McpProxyFactory implements McpStreamFactory
             initialPad = padding;
 
             assert initialAck <= initialSeq;
+
+            server.flushServerWindow(traceId, budgetId, padding, initialSeq - initialAck, initialMax);
         }
 
         private void onClientReset(
@@ -2182,7 +2204,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
             state = McpState.openingInitial(state);
 
-            doServerWindow(traceId, 0L, 0);
+            flushServerWindow(traceId, 0L, 0, 0L, 0);
 
             doServerBegin(traceId);
             doEncodeBeginItems(traceId);
@@ -2241,6 +2263,8 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = window.sequence();
             final long acknowledge = window.acknowledge();
+            final long traceId = window.traceId();
+            final long budgetId = window.budgetId();
             final int maximum = window.maximum();
             final int padding = window.padding();
 
@@ -2254,6 +2278,11 @@ public final class McpProxyFactory implements McpStreamFactory
             replyPad = padding;
 
             assert replyAck <= replySeq;
+
+            if (client != null)
+            {
+                client.flushClientWindow(traceId, budgetId, padding, replySeq - replyAck, replyMax);
+            }
         }
 
         private void onServerReset(
@@ -2423,8 +2452,27 @@ public final class McpProxyFactory implements McpStreamFactory
             long budgetId,
             int padding)
         {
+            state = McpState.openedInitial(state);
             doWindow(lifecycle.sender, lifecycle.originId, lifecycle.routedId, initialId, initialSeq, initialAck, initialMax,
                 traceId, authorization, budgetId, padding);
+        }
+
+        private void flushServerWindow(
+            long traceId,
+            long budgetId,
+            int padding,
+            long minInitialNoAck,
+            int minInitialMax)
+        {
+            final long newInitialAck = Math.max(initialAck, initialSeq - minInitialNoAck);
+            final int newInitialMax = Math.max(initialMax, minInitialMax);
+
+            if (newInitialAck > initialAck || newInitialMax > initialMax || !McpState.initialOpened(state))
+            {
+                initialAck = newInitialAck;
+                initialMax = newInitialMax;
+                doServerWindow(traceId, budgetId, padding);
+            }
         }
     }
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -23,8 +23,6 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeg
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
 
-import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
@@ -55,6 +53,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.FlushFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.ResetFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.WindowFW;
+import io.aklivity.zilla.runtime.common.json.DirectBufferInputStreamEx;
 import io.aklivity.zilla.runtime.common.json.StreamingJson;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
@@ -1123,6 +1122,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private final McpExit exit;
         private final long resolvedId;
         private final String prefix;
+        private final byte[] prefixBytes;
 
         private long initialId;
         private long replyId;
@@ -1130,6 +1130,19 @@ public final class McpProxyFactory implements McpStreamFactory
         private int state;
         private int replySlot = NO_SLOT;
         private int replySlotOffset;
+
+        // streaming JSON state — built lazily on first DATA frame
+        private JsonParser parser;
+        private DirectBufferInputStreamEx jsonInput;
+        private ByteArrayOutputStream itemOut;
+        private long parserBaseOffset;       // absolute streamOffset of slot[0]
+        private int depth;
+        private int itemDepth = -1;          // depth at which target items live, set on START_ARRAY
+        private boolean inTargetArray;
+        private boolean awaitingArrayValue;
+        private boolean awaitingIdValue;
+        private long itemStartStreamOffset = -1;
+        private long itemLastEmittedStreamOffset = -1;
 
         private McpListClient(
             McpListServer server,
@@ -1141,6 +1154,7 @@ public final class McpProxyFactory implements McpStreamFactory
             this.exit = exit;
             this.resolvedId = resolvedId;
             this.prefix = prefix;
+            this.prefixBytes = prefix.getBytes(StandardCharsets.UTF_8);
         }
 
         @Override
@@ -1273,7 +1287,15 @@ public final class McpProxyFactory implements McpStreamFactory
             final OctetsFW payload = data.payload();
             if (payload != null)
             {
-                bufferClientPayload(payload);
+                final long traceId = data.traceId();
+                final boolean appended = appendToSlot(payload);
+                if (!appended)
+                {
+                    state = McpState.closedReply(state);
+                    server.clientFailed(this, traceId);
+                    return;
+                }
+                streamItems(traceId);
             }
         }
 
@@ -1284,9 +1306,8 @@ public final class McpProxyFactory implements McpStreamFactory
             if (!McpState.replyClosed(state))
             {
                 state = McpState.closedReply(state);
-                final byte[] reply = bufferedClientReply();
                 cleanupClientSlot();
-                server.clientDone(this, reply, traceId);
+                server.clientDone(this, traceId);
             }
         }
 
@@ -1314,30 +1335,183 @@ public final class McpProxyFactory implements McpStreamFactory
             }
         }
 
-        private void bufferClientPayload(
+        private boolean appendToSlot(
             OctetsFW payload)
         {
             if (replySlot == NO_SLOT)
             {
                 replySlot = bufferPool.acquire(initialId);
             }
-            if (replySlot != NO_SLOT)
+            if (replySlot == NO_SLOT)
             {
-                final MutableDirectBuffer buf = bufferPool.buffer(replySlot);
-                buf.putBytes(replySlotOffset, payload.buffer(), payload.offset(), payload.sizeof());
-                replySlotOffset += payload.sizeof();
+                return false;
+            }
+            final MutableDirectBuffer buf = bufferPool.buffer(replySlot);
+            if (replySlotOffset + payload.sizeof() > buf.capacity())
+            {
+                return false;
+            }
+            buf.putBytes(replySlotOffset, payload.buffer(), payload.offset(), payload.sizeof());
+            replySlotOffset += payload.sizeof();
+            return true;
+        }
+
+        private void streamItems(
+            long traceId)
+        {
+            if (parser == null)
+            {
+                final JsonParserFactory parserFactory = switch (server.beginKind)
+                {
+                case KIND_TOOLS_LIST -> TOOLS_LIST_ITEM_PARSER_FACTORY;
+                case KIND_PROMPTS_LIST -> PROMPTS_LIST_ITEM_PARSER_FACTORY;
+                case KIND_RESOURCES_LIST -> RESOURCES_LIST_ITEM_PARSER_FACTORY;
+                default -> null;
+                };
+                if (parserFactory == null)
+                {
+                    return;
+                }
+                jsonInput = new DirectBufferInputStreamEx();
+                parser = parserFactory.createParser(jsonInput);
+                itemOut = new ByteArrayOutputStream(256);
+            }
+
+            final MutableDirectBuffer slotBuffer = bufferPool.buffer(replySlot);
+            final int parserPosInSlot = (int) (parser.getLocation().getStreamOffset() - parserBaseOffset);
+            jsonInput.wrap(slotBuffer, parserPosInSlot, replySlotOffset - parserPosInSlot);
+
+            final String idKey = server.beginKind == KIND_RESOURCES_LIST ? "uri" : "name";
+            final String arrayKey = switch (server.beginKind)
+            {
+            case KIND_TOOLS_LIST -> "tools";
+            case KIND_PROMPTS_LIST -> "prompts";
+            case KIND_RESOURCES_LIST -> "resources";
+            default -> null;
+            };
+
+            walk:
+            while (true)
+            {
+                final long beforeStreamOffset = parser.getLocation().getStreamOffset();
+                if (!parser.hasNext())
+                {
+                    break;
+                }
+                final long afterStreamOffset = parser.getLocation().getStreamOffset();
+                final JsonParser.Event ev = parser.next();
+                final int afterInSlot = (int) (afterStreamOffset - parserBaseOffset);
+                final int beforeInSlot = (int) (beforeStreamOffset - parserBaseOffset);
+                switch (ev)
+                {
+                case START_OBJECT:
+                    depth++;
+                    if (inTargetArray && depth == itemDepth)
+                    {
+                        itemStartStreamOffset = afterStreamOffset - 1;
+                        itemLastEmittedStreamOffset = itemStartStreamOffset;
+                        itemOut.reset();
+                    }
+                    break;
+                case START_ARRAY:
+                    depth++;
+                    if (awaitingArrayValue)
+                    {
+                        awaitingArrayValue = false;
+                        inTargetArray = true;
+                        itemDepth = depth + 1;
+                    }
+                    break;
+                case END_OBJECT:
+                    if (depth == itemDepth && itemStartStreamOffset >= 0)
+                    {
+                        final int itemLastEmittedInSlot = (int) (itemLastEmittedStreamOffset - parserBaseOffset);
+                        slotBuffer.getBytes(itemLastEmittedInSlot, itemBuffer(),
+                            0, afterInSlot - itemLastEmittedInSlot);
+                        itemOut.write(itemBuffer(), 0, afterInSlot - itemLastEmittedInSlot);
+                        server.streamItem(itemOut.toByteArray(), 0, itemOut.size(), traceId);
+                        itemStartStreamOffset = -1;
+                        itemLastEmittedStreamOffset = -1;
+                    }
+                    depth--;
+                    break;
+                case END_ARRAY:
+                    depth--;
+                    if (inTargetArray && depth + 1 == itemDepth - 1)
+                    {
+                        inTargetArray = false;
+                        itemDepth = -1;
+                    }
+                    break;
+                case KEY_NAME:
+                    final String key = parser.getString();
+                    if (depth == 1 && arrayKey.equals(key))
+                    {
+                        awaitingArrayValue = true;
+                    }
+                    else if (inTargetArray && depth == itemDepth && idKey.equals(key))
+                    {
+                        awaitingIdValue = true;
+                    }
+                    break;
+                case VALUE_STRING:
+                    if (awaitingIdValue && itemStartStreamOffset >= 0 && prefixBytes.length > 0)
+                    {
+                        awaitingIdValue = false;
+                        // bytes [beforeInSlot..afterInSlot) span ":<ws>\"<content>\"" — find opening quote
+                        int openingQuote = beforeInSlot;
+                        while (openingQuote < afterInSlot && slotBuffer.getByte(openingQuote) != (byte) '"')
+                        {
+                            openingQuote++;
+                        }
+                        final int contentStart = openingQuote + 1;
+                        final int itemLastEmittedInSlot = (int) (itemLastEmittedStreamOffset - parserBaseOffset);
+                        // emit verbatim up to and including opening quote
+                        slotBuffer.getBytes(itemLastEmittedInSlot, itemBuffer(),
+                            0, contentStart - itemLastEmittedInSlot);
+                        itemOut.write(itemBuffer(), 0, contentStart - itemLastEmittedInSlot);
+                        // splice in the prefix
+                        itemOut.write(prefixBytes, 0, prefixBytes.length);
+                        itemLastEmittedStreamOffset = parserBaseOffset + contentStart;
+                    }
+                    else if (awaitingIdValue)
+                    {
+                        awaitingIdValue = false;
+                    }
+                    break;
+                default:
+                    break;
+                }
+            }
+
+            // Compact slot: drop bytes that are no longer needed (consumed and not part of an in-progress item)
+            final int compactBoundaryInSlot;
+            if (itemStartStreamOffset >= 0)
+            {
+                compactBoundaryInSlot = (int) (itemStartStreamOffset - parserBaseOffset);
+            }
+            else
+            {
+                compactBoundaryInSlot = (int) (parser.getLocation().getStreamOffset() - parserBaseOffset);
+            }
+            if (compactBoundaryInSlot > 0)
+            {
+                slotBuffer.putBytes(0, slotBuffer, compactBoundaryInSlot, replySlotOffset - compactBoundaryInSlot);
+                replySlotOffset -= compactBoundaryInSlot;
+                parserBaseOffset += compactBoundaryInSlot;
             }
         }
 
-        private byte[] bufferedClientReply()
+        private byte[] itemTransferBuffer;
+
+        private byte[] itemBuffer()
         {
-            if (replySlot == NO_SLOT || replySlotOffset == 0)
+            // grows as needed; reused across items
+            if (itemTransferBuffer == null || itemTransferBuffer.length < bufferPool.slotCapacity())
             {
-                return null;
+                itemTransferBuffer = new byte[bufferPool.slotCapacity()];
             }
-            final byte[] inputBytes = new byte[replySlotOffset];
-            bufferPool.buffer(replySlot).getBytes(0, inputBytes);
-            return inputBytes;
+            return itemTransferBuffer;
         }
 
         private void cleanupClientSlot()
@@ -1501,13 +1675,8 @@ public final class McpProxyFactory implements McpStreamFactory
 
         private void clientDone(
             McpListClient client,
-            byte[] data,
             long traceId)
         {
-            if (data != null)
-            {
-                forEachListItem(data, beginKind, client.prefix, traceId, this::streamItem);
-            }
             currentClient = null;
             startNextRoute(traceId);
         }
@@ -1663,137 +1832,6 @@ public final class McpProxyFactory implements McpStreamFactory
         case KIND_RESOURCES_READ -> beginEx.resourcesRead().sessionId().asString();
         default -> null;
         };
-    }
-
-    @FunctionalInterface
-    private interface ListItemEmitter
-    {
-        void emit(byte[] item, int offset, int length, long traceId);
-    }
-
-    /**
-     * Walks a single route's list reply (e.g. {@code {"tools":[{...},{...}]}}) and emits each
-     * item one at a time via {@code emitter}. The idKey value in each item is spliced with
-     * {@code prefix} during the walk; remaining bytes flow through verbatim. Non-conforming
-     * replies (no matching arrayKey) result in zero emitted items.
-     */
-    private static void forEachListItem(
-        byte[] jsonBytes,
-        int beginKind,
-        String prefix,
-        long traceId,
-        ListItemEmitter emitter)
-    {
-        final String arrayKey;
-        final String idKey;
-        final JsonParserFactory parserFactory;
-        switch (beginKind)
-        {
-        case KIND_TOOLS_LIST:
-            arrayKey = "tools";
-            idKey = "name";
-            parserFactory = TOOLS_LIST_ITEM_PARSER_FACTORY;
-            break;
-        case KIND_PROMPTS_LIST:
-            arrayKey = "prompts";
-            idKey = "name";
-            parserFactory = PROMPTS_LIST_ITEM_PARSER_FACTORY;
-            break;
-        case KIND_RESOURCES_LIST:
-            arrayKey = "resources";
-            idKey = "uri";
-            parserFactory = RESOURCES_LIST_ITEM_PARSER_FACTORY;
-            break;
-        default:
-            return;
-        }
-        final byte[] prefixBytes = prefix.getBytes(StandardCharsets.UTF_8);
-
-        final ByteArrayOutputStream itemOut = new ByteArrayOutputStream(256);
-        int depth = 0;
-        int targetItemDepth = -1;
-        int itemStart = -1;
-        int itemLastEmitted = -1;
-        boolean awaitingIdValue = false;
-
-        final BufferedInputStream in = new BufferedInputStream(new ByteArrayInputStream(jsonBytes));
-        try (JsonParser parser = parserFactory.createParser(in))
-        {
-            while (true)
-            {
-                final long beforeOffset = parser.getLocation().getStreamOffset();
-                if (!parser.hasNext())
-                {
-                    break;
-                }
-                final long afterOffset = parser.getLocation().getStreamOffset();
-                final JsonParser.Event ev = parser.next();
-                switch (ev)
-                {
-                case START_OBJECT:
-                    depth++;
-                    if (depth == targetItemDepth)
-                    {
-                        // first byte of the item is the `{` at afterOffset - 1
-                        itemStart = (int) (afterOffset - 1);
-                        itemLastEmitted = itemStart;
-                        itemOut.reset();
-                    }
-                    break;
-                case START_ARRAY:
-                    depth++;
-                    break;
-                case END_OBJECT:
-                    if (depth == targetItemDepth && itemStart >= 0)
-                    {
-                        // emit any tail since the last splice through the closing `}`
-                        itemOut.write(jsonBytes, itemLastEmitted, (int) afterOffset - itemLastEmitted);
-                        emitter.emit(itemOut.toByteArray(), 0, itemOut.size(), traceId);
-                        itemStart = -1;
-                        itemLastEmitted = -1;
-                    }
-                    depth--;
-                    break;
-                case END_ARRAY:
-                    depth--;
-                    break;
-                case KEY_NAME:
-                    final String key = parser.getString();
-                    if (depth == 1 && arrayKey.equals(key))
-                    {
-                        // upcoming START_ARRAY at depth 2; items are at depth 3
-                        targetItemDepth = 3;
-                    }
-                    else if (depth == targetItemDepth && idKey.equals(key))
-                    {
-                        awaitingIdValue = true;
-                    }
-                    break;
-                case VALUE_STRING:
-                    if (awaitingIdValue)
-                    {
-                        awaitingIdValue = false;
-                        if (itemStart >= 0 && prefixBytes.length > 0)
-                        {
-                            int openingQuote = (int) beforeOffset;
-                            while (openingQuote < (int) afterOffset && jsonBytes[openingQuote] != '"')
-                            {
-                                openingQuote++;
-                            }
-                            final int contentStart = openingQuote + 1;
-                            // emit bytes from item start up to and including opening quote
-                            itemOut.write(jsonBytes, itemLastEmitted, contentStart - itemLastEmitted);
-                            // splice in the prefix
-                            itemOut.write(prefixBytes, 0, prefixBytes.length);
-                            itemLastEmitted = contentStart;
-                        }
-                    }
-                    break;
-                default:
-                    break;
-                }
-            }
-        }
     }
 
     private MessageConsumer newStream(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -557,7 +557,7 @@ public final class McpProxyFactory implements McpStreamFactory
             }
             final McpBeginExFW beginEx = builder.build();
 
-            sender = openStream(this::onClientMessage, server.originId, resolvedId, initialId,
+            sender = newStream(this::onClientMessage, server.originId, resolvedId, initialId,
                 traceId, server.authorization, server.affinity, beginEx);
             state = McpState.openingInitial(state);
         }
@@ -960,7 +960,7 @@ public final class McpProxyFactory implements McpStreamFactory
                 .lifecycle(l -> l.sessionId(sid).capabilities(clientCapabilities))
                 .build();
 
-            sender = openStream(this::onClientMessage, session.originId, exit.exitId, initialId,
+            sender = newStream(this::onClientMessage, session.originId, exit.exitId, initialId,
                 traceId, session.authorization, session.affinity, beginEx);
             state = McpState.openingInitial(state);
         }
@@ -1094,6 +1094,38 @@ public final class McpProxyFactory implements McpStreamFactory
         };
     }
 
+    private MessageConsumer newStream(
+        MessageConsumer sender,
+        long originId,
+        long routedId,
+        long streamId,
+        long traceId,
+        long authorization,
+        long affinity,
+        Flyweight extension)
+    {
+        final BeginFW begin = beginRW.wrap(writeBuffer, 0, writeBuffer.capacity())
+            .originId(originId)
+            .routedId(routedId)
+            .streamId(streamId)
+            .sequence(0)
+            .acknowledge(0)
+            .maximum(0)
+            .traceId(traceId)
+            .authorization(authorization)
+            .affinity(affinity)
+            .extension(extension.buffer(), extension.offset(), extension.sizeof())
+            .build();
+
+        final MessageConsumer receiver =
+            streamFactory.newStream(begin.typeId(), begin.buffer(), begin.offset(), begin.sizeof(), sender);
+        assert receiver != null;
+
+        receiver.accept(begin.typeId(), begin.buffer(), begin.offset(), begin.sizeof());
+
+        return receiver;
+    }
+
     private void doBegin(
         MessageConsumer receiver,
         long originId,
@@ -1118,35 +1150,6 @@ public final class McpProxyFactory implements McpStreamFactory
             .build();
 
         receiver.accept(begin.typeId(), begin.buffer(), begin.offset(), begin.sizeof());
-    }
-
-    private MessageConsumer openStream(
-        MessageConsumer sender,
-        long originId,
-        long routedId,
-        long streamId,
-        long traceId,
-        long authorization,
-        long affinity,
-        Flyweight extension)
-    {
-        final BeginFW begin = beginRW.wrap(writeBuffer, 0, writeBuffer.capacity())
-            .originId(originId)
-            .routedId(routedId)
-            .streamId(streamId)
-            .sequence(0)
-            .acknowledge(0)
-            .maximum(0)
-            .traceId(traceId)
-            .authorization(authorization)
-            .affinity(affinity)
-            .extension(extension.buffer(), extension.offset(), extension.sizeof())
-            .build();
-
-        final MessageConsumer receiver = streamFactory.newStream(
-            begin.typeId(), begin.buffer(), begin.offset(), begin.sizeof(), sender);
-        receiver.accept(begin.typeId(), begin.buffer(), begin.offset(), begin.sizeof());
-        return receiver;
     }
 
     private void doData(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -1351,6 +1351,13 @@ public final class McpProxyFactory implements McpStreamFactory
         }
     }
 
+    private static final JsonParserFactory TOOLS_LIST_ITEM_PARSER_FACTORY = StreamingJson.createParserFactory(
+        Map.of(StreamingJson.PATH_INCLUDES, List.of("/tools/-/name")));
+    private static final JsonParserFactory PROMPTS_LIST_ITEM_PARSER_FACTORY = StreamingJson.createParserFactory(
+        Map.of(StreamingJson.PATH_INCLUDES, List.of("/prompts/-/name")));
+    private static final JsonParserFactory RESOURCES_LIST_ITEM_PARSER_FACTORY = StreamingJson.createParserFactory(
+        Map.of(StreamingJson.PATH_INCLUDES, List.of("/resources/-/uri")));
+
     private static final byte[] LIST_REPLY_TOOLS_OPEN = "{\"tools\":[".getBytes(StandardCharsets.UTF_8);
     private static final byte[] LIST_REPLY_PROMPTS_OPEN = "{\"prompts\":[".getBytes(StandardCharsets.UTF_8);
     private static final byte[] LIST_REPLY_RESOURCES_OPEN = "{\"resources\":[".getBytes(StandardCharsets.UTF_8);
@@ -1677,22 +1684,29 @@ public final class McpProxyFactory implements McpStreamFactory
         long traceId,
         ListItemEmitter emitter)
     {
-        final String arrayKey = switch (beginKind)
+        final String arrayKey;
+        final String idKey;
+        final JsonParserFactory parserFactory;
+        switch (beginKind)
         {
-        case KIND_TOOLS_LIST -> "tools";
-        case KIND_PROMPTS_LIST -> "prompts";
-        case KIND_RESOURCES_LIST -> "resources";
-        default -> null;
-        };
-        if (arrayKey == null)
-        {
+        case KIND_TOOLS_LIST:
+            arrayKey = "tools";
+            idKey = "name";
+            parserFactory = TOOLS_LIST_ITEM_PARSER_FACTORY;
+            break;
+        case KIND_PROMPTS_LIST:
+            arrayKey = "prompts";
+            idKey = "name";
+            parserFactory = PROMPTS_LIST_ITEM_PARSER_FACTORY;
+            break;
+        case KIND_RESOURCES_LIST:
+            arrayKey = "resources";
+            idKey = "uri";
+            parserFactory = RESOURCES_LIST_ITEM_PARSER_FACTORY;
+            break;
+        default:
             return;
         }
-        final String idKey = beginKind == KIND_RESOURCES_LIST ? "uri" : "name";
-        final String idPath = "/" + arrayKey + "/-/" + idKey;
-        final JsonParserFactory factory = StreamingJson.createParserFactory(Map.of(
-            StreamingJson.PATH_INCLUDES, List.of(idPath),
-            StreamingJson.TOKEN_MAX_BYTES, jsonBytes.length));
         final byte[] prefixBytes = prefix.getBytes(StandardCharsets.UTF_8);
 
         final ByteArrayOutputStream itemOut = new ByteArrayOutputStream(256);
@@ -1703,7 +1717,7 @@ public final class McpProxyFactory implements McpStreamFactory
         boolean awaitingIdValue = false;
 
         final BufferedInputStream in = new BufferedInputStream(new ByteArrayInputStream(jsonBytes));
-        try (JsonParser parser = factory.createParser(in))
+        try (JsonParser parser = parserFactory.createParser(in))
         {
             while (true)
             {

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -23,7 +23,6 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeg
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
 
-import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -79,7 +78,6 @@ public final class McpProxyFactory implements McpStreamFactory
     private final ResetFW resetRO = new ResetFW();
     private final McpBeginExFW mcpBeginExRO = new McpBeginExFW();
     private final OctetsFW emptyRO = new OctetsFW().wrap(new UnsafeBuffer(), 0, 0);
-    private final UnsafeBuffer itemRO = new UnsafeBuffer(0, 0);
     private final DirectBufferInputStreamEx inputRO = new DirectBufferInputStreamEx();
     private final DirectBuffer listReplyToolsOpenRO =
         new UnsafeBuffer("{\"tools\":[".getBytes(StandardCharsets.UTF_8));
@@ -1389,6 +1387,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private final long resolvedId;
         private final String prefix;
         private final byte[] prefixBytes;
+        private final DirectBuffer prefixBufferRO;
         private final McpLifecycleClient lifecycle;
         private final long initialId;
         private final long replyId;
@@ -1408,18 +1407,15 @@ public final class McpProxyFactory implements McpStreamFactory
         private int replyMax;
         private int replyPad;
 
-        // streaming JSON state — built lazily on first DATA frame
         private JsonParser decodableJson;
-        private ByteArrayOutputStream itemOut;
-        private byte[] itemTransferBuffer;
-        private long parserBaseOffset;            // absolute streamOffset of buffer[offset] passed to decode
+        private long decodedParserProgress;       // absolute streamOffset of buffer[offset] passed to decode
         private int decodeDepth;                  // JSON nesting depth in the reply envelope
         private int decodeItemDepth;              // JSON nesting depth within the current item
         private int decodeSkipDepth;              // JSON nesting depth within a skipped value
         private boolean awaitingIdValue;
         private long itemStartStreamOffset = -1;
-        private long itemLastEmittedStreamOffset = -1;
-        private McpListClientDecoder decoder;
+        private long itemEmittedStreamOffset = -1;
+        private McpListClientDecoder decoder = decodeInit;
         private String arrayKey;
         private String idKey;
 
@@ -1432,6 +1428,7 @@ public final class McpProxyFactory implements McpStreamFactory
             this.resolvedId = resolvedId;
             this.prefix = prefix;
             this.prefixBytes = prefix.getBytes(StandardCharsets.UTF_8);
+            this.prefixBufferRO = new UnsafeBuffer(prefixBytes);
             this.lifecycle = server.lifecycle.supplyClient(resolvedId);
             this.initialId = supplyInitialId.applyAsLong(resolvedId);
             this.replyId = supplyReplyId.applyAsLong(initialId);
@@ -1700,35 +1697,11 @@ public final class McpProxyFactory implements McpStreamFactory
             int offset,
             int limit)
         {
-            if (decodableJson == null)
+            if (decodableJson != null)
             {
-                final JsonParserFactory parserFactory = switch (server.kind)
-                {
-                case KIND_TOOLS_LIST -> toolsListItemParserFactory;
-                case KIND_PROMPTS_LIST -> promptsListItemParserFactory;
-                case KIND_RESOURCES_LIST -> resourcesListItemParserFactory;
-                default -> null;
-                };
-                if (parserFactory == null)
-                {
-                    return;
-                }
-                decodableJson = parserFactory.createParser(inputRO);
-                itemOut = new ByteArrayOutputStream(256);
-                itemTransferBuffer = new byte[bufferPool.slotCapacity()];
-                arrayKey = switch (server.kind)
-                {
-                case KIND_TOOLS_LIST -> "tools";
-                case KIND_PROMPTS_LIST -> "prompts";
-                case KIND_RESOURCES_LIST -> "resources";
-                default -> null;
-                };
-                idKey = server.kind == KIND_RESOURCES_LIST ? "uri" : "name";
-                decoder = decodeReply;
+                final int delta = (int) (decodableJson.getLocation().getStreamOffset() - decodedParserProgress);
+                inputRO.wrap(buffer, offset + delta, limit - offset - delta);
             }
-
-            final int delta = (int) (decodableJson.getLocation().getStreamOffset() - parserBaseOffset);
-            inputRO.wrap(buffer, offset + delta, limit - offset - delta);
 
             McpListClientDecoder previous = null;
             int progress = offset;
@@ -1742,11 +1715,11 @@ public final class McpProxyFactory implements McpStreamFactory
             final int compactBoundaryInBuf;
             if (itemStartStreamOffset >= 0)
             {
-                compactBoundaryInBuf = offset + (int) (itemStartStreamOffset - parserBaseOffset);
+                compactBoundaryInBuf = offset + (int) (itemEmittedStreamOffset - decodedParserProgress);
             }
             else
             {
-                compactBoundaryInBuf = offset + (int) (decodableJson.getLocation().getStreamOffset() - parserBaseOffset);
+                compactBoundaryInBuf = offset + (int) (decodableJson.getLocation().getStreamOffset() - decodedParserProgress);
             }
 
             if (compactBoundaryInBuf < limit)
@@ -1771,12 +1744,12 @@ public final class McpProxyFactory implements McpStreamFactory
                 }
                 slot.putBytes(0, buffer, compactBoundaryInBuf, retained);
                 replySlotOffset = retained;
-                parserBaseOffset += compactBoundaryInBuf - offset;
+                decodedParserProgress += compactBoundaryInBuf - offset;
             }
             else
             {
                 cleanupClientSlot();
-                parserBaseOffset += compactBoundaryInBuf - offset;
+                decodedParserProgress += compactBoundaryInBuf - offset;
             }
         }
 
@@ -1806,12 +1779,53 @@ public final class McpProxyFactory implements McpStreamFactory
             int limit);
     }
 
+    private final McpListClientDecoder decodeInit = this::decodeInit;
     private final McpListClientDecoder decodeReply = this::decodeReply;
     private final McpListClientDecoder decodeItemsKey = this::decodeItemsKey;
     private final McpListClientDecoder decodeSkipObject = this::decodeSkipObject;
     private final McpListClientDecoder decodeItems = this::decodeItems;
     private final McpListClientDecoder decodeItem = this::decodeItem;
     private final McpListClientDecoder decodeIgnore = this::decodeIgnore;
+
+    private int decodeInit(
+        McpListClient client,
+        long traceId,
+        long authorization,
+        long budgetId,
+        int reserved,
+        DirectBuffer buffer,
+        int offset,
+        int progress,
+        int limit)
+    {
+        final JsonParserFactory parserFactory = switch (client.server.kind)
+        {
+        case KIND_TOOLS_LIST -> toolsListItemParserFactory;
+        case KIND_PROMPTS_LIST -> promptsListItemParserFactory;
+        case KIND_RESOURCES_LIST -> resourcesListItemParserFactory;
+        default -> null;
+        };
+
+        if (parserFactory == null)
+        {
+            client.decoder = decodeIgnore;
+            return limit;
+        }
+
+        inputRO.wrap(buffer, progress, limit - progress);
+        client.decodableJson = parserFactory.createParser(inputRO);
+        client.arrayKey = switch (client.server.kind)
+        {
+        case KIND_TOOLS_LIST -> "tools";
+        case KIND_PROMPTS_LIST -> "prompts";
+        case KIND_RESOURCES_LIST -> "resources";
+        default -> null;
+        };
+        client.idKey = client.server.kind == KIND_RESOURCES_LIST ? "uri" : "name";
+        client.decoder = decodeReply;
+
+        return progress;
+    }
 
     private int decodeReply(
         McpListClient client,
@@ -1838,7 +1852,7 @@ public final class McpProxyFactory implements McpStreamFactory
             }
         }
 
-        return offset + (int) (parser.getLocation().getStreamOffset() - client.parserBaseOffset);
+        return offset + (int) (parser.getLocation().getStreamOffset() - client.decodedParserProgress);
     }
 
     private int decodeItemsKey(
@@ -1889,7 +1903,7 @@ public final class McpProxyFactory implements McpStreamFactory
             }
         }
 
-        return offset + (int) (parser.getLocation().getStreamOffset() - client.parserBaseOffset);
+        return offset + (int) (parser.getLocation().getStreamOffset() - client.decodedParserProgress);
     }
 
     private int decodeSkipObject(
@@ -1940,7 +1954,7 @@ public final class McpProxyFactory implements McpStreamFactory
             }
         }
 
-        return offset + (int) (parser.getLocation().getStreamOffset() - client.parserBaseOffset);
+        return offset + (int) (parser.getLocation().getStreamOffset() - client.decodedParserProgress);
     }
 
     private int decodeItems(
@@ -1968,7 +1982,7 @@ public final class McpProxyFactory implements McpStreamFactory
             }
         }
 
-        return offset + (int) (parser.getLocation().getStreamOffset() - client.parserBaseOffset);
+        return offset + (int) (parser.getLocation().getStreamOffset() - client.decodedParserProgress);
     }
 
     private int decodeItem(
@@ -2000,8 +2014,8 @@ public final class McpProxyFactory implements McpStreamFactory
                 if (client.decodeItemDepth == 0)
                 {
                     client.itemStartStreamOffset = afterStreamOffset - 1;
-                    client.itemLastEmittedStreamOffset = client.itemStartStreamOffset;
-                    client.itemOut.reset();
+                    client.itemEmittedStreamOffset = client.itemStartStreamOffset;
+                    client.server.streamItemBegin(traceId);
                 }
                 client.decodeItemDepth++;
                 break;
@@ -2012,15 +2026,13 @@ public final class McpProxyFactory implements McpStreamFactory
                 client.decodeItemDepth--;
                 if (client.decodeItemDepth == 0 && client.itemStartStreamOffset >= 0)
                 {
-                    final int afterInBuf = offset + (int) (afterStreamOffset - client.parserBaseOffset);
-                    final int lastEmittedInBuf =
-                        offset + (int) (client.itemLastEmittedStreamOffset - client.parserBaseOffset);
-                    final int len = afterInBuf - lastEmittedInBuf;
-                    buffer.getBytes(lastEmittedInBuf, client.itemTransferBuffer, 0, len);
-                    client.itemOut.write(client.itemTransferBuffer, 0, len);
-                    client.server.streamItem(client.itemOut.toByteArray(), 0, client.itemOut.size(), traceId);
+                    final int afterInBuf = offset + (int) (afterStreamOffset - client.decodedParserProgress);
+                    final int emittedInBuf =
+                        offset + (int) (client.itemEmittedStreamOffset - client.decodedParserProgress);
+                    client.server.streamItemChunk(buffer, emittedInBuf, afterInBuf - emittedInBuf, traceId);
+                    client.server.streamItemEnd(traceId);
                     client.itemStartStreamOffset = -1;
-                    client.itemLastEmittedStreamOffset = -1;
+                    client.itemEmittedStreamOffset = -1;
                 }
                 break;
             case END_ARRAY:
@@ -2042,22 +2054,20 @@ public final class McpProxyFactory implements McpStreamFactory
                 if (client.awaitingIdValue && client.itemStartStreamOffset >= 0 && client.prefixBytes.length > 0)
                 {
                     client.awaitingIdValue = false;
-                    final int beforeInBuf = offset + (int) (beforeStreamOffset - client.parserBaseOffset);
-                    final int afterInBuf = offset + (int) (afterStreamOffset - client.parserBaseOffset);
+                    final int beforeInBuf = offset + (int) (beforeStreamOffset - client.decodedParserProgress);
+                    final int afterInBuf = offset + (int) (afterStreamOffset - client.decodedParserProgress);
                     int openingQuote = beforeInBuf;
                     while (openingQuote < afterInBuf && buffer.getByte(openingQuote) != (byte) '"')
                     {
                         openingQuote++;
                     }
                     final int contentStart = openingQuote + 1;
-                    final int lastEmittedInBuf =
-                        offset + (int) (client.itemLastEmittedStreamOffset - client.parserBaseOffset);
-                    final int len = contentStart - lastEmittedInBuf;
-                    buffer.getBytes(lastEmittedInBuf, client.itemTransferBuffer, 0, len);
-                    client.itemOut.write(client.itemTransferBuffer, 0, len);
-                    client.itemOut.write(client.prefixBytes, 0, client.prefixBytes.length);
-                    client.itemLastEmittedStreamOffset =
-                        client.parserBaseOffset + (long) (contentStart - offset);
+                    final int emittedInBuf =
+                        offset + (int) (client.itemEmittedStreamOffset - client.decodedParserProgress);
+                    client.server.streamItemChunk(buffer, emittedInBuf, contentStart - emittedInBuf, traceId);
+                    client.server.streamItemChunk(client.prefixBufferRO, 0, client.prefixBytes.length, traceId);
+                    client.itemEmittedStreamOffset =
+                        client.decodedParserProgress + (long) (contentStart - offset);
                 }
                 else if (client.awaitingIdValue)
                 {
@@ -2069,7 +2079,7 @@ public final class McpProxyFactory implements McpStreamFactory
             }
         }
 
-        return offset + (int) (parser.getLocation().getStreamOffset() - client.parserBaseOffset);
+        return offset + (int) (parser.getLocation().getStreamOffset() - client.decodedParserProgress);
     }
 
     private int decodeIgnore(
@@ -2302,10 +2312,7 @@ public final class McpProxyFactory implements McpStreamFactory
             }
         }
 
-        private void streamItem(
-            byte[] item,
-            int offset,
-            int length,
+        private void streamItemBegin(
             long traceId)
         {
             if (itemsEmitted > 0)
@@ -2313,9 +2320,21 @@ public final class McpProxyFactory implements McpStreamFactory
                 doServerData(traceId, 0L, 0x03, listReplySeparatorRO.capacity(),
                     listReplySeparatorRO, 0, listReplySeparatorRO.capacity());
             }
-            itemRO.wrap(item, offset, length);
-            doServerData(traceId, 0L, 0x03, length, itemRO, 0, length);
             itemsEmitted++;
+        }
+
+        private void streamItemChunk(
+            DirectBuffer buffer,
+            int offset,
+            int length,
+            long traceId)
+        {
+            doServerData(traceId, 0L, 0x03, length, buffer, offset, length);
+        }
+
+        private void streamItemEnd(
+            long traceId)
+        {
         }
 
         private void doEncodeBeginItems(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -143,6 +143,7 @@ public final class McpProxyFactory implements McpStreamFactory
                 final int beginKind = beginEx.kind();
                 final String sessionId = sessionId(beginEx);
                 final String identifier = route.strip(beginEx);
+                final int capabilities = beginKind == KIND_LIFECYCLE ? beginEx.lifecycle().capabilities() : 0;
 
                 newStream = new McpServer(
                     sender,
@@ -154,7 +155,8 @@ public final class McpProxyFactory implements McpStreamFactory
                     authorization,
                     beginKind,
                     sessionId,
-                    identifier)::onServerMessage;
+                    identifier,
+                    capabilities)::onServerMessage;
             }
         }
 
@@ -174,6 +176,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private final int beginKind;
         private final String sessionId;
         private final String identifier;
+        private final int capabilities;
 
         private int state;
 
@@ -187,7 +190,8 @@ public final class McpProxyFactory implements McpStreamFactory
             long authorization,
             int beginKind,
             String sessionId,
-            String identifier)
+            String identifier,
+            int capabilities)
         {
             this.sender = sender;
             this.originId = originId;
@@ -199,6 +203,7 @@ public final class McpProxyFactory implements McpStreamFactory
             this.beginKind = beginKind;
             this.sessionId = sessionId;
             this.identifier = identifier;
+            this.capabilities = capabilities;
             this.client = new McpClient(this, resolvedId);
         }
 
@@ -415,13 +420,14 @@ public final class McpProxyFactory implements McpStreamFactory
 
             final String sessionId = server.sessionId;
             final String identifier = server.identifier;
+            final int capabilities = server.capabilities;
             final McpBeginExFW.Builder builder = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId);
             switch (server.beginKind)
             {
             case KIND_LIFECYCLE -> builder
-                .lifecycle(l -> l.sessionId(sessionId));
+                .lifecycle(l -> l.sessionId(sessionId).capabilities(capabilities));
             case KIND_TOOLS_LIST -> builder
                 .toolsList(t -> t.sessionId(sessionId));
             case KIND_TOOLS_CALL -> builder

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -154,10 +154,10 @@ public final class McpProxyFactory implements McpStreamFactory
 
         MessageConsumer newStream = null;
 
-        if (binding != null && extension.sizeof() > 0)
+        final McpBeginExFW beginEx = extension.get(mcpBeginExRO::tryWrap);
+
+        if (binding != null && beginEx != null)
         {
-            final McpBeginExFW beginEx = mcpBeginExRO.wrap(
-                extension.buffer(), extension.offset(), extension.limit());
             final int kind = beginEx.kind();
             final String sessionId = sessionId(beginEx);
 
@@ -727,9 +727,9 @@ public final class McpProxyFactory implements McpStreamFactory
 
             state = McpState.openedInitial(state);
 
-            final Flyweight replyExtension = extension.sizeof() > 0
-                ? rewriteReplyBeginEx(mcpBeginExRO.wrap(
-                    extension.buffer(), extension.offset(), extension.limit()))
+            final McpBeginExFW beginEx = extension.get(mcpBeginExRO::tryWrap);
+            final Flyweight replyExtension = beginEx != null
+                ? rewriteReplyBeginEx(beginEx)
                 : emptyRO;
 
             server.doServerBegin(traceId, replyExtension);
@@ -1268,14 +1268,10 @@ public final class McpProxyFactory implements McpStreamFactory
 
             state = McpState.openedInitial(state);
 
-            if (extension.sizeof() > 0)
+            final McpBeginExFW beginEx = extension.get(mcpBeginExRO::tryWrap);
+            if (beginEx != null && beginEx.kind() == KIND_LIFECYCLE)
             {
-                final McpBeginExFW beginEx = mcpBeginExRO.wrap(
-                    extension.buffer(), extension.offset(), extension.limit());
-                if (beginEx.kind() == KIND_LIFECYCLE)
-                {
-                    sessionId = beginEx.lifecycle().sessionId().asString();
-                }
+                sessionId = beginEx.lifecycle().sessionId().asString();
             }
 
             replyMax = writeBuffer.capacity();

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -478,20 +478,20 @@ public final class McpProxyFactory implements McpStreamFactory
             final String outboundSessionId = upstreamSessionId != null
                 ? upstreamSessionId
                 : server.sessionId();
-            final McpBeginExFW.Builder builder = mcpBeginExRW
+            final McpBeginExFW beginEx = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
-                .typeId(mcpTypeId);
-            switch (server.kind)
-            {
-            case KIND_TOOLS_CALL -> builder
-                .toolsCall(t -> t.sessionId(outboundSessionId).name(identifier));
-            case KIND_PROMPTS_GET -> builder
-                .promptsGet(p -> p.sessionId(outboundSessionId).name(identifier));
-            case KIND_RESOURCES_READ -> builder
-                .resourcesRead(r -> r.sessionId(outboundSessionId).uri(identifier));
-            default -> throw new IllegalStateException("unexpected McpBeginEx kind: " + server.kind);
-            }
-            final McpBeginExFW beginEx = builder.build();
+                .typeId(mcpTypeId)
+                .inject(b ->
+                {
+                    switch (server.kind)
+                    {
+                    case KIND_TOOLS_CALL -> b.toolsCall(t -> t.sessionId(outboundSessionId).name(identifier));
+                    case KIND_PROMPTS_GET -> b.promptsGet(p -> p.sessionId(outboundSessionId).name(identifier));
+                    case KIND_RESOURCES_READ -> b.resourcesRead(r -> r.sessionId(outboundSessionId).uri(identifier));
+                    default -> throw new IllegalStateException("unexpected McpBeginEx kind: " + server.kind);
+                    }
+                })
+                .build();
 
             sender = newStream(this::onClientMessage, server.lifecycle.originId, resolvedId, initialId,
                 traceId, server.authorization, server.affinity, beginEx);
@@ -613,29 +613,30 @@ public final class McpProxyFactory implements McpStreamFactory
         private Flyweight rewriteReplyBeginEx(
             McpBeginExFW beginEx)
         {
-            final String sid = server.sessionId();
-            final McpBeginExFW.Builder builder = mcpBeginExRW
-                .wrap(codecBuffer, 0, codecBuffer.capacity())
-                .typeId(mcpTypeId);
-
-            switch (beginEx.kind())
+            final int kind = beginEx.kind();
+            if (kind != KIND_TOOLS_CALL && kind != KIND_PROMPTS_GET && kind != KIND_RESOURCES_READ)
             {
-            case KIND_TOOLS_CALL:
-                final String toolName = beginEx.toolsCall().name().asString();
-                builder.toolsCall(t -> t.sessionId(sid).name(toolName));
-                break;
-            case KIND_PROMPTS_GET:
-                final String promptName = beginEx.promptsGet().name().asString();
-                builder.promptsGet(p -> p.sessionId(sid).name(promptName));
-                break;
-            case KIND_RESOURCES_READ:
-                final String uri = beginEx.resourcesRead().uri().asString();
-                builder.resourcesRead(r -> r.sessionId(sid).uri(uri));
-                break;
-            default:
                 return beginEx;
             }
-            return builder.build();
+
+            final String sid = server.sessionId();
+            return mcpBeginExRW
+                .wrap(codecBuffer, 0, codecBuffer.capacity())
+                .typeId(mcpTypeId)
+                .inject(b ->
+                {
+                    switch (kind)
+                    {
+                    case KIND_TOOLS_CALL ->
+                        b.toolsCall(t -> t.sessionId(sid).name(beginEx.toolsCall().name().asString()));
+                    case KIND_PROMPTS_GET ->
+                        b.promptsGet(p -> p.sessionId(sid).name(beginEx.promptsGet().name().asString()));
+                    case KIND_RESOURCES_READ ->
+                        b.resourcesRead(r -> r.sessionId(sid).uri(beginEx.resourcesRead().uri().asString()));
+                    default -> throw new IllegalStateException("unexpected McpBeginEx kind: " + kind);
+                    }
+                })
+                .build();
         }
 
         private void onClientData(
@@ -1057,17 +1058,20 @@ public final class McpProxyFactory implements McpStreamFactory
 
             final String upstreamSessionId = lifecycle.sessionId;
             final String sid = upstreamSessionId != null ? upstreamSessionId : server.lifecycle.sessionId;
-            final McpBeginExFW.Builder builder = mcpBeginExRW
+            final McpBeginExFW beginEx = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
-                .typeId(mcpTypeId);
-            switch (server.kind)
-            {
-            case KIND_TOOLS_LIST -> builder.toolsList(t -> t.sessionId(sid));
-            case KIND_PROMPTS_LIST -> builder.promptsList(p -> p.sessionId(sid));
-            case KIND_RESOURCES_LIST -> builder.resourcesList(r -> r.sessionId(sid));
-            default -> throw new IllegalStateException("unexpected list kind: " + server.kind);
-            }
-            final McpBeginExFW beginEx = builder.build();
+                .typeId(mcpTypeId)
+                .inject(b ->
+                {
+                    switch (server.kind)
+                    {
+                    case KIND_TOOLS_LIST -> b.toolsList(t -> t.sessionId(sid));
+                    case KIND_PROMPTS_LIST -> b.promptsList(p -> p.sessionId(sid));
+                    case KIND_RESOURCES_LIST -> b.resourcesList(r -> r.sessionId(sid));
+                    default -> throw new IllegalStateException("unexpected list kind: " + server.kind);
+                    }
+                })
+                .build();
 
             sender = newStream(this::onClientMessage, server.lifecycle.originId, resolvedId, initialId,
                 traceId, server.authorization, server.affinity, beginEx);
@@ -1820,17 +1824,20 @@ public final class McpProxyFactory implements McpStreamFactory
             long traceId)
         {
             final String sid = lifecycle.sessionId;
-            final McpBeginExFW.Builder builder = mcpBeginExRW
+            final McpBeginExFW beginEx = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
-                .typeId(mcpTypeId);
-            switch (kind)
-            {
-            case KIND_TOOLS_LIST -> builder.toolsList(t -> t.sessionId(sid));
-            case KIND_PROMPTS_LIST -> builder.promptsList(p -> p.sessionId(sid));
-            case KIND_RESOURCES_LIST -> builder.resourcesList(r -> r.sessionId(sid));
-            default -> throw new IllegalStateException("unexpected list kind: " + kind);
-            }
-            final McpBeginExFW beginEx = builder.build();
+                .typeId(mcpTypeId)
+                .inject(b ->
+                {
+                    switch (kind)
+                    {
+                    case KIND_TOOLS_LIST -> b.toolsList(t -> t.sessionId(sid));
+                    case KIND_PROMPTS_LIST -> b.promptsList(p -> p.sessionId(sid));
+                    case KIND_RESOURCES_LIST -> b.resourcesList(r -> r.sessionId(sid));
+                    default -> throw new IllegalStateException("unexpected list kind: " + kind);
+                    }
+                })
+                .build();
 
             doBegin(lifecycle.sender, lifecycle.originId, lifecycle.routedId, replyId, traceId, authorization,
                 affinity, beginEx);

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -444,7 +444,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
         private void doServerBegin(
             long traceId,
-            OctetsFW extension)
+            Flyweight extension)
         {
             doBegin(sender, originId, routedId, replyId, traceId, authorization, affinity, extension);
             state = McpState.openedReply(state);
@@ -668,7 +668,55 @@ public final class McpProxyFactory implements McpStreamFactory
 
             state = McpState.openedInitial(state);
 
-            server.doServerBegin(traceId, extension);
+            final Flyweight replyExtension = extension.sizeof() > 0
+                ? rewriteReplyBeginEx(mcpBeginExRO.wrap(
+                    extension.buffer(), extension.offset(), extension.limit()))
+                : emptyRO;
+
+            server.doServerBegin(traceId, replyExtension);
+        }
+
+        private Flyweight rewriteReplyBeginEx(
+            McpBeginExFW beginEx)
+        {
+            final String sid = server.sessionId;
+            final McpBeginExFW.Builder builder = mcpBeginExRW
+                .wrap(codecBuffer, 0, codecBuffer.capacity())
+                .typeId(mcpTypeId);
+
+            return switch (beginEx.kind())
+            {
+            case KIND_LIFECYCLE ->
+            {
+                final int caps = beginEx.lifecycle().capabilities();
+                yield builder.lifecycle(l -> l.sessionId(sid).capabilities(caps)).build();
+            }
+            case KIND_TOOLS_LIST -> builder
+                .toolsList(t -> t.sessionId(sid))
+                .build();
+            case KIND_TOOLS_CALL ->
+            {
+                final String name = beginEx.toolsCall().name().asString();
+                yield builder.toolsCall(t -> t.sessionId(sid).name(name)).build();
+            }
+            case KIND_PROMPTS_LIST -> builder
+                .promptsList(p -> p.sessionId(sid))
+                .build();
+            case KIND_PROMPTS_GET ->
+            {
+                final String name = beginEx.promptsGet().name().asString();
+                yield builder.promptsGet(p -> p.sessionId(sid).name(name)).build();
+            }
+            case KIND_RESOURCES_LIST -> builder
+                .resourcesList(r -> r.sessionId(sid))
+                .build();
+            case KIND_RESOURCES_READ ->
+            {
+                final String uri = beginEx.resourcesRead().uri().asString();
+                yield builder.resourcesRead(r -> r.sessionId(sid).uri(uri)).build();
+            }
+            default -> beginEx;
+            };
         }
 
         private void onClientData(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -1131,7 +1131,6 @@ public final class McpProxyFactory implements McpStreamFactory
         private int state;
         private int replySlot = NO_SLOT;
         private int replySlotOffset;
-        private boolean completed;
 
         private McpListClient(
             McpListServer server,
@@ -1150,7 +1149,7 @@ public final class McpProxyFactory implements McpStreamFactory
             long traceId)
         {
             doClientBegin(traceId);
-            if (server.endReceived)
+            if (McpState.initialClosed(server.state))
             {
                 doClientEnd(traceId);
             }
@@ -1160,9 +1159,9 @@ public final class McpProxyFactory implements McpStreamFactory
         public void doServerReset(
             long traceId)
         {
-            if (!completed)
+            if (!McpState.replyClosed(state))
             {
-                completed = true;
+                state = McpState.closedReply(state);
                 server.clientFailed(this, traceId);
             }
         }
@@ -1283,10 +1282,9 @@ public final class McpProxyFactory implements McpStreamFactory
             EndFW end)
         {
             final long traceId = end.traceId();
-            state = McpState.closedReply(state);
-            if (!completed)
+            if (!McpState.replyClosed(state))
             {
-                completed = true;
+                state = McpState.closedReply(state);
                 final byte[] reply = bufferedClientReply();
                 cleanupClientSlot();
                 server.clientDone(this, reply, traceId);
@@ -1297,11 +1295,10 @@ public final class McpProxyFactory implements McpStreamFactory
             AbortFW abort)
         {
             final long traceId = abort.traceId();
-            state = McpState.closedReply(state);
-            cleanupClientSlot();
-            if (!completed)
+            if (!McpState.replyClosed(state))
             {
-                completed = true;
+                state = McpState.closedReply(state);
+                cleanupClientSlot();
                 server.clientFailed(this, traceId);
             }
         }
@@ -1311,9 +1308,9 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long traceId = reset.traceId();
             state = McpState.closedInitial(state);
-            if (!completed)
+            if (!McpState.replyClosed(state))
             {
-                completed = true;
+                state = McpState.closedReply(state);
                 server.clientFailed(this, traceId);
             }
         }
@@ -1376,7 +1373,6 @@ public final class McpProxyFactory implements McpStreamFactory
         private final Deque<McpListClient> remaining;
 
         private int state;
-        private boolean endReceived;
         private int itemsEmitted;
         private McpListClient currentClient;
 
@@ -1462,7 +1458,6 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long traceId = end.traceId();
             state = McpState.closedInitial(state);
-            endReceived = true;
 
             if (currentClient != null && McpState.initialOpened(currentClient.state))
             {
@@ -1475,7 +1470,6 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long traceId = abort.traceId();
             state = McpState.closedInitial(state);
-            endReceived = true;
 
             if (currentClient != null)
             {

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -158,10 +158,10 @@ public final class McpProxyFactory implements McpStreamFactory
                     session.affinity = affinity;
                     session.clientCapabilities = beginEx.lifecycle().capabilities();
 
-                    final McpInboundLifecycle inboundLifecycle = new McpInboundLifecycle(
+                    final McpLifecycleServer lifecycle = new McpLifecycleServer(
                         sender, originId, routedId, initialId, affinity, authorization, session, binding);
-                    session.lifecycle = inboundLifecycle;
-                    newStream = inboundLifecycle::onServerMessage;
+                    session.lifecycle = lifecycle;
+                    newStream = lifecycle::onServerMessage;
                 }
                 else
                 {
@@ -203,7 +203,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private long authorization;
         private long affinity;
         private int clientCapabilities;
-        private McpInboundLifecycle lifecycle;
+        private McpLifecycleServer lifecycle;
 
         private McpSession(
             String sessionId)
@@ -230,7 +230,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
         private int state;
         private String exitSessionId;
-        private McpOutboundLifecycle lifecycle;
+        private McpLifecycleClient lifecycle;
 
         private McpExit(
             long exitId)
@@ -348,7 +348,7 @@ public final class McpProxyFactory implements McpStreamFactory
                 if (exit.state == McpExit.UNINITIALIZED)
                 {
                     exit.state = McpExit.OPENING;
-                    exit.lifecycle = new McpOutboundLifecycle(exit, session);
+                    exit.lifecycle = new McpLifecycleClient(exit, session);
                     exit.lifecycle.doClientBegin(traceId);
                 }
             }
@@ -775,7 +775,7 @@ public final class McpProxyFactory implements McpStreamFactory
         }
     }
 
-    private final class McpInboundLifecycle
+    private final class McpLifecycleServer
     {
         private final MessageConsumer sender;
         private final long originId;
@@ -789,7 +789,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
         private int state;
 
-        private McpInboundLifecycle(
+        private McpLifecycleServer(
             MessageConsumer sender,
             long originId,
             long routedId,
@@ -929,7 +929,7 @@ public final class McpProxyFactory implements McpStreamFactory
         }
     }
 
-    private final class McpOutboundLifecycle
+    private final class McpLifecycleClient
     {
         private final McpExit exit;
         private final McpSession session;
@@ -939,7 +939,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
         private int state;
 
-        private McpOutboundLifecycle(
+        private McpLifecycleClient(
             McpExit exit,
             McpSession session)
         {
@@ -1175,9 +1175,9 @@ public final class McpProxyFactory implements McpStreamFactory
             .maximum(0)
             .traceId(traceId)
             .authorization(authorization)
+            .flags(flags)
             .budgetId(budgetId)
             .reserved(reserved)
-            .flags(flags)
             .payload(payload, offset, length)
             .build();
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -23,7 +23,9 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeg
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -37,8 +39,10 @@ import jakarta.json.JsonArray;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonPointer;
 import jakarta.json.JsonReader;
 import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonParser;
 
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -59,6 +63,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.FlushFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.ResetFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.WindowFW;
+import io.aklivity.zilla.runtime.common.json.StreamingJson;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
@@ -1721,37 +1726,85 @@ public final class McpProxyFactory implements McpStreamFactory
         case KIND_RESOURCES_LIST -> "resources";
         default -> null;
         };
-        final String idKey = beginKind == KIND_RESOURCES_LIST ? "uri" : "name";
-
-        byte[] result = jsonBytes;
-        if (arrayKey != null)
+        if (prefix.isEmpty() || arrayKey == null)
         {
-            try (JsonReader reader = Json.createReader(new ByteArrayInputStream(jsonBytes)))
+            return jsonBytes;
+        }
+        final String idKey = beginKind == KIND_RESOURCES_LIST ? "uri" : "name";
+        final JsonPointer idPath = Json.createPointer("/" + arrayKey + "/-/" + idKey);
+        final Map<String, ?> config = Map.of(
+            StreamingJson.PATH_INCLUDES, List.of(idPath),
+            StreamingJson.TOKEN_MAX_BYTES, jsonBytes.length);
+
+        final ByteArrayOutputStream out = new ByteArrayOutputStream(jsonBytes.length + 64);
+        final byte[] prefixBytes = prefix.getBytes(StandardCharsets.UTF_8);
+        int lastEmitted = 0;
+        boolean awaitingIdValue = false;
+        int depth = 0;
+        int targetItemDepth = -1;
+
+        final BufferedInputStream in = new BufferedInputStream(new ByteArrayInputStream(jsonBytes));
+        try (JsonParser parser = StreamingJson.createParser(in, config))
+        {
+            while (true)
             {
-                final JsonObject root = reader.readObject();
-                final JsonArray items = root.getJsonArray(arrayKey);
-                if (items != null)
+                final long beforeOffset = parser.getLocation().getStreamOffset();
+                if (!parser.hasNext())
                 {
-                    final JsonArrayBuilder transformed = Json.createArrayBuilder();
-                    for (JsonValue item : items)
+                    break;
+                }
+                final long afterOffset = parser.getLocation().getStreamOffset();
+                final JsonParser.Event ev = parser.next();
+                switch (ev)
+                {
+                case START_OBJECT:
+                case START_ARRAY:
+                    depth++;
+                    break;
+                case END_OBJECT:
+                case END_ARRAY:
+                    depth--;
+                    break;
+                case KEY_NAME:
+                    final String key = parser.getString();
+                    if (depth == 1 && arrayKey.equals(key))
                     {
-                        final JsonObject obj = item.asJsonObject();
-                        final JsonObjectBuilder builder = Json.createObjectBuilder(obj);
-                        final String oldId = obj.containsKey(idKey) ? obj.getString(idKey) : null;
-                        if (oldId != null)
-                        {
-                            builder.add(idKey, prefix + oldId);
-                        }
-                        transformed.add(builder.build());
+                        // next event will be START_ARRAY of the items array; items live at depth == 3
+                        targetItemDepth = 3;
                     }
-                    final JsonObjectBuilder rootBuilder = Json.createObjectBuilder(root);
-                    rootBuilder.add(arrayKey, transformed.build());
-                    result = rootBuilder.build().toString().getBytes(StandardCharsets.UTF_8);
+                    else if (depth == targetItemDepth && idKey.equals(key))
+                    {
+                        awaitingIdValue = true;
+                    }
+                    break;
+                case VALUE_STRING:
+                    if (awaitingIdValue)
+                    {
+                        awaitingIdValue = false;
+                        // bytes [beforeOffset..afterOffset) span ":<ws>\"<content>\"" — find opening quote
+                        int openingQuote = (int) beforeOffset;
+                        while (openingQuote < (int) afterOffset && jsonBytes[openingQuote] != '"')
+                        {
+                            openingQuote++;
+                        }
+                        final int contentStart = openingQuote + 1;
+                        // emit verbatim up to and including opening quote
+                        out.write(jsonBytes, lastEmitted, contentStart - lastEmitted);
+                        // splice prefix
+                        out.write(prefixBytes, 0, prefixBytes.length);
+                        // continue with original content + closing quote
+                        out.write(jsonBytes, contentStart, (int) afterOffset - contentStart);
+                        lastEmitted = (int) afterOffset;
+                    }
+                    break;
+                default:
+                    break;
                 }
             }
         }
-
-        return result;
+        // emit any trailing bytes (typically empty for well-formed JSON)
+        out.write(jsonBytes, lastEmitted, jsonBytes.length - lastEmitted);
+        return out.toByteArray();
     }
 
     private static byte[] mergeListReplies(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -66,6 +66,10 @@ public final class McpProxyFactory implements McpStreamFactory
 {
     private static final String MCP_TYPE_NAME = "mcp";
 
+    private static final List<String> TOOLS_LIST_ITEM_JSON_PATH_INCLUDES = List.of("/tools/-/name");
+    private static final List<String> PROMPTS_LIST_ITEM_JSON_PATH_INCLUDES = List.of("/prompts/-/name");
+    private static final List<String> RESOURCES_LIST_ITEM_JSON_PATH_INCLUDES = List.of("/resources/-/uri");
+
     private final BeginFW beginRO = new BeginFW();
     private final DataFW dataRO = new DataFW();
     private final EndFW endRO = new EndFW();
@@ -98,6 +102,10 @@ public final class McpProxyFactory implements McpStreamFactory
     private final Long2ObjectHashMap<McpBindingConfig> bindings;
     private final Map<String, McpLifecycleServer> sessions;
 
+    private final JsonParserFactory toolsListItemParserFactory;
+    private final JsonParserFactory promptsListItemParserFactory;
+    private final JsonParserFactory resourcesListItemParserFactory;
+
     public McpProxyFactory(
         McpConfiguration config,
         EngineContext context)
@@ -111,6 +119,12 @@ public final class McpProxyFactory implements McpStreamFactory
         this.bindings = new Long2ObjectHashMap<>();
         this.sessions = new Object2ObjectHashMap<>();
         this.mcpTypeId = context.supplyTypeId(MCP_TYPE_NAME);
+        this.toolsListItemParserFactory = StreamingJson.createParserFactory(
+            Map.of(StreamingJson.PATH_INCLUDES, TOOLS_LIST_ITEM_JSON_PATH_INCLUDES));
+        this.promptsListItemParserFactory = StreamingJson.createParserFactory(
+            Map.of(StreamingJson.PATH_INCLUDES, PROMPTS_LIST_ITEM_JSON_PATH_INCLUDES));
+        this.resourcesListItemParserFactory = StreamingJson.createParserFactory(
+            Map.of(StreamingJson.PATH_INCLUDES, RESOURCES_LIST_ITEM_JSON_PATH_INCLUDES));
     }
 
     @Override
@@ -1680,9 +1694,9 @@ public final class McpProxyFactory implements McpStreamFactory
             {
                 final JsonParserFactory parserFactory = switch (server.kind)
                 {
-                case KIND_TOOLS_LIST -> TOOLS_LIST_ITEM_PARSER_FACTORY;
-                case KIND_PROMPTS_LIST -> PROMPTS_LIST_ITEM_PARSER_FACTORY;
-                case KIND_RESOURCES_LIST -> RESOURCES_LIST_ITEM_PARSER_FACTORY;
+                case KIND_TOOLS_LIST -> toolsListItemParserFactory;
+                case KIND_PROMPTS_LIST -> promptsListItemParserFactory;
+                case KIND_RESOURCES_LIST -> resourcesListItemParserFactory;
                 default -> null;
                 };
                 if (parserFactory == null)
@@ -2061,13 +2075,6 @@ public final class McpProxyFactory implements McpStreamFactory
     {
         return limit;
     }
-
-    private static final JsonParserFactory TOOLS_LIST_ITEM_PARSER_FACTORY = StreamingJson.createParserFactory(
-        Map.of(StreamingJson.PATH_INCLUDES, List.of("/tools/-/name")));
-    private static final JsonParserFactory PROMPTS_LIST_ITEM_PARSER_FACTORY = StreamingJson.createParserFactory(
-        Map.of(StreamingJson.PATH_INCLUDES, List.of("/prompts/-/name")));
-    private static final JsonParserFactory RESOURCES_LIST_ITEM_PARSER_FACTORY = StreamingJson.createParserFactory(
-        Map.of(StreamingJson.PATH_INCLUDES, List.of("/resources/-/uri")));
 
     private static final DirectBuffer LIST_REPLY_TOOLS_OPEN_RO =
         new UnsafeBuffer("{\"tools\":[".getBytes(StandardCharsets.UTF_8));

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -1775,6 +1775,16 @@ public final class McpProxyFactory implements McpStreamFactory
             }
         }
 
+        private void decodeFromSlot(
+            long traceId)
+        {
+            if (replySlot != NO_SLOT)
+            {
+                final MutableDirectBuffer slot = bufferPool.buffer(replySlot);
+                decode(traceId, server.authorization, 0L, 0, slot, 0, replySlotOffset);
+            }
+        }
+
         private void cleanupClientSlot()
         {
             if (replySlot != NO_SLOT)
@@ -2288,6 +2298,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
             if (client != null)
             {
+                client.decodeFromSlot(traceId);
                 client.flushClientWindow(traceId, budgetId, padding, replySeq - replyAck, replyMax);
             }
         }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -1006,7 +1006,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private void doClientEnd(
             long traceId)
         {
-            if (sender != null && !McpState.initialClosed(state))
+            if (!McpState.initialClosed(state))
             {
                 final McpLifecycleServer server = session.lifecycle;
                 doEnd(sender, server.originId, exit.exitId, initialId, traceId, server.authorization);
@@ -1194,7 +1194,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private void doClientEnd(
             long traceId)
         {
-            if (sender != null && !McpState.initialClosed(state))
+            if (!McpState.initialClosed(state))
             {
                 doEnd(sender, server.originId, resolvedId, initialId,
                     traceId, server.authorization);
@@ -1205,7 +1205,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private void doClientAbort(
             long traceId)
         {
-            if (sender != null && !McpState.initialClosed(state))
+            if (!McpState.initialClosed(state))
             {
                 doAbort(sender, server.originId, resolvedId, initialId,
                     traceId, server.authorization);
@@ -1216,7 +1216,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private void doClientReset(
             long traceId)
         {
-            if (sender != null && !McpState.replyClosed(state))
+            if (!McpState.replyClosed(state))
             {
                 doReset(sender, server.originId, resolvedId, replyId,
                     traceId, server.authorization);
@@ -1475,10 +1475,7 @@ public final class McpProxyFactory implements McpStreamFactory
             {
                 currentClient.doClientAbort(traceId);
             }
-            for (final McpListClient queued : remaining)
-            {
-                queued.doClientAbort(traceId);
-            }
+            // queued clients have not opened an upstream stream — drop them
             remaining.clear();
         }
 
@@ -1492,10 +1489,7 @@ public final class McpProxyFactory implements McpStreamFactory
             {
                 currentClient.doClientReset(traceId);
             }
-            for (final McpListClient queued : remaining)
-            {
-                queued.doClientReset(traceId);
-            }
+            // queued clients have not opened an upstream stream — drop them
             remaining.clear();
         }
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -150,8 +150,11 @@ public final class McpProxyFactory implements McpStreamFactory
                 final McpSession session = lifecycle
                     ? sessions.computeIfAbsent(sessionId, McpSession::new)
                     : sessions.get(sessionId);
+                final McpExit exit = session != null
+                    ? (lifecycle ? session.supplyExit(route.id) : session.exits.get(route.id))
+                    : null;
 
-                if (session != null)
+                if (exit != null)
                 {
                     final String identifier = route.strip(beginEx);
                     final int capabilities = lifecycle ? beginEx.lifecycle().capabilities() : 0;
@@ -168,7 +171,8 @@ public final class McpProxyFactory implements McpStreamFactory
                         sessionId,
                         identifier,
                         capabilities,
-                        session)::onServerMessage;
+                        session,
+                        exit)::onServerMessage;
                 }
             }
         }
@@ -179,11 +183,31 @@ public final class McpProxyFactory implements McpStreamFactory
     private final class McpSession
     {
         private final String sessionId;
+        private final Long2ObjectHashMap<McpExit> exits;
 
         private McpSession(
             String sessionId)
         {
             this.sessionId = sessionId;
+            this.exits = new Long2ObjectHashMap<>();
+        }
+
+        private McpExit supplyExit(
+            long exitId)
+        {
+            return exits.computeIfAbsent(exitId, McpExit::new);
+        }
+    }
+
+    private static final class McpExit
+    {
+        private final long exitId;
+        private String exitSessionId;
+
+        private McpExit(
+            long exitId)
+        {
+            this.exitId = exitId;
         }
     }
 
@@ -202,6 +226,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private final String identifier;
         private final int capabilities;
         private final McpSession session;
+        private final McpExit exit;
 
         private int state;
 
@@ -217,7 +242,8 @@ public final class McpProxyFactory implements McpStreamFactory
             String sessionId,
             String identifier,
             int capabilities,
-            McpSession session)
+            McpSession session,
+            McpExit exit)
         {
             this.sender = sender;
             this.originId = originId;
@@ -231,6 +257,7 @@ public final class McpProxyFactory implements McpStreamFactory
             this.identifier = identifier;
             this.capabilities = capabilities;
             this.session = session;
+            this.exit = exit;
             this.client = new McpClient(this, resolvedId);
         }
 
@@ -455,28 +482,31 @@ public final class McpProxyFactory implements McpStreamFactory
             sender = streamFactory.newStream(BeginFW.TYPE_ID, writeBuffer, 0, 0, this::onClientMessage);
             assert sender != null;
 
-            final String sessionId = server.sessionId;
             final String identifier = server.identifier;
             final int capabilities = server.capabilities;
+            final boolean lifecycle = server.beginKind == KIND_LIFECYCLE;
+            final String outboundSessionId = lifecycle || server.exit.exitSessionId == null
+                ? server.sessionId
+                : server.exit.exitSessionId;
             final McpBeginExFW.Builder builder = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId);
             switch (server.beginKind)
             {
             case KIND_LIFECYCLE -> builder
-                .lifecycle(l -> l.sessionId(sessionId).capabilities(capabilities));
+                .lifecycle(l -> l.sessionId(outboundSessionId).capabilities(capabilities));
             case KIND_TOOLS_LIST -> builder
-                .toolsList(t -> t.sessionId(sessionId));
+                .toolsList(t -> t.sessionId(outboundSessionId));
             case KIND_TOOLS_CALL -> builder
-                .toolsCall(t -> t.sessionId(sessionId).name(identifier));
+                .toolsCall(t -> t.sessionId(outboundSessionId).name(identifier));
             case KIND_PROMPTS_LIST -> builder
-                .promptsList(p -> p.sessionId(sessionId));
+                .promptsList(p -> p.sessionId(outboundSessionId));
             case KIND_PROMPTS_GET -> builder
-                .promptsGet(p -> p.sessionId(sessionId).name(identifier));
+                .promptsGet(p -> p.sessionId(outboundSessionId).name(identifier));
             case KIND_RESOURCES_LIST -> builder
-                .resourcesList(r -> r.sessionId(sessionId));
+                .resourcesList(r -> r.sessionId(outboundSessionId));
             case KIND_RESOURCES_READ -> builder
-                .resourcesRead(r -> r.sessionId(sessionId).uri(identifier));
+                .resourcesRead(r -> r.sessionId(outboundSessionId).uri(identifier));
             default -> throw new IllegalStateException("unexpected McpBeginEx kind: " + server.beginKind);
             }
             final McpBeginExFW beginEx = builder.build();
@@ -589,6 +619,16 @@ public final class McpProxyFactory implements McpStreamFactory
             final OctetsFW extension = begin.extension();
 
             state = McpState.openedInitial(state);
+
+            if (server.beginKind == KIND_LIFECYCLE && extension.sizeof() > 0)
+            {
+                final McpBeginExFW beginEx = mcpBeginExRO.wrap(
+                    extension.buffer(), extension.offset(), extension.limit());
+                if (beginEx.kind() == KIND_LIFECYCLE)
+                {
+                    server.exit.exitSessionId = beginEx.lifecycle().sessionId().asString();
+                }
+            }
 
             server.doServerBegin(traceId, extension);
         }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -410,11 +410,8 @@ public final class McpProxyFactory implements McpStreamFactory
             final int reserved = data.reserved();
             final OctetsFW payload = data.payload();
 
-            if (!McpState.closed(state) && payload != null)
-            {
-                client.doClientData(traceId, budgetId, flags, reserved,
-                    payload.buffer(), payload.offset(), payload.sizeof());
-            }
+            client.doClientData(traceId, budgetId, flags, reserved,
+                payload.buffer(), payload.offset(), payload.sizeof());
         }
 
         private void onServerEnd(
@@ -424,10 +421,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
             state = McpState.closedInitial(state);
 
-            if (!McpState.closed(state))
-            {
-                client.doClientEnd(traceId);
-            }
+            client.doClientEnd(traceId);
 
             if (beginKind == KIND_LIFECYCLE)
             {
@@ -442,10 +436,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
             state = McpState.closedInitial(state);
 
-            if (!McpState.closed(state))
-            {
-                client.doClientAbort(traceId);
-            }
+            client.doClientAbort(traceId);
 
             if (beginKind == KIND_LIFECYCLE)
             {
@@ -764,11 +755,8 @@ public final class McpProxyFactory implements McpStreamFactory
             final int reserved = data.reserved();
             final OctetsFW payload = data.payload();
 
-            if (payload != null)
-            {
-                server.doServerData(traceId, budgetId, flags, reserved,
-                    payload.buffer(), payload.offset(), payload.sizeof());
-            }
+            server.doServerData(traceId, budgetId, flags, reserved,
+                payload.buffer(), payload.offset(), payload.sizeof());
         }
 
         private void onClientEnd(
@@ -1135,6 +1123,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private JsonParser parser;
         private DirectBufferInputStreamEx jsonInput;
         private ByteArrayOutputStream itemOut;
+        private byte[] itemTransferBuffer;
         private long parserBaseOffset;       // absolute streamOffset of slot[0]
         private int depth;
         private int itemDepth = -1;          // depth at which target items live, set on START_ARRAY
@@ -1284,19 +1273,16 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onClientData(
             DataFW data)
         {
+            final long traceId = data.traceId();
             final OctetsFW payload = data.payload();
-            if (payload != null)
+            final boolean appended = appendToSlot(payload);
+            if (!appended)
             {
-                final long traceId = data.traceId();
-                final boolean appended = appendToSlot(payload);
-                if (!appended)
-                {
-                    state = McpState.closedReply(state);
-                    server.clientFailed(this, traceId);
-                    return;
-                }
-                streamItems(traceId);
+                state = McpState.closedReply(state);
+                server.clientFailed(this, traceId);
+                return;
             }
+            streamItems(traceId);
         }
 
         private void onClientEnd(
@@ -1375,6 +1361,7 @@ public final class McpProxyFactory implements McpStreamFactory
                 jsonInput = new DirectBufferInputStreamEx();
                 parser = parserFactory.createParser(jsonInput);
                 itemOut = new ByteArrayOutputStream(256);
+                itemTransferBuffer = new byte[bufferPool.slotCapacity()];
             }
 
             final MutableDirectBuffer slotBuffer = bufferPool.buffer(replySlot);
@@ -1426,9 +1413,9 @@ public final class McpProxyFactory implements McpStreamFactory
                     if (depth == itemDepth && itemStartStreamOffset >= 0)
                     {
                         final int itemLastEmittedInSlot = (int) (itemLastEmittedStreamOffset - parserBaseOffset);
-                        slotBuffer.getBytes(itemLastEmittedInSlot, itemBuffer(),
+                        slotBuffer.getBytes(itemLastEmittedInSlot, itemTransferBuffer,
                             0, afterInSlot - itemLastEmittedInSlot);
-                        itemOut.write(itemBuffer(), 0, afterInSlot - itemLastEmittedInSlot);
+                        itemOut.write(itemTransferBuffer, 0, afterInSlot - itemLastEmittedInSlot);
                         server.streamItem(itemOut.toByteArray(), 0, itemOut.size(), traceId);
                         itemStartStreamOffset = -1;
                         itemLastEmittedStreamOffset = -1;
@@ -1467,9 +1454,9 @@ public final class McpProxyFactory implements McpStreamFactory
                         final int contentStart = openingQuote + 1;
                         final int itemLastEmittedInSlot = (int) (itemLastEmittedStreamOffset - parserBaseOffset);
                         // emit verbatim up to and including opening quote
-                        slotBuffer.getBytes(itemLastEmittedInSlot, itemBuffer(),
+                        slotBuffer.getBytes(itemLastEmittedInSlot, itemTransferBuffer,
                             0, contentStart - itemLastEmittedInSlot);
-                        itemOut.write(itemBuffer(), 0, contentStart - itemLastEmittedInSlot);
+                        itemOut.write(itemTransferBuffer, 0, contentStart - itemLastEmittedInSlot);
                         // splice in the prefix
                         itemOut.write(prefixBytes, 0, prefixBytes.length);
                         itemLastEmittedStreamOffset = parserBaseOffset + contentStart;
@@ -1500,18 +1487,6 @@ public final class McpProxyFactory implements McpStreamFactory
                 replySlotOffset -= compactBoundaryInSlot;
                 parserBaseOffset += compactBoundaryInSlot;
             }
-        }
-
-        private byte[] itemTransferBuffer;
-
-        private byte[] itemBuffer()
-        {
-            // grows as needed; reused across items
-            if (itemTransferBuffer == null || itemTransferBuffer.length < bufferPool.slotCapacity())
-            {
-                itemTransferBuffer = new byte[bufferPool.slotCapacity()];
-            }
-            return itemTransferBuffer;
         }
 
         private void cleanupClientSlot()

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -21,11 +21,22 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeg
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_READ;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_CALL;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
+import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Map;
 import java.util.function.LongUnaryOperator;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonValue;
 
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -49,6 +60,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.WindowFW;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.buffer.BufferPool;
 import io.aklivity.zilla.runtime.engine.config.BindingConfig;
 
 public final class McpProxyFactory implements McpStreamFactory
@@ -76,6 +88,7 @@ public final class McpProxyFactory implements McpStreamFactory
     private final MutableDirectBuffer writeBuffer;
     private final MutableDirectBuffer codecBuffer;
     private final BindingHandler streamFactory;
+    private final BufferPool bufferPool;
     private final LongUnaryOperator supplyInitialId;
     private final LongUnaryOperator supplyReplyId;
     private final int mcpTypeId;
@@ -90,6 +103,7 @@ public final class McpProxyFactory implements McpStreamFactory
         this.writeBuffer = context.writeBuffer();
         this.codecBuffer = new UnsafeBuffer(new byte[context.writeBuffer().capacity()]);
         this.streamFactory = context.streamFactory();
+        this.bufferPool = context.bufferPool();
         this.supplyInitialId = context::supplyInitialId;
         this.supplyReplyId = context::supplyReplyId;
         this.bindings = new Long2ObjectHashMap<>();
@@ -170,6 +184,7 @@ public final class McpProxyFactory implements McpStreamFactory
                     {
                         final McpExit exit = session.supplyExit(route.id);
                         final String identifier = route.strip(beginEx);
+                        final String prefix = route.prefix(beginEx);
 
                         newStream = new McpServer(
                             sender,
@@ -182,6 +197,7 @@ public final class McpProxyFactory implements McpStreamFactory
                             beginKind,
                             sessionId,
                             identifier,
+                            prefix,
                             0,
                             session,
                             exit)::onServerMessage;
@@ -253,6 +269,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private final int beginKind;
         private final String sessionId;
         private final String identifier;
+        private final String prefix;
         private final int capabilities;
         private final McpSession session;
         private final McpExit exit;
@@ -270,6 +287,7 @@ public final class McpProxyFactory implements McpStreamFactory
             int beginKind,
             String sessionId,
             String identifier,
+            String prefix,
             int capabilities,
             McpSession session,
             McpExit exit)
@@ -284,6 +302,7 @@ public final class McpProxyFactory implements McpStreamFactory
             this.beginKind = beginKind;
             this.sessionId = sessionId;
             this.identifier = identifier;
+            this.prefix = prefix;
             this.capabilities = capabilities;
             this.session = session;
             this.exit = exit;
@@ -513,6 +532,8 @@ public final class McpProxyFactory implements McpStreamFactory
         private MessageConsumer sender;
 
         private int state;
+        private int replySlot = NO_SLOT;
+        private int replySlotOffset;
 
         private McpClient(
             McpServer server,
@@ -728,8 +749,15 @@ public final class McpProxyFactory implements McpStreamFactory
 
             if (payload != null)
             {
-                server.doServerData(traceId, budgetId, flags, reserved,
-                    payload.buffer(), payload.offset(), payload.sizeof());
+                if (transformsList())
+                {
+                    bufferReplyPayload(payload);
+                }
+                else
+                {
+                    server.doServerData(traceId, budgetId, flags, reserved,
+                        payload.buffer(), payload.offset(), payload.sizeof());
+                }
             }
         }
 
@@ -739,6 +767,13 @@ public final class McpProxyFactory implements McpStreamFactory
             final long traceId = end.traceId();
 
             state = McpState.closedReply(state);
+
+            if (transformsList() && replySlot != NO_SLOT)
+            {
+                emitTransformedListReply(traceId);
+            }
+
+            cleanupReplySlot();
 
             server.doServerEnd(traceId);
         }
@@ -750,7 +785,56 @@ public final class McpProxyFactory implements McpStreamFactory
 
             state = McpState.closedReply(state);
 
+            cleanupReplySlot();
+
             server.doServerAbort(traceId);
+        }
+
+        private boolean transformsList()
+        {
+            return !server.prefix.isEmpty() &&
+                (server.beginKind == KIND_TOOLS_LIST ||
+                 server.beginKind == KIND_PROMPTS_LIST ||
+                 server.beginKind == KIND_RESOURCES_LIST);
+        }
+
+        private void bufferReplyPayload(
+            OctetsFW payload)
+        {
+            if (replySlot == NO_SLOT)
+            {
+                replySlot = bufferPool.acquire(initialId);
+            }
+
+            if (replySlot != NO_SLOT)
+            {
+                final MutableDirectBuffer buffer = bufferPool.buffer(replySlot);
+                buffer.putBytes(replySlotOffset, payload.buffer(), payload.offset(), payload.sizeof());
+                replySlotOffset += payload.sizeof();
+            }
+        }
+
+        private void emitTransformedListReply(
+            long traceId)
+        {
+            final byte[] inputBytes = new byte[replySlotOffset];
+            bufferPool.buffer(replySlot).getBytes(0, inputBytes);
+
+            final byte[] outputBytes = applyListPrefix(server.prefix, server.beginKind, inputBytes);
+
+            final UnsafeBuffer outputBuffer = new UnsafeBuffer(outputBytes);
+            server.doServerData(traceId, 0L, 0x03, outputBytes.length,
+                outputBuffer, 0, outputBytes.length);
+        }
+
+        private void cleanupReplySlot()
+        {
+            if (replySlot != NO_SLOT)
+            {
+                bufferPool.release(replySlot);
+                replySlot = NO_SLOT;
+                replySlotOffset = 0;
+            }
         }
 
         private void onClientWindow(
@@ -1092,6 +1176,51 @@ public final class McpProxyFactory implements McpStreamFactory
         case KIND_RESOURCES_READ -> beginEx.resourcesRead().sessionId().asString();
         default -> null;
         };
+    }
+
+    private static byte[] applyListPrefix(
+        String prefix,
+        int beginKind,
+        byte[] jsonBytes)
+    {
+        final String arrayKey = switch (beginKind)
+        {
+        case KIND_TOOLS_LIST -> "tools";
+        case KIND_PROMPTS_LIST -> "prompts";
+        case KIND_RESOURCES_LIST -> "resources";
+        default -> null;
+        };
+        final String idKey = beginKind == KIND_RESOURCES_LIST ? "uri" : "name";
+
+        byte[] result = jsonBytes;
+        if (arrayKey != null)
+        {
+            try (JsonReader reader = Json.createReader(new ByteArrayInputStream(jsonBytes)))
+            {
+                final JsonObject root = reader.readObject();
+                final JsonArray items = root.getJsonArray(arrayKey);
+                if (items != null)
+                {
+                    final JsonArrayBuilder transformed = Json.createArrayBuilder();
+                    for (JsonValue item : items)
+                    {
+                        final JsonObject obj = item.asJsonObject();
+                        final JsonObjectBuilder builder = Json.createObjectBuilder(obj);
+                        final String oldId = obj.containsKey(idKey) ? obj.getString(idKey) : null;
+                        if (oldId != null)
+                        {
+                            builder.add(idKey, prefix + oldId);
+                        }
+                        transformed.add(builder.build());
+                    }
+                    final JsonObjectBuilder rootBuilder = Json.createObjectBuilder(root);
+                    rootBuilder.add(arrayKey, transformed.build());
+                    result = rootBuilder.build().toString().getBytes(StandardCharsets.UTF_8);
+                }
+            }
+        }
+
+        return result;
     }
 
     private MessageConsumer newStream(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -1,0 +1,702 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
+
+import java.util.function.LongUnaryOperator;
+
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.collections.Long2ObjectHashMap;
+
+import io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration;
+import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpBindingConfig;
+import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpRouteConfig;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.OctetsFW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.AbortFW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.BeginFW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.DataFW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.EndFW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.FlushFW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.ResetFW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.WindowFW;
+import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
+import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.config.BindingConfig;
+
+public final class McpProxyFactory implements McpStreamFactory
+{
+    private static final String MCP_TYPE_NAME = "mcp";
+
+    private final BeginFW beginRO = new BeginFW();
+    private final DataFW dataRO = new DataFW();
+    private final EndFW endRO = new EndFW();
+    private final AbortFW abortRO = new AbortFW();
+    private final FlushFW flushRO = new FlushFW();
+    private final WindowFW windowRO = new WindowFW();
+    private final ResetFW resetRO = new ResetFW();
+    private final McpBeginExFW mcpBeginExRO = new McpBeginExFW();
+
+    private final BeginFW.Builder beginRW = new BeginFW.Builder();
+    private final DataFW.Builder dataRW = new DataFW.Builder();
+    private final EndFW.Builder endRW = new EndFW.Builder();
+    private final AbortFW.Builder abortRW = new AbortFW.Builder();
+    private final WindowFW.Builder windowRW = new WindowFW.Builder();
+    private final ResetFW.Builder resetRW = new ResetFW.Builder();
+
+    private final MutableDirectBuffer writeBuffer;
+    private final BindingHandler streamFactory;
+    private final LongUnaryOperator supplyInitialId;
+    private final LongUnaryOperator supplyReplyId;
+    private final int mcpTypeId;
+
+    private final Long2ObjectHashMap<McpBindingConfig> bindings;
+
+    public McpProxyFactory(
+        McpConfiguration config,
+        EngineContext context)
+    {
+        this.writeBuffer = context.writeBuffer();
+        this.streamFactory = context.streamFactory();
+        this.supplyInitialId = context::supplyInitialId;
+        this.supplyReplyId = context::supplyReplyId;
+        this.bindings = new Long2ObjectHashMap<>();
+        this.mcpTypeId = context.supplyTypeId(MCP_TYPE_NAME);
+    }
+
+    @Override
+    public int originTypeId()
+    {
+        return mcpTypeId;
+    }
+
+    @Override
+    public void attach(
+        BindingConfig binding)
+    {
+        McpBindingConfig newBinding = new McpBindingConfig(binding);
+        bindings.put(binding.id, newBinding);
+    }
+
+    @Override
+    public void detach(
+        long bindingId)
+    {
+        bindings.remove(bindingId);
+    }
+
+    @Override
+    public MessageConsumer newStream(
+        int msgTypeId,
+        DirectBuffer buffer,
+        int index,
+        int length,
+        MessageConsumer sender)
+    {
+        final BeginFW begin = beginRO.wrap(buffer, index, index + length);
+        final long originId = begin.originId();
+        final long routedId = begin.routedId();
+        final long initialId = begin.streamId();
+        final long affinity = begin.affinity();
+        final long authorization = begin.authorization();
+        final OctetsFW extension = begin.extension();
+
+        final McpBindingConfig binding = bindings.get(routedId);
+
+        MessageConsumer newStream = null;
+
+        if (binding != null && extension.sizeof() > 0)
+        {
+            final McpBeginExFW beginEx = mcpBeginExRO.wrap(
+                extension.buffer(), extension.offset(), extension.limit());
+            final McpRouteConfig route = binding.resolve(beginEx, authorization);
+
+            if (route != null)
+            {
+                newStream = new McpServer(
+                    sender,
+                    originId,
+                    routedId,
+                    initialId,
+                    route.id,
+                    affinity,
+                    authorization)::onServerMessage;
+            }
+        }
+
+        return newStream;
+    }
+
+    private final class McpServer
+    {
+        private final MessageConsumer sender;
+        private final long originId;
+        private final long routedId;
+        private final long initialId;
+        private final long replyId;
+        private final long affinity;
+        private final long authorization;
+        private final McpClient client;
+
+        private int state;
+
+        private McpServer(
+            MessageConsumer sender,
+            long originId,
+            long routedId,
+            long initialId,
+            long resolvedId,
+            long affinity,
+            long authorization)
+        {
+            this.sender = sender;
+            this.originId = originId;
+            this.routedId = routedId;
+            this.initialId = initialId;
+            this.replyId = supplyReplyId.applyAsLong(initialId);
+            this.affinity = affinity;
+            this.authorization = authorization;
+            this.client = new McpClient(this, resolvedId);
+        }
+
+        private void onServerMessage(
+            int msgTypeId,
+            DirectBuffer buffer,
+            int index,
+            int length)
+        {
+            switch (msgTypeId)
+            {
+            case BeginFW.TYPE_ID:
+                final BeginFW begin = beginRO.wrap(buffer, index, index + length);
+                onServerBegin(begin);
+                break;
+            case DataFW.TYPE_ID:
+                final DataFW data = dataRO.wrap(buffer, index, index + length);
+                onServerData(data);
+                break;
+            case EndFW.TYPE_ID:
+                final EndFW end = endRO.wrap(buffer, index, index + length);
+                onServerEnd(end);
+                break;
+            case AbortFW.TYPE_ID:
+                final AbortFW abort = abortRO.wrap(buffer, index, index + length);
+                onServerAbort(abort);
+                break;
+            case FlushFW.TYPE_ID:
+                final FlushFW flush = flushRO.wrap(buffer, index, index + length);
+                onServerFlush(flush);
+                break;
+            case WindowFW.TYPE_ID:
+                final WindowFW window = windowRO.wrap(buffer, index, index + length);
+                onServerWindow(window);
+                break;
+            case ResetFW.TYPE_ID:
+                final ResetFW reset = resetRO.wrap(buffer, index, index + length);
+                onServerReset(reset);
+                break;
+            default:
+                break;
+            }
+        }
+
+        private void onServerBegin(
+            BeginFW begin)
+        {
+            final long traceId = begin.traceId();
+
+            state = McpState.openingInitial(state);
+
+            client.doClientBegin(traceId);
+
+            doWindow(sender, originId, routedId, replyId, traceId, authorization, 0,
+                writeBuffer.capacity(), 0);
+        }
+
+        private void onServerData(
+            DataFW data)
+        {
+            final long traceId = data.traceId();
+            final long budgetId = data.budgetId();
+            final int flags = data.flags();
+            final int reserved = data.reserved();
+            final OctetsFW payload = data.payload();
+
+            if (!McpState.closed(state) && payload != null)
+            {
+                client.doClientData(traceId, budgetId, flags, reserved,
+                    payload.buffer(), payload.offset(), payload.sizeof());
+            }
+        }
+
+        private void onServerEnd(
+            EndFW end)
+        {
+            final long traceId = end.traceId();
+
+            state = McpState.closedInitial(state);
+
+            if (!McpState.closed(state))
+            {
+                client.doClientEnd(traceId);
+            }
+        }
+
+        private void onServerAbort(
+            AbortFW abort)
+        {
+            final long traceId = abort.traceId();
+
+            state = McpState.closedInitial(state);
+
+            if (!McpState.closed(state))
+            {
+                client.doClientAbort(traceId);
+            }
+        }
+
+        private void onServerFlush(
+            FlushFW flush)
+        {
+            // pass-through flush — no action required for proxy kind
+        }
+
+        private void onServerWindow(
+            WindowFW window)
+        {
+            final long traceId = window.traceId();
+            final long budgetId = window.budgetId();
+            final int credit = window.maximum();
+            final int padding = window.padding();
+
+            client.doClientWindow(traceId, budgetId, credit, padding);
+        }
+
+        private void onServerReset(
+            ResetFW reset)
+        {
+            final long traceId = reset.traceId();
+
+            state = McpState.closedReply(state);
+
+            client.doClientReset(traceId);
+        }
+
+        private void doServerBeginReply(
+            long traceId)
+        {
+            doBegin(sender, originId, routedId, replyId, traceId, authorization, affinity);
+            state = McpState.openedReply(state);
+        }
+
+        private void doServerData(
+            long traceId,
+            long budgetId,
+            int flags,
+            int reserved,
+            DirectBuffer payload,
+            int offset,
+            int length)
+        {
+            doData(sender, originId, routedId, replyId, traceId, authorization,
+                budgetId, flags, reserved, payload, offset, length);
+        }
+
+        private void doServerEnd(
+            long traceId)
+        {
+            if (!McpState.replyClosed(state))
+            {
+                doEnd(sender, originId, routedId, replyId, traceId, authorization);
+                state = McpState.closedReply(state);
+            }
+        }
+
+        private void doServerAbort(
+            long traceId)
+        {
+            if (!McpState.replyClosed(state))
+            {
+                doAbort(sender, originId, routedId, replyId, traceId, authorization);
+                state = McpState.closedReply(state);
+            }
+        }
+
+        private void doServerWindow(
+            long traceId,
+            long budgetId,
+            int credit,
+            int padding)
+        {
+            doWindow(sender, originId, routedId, initialId, traceId, authorization, budgetId, credit, padding);
+        }
+
+        private void doServerReset(
+            long traceId)
+        {
+            if (!McpState.initialClosed(state))
+            {
+                doReset(sender, originId, routedId, initialId, traceId, authorization);
+                state = McpState.closedInitial(state);
+            }
+        }
+    }
+
+    private final class McpClient
+    {
+        private final McpServer server;
+        private final long resolvedId;
+
+        private long initialId;
+        private long replyId;
+        private MessageConsumer sender;
+
+        private int state;
+
+        private McpClient(
+            McpServer server,
+            long resolvedId)
+        {
+            this.server = server;
+            this.resolvedId = resolvedId;
+        }
+
+        private void doClientBegin(
+            long traceId)
+        {
+            initialId = supplyInitialId.applyAsLong(resolvedId);
+            replyId = supplyReplyId.applyAsLong(initialId);
+            sender = streamFactory.newStream(BeginFW.TYPE_ID, writeBuffer, 0, 0, this::onClientMessage);
+            assert sender != null;
+
+            doBegin(sender, server.originId, resolvedId, initialId,
+                traceId, server.authorization, server.affinity);
+            state = McpState.openingInitial(state);
+        }
+
+        private void doClientData(
+            long traceId,
+            long budgetId,
+            int flags,
+            int reserved,
+            DirectBuffer payload,
+            int offset,
+            int length)
+        {
+            if (!McpState.closed(state))
+            {
+                doData(sender, server.originId, resolvedId, initialId,
+                    traceId, server.authorization, budgetId, flags, reserved, payload, offset, length);
+            }
+        }
+
+        private void doClientEnd(
+            long traceId)
+        {
+            if (!McpState.initialClosed(state))
+            {
+                doEnd(sender, server.originId, resolvedId, initialId,
+                    traceId, server.authorization);
+                state = McpState.closedInitial(state);
+            }
+        }
+
+        private void doClientAbort(
+            long traceId)
+        {
+            if (!McpState.initialClosed(state))
+            {
+                doAbort(sender, server.originId, resolvedId, initialId,
+                    traceId, server.authorization);
+                state = McpState.closedInitial(state);
+            }
+        }
+
+        private void doClientWindow(
+            long traceId,
+            long budgetId,
+            int credit,
+            int padding)
+        {
+            doWindow(sender, server.originId, resolvedId, replyId,
+                traceId, server.authorization, budgetId, credit, padding);
+        }
+
+        private void doClientReset(
+            long traceId)
+        {
+            if (!McpState.replyClosed(state))
+            {
+                doReset(sender, server.originId, resolvedId, replyId,
+                    traceId, server.authorization);
+                state = McpState.closedReply(state);
+            }
+        }
+
+        private void onClientMessage(
+            int msgTypeId,
+            DirectBuffer buffer,
+            int index,
+            int length)
+        {
+            switch (msgTypeId)
+            {
+            case BeginFW.TYPE_ID:
+                final BeginFW begin = beginRO.wrap(buffer, index, index + length);
+                onClientBegin(begin);
+                break;
+            case DataFW.TYPE_ID:
+                final DataFW data = dataRO.wrap(buffer, index, index + length);
+                onClientData(data);
+                break;
+            case EndFW.TYPE_ID:
+                final EndFW end = endRO.wrap(buffer, index, index + length);
+                onClientEnd(end);
+                break;
+            case AbortFW.TYPE_ID:
+                final AbortFW abort = abortRO.wrap(buffer, index, index + length);
+                onClientAbort(abort);
+                break;
+            case WindowFW.TYPE_ID:
+                final WindowFW window = windowRO.wrap(buffer, index, index + length);
+                onClientWindow(window);
+                break;
+            case ResetFW.TYPE_ID:
+                final ResetFW reset = resetRO.wrap(buffer, index, index + length);
+                onClientReset(reset);
+                break;
+            default:
+                break;
+            }
+        }
+
+        private void onClientBegin(
+            BeginFW begin)
+        {
+            final long traceId = begin.traceId();
+
+            state = McpState.openedInitial(state);
+
+            server.doServerBeginReply(traceId);
+        }
+
+        private void onClientData(
+            DataFW data)
+        {
+            final long traceId = data.traceId();
+            final long budgetId = data.budgetId();
+            final int flags = data.flags();
+            final int reserved = data.reserved();
+            final OctetsFW payload = data.payload();
+
+            if (payload != null)
+            {
+                server.doServerData(traceId, budgetId, flags, reserved,
+                    payload.buffer(), payload.offset(), payload.sizeof());
+            }
+        }
+
+        private void onClientEnd(
+            EndFW end)
+        {
+            final long traceId = end.traceId();
+
+            state = McpState.closedReply(state);
+
+            server.doServerEnd(traceId);
+        }
+
+        private void onClientAbort(
+            AbortFW abort)
+        {
+            final long traceId = abort.traceId();
+
+            state = McpState.closedReply(state);
+
+            server.doServerAbort(traceId);
+        }
+
+        private void onClientWindow(
+            WindowFW window)
+        {
+            final long traceId = window.traceId();
+            final long budgetId = window.budgetId();
+            final int credit = window.maximum();
+            final int padding = window.padding();
+
+            server.doServerWindow(traceId, budgetId, credit, padding);
+        }
+
+        private void onClientReset(
+            ResetFW reset)
+        {
+            final long traceId = reset.traceId();
+
+            state = McpState.closedInitial(state);
+
+            server.doServerReset(traceId);
+        }
+    }
+
+    private void doBegin(
+        MessageConsumer receiver,
+        long originId,
+        long routedId,
+        long streamId,
+        long traceId,
+        long authorization,
+        long affinity)
+    {
+        final BeginFW begin = beginRW.wrap(writeBuffer, 0, writeBuffer.capacity())
+            .originId(originId)
+            .routedId(routedId)
+            .streamId(streamId)
+            .sequence(0)
+            .acknowledge(0)
+            .maximum(0)
+            .traceId(traceId)
+            .authorization(authorization)
+            .affinity(affinity)
+            .build();
+
+        receiver.accept(begin.typeId(), begin.buffer(), begin.offset(), begin.sizeof());
+    }
+
+    private void doData(
+        MessageConsumer receiver,
+        long originId,
+        long routedId,
+        long streamId,
+        long traceId,
+        long authorization,
+        long budgetId,
+        int flags,
+        int reserved,
+        DirectBuffer payload,
+        int offset,
+        int length)
+    {
+        final DataFW data = dataRW.wrap(writeBuffer, 0, writeBuffer.capacity())
+            .originId(originId)
+            .routedId(routedId)
+            .streamId(streamId)
+            .sequence(0)
+            .acknowledge(0)
+            .maximum(0)
+            .traceId(traceId)
+            .authorization(authorization)
+            .budgetId(budgetId)
+            .reserved(reserved)
+            .flags(flags)
+            .payload(payload, offset, length)
+            .build();
+
+        receiver.accept(data.typeId(), data.buffer(), data.offset(), data.sizeof());
+    }
+
+    private void doEnd(
+        MessageConsumer receiver,
+        long originId,
+        long routedId,
+        long streamId,
+        long traceId,
+        long authorization)
+    {
+        final EndFW end = endRW.wrap(writeBuffer, 0, writeBuffer.capacity())
+            .originId(originId)
+            .routedId(routedId)
+            .streamId(streamId)
+            .sequence(0)
+            .acknowledge(0)
+            .maximum(0)
+            .traceId(traceId)
+            .authorization(authorization)
+            .build();
+
+        receiver.accept(end.typeId(), end.buffer(), end.offset(), end.sizeof());
+    }
+
+    private void doAbort(
+        MessageConsumer receiver,
+        long originId,
+        long routedId,
+        long streamId,
+        long traceId,
+        long authorization)
+    {
+        final AbortFW abort = abortRW.wrap(writeBuffer, 0, writeBuffer.capacity())
+            .originId(originId)
+            .routedId(routedId)
+            .streamId(streamId)
+            .sequence(0)
+            .acknowledge(0)
+            .maximum(0)
+            .traceId(traceId)
+            .authorization(authorization)
+            .build();
+
+        receiver.accept(abort.typeId(), abort.buffer(), abort.offset(), abort.sizeof());
+    }
+
+    private void doReset(
+        MessageConsumer receiver,
+        long originId,
+        long routedId,
+        long streamId,
+        long traceId,
+        long authorization)
+    {
+        final ResetFW reset = resetRW.wrap(writeBuffer, 0, writeBuffer.capacity())
+            .originId(originId)
+            .routedId(routedId)
+            .streamId(streamId)
+            .sequence(0)
+            .acknowledge(0)
+            .maximum(0)
+            .traceId(traceId)
+            .authorization(authorization)
+            .build();
+
+        receiver.accept(reset.typeId(), reset.buffer(), reset.offset(), reset.sizeof());
+    }
+
+    private void doWindow(
+        MessageConsumer receiver,
+        long originId,
+        long routedId,
+        long streamId,
+        long traceId,
+        long authorization,
+        long budgetId,
+        int credit,
+        int padding)
+    {
+        final WindowFW window = windowRW.wrap(writeBuffer, 0, writeBuffer.capacity())
+            .originId(originId)
+            .routedId(routedId)
+            .streamId(streamId)
+            .sequence(0)
+            .acknowledge(0)
+            .maximum(credit)
+            .traceId(traceId)
+            .authorization(authorization)
+            .budgetId(budgetId)
+            .padding(padding)
+            .build();
+
+        receiver.accept(window.typeId(), window.buffer(), window.offset(), window.sizeof());
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -2176,8 +2176,8 @@ public final class McpProxyFactory implements McpStreamFactory
             {
                 final int decodedKeyOffset = offset + (int) (decodedKeyProgress - client.decodedParserProgress);
                 final int decodedValueOffset = offset + (int) (decodedValueProgress - client.decodedParserProgress);
-                final int openingQuote = indexOfByte(buffer, decodedKeyOffset, decodedValueOffset, (byte) '"');
-                final int decodedContent = (openingQuote != -1 ? openingQuote : decodedValueOffset) + 1;
+                final int decodedOpenQuote = indexOfByte(buffer, decodedKeyOffset, decodedValueOffset, (byte) '"');
+                final int decodedContent = (decodedOpenQuote != -1 ? decodedOpenQuote : decodedValueOffset) + 1;
                 final int decodedOffset =
                     offset + (int) (client.decodedItemProgress - client.decodedParserProgress);
                 client.server.streamItemChunk(buffer, decodedOffset, decodedContent - decodedOffset, traceId);

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -154,10 +154,10 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final McpBeginExFW beginEx = mcpBeginExRO.wrap(
                 extension.buffer(), extension.offset(), extension.limit());
-            final int beginKind = beginEx.kind();
+            final int kind = beginEx.kind();
             final String sessionId = sessionId(beginEx);
 
-            if (beginKind == KIND_LIFECYCLE)
+            if (kind == KIND_LIFECYCLE)
             {
                 final McpRouteConfig route = binding.resolve(beginEx, authorization);
                 if (route != null)
@@ -176,7 +176,7 @@ public final class McpProxyFactory implements McpStreamFactory
                 final McpSession session = sessions.get(sessionId);
                 if (session != null)
                 {
-                    if (isListKind(beginKind))
+                    if (isListKind(kind))
                     {
                         final List<McpRouteConfig> routes = binding.resolveAll(beginEx, authorization);
                         final McpListServer server = new McpListServer(
@@ -186,7 +186,7 @@ public final class McpProxyFactory implements McpStreamFactory
                             initialId,
                             affinity,
                             authorization,
-                            beginKind,
+                            kind,
                             sessionId,
                             session,
                             routes,
@@ -210,7 +210,7 @@ public final class McpProxyFactory implements McpStreamFactory
                                 route.id,
                                 affinity,
                                 authorization,
-                                beginKind,
+                                kind,
                                 sessionId,
                                 identifier,
                                 prefix,
@@ -285,7 +285,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private final long affinity;
         private final long authorization;
         private final McpClient client;
-        private final int beginKind;
+        private final int kind;
         private final String sessionId;
         private final String identifier;
         private final String prefix;
@@ -303,7 +303,7 @@ public final class McpProxyFactory implements McpStreamFactory
             long resolvedId,
             long affinity,
             long authorization,
-            int beginKind,
+            int kind,
             String sessionId,
             String identifier,
             String prefix,
@@ -318,7 +318,7 @@ public final class McpProxyFactory implements McpStreamFactory
             this.replyId = supplyReplyId.applyAsLong(initialId);
             this.affinity = affinity;
             this.authorization = authorization;
-            this.beginKind = beginKind;
+            this.kind = kind;
             this.sessionId = sessionId;
             this.identifier = identifier;
             this.prefix = prefix;
@@ -423,7 +423,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
             client.doClientEnd(traceId);
 
-            if (beginKind == KIND_LIFECYCLE)
+            if (kind == KIND_LIFECYCLE)
             {
                 sessions.remove(session.sessionId);
             }
@@ -438,7 +438,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
             client.doClientAbort(traceId);
 
-            if (beginKind == KIND_LIFECYCLE)
+            if (kind == KIND_LIFECYCLE)
             {
                 sessions.remove(session.sessionId);
             }
@@ -559,14 +559,14 @@ public final class McpProxyFactory implements McpStreamFactory
 
             final String identifier = server.identifier;
             final int capabilities = server.capabilities;
-            final boolean lifecycle = server.beginKind == KIND_LIFECYCLE;
+            final boolean lifecycle = server.kind == KIND_LIFECYCLE;
             final String outboundSessionId = lifecycle || server.exit.sessionId == null
                 ? server.sessionId
                 : server.exit.sessionId;
             final McpBeginExFW.Builder builder = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId);
-            switch (server.beginKind)
+            switch (server.kind)
             {
             case KIND_LIFECYCLE -> builder
                 .lifecycle(l -> l.sessionId(outboundSessionId).capabilities(capabilities));
@@ -582,7 +582,7 @@ public final class McpProxyFactory implements McpStreamFactory
                 .resourcesList(r -> r.sessionId(outboundSessionId));
             case KIND_RESOURCES_READ -> builder
                 .resourcesRead(r -> r.sessionId(outboundSessionId).uri(identifier));
-            default -> throw new IllegalStateException("unexpected McpBeginEx kind: " + server.beginKind);
+            default -> throw new IllegalStateException("unexpected McpBeginEx kind: " + server.kind);
             }
             final McpBeginExFW beginEx = builder.build();
 
@@ -1179,12 +1179,12 @@ public final class McpProxyFactory implements McpStreamFactory
             final McpBeginExFW.Builder builder = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId);
-            switch (server.beginKind)
+            switch (server.kind)
             {
             case KIND_TOOLS_LIST -> builder.toolsList(t -> t.sessionId(sid));
             case KIND_PROMPTS_LIST -> builder.promptsList(p -> p.sessionId(sid));
             case KIND_RESOURCES_LIST -> builder.resourcesList(r -> r.sessionId(sid));
-            default -> throw new IllegalStateException("unexpected list kind: " + server.beginKind);
+            default -> throw new IllegalStateException("unexpected list kind: " + server.kind);
             }
             final McpBeginExFW beginEx = builder.build();
 
@@ -1347,7 +1347,7 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (parser == null)
             {
-                final JsonParserFactory parserFactory = switch (server.beginKind)
+                final JsonParserFactory parserFactory = switch (server.kind)
                 {
                 case KIND_TOOLS_LIST -> TOOLS_LIST_ITEM_PARSER_FACTORY;
                 case KIND_PROMPTS_LIST -> PROMPTS_LIST_ITEM_PARSER_FACTORY;
@@ -1368,8 +1368,8 @@ public final class McpProxyFactory implements McpStreamFactory
             final int parserPosInSlot = (int) (parser.getLocation().getStreamOffset() - parserBaseOffset);
             jsonInput.wrap(slotBuffer, parserPosInSlot, replySlotOffset - parserPosInSlot);
 
-            final String idKey = server.beginKind == KIND_RESOURCES_LIST ? "uri" : "name";
-            final String arrayKey = switch (server.beginKind)
+            final String idKey = server.kind == KIND_RESOURCES_LIST ? "uri" : "name";
+            final String arrayKey = switch (server.kind)
             {
             case KIND_TOOLS_LIST -> "tools";
             case KIND_PROMPTS_LIST -> "prompts";
@@ -1522,7 +1522,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private final long replyId;
         private final long affinity;
         private final long authorization;
-        private final int beginKind;
+        private final int kind;
         private final String sessionId;
         private final McpSession session;
         private final Deque<McpListClient> remaining;
@@ -1538,7 +1538,7 @@ public final class McpProxyFactory implements McpStreamFactory
             long initialId,
             long affinity,
             long authorization,
-            int beginKind,
+            int kind,
             String sessionId,
             McpSession session,
             List<McpRouteConfig> routes,
@@ -1551,7 +1551,7 @@ public final class McpProxyFactory implements McpStreamFactory
             this.replyId = supplyReplyId.applyAsLong(initialId);
             this.affinity = affinity;
             this.authorization = authorization;
-            this.beginKind = beginKind;
+            this.kind = kind;
             this.sessionId = sessionId;
             this.session = session;
             this.remaining = new ArrayDeque<>(routes.size());
@@ -1714,12 +1714,12 @@ public final class McpProxyFactory implements McpStreamFactory
         private void emitPrelude(
             long traceId)
         {
-            final byte[] preludeBytes = switch (beginKind)
+            final byte[] preludeBytes = switch (kind)
             {
             case KIND_TOOLS_LIST -> LIST_REPLY_TOOLS_OPEN;
             case KIND_PROMPTS_LIST -> LIST_REPLY_PROMPTS_OPEN;
             case KIND_RESOURCES_LIST -> LIST_REPLY_RESOURCES_OPEN;
-            default -> throw new IllegalStateException("unexpected list kind: " + beginKind);
+            default -> throw new IllegalStateException("unexpected list kind: " + kind);
             };
             final UnsafeBuffer buf = new UnsafeBuffer(preludeBytes);
             doServerData(traceId, 0L, 0x03, preludeBytes.length, buf, 0, preludeBytes.length);
@@ -1740,12 +1740,12 @@ public final class McpProxyFactory implements McpStreamFactory
             final McpBeginExFW.Builder builder = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId);
-            switch (beginKind)
+            switch (kind)
             {
             case KIND_TOOLS_LIST -> builder.toolsList(t -> t.sessionId(sid));
             case KIND_PROMPTS_LIST -> builder.promptsList(p -> p.sessionId(sid));
             case KIND_RESOURCES_LIST -> builder.resourcesList(r -> r.sessionId(sid));
-            default -> throw new IllegalStateException("unexpected list kind: " + beginKind);
+            default -> throw new IllegalStateException("unexpected list kind: " + kind);
             }
             final McpBeginExFW beginEx = builder.build();
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -59,6 +59,7 @@ public final class McpProxyFactory implements McpStreamFactory
     private final WindowFW windowRO = new WindowFW();
     private final ResetFW resetRO = new ResetFW();
     private final McpBeginExFW mcpBeginExRO = new McpBeginExFW();
+    private final OctetsFW emptyRO = new OctetsFW().wrap(new UnsafeBuffer(), 0, 0);
 
     private final BeginFW.Builder beginRW = new BeginFW.Builder();
     private final DataFW.Builder dataRW = new DataFW.Builder();
@@ -139,6 +140,10 @@ public final class McpProxyFactory implements McpStreamFactory
 
             if (route != null)
             {
+                final int beginKind = beginEx.kind();
+                final String sessionId = sessionId(beginEx);
+                final String identifier = route.strip(beginEx);
+
                 newStream = new McpServer(
                     sender,
                     originId,
@@ -147,9 +152,9 @@ public final class McpProxyFactory implements McpStreamFactory
                     route.id,
                     affinity,
                     authorization,
-                    beginEx.kind(),
-                    sessionId(beginEx),
-                    route.strip(beginEx))::onServerMessage;
+                    beginKind,
+                    sessionId,
+                    identifier)::onServerMessage;
             }
         }
 
@@ -320,7 +325,7 @@ public final class McpProxyFactory implements McpStreamFactory
             client.doClientReset(traceId);
         }
 
-        private void doServerBeginReply(
+        private void doServerBegin(
             long traceId,
             OctetsFW extension)
         {
@@ -408,7 +413,30 @@ public final class McpProxyFactory implements McpStreamFactory
             sender = streamFactory.newStream(BeginFW.TYPE_ID, writeBuffer, 0, 0, this::onClientMessage);
             assert sender != null;
 
-            final McpBeginExFW beginEx = buildBeginEx(server.beginKind, server.sessionId, server.identifier);
+            final String sessionId = server.sessionId;
+            final String identifier = server.identifier;
+            final McpBeginExFW.Builder builder = mcpBeginExRW
+                .wrap(codecBuffer, 0, codecBuffer.capacity())
+                .typeId(mcpTypeId);
+            switch (server.beginKind)
+            {
+            case KIND_LIFECYCLE -> builder
+                .lifecycle(l -> l.sessionId(sessionId));
+            case KIND_TOOLS_LIST -> builder
+                .toolsList(t -> t.sessionId(sessionId));
+            case KIND_TOOLS_CALL -> builder
+                .toolsCall(t -> t.sessionId(sessionId).name(identifier));
+            case KIND_PROMPTS_LIST -> builder
+                .promptsList(p -> p.sessionId(sessionId));
+            case KIND_PROMPTS_GET -> builder
+                .promptsGet(p -> p.sessionId(sessionId).name(identifier));
+            case KIND_RESOURCES_LIST -> builder
+                .resourcesList(r -> r.sessionId(sessionId));
+            case KIND_RESOURCES_READ -> builder
+                .resourcesRead(r -> r.sessionId(sessionId).uri(identifier));
+            default -> throw new IllegalStateException("unexpected McpBeginEx kind: " + server.beginKind);
+            }
+            final McpBeginExFW beginEx = builder.build();
 
             doBegin(sender, server.originId, resolvedId, initialId,
                 traceId, server.authorization, server.affinity, beginEx);
@@ -519,7 +547,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
             state = McpState.openedInitial(state);
 
-            server.doServerBeginReply(traceId, extension);
+            server.doServerBegin(traceId, extension);
         }
 
         private void onClientData(
@@ -596,42 +624,6 @@ public final class McpProxyFactory implements McpStreamFactory
         };
     }
 
-    private McpBeginExFW buildBeginEx(
-        int kind,
-        String sessionId,
-        String identifier)
-    {
-        final McpBeginExFW.Builder builder = mcpBeginExRW
-            .wrap(codecBuffer, 0, codecBuffer.capacity())
-            .typeId(mcpTypeId);
-
-        return switch (kind)
-        {
-        case KIND_LIFECYCLE -> builder
-            .lifecycle(l -> l.sessionId(sessionId))
-            .build();
-        case KIND_TOOLS_LIST -> builder
-            .toolsList(t -> t.sessionId(sessionId))
-            .build();
-        case KIND_TOOLS_CALL -> builder
-            .toolsCall(t -> t.sessionId(sessionId).name(identifier))
-            .build();
-        case KIND_PROMPTS_LIST -> builder
-            .promptsList(p -> p.sessionId(sessionId))
-            .build();
-        case KIND_PROMPTS_GET -> builder
-            .promptsGet(p -> p.sessionId(sessionId).name(identifier))
-            .build();
-        case KIND_RESOURCES_LIST -> builder
-            .resourcesList(r -> r.sessionId(sessionId))
-            .build();
-        case KIND_RESOURCES_READ -> builder
-            .resourcesRead(r -> r.sessionId(sessionId).uri(identifier))
-            .build();
-        default -> null;
-        };
-    }
-
     private void doBegin(
         MessageConsumer receiver,
         long originId,
@@ -642,7 +634,7 @@ public final class McpProxyFactory implements McpStreamFactory
         long affinity,
         Flyweight extension)
     {
-        final BeginFW.Builder builder = beginRW.wrap(writeBuffer, 0, writeBuffer.capacity())
+        final BeginFW begin = beginRW.wrap(writeBuffer, 0, writeBuffer.capacity())
             .originId(originId)
             .routedId(routedId)
             .streamId(streamId)
@@ -651,14 +643,9 @@ public final class McpProxyFactory implements McpStreamFactory
             .maximum(0)
             .traceId(traceId)
             .authorization(authorization)
-            .affinity(affinity);
-
-        if (extension != null && extension.sizeof() > 0)
-        {
-            builder.extension(extension.buffer(), extension.offset(), extension.sizeof());
-        }
-
-        final BeginFW begin = builder.build();
+            .affinity(affinity)
+            .extension(extension.buffer(), extension.offset(), extension.sizeof())
+            .build();
 
         receiver.accept(begin.typeId(), begin.buffer(), begin.offset(), begin.sizeof());
     }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -325,18 +325,15 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = begin.sequence();
             final long acknowledge = begin.acknowledge();
-            final int maximum = begin.maximum();
             final long traceId = begin.traceId();
 
             initialSeq = sequence;
             initialAck = acknowledge;
-            initialMax = maximum;
 
             state = McpState.openingInitial(state);
 
             client.doClientBegin(traceId);
 
-            initialAck = initialSeq;
             initialMax = writeBuffer.capacity();
             doServerWindow(traceId, 0L, 0);
         }
@@ -346,16 +343,19 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = data.sequence();
             final long acknowledge = data.acknowledge();
-            final int maximum = data.maximum();
             final long traceId = data.traceId();
             final long budgetId = data.budgetId();
             final int flags = data.flags();
             final int reserved = data.reserved();
             final OctetsFW payload = data.payload();
 
+            assert acknowledge <= sequence;
+            assert sequence >= initialSeq;
+            assert acknowledge <= initialAck;
+
             initialSeq = sequence + reserved;
-            initialAck = acknowledge;
-            initialMax = maximum;
+
+            assert initialAck <= initialSeq;
 
             client.doClientData(traceId, budgetId, flags, reserved,
                 payload.buffer(), payload.offset(), payload.sizeof());
@@ -366,12 +366,15 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = end.sequence();
             final long acknowledge = end.acknowledge();
-            final int maximum = end.maximum();
             final long traceId = end.traceId();
 
+            assert acknowledge <= sequence;
+            assert sequence >= initialSeq;
+            assert acknowledge <= initialAck;
+
             initialSeq = sequence;
-            initialAck = acknowledge;
-            initialMax = maximum;
+
+            assert initialAck <= initialSeq;
 
             state = McpState.closedInitial(state);
 
@@ -383,12 +386,15 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = abort.sequence();
             final long acknowledge = abort.acknowledge();
-            final int maximum = abort.maximum();
             final long traceId = abort.traceId();
 
+            assert acknowledge <= sequence;
+            assert sequence >= initialSeq;
+            assert acknowledge <= initialAck;
+
             initialSeq = sequence;
-            initialAck = acknowledge;
-            initialMax = maximum;
+
+            assert initialAck <= initialSeq;
 
             state = McpState.closedInitial(state);
 
@@ -411,10 +417,17 @@ public final class McpProxyFactory implements McpStreamFactory
             final long budgetId = window.budgetId();
             final int padding = window.padding();
 
+            assert acknowledge <= sequence;
+            assert sequence <= replySeq;
+            assert acknowledge >= replyAck;
+            assert maximum >= replyMax;
+
             replyAck = acknowledge;
             replyMax = maximum;
 
-            client.doClientWindow(traceId, budgetId, sequence, acknowledge, maximum, padding);
+            assert replyAck <= replySeq;
+
+            client.doClientWindow(traceId, budgetId, padding);
         }
 
         private void onServerReset(
@@ -422,11 +435,15 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = reset.sequence();
             final long acknowledge = reset.acknowledge();
-            final int maximum = reset.maximum();
             final long traceId = reset.traceId();
 
+            assert acknowledge <= sequence;
+            assert sequence <= replySeq;
+            assert acknowledge >= replyAck;
+
             replyAck = acknowledge;
-            replyMax = maximum;
+
+            assert replyAck <= replySeq;
 
             state = McpState.closedReply(state);
 
@@ -601,15 +618,10 @@ public final class McpProxyFactory implements McpStreamFactory
         private void doClientWindow(
             long traceId,
             long budgetId,
-            long sequence,
-            long acknowledge,
-            int maximum,
             int padding)
         {
-            replyAck = acknowledge;
-            replyMax = maximum;
             doWindow(sender, server.lifecycle.originId, resolvedId, replyId,
-                sequence, acknowledge, maximum, traceId, server.authorization, budgetId, padding);
+                replySeq, replyAck, replyMax, traceId, server.authorization, budgetId, padding);
         }
 
         private void doClientReset(
@@ -665,13 +677,11 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = begin.sequence();
             final long acknowledge = begin.acknowledge();
-            final int maximum = begin.maximum();
             final long traceId = begin.traceId();
             final OctetsFW extension = begin.extension();
 
             replySeq = sequence;
             replyAck = acknowledge;
-            replyMax = maximum;
 
             state = McpState.openedInitial(state);
 
@@ -681,6 +691,9 @@ public final class McpProxyFactory implements McpStreamFactory
                 : emptyRO;
 
             server.doServerBegin(traceId, replyExtension);
+
+            replyMax = writeBuffer.capacity();
+            doClientWindow(traceId, 0L, 0);
         }
 
         private Flyweight rewriteReplyBeginEx(
@@ -717,16 +730,19 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = data.sequence();
             final long acknowledge = data.acknowledge();
-            final int maximum = data.maximum();
             final long traceId = data.traceId();
             final long budgetId = data.budgetId();
             final int flags = data.flags();
             final int reserved = data.reserved();
             final OctetsFW payload = data.payload();
 
+            assert acknowledge <= sequence;
+            assert sequence >= replySeq;
+            assert acknowledge <= replyAck;
+
             replySeq = sequence + reserved;
-            replyAck = acknowledge;
-            replyMax = maximum;
+
+            assert replyAck <= replySeq;
 
             server.doServerData(traceId, budgetId, flags, reserved,
                 payload.buffer(), payload.offset(), payload.sizeof());
@@ -737,12 +753,15 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = end.sequence();
             final long acknowledge = end.acknowledge();
-            final int maximum = end.maximum();
             final long traceId = end.traceId();
 
+            assert acknowledge <= sequence;
+            assert sequence >= replySeq;
+            assert acknowledge <= replyAck;
+
             replySeq = sequence;
-            replyAck = acknowledge;
-            replyMax = maximum;
+
+            assert replyAck <= replySeq;
 
             state = McpState.closedReply(state);
             server.doServerEnd(traceId);
@@ -753,12 +772,15 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = abort.sequence();
             final long acknowledge = abort.acknowledge();
-            final int maximum = abort.maximum();
             final long traceId = abort.traceId();
 
+            assert acknowledge <= sequence;
+            assert sequence >= replySeq;
+            assert acknowledge <= replyAck;
+
             replySeq = sequence;
-            replyAck = acknowledge;
-            replyMax = maximum;
+
+            assert replyAck <= replySeq;
 
             state = McpState.closedReply(state);
             server.doServerAbort(traceId);
@@ -774,8 +796,15 @@ public final class McpProxyFactory implements McpStreamFactory
             final long budgetId = window.budgetId();
             final int padding = window.padding();
 
+            assert acknowledge <= sequence;
+            assert sequence <= initialSeq;
+            assert acknowledge >= initialAck;
+            assert maximum >= initialMax;
+
             initialAck = acknowledge;
             initialMax = maximum;
+
+            assert initialAck <= initialSeq;
 
             server.doServerWindow(traceId, budgetId, padding);
         }
@@ -785,11 +814,15 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = reset.sequence();
             final long acknowledge = reset.acknowledge();
-            final int maximum = reset.maximum();
             final long traceId = reset.traceId();
 
+            assert acknowledge <= sequence;
+            assert sequence <= initialSeq;
+            assert acknowledge >= initialAck;
+
             initialAck = acknowledge;
-            initialMax = maximum;
+
+            assert initialAck <= initialSeq;
 
             state = McpState.closedInitial(state);
 
@@ -889,12 +922,10 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = begin.sequence();
             final long acknowledge = begin.acknowledge();
-            final int maximum = begin.maximum();
             final long traceId = begin.traceId();
 
             initialSeq = sequence;
             initialAck = acknowledge;
-            initialMax = maximum;
 
             state = McpState.openingInitial(state);
 
@@ -909,7 +940,6 @@ public final class McpProxyFactory implements McpStreamFactory
 
             doServerBegin(traceId, beginEx);
 
-            initialAck = initialSeq;
             initialMax = writeBuffer.capacity();
             doServerWindow(traceId, 0L, 0);
         }
@@ -919,12 +949,15 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = end.sequence();
             final long acknowledge = end.acknowledge();
-            final int maximum = end.maximum();
             final long traceId = end.traceId();
 
+            assert acknowledge <= sequence;
+            assert sequence >= initialSeq;
+            assert acknowledge <= initialAck;
+
             initialSeq = sequence;
-            initialAck = acknowledge;
-            initialMax = maximum;
+
+            assert initialAck <= initialSeq;
 
             state = McpState.closedInitial(state);
 
@@ -938,12 +971,15 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = abort.sequence();
             final long acknowledge = abort.acknowledge();
-            final int maximum = abort.maximum();
             final long traceId = abort.traceId();
 
+            assert acknowledge <= sequence;
+            assert sequence >= initialSeq;
+            assert acknowledge <= initialAck;
+
             initialSeq = sequence;
-            initialAck = acknowledge;
-            initialMax = maximum;
+
+            assert initialAck <= initialSeq;
 
             state = McpState.closedInitial(state);
 
@@ -955,11 +991,19 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onServerWindow(
             WindowFW window)
         {
+            final long sequence = window.sequence();
             final long acknowledge = window.acknowledge();
             final int maximum = window.maximum();
 
+            assert acknowledge <= sequence;
+            assert sequence <= replySeq;
+            assert acknowledge >= replyAck;
+            assert maximum >= replyMax;
+
             replyAck = acknowledge;
             replyMax = maximum;
+
+            assert replyAck <= replySeq;
         }
 
         private void onServerReset(
@@ -967,11 +1011,15 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = reset.sequence();
             final long acknowledge = reset.acknowledge();
-            final int maximum = reset.maximum();
             final long traceId = reset.traceId();
 
+            assert acknowledge <= sequence;
+            assert sequence <= replySeq;
+            assert acknowledge >= replyAck;
+
             replyAck = acknowledge;
-            replyMax = maximum;
+
+            assert replyAck <= replySeq;
 
             state = McpState.closedReply(state);
 
@@ -1164,13 +1212,11 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = begin.sequence();
             final long acknowledge = begin.acknowledge();
-            final int maximum = begin.maximum();
             final long traceId = begin.traceId();
             final OctetsFW extension = begin.extension();
 
             replySeq = sequence;
             replyAck = acknowledge;
-            replyMax = maximum;
 
             state = McpState.openedInitial(state);
 
@@ -1184,7 +1230,6 @@ public final class McpProxyFactory implements McpStreamFactory
                 }
             }
 
-            replyAck = replySeq;
             replyMax = writeBuffer.capacity();
             doClientWindow(traceId, 0L, 0);
 
@@ -1196,12 +1241,15 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = end.sequence();
             final long acknowledge = end.acknowledge();
-            final int maximum = end.maximum();
             final long traceId = end.traceId();
 
+            assert acknowledge <= sequence;
+            assert sequence >= replySeq;
+            assert acknowledge <= replyAck;
+
             replySeq = sequence;
-            replyAck = acknowledge;
-            replyMax = maximum;
+
+            assert replyAck <= replySeq;
 
             state = McpState.closedReply(state);
             doClientEnd(traceId);
@@ -1213,12 +1261,15 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = abort.sequence();
             final long acknowledge = abort.acknowledge();
-            final int maximum = abort.maximum();
             final long traceId = abort.traceId();
 
+            assert acknowledge <= sequence;
+            assert sequence >= replySeq;
+            assert acknowledge <= replyAck;
+
             replySeq = sequence;
-            replyAck = acknowledge;
-            replyMax = maximum;
+
+            assert replyAck <= replySeq;
 
             state = McpState.closedReply(state);
             doClientAbort(traceId);
@@ -1228,22 +1279,35 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onClientWindow(
             WindowFW window)
         {
+            final long sequence = window.sequence();
             final long acknowledge = window.acknowledge();
             final int maximum = window.maximum();
 
+            assert acknowledge <= sequence;
+            assert sequence <= initialSeq;
+            assert acknowledge >= initialAck;
+            assert maximum >= initialMax;
+
             initialAck = acknowledge;
             initialMax = maximum;
+
+            assert initialAck <= initialSeq;
         }
 
         private void onClientReset(
             ResetFW reset)
         {
+            final long sequence = reset.sequence();
             final long acknowledge = reset.acknowledge();
-            final int maximum = reset.maximum();
             final long traceId = reset.traceId();
 
+            assert acknowledge <= sequence;
+            assert sequence <= initialSeq;
+            assert acknowledge >= initialAck;
+
             initialAck = acknowledge;
-            initialMax = maximum;
+
+            assert initialAck <= initialSeq;
 
             state = McpState.closedInitial(state);
             doClientReset(traceId);
@@ -1414,16 +1478,13 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = begin.sequence();
             final long acknowledge = begin.acknowledge();
-            final int maximum = begin.maximum();
             final long traceId = begin.traceId();
 
             replySeq = sequence;
             replyAck = acknowledge;
-            replyMax = maximum;
 
             state = McpState.openedInitial(state);
 
-            replyAck = replySeq;
             replyMax = writeBuffer.capacity();
             doClientWindow(traceId, 0L, 0);
         }
@@ -1433,16 +1494,19 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = data.sequence();
             final long acknowledge = data.acknowledge();
-            final int maximum = data.maximum();
             final long traceId = data.traceId();
             final long authorization = data.authorization();
             final long budgetId = data.budgetId();
             final int reserved = data.reserved();
             final OctetsFW payload = data.payload();
 
+            assert acknowledge <= sequence;
+            assert sequence >= replySeq;
+            assert acknowledge <= replyAck;
+
             replySeq = sequence + reserved;
-            replyAck = acknowledge;
-            replyMax = maximum;
+
+            assert replyAck <= replySeq;
 
             DirectBuffer buffer = payload.buffer();
             int offset = payload.offset();
@@ -1473,12 +1537,15 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = end.sequence();
             final long acknowledge = end.acknowledge();
-            final int maximum = end.maximum();
             final long traceId = end.traceId();
 
+            assert acknowledge <= sequence;
+            assert sequence >= replySeq;
+            assert acknowledge <= replyAck;
+
             replySeq = sequence;
-            replyAck = acknowledge;
-            replyMax = maximum;
+
+            assert replyAck <= replySeq;
 
             if (!McpState.replyClosed(state))
             {
@@ -1493,12 +1560,15 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = abort.sequence();
             final long acknowledge = abort.acknowledge();
-            final int maximum = abort.maximum();
             final long traceId = abort.traceId();
 
+            assert acknowledge <= sequence;
+            assert sequence >= replySeq;
+            assert acknowledge <= replyAck;
+
             replySeq = sequence;
-            replyAck = acknowledge;
-            replyMax = maximum;
+
+            assert replyAck <= replySeq;
 
             if (!McpState.replyClosed(state))
             {
@@ -1511,22 +1581,35 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onClientWindow(
             WindowFW window)
         {
+            final long sequence = window.sequence();
             final long acknowledge = window.acknowledge();
             final int maximum = window.maximum();
 
+            assert acknowledge <= sequence;
+            assert sequence <= initialSeq;
+            assert acknowledge >= initialAck;
+            assert maximum >= initialMax;
+
             initialAck = acknowledge;
             initialMax = maximum;
+
+            assert initialAck <= initialSeq;
         }
 
         private void onClientReset(
             ResetFW reset)
         {
+            final long sequence = reset.sequence();
             final long acknowledge = reset.acknowledge();
-            final int maximum = reset.maximum();
             final long traceId = reset.traceId();
 
+            assert acknowledge <= sequence;
+            assert sequence <= initialSeq;
+            assert acknowledge >= initialAck;
+
             initialAck = acknowledge;
-            initialMax = maximum;
+
+            assert initialAck <= initialSeq;
 
             state = McpState.closedInitial(state);
             if (!McpState.replyClosed(state))
@@ -2026,16 +2109,13 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = begin.sequence();
             final long acknowledge = begin.acknowledge();
-            final int maximum = begin.maximum();
             final long traceId = begin.traceId();
 
             initialSeq = sequence;
             initialAck = acknowledge;
-            initialMax = maximum;
 
             state = McpState.openingInitial(state);
 
-            initialAck = initialSeq;
             initialMax = writeBuffer.capacity();
             doServerWindow(traceId, 0L, 0);
 
@@ -2049,12 +2129,15 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = end.sequence();
             final long acknowledge = end.acknowledge();
-            final int maximum = end.maximum();
             final long traceId = end.traceId();
 
+            assert acknowledge <= sequence;
+            assert sequence >= initialSeq;
+            assert acknowledge <= initialAck;
+
             initialSeq = sequence;
-            initialAck = acknowledge;
-            initialMax = maximum;
+
+            assert initialAck <= initialSeq;
 
             state = McpState.closedInitial(state);
 
@@ -2069,12 +2152,15 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long sequence = abort.sequence();
             final long acknowledge = abort.acknowledge();
-            final int maximum = abort.maximum();
             final long traceId = abort.traceId();
 
+            assert acknowledge <= sequence;
+            assert sequence >= initialSeq;
+            assert acknowledge <= initialAck;
+
             initialSeq = sequence;
-            initialAck = acknowledge;
-            initialMax = maximum;
+
+            assert initialAck <= initialSeq;
 
             state = McpState.closedInitial(state);
 
@@ -2088,22 +2174,35 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onServerWindow(
             WindowFW window)
         {
+            final long sequence = window.sequence();
             final long acknowledge = window.acknowledge();
             final int maximum = window.maximum();
 
+            assert acknowledge <= sequence;
+            assert sequence <= replySeq;
+            assert acknowledge >= replyAck;
+            assert maximum >= replyMax;
+
             replyAck = acknowledge;
             replyMax = maximum;
+
+            assert replyAck <= replySeq;
         }
 
         private void onServerReset(
             ResetFW reset)
         {
+            final long sequence = reset.sequence();
             final long acknowledge = reset.acknowledge();
-            final int maximum = reset.maximum();
             final long traceId = reset.traceId();
 
+            assert acknowledge <= sequence;
+            assert sequence <= replySeq;
+            assert acknowledge >= replyAck;
+
             replyAck = acknowledge;
-            replyMax = maximum;
+
+            assert replyAck <= replySeq;
 
             state = McpState.closedReply(state);
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -2051,7 +2051,14 @@ public final class McpProxyFactory implements McpStreamFactory
                     final int afterInBuf = offset + (int) (afterStreamOffset - client.decodedParserProgress);
                     final int emittedInBuf =
                         offset + (int) (client.itemEmittedStreamOffset - client.decodedParserProgress);
-                    client.server.streamItemChunk(buffer, emittedInBuf, afterInBuf - emittedInBuf, traceId);
+                    final int chunkLen = afterInBuf - emittedInBuf;
+                    final int emitted = client.server.streamItemChunk(buffer, emittedInBuf, chunkLen, traceId);
+                    client.itemEmittedStreamOffset += emitted;
+                    if (emitted < chunkLen)
+                    {
+                        client.decodeItemDepth++;
+                        break decode;
+                    }
                     client.server.streamItemEnd(traceId);
                     client.itemStartStreamOffset = -1;
                     client.itemEmittedStreamOffset = -1;
@@ -2352,13 +2359,19 @@ public final class McpProxyFactory implements McpStreamFactory
             itemsEmitted++;
         }
 
-        private void streamItemChunk(
+        private int streamItemChunk(
             DirectBuffer buffer,
             int offset,
             int length,
             long traceId)
         {
-            doServerData(traceId, 0L, 0x03, length, buffer, offset, length);
+            final int replyWin = replyMax - (int) (replySeq - replyAck) - replyPad;
+            final int emit = Math.min(Math.max(replyWin, 0), length);
+            if (emit > 0)
+            {
+                doServerData(traceId, 0L, 0x03, emit, buffer, offset, emit);
+            }
+            return emit;
         }
 
         private void streamItemEnd(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -22,11 +22,13 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeg
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_CALL;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 
+import java.util.Map;
 import java.util.function.LongUnaryOperator;
 
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.Long2ObjectHashMap;
+import org.agrona.collections.Object2ObjectHashMap;
 import org.agrona.concurrent.UnsafeBuffer;
 
 import io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration;
@@ -77,6 +79,7 @@ public final class McpProxyFactory implements McpStreamFactory
     private final int mcpTypeId;
 
     private final Long2ObjectHashMap<McpBindingConfig> bindings;
+    private final Map<String, McpSession> sessions;
 
     public McpProxyFactory(
         McpConfiguration config,
@@ -88,6 +91,7 @@ public final class McpProxyFactory implements McpStreamFactory
         this.supplyInitialId = context::supplyInitialId;
         this.supplyReplyId = context::supplyReplyId;
         this.bindings = new Long2ObjectHashMap<>();
+        this.sessions = new Object2ObjectHashMap<>();
         this.mcpTypeId = context.supplyTypeId(MCP_TYPE_NAME);
     }
 
@@ -142,25 +146,45 @@ public final class McpProxyFactory implements McpStreamFactory
             {
                 final int beginKind = beginEx.kind();
                 final String sessionId = sessionId(beginEx);
-                final String identifier = route.strip(beginEx);
-                final int capabilities = beginKind == KIND_LIFECYCLE ? beginEx.lifecycle().capabilities() : 0;
+                final boolean lifecycle = beginKind == KIND_LIFECYCLE;
+                final McpSession session = lifecycle
+                    ? sessions.computeIfAbsent(sessionId, McpSession::new)
+                    : sessions.get(sessionId);
 
-                newStream = new McpServer(
-                    sender,
-                    originId,
-                    routedId,
-                    initialId,
-                    route.id,
-                    affinity,
-                    authorization,
-                    beginKind,
-                    sessionId,
-                    identifier,
-                    capabilities)::onServerMessage;
+                if (session != null)
+                {
+                    final String identifier = route.strip(beginEx);
+                    final int capabilities = lifecycle ? beginEx.lifecycle().capabilities() : 0;
+
+                    newStream = new McpServer(
+                        sender,
+                        originId,
+                        routedId,
+                        initialId,
+                        route.id,
+                        affinity,
+                        authorization,
+                        beginKind,
+                        sessionId,
+                        identifier,
+                        capabilities,
+                        session)::onServerMessage;
+                }
             }
         }
 
         return newStream;
+    }
+
+    private final class McpSession
+    {
+        private final String sessionId;
+
+        private McpSession(
+            String sessionId)
+        {
+            this.sessionId = sessionId;
+        }
     }
 
     private final class McpServer
@@ -177,6 +201,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private final String sessionId;
         private final String identifier;
         private final int capabilities;
+        private final McpSession session;
 
         private int state;
 
@@ -191,7 +216,8 @@ public final class McpProxyFactory implements McpStreamFactory
             int beginKind,
             String sessionId,
             String identifier,
-            int capabilities)
+            int capabilities,
+            McpSession session)
         {
             this.sender = sender;
             this.originId = originId;
@@ -204,6 +230,7 @@ public final class McpProxyFactory implements McpStreamFactory
             this.sessionId = sessionId;
             this.identifier = identifier;
             this.capabilities = capabilities;
+            this.session = session;
             this.client = new McpClient(this, resolvedId);
         }
 
@@ -288,6 +315,11 @@ public final class McpProxyFactory implements McpStreamFactory
             {
                 client.doClientEnd(traceId);
             }
+
+            if (beginKind == KIND_LIFECYCLE)
+            {
+                sessions.remove(session.sessionId);
+            }
         }
 
         private void onServerAbort(
@@ -300,6 +332,11 @@ public final class McpProxyFactory implements McpStreamFactory
             if (!McpState.closed(state))
             {
                 client.doClientAbort(traceId);
+            }
+
+            if (beginKind == KIND_LIFECYCLE)
+            {
+                sessions.remove(session.sessionId);
             }
         }
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -82,6 +82,7 @@ public final class McpProxyFactory implements McpStreamFactory
     private final DataFW.Builder dataRW = new DataFW.Builder();
     private final EndFW.Builder endRW = new EndFW.Builder();
     private final AbortFW.Builder abortRW = new AbortFW.Builder();
+    private final FlushFW.Builder flushRW = new FlushFW.Builder();
     private final WindowFW.Builder windowRW = new WindowFW.Builder();
     private final ResetFW.Builder resetRW = new ResetFW.Builder();
     private final McpBeginExFW.Builder mcpBeginExRW = new McpBeginExFW.Builder();
@@ -238,6 +239,14 @@ public final class McpProxyFactory implements McpStreamFactory
 
         private int state;
 
+        private long initialSeq;
+        private long initialAck;
+        private int initialMax;
+
+        private long replySeq;
+        private long replyAck;
+        private int replyMax;
+
         private McpServer(
             McpLifecycleServer lifecycle,
             int kind,
@@ -314,24 +323,39 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onServerBegin(
             BeginFW begin)
         {
+            final long sequence = begin.sequence();
+            final long acknowledge = begin.acknowledge();
+            final int maximum = begin.maximum();
             final long traceId = begin.traceId();
+
+            initialSeq = sequence;
+            initialAck = acknowledge;
+            initialMax = maximum;
 
             state = McpState.openingInitial(state);
 
             client.doClientBegin(traceId);
 
-            doWindow(sender, originId, routedId, initialId, traceId, authorization, 0,
-                writeBuffer.capacity(), 0);
+            initialAck = initialSeq;
+            initialMax = writeBuffer.capacity();
+            doServerWindow(traceId, 0L, 0);
         }
 
         private void onServerData(
             DataFW data)
         {
+            final long sequence = data.sequence();
+            final long acknowledge = data.acknowledge();
+            final int maximum = data.maximum();
             final long traceId = data.traceId();
             final long budgetId = data.budgetId();
             final int flags = data.flags();
             final int reserved = data.reserved();
             final OctetsFW payload = data.payload();
+
+            initialSeq = sequence + reserved;
+            initialAck = acknowledge;
+            initialMax = maximum;
 
             client.doClientData(traceId, budgetId, flags, reserved,
                 payload.buffer(), payload.offset(), payload.sizeof());
@@ -340,7 +364,14 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onServerEnd(
             EndFW end)
         {
+            final long sequence = end.sequence();
+            final long acknowledge = end.acknowledge();
+            final int maximum = end.maximum();
             final long traceId = end.traceId();
+
+            initialSeq = sequence;
+            initialAck = acknowledge;
+            initialMax = maximum;
 
             state = McpState.closedInitial(state);
 
@@ -350,7 +381,14 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onServerAbort(
             AbortFW abort)
         {
+            final long sequence = abort.sequence();
+            final long acknowledge = abort.acknowledge();
+            final int maximum = abort.maximum();
             final long traceId = abort.traceId();
+
+            initialSeq = sequence;
+            initialAck = acknowledge;
+            initialMax = maximum;
 
             state = McpState.closedInitial(state);
 
@@ -366,18 +404,29 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onServerWindow(
             WindowFW window)
         {
+            final long sequence = window.sequence();
+            final long acknowledge = window.acknowledge();
+            final int maximum = window.maximum();
             final long traceId = window.traceId();
             final long budgetId = window.budgetId();
-            final int credit = window.maximum();
             final int padding = window.padding();
 
-            client.doClientWindow(traceId, budgetId, credit, padding);
+            replyAck = acknowledge;
+            replyMax = maximum;
+
+            client.doClientWindow(traceId, budgetId, sequence, acknowledge, maximum, padding);
         }
 
         private void onServerReset(
             ResetFW reset)
         {
+            final long sequence = reset.sequence();
+            final long acknowledge = reset.acknowledge();
+            final int maximum = reset.maximum();
             final long traceId = reset.traceId();
+
+            replyAck = acknowledge;
+            replyMax = maximum;
 
             state = McpState.closedReply(state);
 
@@ -388,7 +437,8 @@ public final class McpProxyFactory implements McpStreamFactory
             long traceId,
             Flyweight extension)
         {
-            doBegin(sender, originId, routedId, replyId, traceId, authorization, affinity, extension);
+            doBegin(sender, originId, routedId, replyId, replySeq, replyAck, replyMax, traceId, authorization,
+                affinity, extension);
             state = McpState.openedReply(state);
         }
 
@@ -401,8 +451,9 @@ public final class McpProxyFactory implements McpStreamFactory
             int offset,
             int length)
         {
-            doData(sender, originId, routedId, replyId, traceId, authorization,
-                budgetId, flags, reserved, payload, offset, length);
+            doData(sender, originId, routedId, replyId, replySeq, replyAck, replyMax, traceId, authorization,
+                flags, budgetId, reserved, payload, offset, length);
+            replySeq += reserved;
         }
 
         private void doServerEnd(
@@ -410,7 +461,7 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (!McpState.replyClosed(state))
             {
-                doEnd(sender, originId, routedId, replyId, traceId, authorization);
+                doEnd(sender, originId, routedId, replyId, replySeq, replyAck, replyMax, traceId, authorization);
                 state = McpState.closedReply(state);
             }
         }
@@ -420,7 +471,7 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (!McpState.replyClosed(state))
             {
-                doAbort(sender, originId, routedId, replyId, traceId, authorization);
+                doAbort(sender, originId, routedId, replyId, replySeq, replyAck, replyMax, traceId, authorization);
                 state = McpState.closedReply(state);
             }
         }
@@ -428,10 +479,10 @@ public final class McpProxyFactory implements McpStreamFactory
         private void doServerWindow(
             long traceId,
             long budgetId,
-            int credit,
             int padding)
         {
-            doWindow(sender, originId, routedId, initialId, traceId, authorization, budgetId, credit, padding);
+            doWindow(sender, originId, routedId, initialId, initialSeq, initialAck, initialMax, traceId, authorization,
+                budgetId, padding);
         }
 
         private void doServerReset(
@@ -439,7 +490,8 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (!McpState.initialClosed(state))
             {
-                doReset(sender, originId, routedId, initialId, traceId, authorization);
+                doReset(sender, originId, routedId, initialId, initialSeq, initialAck, initialMax, traceId, authorization,
+                    emptyRO);
                 state = McpState.closedInitial(state);
             }
         }
@@ -456,6 +508,14 @@ public final class McpProxyFactory implements McpStreamFactory
 
         private MessageConsumer sender;
         private int state;
+
+        private long initialSeq;
+        private long initialAck;
+        private int initialMax;
+
+        private long replySeq;
+        private long replyAck;
+        private int replyMax;
 
         private McpClient(
             McpServer server,
@@ -494,7 +554,7 @@ public final class McpProxyFactory implements McpStreamFactory
                 .build();
 
             sender = newStream(this::onClientMessage, server.lifecycle.originId, resolvedId, initialId,
-                traceId, server.authorization, server.affinity, beginEx);
+                initialSeq, initialAck, initialMax, traceId, server.authorization, server.affinity, beginEx);
             state = McpState.openingInitial(state);
         }
 
@@ -510,7 +570,9 @@ public final class McpProxyFactory implements McpStreamFactory
             if (!McpState.closed(state))
             {
                 doData(sender, server.lifecycle.originId, resolvedId, initialId,
-                    traceId, server.authorization, budgetId, flags, reserved, payload, offset, length);
+                    initialSeq, initialAck, initialMax, traceId, server.authorization,
+                    flags, budgetId, reserved, payload, offset, length);
+                initialSeq += reserved;
             }
         }
 
@@ -520,7 +582,7 @@ public final class McpProxyFactory implements McpStreamFactory
             if (!McpState.initialClosed(state))
             {
                 doEnd(sender, server.lifecycle.originId, resolvedId, initialId,
-                    traceId, server.authorization);
+                    initialSeq, initialAck, initialMax, traceId, server.authorization);
                 state = McpState.closedInitial(state);
             }
         }
@@ -531,7 +593,7 @@ public final class McpProxyFactory implements McpStreamFactory
             if (!McpState.initialClosed(state))
             {
                 doAbort(sender, server.lifecycle.originId, resolvedId, initialId,
-                    traceId, server.authorization);
+                    initialSeq, initialAck, initialMax, traceId, server.authorization);
                 state = McpState.closedInitial(state);
             }
         }
@@ -539,11 +601,15 @@ public final class McpProxyFactory implements McpStreamFactory
         private void doClientWindow(
             long traceId,
             long budgetId,
-            int credit,
+            long sequence,
+            long acknowledge,
+            int maximum,
             int padding)
         {
+            replyAck = acknowledge;
+            replyMax = maximum;
             doWindow(sender, server.lifecycle.originId, resolvedId, replyId,
-                traceId, server.authorization, budgetId, credit, padding);
+                sequence, acknowledge, maximum, traceId, server.authorization, budgetId, padding);
         }
 
         private void doClientReset(
@@ -552,7 +618,7 @@ public final class McpProxyFactory implements McpStreamFactory
             if (!McpState.replyClosed(state))
             {
                 doReset(sender, server.lifecycle.originId, resolvedId, replyId,
-                    traceId, server.authorization);
+                    replySeq, replyAck, replyMax, traceId, server.authorization, emptyRO);
                 state = McpState.closedReply(state);
             }
         }
@@ -597,8 +663,15 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onClientBegin(
             BeginFW begin)
         {
+            final long sequence = begin.sequence();
+            final long acknowledge = begin.acknowledge();
+            final int maximum = begin.maximum();
             final long traceId = begin.traceId();
             final OctetsFW extension = begin.extension();
+
+            replySeq = sequence;
+            replyAck = acknowledge;
+            replyMax = maximum;
 
             state = McpState.openedInitial(state);
 
@@ -642,11 +715,18 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onClientData(
             DataFW data)
         {
+            final long sequence = data.sequence();
+            final long acknowledge = data.acknowledge();
+            final int maximum = data.maximum();
             final long traceId = data.traceId();
             final long budgetId = data.budgetId();
             final int flags = data.flags();
             final int reserved = data.reserved();
             final OctetsFW payload = data.payload();
+
+            replySeq = sequence + reserved;
+            replyAck = acknowledge;
+            replyMax = maximum;
 
             server.doServerData(traceId, budgetId, flags, reserved,
                 payload.buffer(), payload.offset(), payload.sizeof());
@@ -655,7 +735,15 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onClientEnd(
             EndFW end)
         {
+            final long sequence = end.sequence();
+            final long acknowledge = end.acknowledge();
+            final int maximum = end.maximum();
             final long traceId = end.traceId();
+
+            replySeq = sequence;
+            replyAck = acknowledge;
+            replyMax = maximum;
+
             state = McpState.closedReply(state);
             server.doServerEnd(traceId);
         }
@@ -663,7 +751,15 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onClientAbort(
             AbortFW abort)
         {
+            final long sequence = abort.sequence();
+            final long acknowledge = abort.acknowledge();
+            final int maximum = abort.maximum();
             final long traceId = abort.traceId();
+
+            replySeq = sequence;
+            replyAck = acknowledge;
+            replyMax = maximum;
+
             state = McpState.closedReply(state);
             server.doServerAbort(traceId);
         }
@@ -671,18 +767,29 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onClientWindow(
             WindowFW window)
         {
+            final long sequence = window.sequence();
+            final long acknowledge = window.acknowledge();
+            final int maximum = window.maximum();
             final long traceId = window.traceId();
             final long budgetId = window.budgetId();
-            final int credit = window.maximum();
             final int padding = window.padding();
 
-            server.doServerWindow(traceId, budgetId, credit, padding);
+            initialAck = acknowledge;
+            initialMax = maximum;
+
+            server.doServerWindow(traceId, budgetId, padding);
         }
 
         private void onClientReset(
             ResetFW reset)
         {
+            final long sequence = reset.sequence();
+            final long acknowledge = reset.acknowledge();
+            final int maximum = reset.maximum();
             final long traceId = reset.traceId();
+
+            initialAck = acknowledge;
+            initialMax = maximum;
 
             state = McpState.closedInitial(state);
 
@@ -704,6 +811,14 @@ public final class McpProxyFactory implements McpStreamFactory
         private final Long2ObjectHashMap<McpLifecycleClient> clients;
 
         private int state;
+
+        private long initialSeq;
+        private long initialAck;
+        private int initialMax;
+
+        private long replySeq;
+        private long replyAck;
+        private int replyMax;
 
         private McpLifecycleServer(
             MessageConsumer sender,
@@ -757,7 +872,8 @@ public final class McpProxyFactory implements McpStreamFactory
                 onServerAbort(abort);
                 break;
             case WindowFW.TYPE_ID:
-                // reply direction window from upstream; no DATA to send so ignore
+                final WindowFW window = windowRO.wrap(buffer, index, index + length);
+                onServerWindow(window);
                 break;
             case ResetFW.TYPE_ID:
                 final ResetFW reset = resetRO.wrap(buffer, index, index + length);
@@ -771,7 +887,14 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onServerBegin(
             BeginFW begin)
         {
+            final long sequence = begin.sequence();
+            final long acknowledge = begin.acknowledge();
+            final int maximum = begin.maximum();
             final long traceId = begin.traceId();
+
+            initialSeq = sequence;
+            initialAck = acknowledge;
+            initialMax = maximum;
 
             state = McpState.openingInitial(state);
 
@@ -784,53 +907,113 @@ public final class McpProxyFactory implements McpStreamFactory
                 .lifecycle(l -> l.sessionId(sid).capabilities(serverCapabilities))
                 .build();
 
-            doBegin(sender, originId, routedId, replyId, traceId, authorization, affinity, beginEx);
-            state = McpState.openedReply(state);
+            doServerBegin(traceId, beginEx);
 
-            doWindow(sender, originId, routedId, initialId, traceId, authorization, 0,
-                writeBuffer.capacity(), 0);
+            initialAck = initialSeq;
+            initialMax = writeBuffer.capacity();
+            doServerWindow(traceId, 0L, 0);
         }
 
         private void onServerEnd(
             EndFW end)
         {
+            final long sequence = end.sequence();
+            final long acknowledge = end.acknowledge();
+            final int maximum = end.maximum();
             final long traceId = end.traceId();
+
+            initialSeq = sequence;
+            initialAck = acknowledge;
+            initialMax = maximum;
 
             state = McpState.closedInitial(state);
 
             cleanup(traceId);
 
-            if (!McpState.replyClosed(state))
-            {
-                doEnd(sender, originId, routedId, replyId, traceId, authorization);
-                state = McpState.closedReply(state);
-            }
+            doServerEnd(traceId);
         }
 
         private void onServerAbort(
             AbortFW abort)
         {
+            final long sequence = abort.sequence();
+            final long acknowledge = abort.acknowledge();
+            final int maximum = abort.maximum();
             final long traceId = abort.traceId();
+
+            initialSeq = sequence;
+            initialAck = acknowledge;
+            initialMax = maximum;
 
             state = McpState.closedInitial(state);
 
             cleanup(traceId);
 
-            if (!McpState.replyClosed(state))
-            {
-                doAbort(sender, originId, routedId, replyId, traceId, authorization);
-                state = McpState.closedReply(state);
-            }
+            doServerAbort(traceId);
+        }
+
+        private void onServerWindow(
+            WindowFW window)
+        {
+            final long acknowledge = window.acknowledge();
+            final int maximum = window.maximum();
+
+            replyAck = acknowledge;
+            replyMax = maximum;
         }
 
         private void onServerReset(
             ResetFW reset)
         {
+            final long sequence = reset.sequence();
+            final long acknowledge = reset.acknowledge();
+            final int maximum = reset.maximum();
             final long traceId = reset.traceId();
+
+            replyAck = acknowledge;
+            replyMax = maximum;
 
             state = McpState.closedReply(state);
 
             cleanup(traceId);
+        }
+
+        private void doServerBegin(
+            long traceId,
+            Flyweight extension)
+        {
+            doBegin(sender, originId, routedId, replyId, replySeq, replyAck, replyMax, traceId, authorization,
+                affinity, extension);
+            state = McpState.openedReply(state);
+        }
+
+        private void doServerEnd(
+            long traceId)
+        {
+            if (!McpState.replyClosed(state))
+            {
+                doEnd(sender, originId, routedId, replyId, replySeq, replyAck, replyMax, traceId, authorization);
+                state = McpState.closedReply(state);
+            }
+        }
+
+        private void doServerAbort(
+            long traceId)
+        {
+            if (!McpState.replyClosed(state))
+            {
+                doAbort(sender, originId, routedId, replyId, replySeq, replyAck, replyMax, traceId, authorization);
+                state = McpState.closedReply(state);
+            }
+        }
+
+        private void doServerWindow(
+            long traceId,
+            long budgetId,
+            int padding)
+        {
+            doWindow(sender, originId, routedId, initialId, initialSeq, initialAck, initialMax, traceId, authorization,
+                budgetId, padding);
         }
 
         private void cleanup(
@@ -855,6 +1038,14 @@ public final class McpProxyFactory implements McpStreamFactory
         private MessageConsumer sender;
         private int state;
         private String sessionId;        // upstream-provided session id, set on BEGIN reply
+
+        private long initialSeq;
+        private long initialAck;
+        private int initialMax;
+
+        private long replySeq;
+        private long replyAck;
+        private int replyMax;
 
         private McpLifecycleClient(
             McpLifecycleServer server,
@@ -881,7 +1072,7 @@ public final class McpProxyFactory implements McpStreamFactory
                     .build();
 
                 sender = newStream(this::onClientMessage, originId, routedId, initialId,
-                    traceId, server.authorization, server.affinity, beginEx);
+                    initialSeq, initialAck, initialMax, traceId, server.authorization, server.affinity, beginEx);
                 state = McpState.openingInitial(state);
             }
         }
@@ -892,7 +1083,8 @@ public final class McpProxyFactory implements McpStreamFactory
             if (!McpState.initialClosed(state))
             {
                 final long originId = server.routedId;
-                doEnd(sender, originId, routedId, initialId, traceId, server.authorization);
+                doEnd(sender, originId, routedId, initialId, initialSeq, initialAck, initialMax, traceId,
+                    server.authorization);
                 state = McpState.closedInitial(state);
             }
         }
@@ -903,7 +1095,8 @@ public final class McpProxyFactory implements McpStreamFactory
             if (!McpState.initialClosed(state))
             {
                 final long originId = server.routedId;
-                doAbort(sender, originId, routedId, initialId, traceId, server.authorization);
+                doAbort(sender, originId, routedId, initialId, initialSeq, initialAck, initialMax, traceId,
+                    server.authorization);
                 state = McpState.closedInitial(state);
             }
         }
@@ -914,9 +1107,20 @@ public final class McpProxyFactory implements McpStreamFactory
             if (!McpState.replyClosed(state))
             {
                 final long originId = server.routedId;
-                doReset(sender, originId, routedId, replyId, traceId, server.authorization);
+                doReset(sender, originId, routedId, replyId, replySeq, replyAck, replyMax, traceId,
+                    server.authorization, emptyRO);
                 state = McpState.closedReply(state);
             }
+        }
+
+        private void doClientWindow(
+            long traceId,
+            long budgetId,
+            int padding)
+        {
+            final long originId = server.routedId;
+            doWindow(sender, originId, routedId, replyId, replySeq, replyAck, replyMax, traceId, server.authorization,
+                budgetId, padding);
         }
 
         private void onClientMessage(
@@ -943,7 +1147,8 @@ public final class McpProxyFactory implements McpStreamFactory
                 onClientAbort(abort);
                 break;
             case WindowFW.TYPE_ID:
-                // we do not send DATA on this stream; nothing to do
+                final WindowFW window = windowRO.wrap(buffer, index, index + length);
+                onClientWindow(window);
                 break;
             case ResetFW.TYPE_ID:
                 final ResetFW reset = resetRO.wrap(buffer, index, index + length);
@@ -957,9 +1162,15 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onClientBegin(
             BeginFW begin)
         {
-            final long originId = server.routedId;
+            final long sequence = begin.sequence();
+            final long acknowledge = begin.acknowledge();
+            final int maximum = begin.maximum();
             final long traceId = begin.traceId();
             final OctetsFW extension = begin.extension();
+
+            replySeq = sequence;
+            replyAck = acknowledge;
+            replyMax = maximum;
 
             state = McpState.openedInitial(state);
 
@@ -973,8 +1184,9 @@ public final class McpProxyFactory implements McpStreamFactory
                 }
             }
 
-            doWindow(sender, originId, routedId, replyId, traceId, server.authorization, 0,
-                writeBuffer.capacity(), 0);
+            replyAck = replySeq;
+            replyMax = writeBuffer.capacity();
+            doClientWindow(traceId, 0L, 0);
 
             state = McpState.openedReply(state);
         }
@@ -982,7 +1194,15 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onClientEnd(
             EndFW end)
         {
+            final long sequence = end.sequence();
+            final long acknowledge = end.acknowledge();
+            final int maximum = end.maximum();
             final long traceId = end.traceId();
+
+            replySeq = sequence;
+            replyAck = acknowledge;
+            replyMax = maximum;
+
             state = McpState.closedReply(state);
             doClientEnd(traceId);
             server.clients.remove(routedId, this);
@@ -991,16 +1211,40 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onClientAbort(
             AbortFW abort)
         {
+            final long sequence = abort.sequence();
+            final long acknowledge = abort.acknowledge();
+            final int maximum = abort.maximum();
             final long traceId = abort.traceId();
+
+            replySeq = sequence;
+            replyAck = acknowledge;
+            replyMax = maximum;
+
             state = McpState.closedReply(state);
             doClientAbort(traceId);
             server.clients.remove(routedId, this);
         }
 
+        private void onClientWindow(
+            WindowFW window)
+        {
+            final long acknowledge = window.acknowledge();
+            final int maximum = window.maximum();
+
+            initialAck = acknowledge;
+            initialMax = maximum;
+        }
+
         private void onClientReset(
             ResetFW reset)
         {
+            final long acknowledge = reset.acknowledge();
+            final int maximum = reset.maximum();
             final long traceId = reset.traceId();
+
+            initialAck = acknowledge;
+            initialMax = maximum;
+
             state = McpState.closedInitial(state);
             doClientReset(traceId);
             server.clients.remove(routedId, this);
@@ -1021,6 +1265,14 @@ public final class McpProxyFactory implements McpStreamFactory
         private int state;
         private int replySlot = NO_SLOT;
         private int replySlotOffset;
+
+        private long initialSeq;
+        private long initialAck;
+        private int initialMax;
+
+        private long replySeq;
+        private long replyAck;
+        private int replyMax;
 
         // streaming JSON state — built lazily on first DATA frame
         private JsonParser decodableJson;
@@ -1074,7 +1326,7 @@ public final class McpProxyFactory implements McpStreamFactory
                 .build();
 
             sender = newStream(this::onClientMessage, server.lifecycle.originId, resolvedId, initialId,
-                traceId, server.authorization, server.affinity, beginEx);
+                initialSeq, initialAck, initialMax, traceId, server.authorization, server.affinity, beginEx);
             state = McpState.openingInitial(state);
         }
 
@@ -1084,7 +1336,7 @@ public final class McpProxyFactory implements McpStreamFactory
             if (!McpState.initialClosed(state))
             {
                 doEnd(sender, server.lifecycle.originId, resolvedId, initialId,
-                    traceId, server.authorization);
+                    initialSeq, initialAck, initialMax, traceId, server.authorization);
                 state = McpState.closedInitial(state);
             }
         }
@@ -1095,7 +1347,7 @@ public final class McpProxyFactory implements McpStreamFactory
             if (!McpState.initialClosed(state))
             {
                 doAbort(sender, server.lifecycle.originId, resolvedId, initialId,
-                    traceId, server.authorization);
+                    initialSeq, initialAck, initialMax, traceId, server.authorization);
                 state = McpState.closedInitial(state);
             }
         }
@@ -1106,9 +1358,18 @@ public final class McpProxyFactory implements McpStreamFactory
             if (!McpState.replyClosed(state))
             {
                 doReset(sender, server.lifecycle.originId, resolvedId, replyId,
-                    traceId, server.authorization);
+                    replySeq, replyAck, replyMax, traceId, server.authorization, emptyRO);
                 state = McpState.closedReply(state);
             }
+        }
+
+        private void doClientWindow(
+            long traceId,
+            long budgetId,
+            int padding)
+        {
+            doWindow(sender, server.lifecycle.originId, resolvedId, replyId,
+                replySeq, replyAck, replyMax, traceId, server.authorization, budgetId, padding);
         }
 
         private void onClientMessage(
@@ -1136,6 +1397,8 @@ public final class McpProxyFactory implements McpStreamFactory
                 onClientAbort(abort);
                 break;
             case WindowFW.TYPE_ID:
+                final WindowFW window = windowRO.wrap(buffer, index, index + length);
+                onClientWindow(window);
                 break;
             case ResetFW.TYPE_ID:
                 final ResetFW reset = resetRO.wrap(buffer, index, index + length);
@@ -1149,20 +1412,37 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onClientBegin(
             BeginFW begin)
         {
+            final long sequence = begin.sequence();
+            final long acknowledge = begin.acknowledge();
+            final int maximum = begin.maximum();
             final long traceId = begin.traceId();
+
+            replySeq = sequence;
+            replyAck = acknowledge;
+            replyMax = maximum;
+
             state = McpState.openedInitial(state);
-            doWindow(sender, server.lifecycle.originId, resolvedId, replyId, traceId,
-                server.authorization, 0, writeBuffer.capacity(), 0);
+
+            replyAck = replySeq;
+            replyMax = writeBuffer.capacity();
+            doClientWindow(traceId, 0L, 0);
         }
 
         private void onClientData(
             DataFW data)
         {
+            final long sequence = data.sequence();
+            final long acknowledge = data.acknowledge();
+            final int maximum = data.maximum();
             final long traceId = data.traceId();
             final long authorization = data.authorization();
             final long budgetId = data.budgetId();
             final int reserved = data.reserved();
             final OctetsFW payload = data.payload();
+
+            replySeq = sequence + reserved;
+            replyAck = acknowledge;
+            replyMax = maximum;
 
             DirectBuffer buffer = payload.buffer();
             int offset = payload.offset();
@@ -1191,7 +1471,15 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onClientEnd(
             EndFW end)
         {
+            final long sequence = end.sequence();
+            final long acknowledge = end.acknowledge();
+            final int maximum = end.maximum();
             final long traceId = end.traceId();
+
+            replySeq = sequence;
+            replyAck = acknowledge;
+            replyMax = maximum;
+
             if (!McpState.replyClosed(state))
             {
                 state = McpState.closedReply(state);
@@ -1203,7 +1491,15 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onClientAbort(
             AbortFW abort)
         {
+            final long sequence = abort.sequence();
+            final long acknowledge = abort.acknowledge();
+            final int maximum = abort.maximum();
             final long traceId = abort.traceId();
+
+            replySeq = sequence;
+            replyAck = acknowledge;
+            replyMax = maximum;
+
             if (!McpState.replyClosed(state))
             {
                 state = McpState.closedReply(state);
@@ -1212,10 +1508,26 @@ public final class McpProxyFactory implements McpStreamFactory
             }
         }
 
+        private void onClientWindow(
+            WindowFW window)
+        {
+            final long acknowledge = window.acknowledge();
+            final int maximum = window.maximum();
+
+            initialAck = acknowledge;
+            initialMax = maximum;
+        }
+
         private void onClientReset(
             ResetFW reset)
         {
+            final long acknowledge = reset.acknowledge();
+            final int maximum = reset.maximum();
             final long traceId = reset.traceId();
+
+            initialAck = acknowledge;
+            initialMax = maximum;
+
             state = McpState.closedInitial(state);
             if (!McpState.replyClosed(state))
             {
@@ -1651,6 +1963,14 @@ public final class McpProxyFactory implements McpStreamFactory
         private int itemsEmitted;
         private McpListClient client;
 
+        private long initialSeq;
+        private long initialAck;
+        private int initialMax;
+
+        private long replySeq;
+        private long replyAck;
+        private int replyMax;
+
         private McpListServer(
             McpLifecycleServer lifecycle,
             int kind,
@@ -1689,6 +2009,8 @@ public final class McpProxyFactory implements McpStreamFactory
                 onServerAbort(abort);
                 break;
             case WindowFW.TYPE_ID:
+                final WindowFW window = windowRO.wrap(buffer, index, index + length);
+                onServerWindow(window);
                 break;
             case ResetFW.TYPE_ID:
                 final ResetFW reset = resetRO.wrap(buffer, index, index + length);
@@ -1702,11 +2024,20 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onServerBegin(
             BeginFW begin)
         {
+            final long sequence = begin.sequence();
+            final long acknowledge = begin.acknowledge();
+            final int maximum = begin.maximum();
             final long traceId = begin.traceId();
+
+            initialSeq = sequence;
+            initialAck = acknowledge;
+            initialMax = maximum;
+
             state = McpState.openingInitial(state);
 
-            doWindow(lifecycle.sender, lifecycle.originId, lifecycle.routedId, initialId, traceId, authorization, 0,
-                writeBuffer.capacity(), 0);
+            initialAck = initialSeq;
+            initialMax = writeBuffer.capacity();
+            doServerWindow(traceId, 0L, 0);
 
             doServerBegin(traceId);
             doEncodeBeginItems(traceId);
@@ -1716,7 +2047,15 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onServerEnd(
             EndFW end)
         {
+            final long sequence = end.sequence();
+            final long acknowledge = end.acknowledge();
+            final int maximum = end.maximum();
             final long traceId = end.traceId();
+
+            initialSeq = sequence;
+            initialAck = acknowledge;
+            initialMax = maximum;
+
             state = McpState.closedInitial(state);
 
             if (client != null)
@@ -1728,7 +2067,15 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onServerAbort(
             AbortFW abort)
         {
+            final long sequence = abort.sequence();
+            final long acknowledge = abort.acknowledge();
+            final int maximum = abort.maximum();
             final long traceId = abort.traceId();
+
+            initialSeq = sequence;
+            initialAck = acknowledge;
+            initialMax = maximum;
+
             state = McpState.closedInitial(state);
 
             if (client != null)
@@ -1738,10 +2085,26 @@ public final class McpProxyFactory implements McpStreamFactory
             remaining.clear();
         }
 
+        private void onServerWindow(
+            WindowFW window)
+        {
+            final long acknowledge = window.acknowledge();
+            final int maximum = window.maximum();
+
+            replyAck = acknowledge;
+            replyMax = maximum;
+        }
+
         private void onServerReset(
             ResetFW reset)
         {
+            final long acknowledge = reset.acknowledge();
+            final int maximum = reset.maximum();
             final long traceId = reset.traceId();
+
+            replyAck = acknowledge;
+            replyMax = maximum;
+
             state = McpState.closedReply(state);
 
             if (client != null)
@@ -1839,8 +2202,8 @@ public final class McpProxyFactory implements McpStreamFactory
                 })
                 .build();
 
-            doBegin(lifecycle.sender, lifecycle.originId, lifecycle.routedId, replyId, traceId, authorization,
-                affinity, beginEx);
+            doBegin(lifecycle.sender, lifecycle.originId, lifecycle.routedId, replyId, replySeq, replyAck, replyMax,
+                traceId, authorization, affinity, beginEx);
             state = McpState.openedReply(state);
         }
 
@@ -1853,8 +2216,9 @@ public final class McpProxyFactory implements McpStreamFactory
             int offset,
             int length)
         {
-            doData(lifecycle.sender, lifecycle.originId, lifecycle.routedId, replyId, traceId, authorization,
-                budgetId, flags, reserved, payload, offset, length);
+            doData(lifecycle.sender, lifecycle.originId, lifecycle.routedId, replyId, replySeq, replyAck, replyMax,
+                traceId, authorization, flags, budgetId, reserved, payload, offset, length);
+            replySeq += reserved;
         }
 
         private void doServerEnd(
@@ -1862,7 +2226,8 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (!McpState.replyClosed(state))
             {
-                doEnd(lifecycle.sender, lifecycle.originId, lifecycle.routedId, replyId, traceId, authorization);
+                doEnd(lifecycle.sender, lifecycle.originId, lifecycle.routedId, replyId, replySeq, replyAck, replyMax,
+                    traceId, authorization);
                 state = McpState.closedReply(state);
             }
         }
@@ -1872,9 +2237,19 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (!McpState.replyClosed(state))
             {
-                doAbort(lifecycle.sender, lifecycle.originId, lifecycle.routedId, replyId, traceId, authorization);
+                doAbort(lifecycle.sender, lifecycle.originId, lifecycle.routedId, replyId, replySeq, replyAck, replyMax,
+                    traceId, authorization);
                 state = McpState.closedReply(state);
             }
+        }
+
+        private void doServerWindow(
+            long traceId,
+            long budgetId,
+            int padding)
+        {
+            doWindow(lifecycle.sender, lifecycle.originId, lifecycle.routedId, initialId, initialSeq, initialAck, initialMax,
+                traceId, authorization, budgetId, padding);
         }
     }
 
@@ -1905,6 +2280,9 @@ public final class McpProxyFactory implements McpStreamFactory
         long originId,
         long routedId,
         long streamId,
+        long sequence,
+        long acknowledge,
+        int maximum,
         long traceId,
         long authorization,
         long affinity,
@@ -1914,9 +2292,9 @@ public final class McpProxyFactory implements McpStreamFactory
             .originId(originId)
             .routedId(routedId)
             .streamId(streamId)
-            .sequence(0)
-            .acknowledge(0)
-            .maximum(0)
+            .sequence(sequence)
+            .acknowledge(acknowledge)
+            .maximum(maximum)
             .traceId(traceId)
             .authorization(authorization)
             .affinity(affinity)
@@ -1937,6 +2315,9 @@ public final class McpProxyFactory implements McpStreamFactory
         long originId,
         long routedId,
         long streamId,
+        long sequence,
+        long acknowledge,
+        int maximum,
         long traceId,
         long authorization,
         long affinity,
@@ -1946,9 +2327,9 @@ public final class McpProxyFactory implements McpStreamFactory
             .originId(originId)
             .routedId(routedId)
             .streamId(streamId)
-            .sequence(0)
-            .acknowledge(0)
-            .maximum(0)
+            .sequence(sequence)
+            .acknowledge(acknowledge)
+            .maximum(maximum)
             .traceId(traceId)
             .authorization(authorization)
             .affinity(affinity)
@@ -1963,10 +2344,13 @@ public final class McpProxyFactory implements McpStreamFactory
         long originId,
         long routedId,
         long streamId,
+        long sequence,
+        long acknowledge,
+        int maximum,
         long traceId,
         long authorization,
-        long budgetId,
         int flags,
+        long budgetId,
         int reserved,
         DirectBuffer payload,
         int offset,
@@ -1976,9 +2360,9 @@ public final class McpProxyFactory implements McpStreamFactory
             .originId(originId)
             .routedId(routedId)
             .streamId(streamId)
-            .sequence(0)
-            .acknowledge(0)
-            .maximum(0)
+            .sequence(sequence)
+            .acknowledge(acknowledge)
+            .maximum(maximum)
             .traceId(traceId)
             .authorization(authorization)
             .flags(flags)
@@ -1995,6 +2379,9 @@ public final class McpProxyFactory implements McpStreamFactory
         long originId,
         long routedId,
         long streamId,
+        long sequence,
+        long acknowledge,
+        int maximum,
         long traceId,
         long authorization)
     {
@@ -2002,9 +2389,9 @@ public final class McpProxyFactory implements McpStreamFactory
             .originId(originId)
             .routedId(routedId)
             .streamId(streamId)
-            .sequence(0)
-            .acknowledge(0)
-            .maximum(0)
+            .sequence(sequence)
+            .acknowledge(acknowledge)
+            .maximum(maximum)
             .traceId(traceId)
             .authorization(authorization)
             .build();
@@ -2017,6 +2404,9 @@ public final class McpProxyFactory implements McpStreamFactory
         long originId,
         long routedId,
         long streamId,
+        long sequence,
+        long acknowledge,
+        int maximum,
         long traceId,
         long authorization)
     {
@@ -2024,9 +2414,9 @@ public final class McpProxyFactory implements McpStreamFactory
             .originId(originId)
             .routedId(routedId)
             .streamId(streamId)
-            .sequence(0)
-            .acknowledge(0)
-            .maximum(0)
+            .sequence(sequence)
+            .acknowledge(acknowledge)
+            .maximum(maximum)
             .traceId(traceId)
             .authorization(authorization)
             .build();
@@ -2034,23 +2424,57 @@ public final class McpProxyFactory implements McpStreamFactory
         receiver.accept(abort.typeId(), abort.buffer(), abort.offset(), abort.sizeof());
     }
 
+    private void doFlush(
+        MessageConsumer receiver,
+        long originId,
+        long routedId,
+        long streamId,
+        long sequence,
+        long acknowledge,
+        int maximum,
+        long traceId,
+        long authorization,
+        long budgetId,
+        int reserved)
+    {
+        final FlushFW flush = flushRW.wrap(writeBuffer, 0, writeBuffer.capacity())
+            .originId(originId)
+            .routedId(routedId)
+            .streamId(streamId)
+            .sequence(sequence)
+            .acknowledge(acknowledge)
+            .maximum(maximum)
+            .traceId(traceId)
+            .authorization(authorization)
+            .budgetId(budgetId)
+            .reserved(reserved)
+            .build();
+
+        receiver.accept(flush.typeId(), flush.buffer(), flush.offset(), flush.sizeof());
+    }
+
     private void doReset(
         MessageConsumer receiver,
         long originId,
         long routedId,
         long streamId,
+        long sequence,
+        long acknowledge,
+        int maximum,
         long traceId,
-        long authorization)
+        long authorization,
+        Flyweight extension)
     {
         final ResetFW reset = resetRW.wrap(writeBuffer, 0, writeBuffer.capacity())
             .originId(originId)
             .routedId(routedId)
             .streamId(streamId)
-            .sequence(0)
-            .acknowledge(0)
-            .maximum(0)
+            .sequence(sequence)
+            .acknowledge(acknowledge)
+            .maximum(maximum)
             .traceId(traceId)
             .authorization(authorization)
+            .extension(extension.buffer(), extension.offset(), extension.sizeof())
             .build();
 
         receiver.accept(reset.typeId(), reset.buffer(), reset.offset(), reset.sizeof());
@@ -2061,19 +2485,21 @@ public final class McpProxyFactory implements McpStreamFactory
         long originId,
         long routedId,
         long streamId,
+        long sequence,
+        long acknowledge,
+        int maximum,
         long traceId,
         long authorization,
         long budgetId,
-        int credit,
         int padding)
     {
         final WindowFW window = windowRW.wrap(writeBuffer, 0, writeBuffer.capacity())
             .originId(originId)
             .routedId(routedId)
             .streamId(streamId)
-            .sequence(0)
-            .acknowledge(0)
-            .maximum(credit)
+            .sequence(sequence)
+            .acknowledge(acknowledge)
+            .maximum(maximum)
             .traceId(traceId)
             .authorization(authorization)
             .budgetId(budgetId)

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -1415,6 +1415,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private boolean awaitingIdValue;
         private long itemStartStreamOffset = -1;
         private long itemEmittedStreamOffset = -1;
+        private boolean pendingFinalize;
         private McpListClientDecoder decoder = decodeInit;
         private String arrayKey;
         private String idKey;
@@ -2033,6 +2034,32 @@ public final class McpProxyFactory implements McpStreamFactory
         decode:
         while (true)
         {
+            if (client.itemStartStreamOffset >= 0)
+            {
+                final long parserStreamOffset = parser.getLocation().getStreamOffset();
+                if (client.itemEmittedStreamOffset < parserStreamOffset)
+                {
+                    final int emittedInBuf =
+                        offset + (int) (client.itemEmittedStreamOffset - client.decodedParserProgress);
+                    final int parserInBuf = offset + (int) (parserStreamOffset - client.decodedParserProgress);
+                    final int chunkLen = parserInBuf - emittedInBuf;
+                    final int emitted = client.server.streamItemChunk(buffer, emittedInBuf, chunkLen, traceId);
+                    client.itemEmittedStreamOffset += emitted;
+                    if (emitted < chunkLen)
+                    {
+                        break decode;
+                    }
+                }
+
+                if (client.pendingFinalize)
+                {
+                    client.server.streamItemEnd(traceId);
+                    client.itemStartStreamOffset = -1;
+                    client.itemEmittedStreamOffset = -1;
+                    client.pendingFinalize = false;
+                }
+            }
+
             final long beforeStreamOffset = parser.getLocation().getStreamOffset();
             if (!parser.hasNext())
             {
@@ -2066,7 +2093,7 @@ public final class McpProxyFactory implements McpStreamFactory
                     client.itemEmittedStreamOffset += emitted;
                     if (emitted < chunkLen)
                     {
-                        client.decodeItemDepth++;
+                        client.pendingFinalize = true;
                         break decode;
                     }
                     client.server.streamItemEnd(traceId);

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -284,8 +284,9 @@ public final class McpProxyFactory implements McpStreamFactory
         private final long replyId;
         private final long affinity;
         private final long authorization;
-        private final McpClient client;
+        private final long resolvedId;
         private final int kind;
+        private McpClient client;
         private final String sessionId;
         private final String identifier;
         private final String prefix;
@@ -316,6 +317,7 @@ public final class McpProxyFactory implements McpStreamFactory
             this.routedId = routedId;
             this.initialId = initialId;
             this.replyId = supplyReplyId.applyAsLong(initialId);
+            this.resolvedId = resolvedId;
             this.affinity = affinity;
             this.authorization = authorization;
             this.kind = kind;
@@ -325,7 +327,6 @@ public final class McpProxyFactory implements McpStreamFactory
             this.capabilities = capabilities;
             this.session = session;
             this.exit = exit;
-            this.client = new McpClient(this, resolvedId);
         }
 
         private void onServerMessage(
@@ -395,7 +396,7 @@ public final class McpProxyFactory implements McpStreamFactory
         public void proceed(
             long traceId)
         {
-            client.doClientBegin(traceId);
+            this.client = new McpClient(this, resolvedId, traceId);
 
             doWindow(sender, originId, routedId, initialId, traceId, authorization, 0,
                 writeBuffer.capacity(), 0);
@@ -537,25 +538,21 @@ public final class McpProxyFactory implements McpStreamFactory
         private final McpServer server;
         private final long resolvedId;
 
-        private long initialId;
-        private long replyId;
-        private MessageConsumer sender;
+        private final long initialId;
+        private final long replyId;
+        private final MessageConsumer sender;
 
         private int state;
 
         private McpClient(
             McpServer server,
-            long resolvedId)
+            long resolvedId,
+            long traceId)
         {
             this.server = server;
             this.resolvedId = resolvedId;
-        }
-
-        private void doClientBegin(
-            long traceId)
-        {
-            initialId = supplyInitialId.applyAsLong(resolvedId);
-            replyId = supplyReplyId.applyAsLong(initialId);
+            this.initialId = supplyInitialId.applyAsLong(resolvedId);
+            this.replyId = supplyReplyId.applyAsLong(initialId);
 
             final String identifier = server.identifier;
             final int capabilities = server.capabilities;
@@ -586,9 +583,9 @@ public final class McpProxyFactory implements McpStreamFactory
             }
             final McpBeginExFW beginEx = builder.build();
 
-            sender = newStream(this::onClientMessage, server.originId, resolvedId, initialId,
+            this.sender = newStream(this::onClientMessage, server.originId, resolvedId, initialId,
                 traceId, server.authorization, server.affinity, beginEx);
-            state = McpState.openingInitial(state);
+            this.state = McpState.openingInitial(0);
         }
 
         private void doClientData(
@@ -711,39 +708,37 @@ public final class McpProxyFactory implements McpStreamFactory
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId);
 
-            return switch (beginEx.kind())
+            switch (beginEx.kind())
             {
-            case KIND_LIFECYCLE ->
-            {
+            case KIND_LIFECYCLE:
                 final int caps = beginEx.lifecycle().capabilities();
-                yield builder.lifecycle(l -> l.sessionId(sid).capabilities(caps)).build();
-            }
-            case KIND_TOOLS_LIST -> builder
-                .toolsList(t -> t.sessionId(sid))
-                .build();
-            case KIND_TOOLS_CALL ->
-            {
-                final String name = beginEx.toolsCall().name().asString();
-                yield builder.toolsCall(t -> t.sessionId(sid).name(name)).build();
-            }
-            case KIND_PROMPTS_LIST -> builder
-                .promptsList(p -> p.sessionId(sid))
-                .build();
-            case KIND_PROMPTS_GET ->
-            {
-                final String name = beginEx.promptsGet().name().asString();
-                yield builder.promptsGet(p -> p.sessionId(sid).name(name)).build();
-            }
-            case KIND_RESOURCES_LIST -> builder
-                .resourcesList(r -> r.sessionId(sid))
-                .build();
-            case KIND_RESOURCES_READ ->
-            {
+                builder.lifecycle(l -> l.sessionId(sid).capabilities(caps));
+                break;
+            case KIND_TOOLS_LIST:
+                builder.toolsList(t -> t.sessionId(sid));
+                break;
+            case KIND_TOOLS_CALL:
+                final String toolName = beginEx.toolsCall().name().asString();
+                builder.toolsCall(t -> t.sessionId(sid).name(toolName));
+                break;
+            case KIND_PROMPTS_LIST:
+                builder.promptsList(p -> p.sessionId(sid));
+                break;
+            case KIND_PROMPTS_GET:
+                final String promptName = beginEx.promptsGet().name().asString();
+                builder.promptsGet(p -> p.sessionId(sid).name(promptName));
+                break;
+            case KIND_RESOURCES_LIST:
+                builder.resourcesList(r -> r.sessionId(sid));
+                break;
+            case KIND_RESOURCES_READ:
                 final String uri = beginEx.resourcesRead().uri().asString();
-                yield builder.resourcesRead(r -> r.sessionId(sid).uri(uri)).build();
+                builder.resourcesRead(r -> r.sessionId(sid).uri(uri));
+                break;
+            default:
+                return beginEx;
             }
-            default -> beginEx;
-            };
+            return builder.build();
         }
 
         private void onClientData(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -43,6 +43,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 import io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration;
 import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpBindingConfig;
 import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpRouteConfig;
+import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpRoutePrefix;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.Flyweight;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.OctetsFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.AbortFW;
@@ -74,6 +75,7 @@ public final class McpProxyFactory implements McpStreamFactory
     private final ResetFW resetRO = new ResetFW();
     private final McpBeginExFW mcpBeginExRO = new McpBeginExFW();
     private final OctetsFW emptyRO = new OctetsFW().wrap(new UnsafeBuffer(), 0, 0);
+    private final UnsafeBuffer itemRO = new UnsafeBuffer(0, 0);
 
     private final BeginFW.Builder beginRW = new BeginFW.Builder();
     private final DataFW.Builder dataRW = new DataFW.Builder();
@@ -177,19 +179,17 @@ public final class McpProxyFactory implements McpStreamFactory
                 {
                     if (isListKind(kind))
                     {
-                        final List<McpRouteConfig> routes = binding.resolveAll(beginEx, authorization);
-                        final McpListServer server = new McpListServer(
-                            sender,
-                            originId,
-                            routedId,
+                        final List<McpRoutePrefix> prefixes = binding.resolveAll(beginEx, authorization)
+                            .stream()
+                            .map(r -> new McpRoutePrefix(r.id, r.prefix(kind)))
+                            .toList();
+                        newStream = new McpListServer(
+                            lifecycle,
+                            kind,
                             initialId,
                             affinity,
                             authorization,
-                            kind,
-                            lifecycle,
-                            routes,
-                            beginEx);
-                        newStream = server::onServerMessage;
+                            prefixes)::onServerMessage;
                     }
                     else
                     {
@@ -200,6 +200,8 @@ public final class McpProxyFactory implements McpStreamFactory
                             final String prefix = route.prefix(beginEx);
 
                             newStream = new McpServer(
+                                lifecycle,
+                                kind,
                                 sender,
                                 originId,
                                 routedId,
@@ -207,11 +209,8 @@ public final class McpProxyFactory implements McpStreamFactory
                                 route.id,
                                 affinity,
                                 authorization,
-                                kind,
                                 identifier,
-                                prefix,
-                                0,
-                                lifecycle)::onServerMessage;
+                                prefix)::onServerMessage;
                         }
                     }
                 }
@@ -223,6 +222,8 @@ public final class McpProxyFactory implements McpStreamFactory
 
     private final class McpServer
     {
+        private final McpLifecycleServer lifecycle;
+        private final int kind;
         private final MessageConsumer sender;
         private final long originId;
         private final long routedId;
@@ -230,17 +231,15 @@ public final class McpProxyFactory implements McpStreamFactory
         private final long replyId;
         private final long affinity;
         private final long authorization;
-        private final long resolvedId;
-        private final int kind;
-        private McpClient client;
         private final String identifier;
         private final String prefix;
-        private final int capabilities;
-        private final McpLifecycleServer lifecycle;
+        private final McpClient client;
 
         private int state;
 
         private McpServer(
+            McpLifecycleServer lifecycle,
+            int kind,
             MessageConsumer sender,
             long originId,
             long routedId,
@@ -248,25 +247,21 @@ public final class McpProxyFactory implements McpStreamFactory
             long resolvedId,
             long affinity,
             long authorization,
-            int kind,
             String identifier,
-            String prefix,
-            int capabilities,
-            McpLifecycleServer lifecycle)
+            String prefix)
         {
+            this.lifecycle = lifecycle;
+            this.kind = kind;
             this.sender = sender;
             this.originId = originId;
             this.routedId = routedId;
             this.initialId = initialId;
             this.replyId = supplyReplyId.applyAsLong(initialId);
-            this.resolvedId = resolvedId;
             this.affinity = affinity;
             this.authorization = authorization;
-            this.kind = kind;
             this.identifier = identifier;
             this.prefix = prefix;
-            this.capabilities = capabilities;
-            this.lifecycle = lifecycle;
+            this.client = new McpClient(this, resolvedId);
         }
 
         private String sessionId()
@@ -322,7 +317,6 @@ public final class McpProxyFactory implements McpStreamFactory
 
             state = McpState.openingInitial(state);
 
-            this.client = new McpClient(this, resolvedId);
             client.doClientBegin(traceId);
 
             doWindow(sender, originId, routedId, initialId, traceId, authorization, 0,
@@ -350,11 +344,6 @@ public final class McpProxyFactory implements McpStreamFactory
             state = McpState.closedInitial(state);
 
             client.doClientEnd(traceId);
-
-            if (kind == KIND_LIFECYCLE)
-            {
-                sessions.remove(lifecycle.sessionId);
-            }
         }
 
         private void onServerAbort(
@@ -365,11 +354,6 @@ public final class McpProxyFactory implements McpStreamFactory
             state = McpState.closedInitial(state);
 
             client.doClientAbort(traceId);
-
-            if (kind == KIND_LIFECYCLE)
-            {
-                sessions.remove(lifecycle.sessionId);
-            }
         }
 
         private void onServerFlush(
@@ -489,36 +473,26 @@ public final class McpProxyFactory implements McpStreamFactory
             lifecycle.doClientBegin(traceId);
 
             final String identifier = server.identifier;
-            final int capabilities = server.capabilities;
-            final boolean lifecycleKind = server.kind == KIND_LIFECYCLE;
             final String upstreamSessionId = lifecycle.sessionId;
-            final String outboundSessionId = lifecycleKind || upstreamSessionId == null
-                ? server.sessionId()
-                : upstreamSessionId;
+            final String outboundSessionId = upstreamSessionId != null
+                ? upstreamSessionId
+                : server.sessionId();
             final McpBeginExFW.Builder builder = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId);
             switch (server.kind)
             {
-            case KIND_LIFECYCLE -> builder
-                .lifecycle(l -> l.sessionId(outboundSessionId).capabilities(capabilities));
-            case KIND_TOOLS_LIST -> builder
-                .toolsList(t -> t.sessionId(outboundSessionId));
             case KIND_TOOLS_CALL -> builder
                 .toolsCall(t -> t.sessionId(outboundSessionId).name(identifier));
-            case KIND_PROMPTS_LIST -> builder
-                .promptsList(p -> p.sessionId(outboundSessionId));
             case KIND_PROMPTS_GET -> builder
                 .promptsGet(p -> p.sessionId(outboundSessionId).name(identifier));
-            case KIND_RESOURCES_LIST -> builder
-                .resourcesList(r -> r.sessionId(outboundSessionId));
             case KIND_RESOURCES_READ -> builder
                 .resourcesRead(r -> r.sessionId(outboundSessionId).uri(identifier));
             default -> throw new IllegalStateException("unexpected McpBeginEx kind: " + server.kind);
             }
             final McpBeginExFW beginEx = builder.build();
 
-            sender = newStream(this::onClientMessage, server.originId, resolvedId, initialId,
+            sender = newStream(this::onClientMessage, server.lifecycle.originId, resolvedId, initialId,
                 traceId, server.authorization, server.affinity, beginEx);
             state = McpState.openingInitial(state);
         }
@@ -534,7 +508,7 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (!McpState.closed(state))
             {
-                doData(sender, server.originId, resolvedId, initialId,
+                doData(sender, server.lifecycle.originId, resolvedId, initialId,
                     traceId, server.authorization, budgetId, flags, reserved, payload, offset, length);
             }
         }
@@ -544,7 +518,7 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (!McpState.initialClosed(state))
             {
-                doEnd(sender, server.originId, resolvedId, initialId,
+                doEnd(sender, server.lifecycle.originId, resolvedId, initialId,
                     traceId, server.authorization);
                 state = McpState.closedInitial(state);
             }
@@ -555,7 +529,7 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (!McpState.initialClosed(state))
             {
-                doAbort(sender, server.originId, resolvedId, initialId,
+                doAbort(sender, server.lifecycle.originId, resolvedId, initialId,
                     traceId, server.authorization);
                 state = McpState.closedInitial(state);
             }
@@ -567,7 +541,7 @@ public final class McpProxyFactory implements McpStreamFactory
             int credit,
             int padding)
         {
-            doWindow(sender, server.originId, resolvedId, replyId,
+            doWindow(sender, server.lifecycle.originId, resolvedId, replyId,
                 traceId, server.authorization, budgetId, credit, padding);
         }
 
@@ -576,7 +550,7 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (!McpState.replyClosed(state))
             {
-                doReset(sender, server.originId, resolvedId, replyId,
+                doReset(sender, server.lifecycle.originId, resolvedId, replyId,
                     traceId, server.authorization);
                 state = McpState.closedReply(state);
             }
@@ -645,26 +619,13 @@ public final class McpProxyFactory implements McpStreamFactory
 
             switch (beginEx.kind())
             {
-            case KIND_LIFECYCLE:
-                final int caps = beginEx.lifecycle().capabilities();
-                builder.lifecycle(l -> l.sessionId(sid).capabilities(caps));
-                break;
-            case KIND_TOOLS_LIST:
-                builder.toolsList(t -> t.sessionId(sid));
-                break;
             case KIND_TOOLS_CALL:
                 final String toolName = beginEx.toolsCall().name().asString();
                 builder.toolsCall(t -> t.sessionId(sid).name(toolName));
                 break;
-            case KIND_PROMPTS_LIST:
-                builder.promptsList(p -> p.sessionId(sid));
-                break;
             case KIND_PROMPTS_GET:
                 final String promptName = beginEx.promptsGet().name().asString();
                 builder.promptsGet(p -> p.sessionId(sid).name(promptName));
-                break;
-            case KIND_RESOURCES_LIST:
-                builder.resourcesList(r -> r.sessionId(sid));
                 break;
             case KIND_RESOURCES_READ:
                 final String uri = beginEx.resourcesRead().uri().asString();
@@ -885,7 +846,7 @@ public final class McpProxyFactory implements McpStreamFactory
     private final class McpLifecycleClient
     {
         private final McpLifecycleServer server;
-        private final long exitId;
+        private final long routedId;
         private final long initialId;
         private final long replyId;
 
@@ -895,11 +856,11 @@ public final class McpProxyFactory implements McpStreamFactory
 
         private McpLifecycleClient(
             McpLifecycleServer server,
-            long exitId)
+            long routedId)
         {
             this.server = server;
-            this.exitId = exitId;
-            this.initialId = supplyInitialId.applyAsLong(exitId);
+            this.routedId = routedId;
+            this.initialId = supplyInitialId.applyAsLong(routedId);
             this.replyId = supplyReplyId.applyAsLong(initialId);
         }
 
@@ -908,6 +869,7 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (!McpState.initialOpening(state))
             {
+                final long originId = server.routedId;
                 final String sid = server.sessionId;
                 final int clientCapabilities = server.clientCapabilities;
                 final McpBeginExFW beginEx = mcpBeginExRW
@@ -916,7 +878,7 @@ public final class McpProxyFactory implements McpStreamFactory
                     .lifecycle(l -> l.sessionId(sid).capabilities(clientCapabilities))
                     .build();
 
-                sender = newStream(this::onClientMessage, server.originId, exitId, initialId,
+                sender = newStream(this::onClientMessage, originId, routedId, initialId,
                     traceId, server.authorization, server.affinity, beginEx);
                 state = McpState.openingInitial(state);
             }
@@ -927,8 +889,31 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (!McpState.initialClosed(state))
             {
-                doEnd(sender, server.originId, exitId, initialId, traceId, server.authorization);
+                final long originId = server.routedId;
+                doEnd(sender, originId, routedId, initialId, traceId, server.authorization);
                 state = McpState.closedInitial(state);
+            }
+        }
+
+        private void doClientAbort(
+            long traceId)
+        {
+            if (!McpState.initialClosed(state))
+            {
+                final long originId = server.routedId;
+                doAbort(sender, originId, routedId, initialId, traceId, server.authorization);
+                state = McpState.closedInitial(state);
+            }
+        }
+
+        private void doClientReset(
+            long traceId)
+        {
+            if (!McpState.replyClosed(state))
+            {
+                final long originId = server.routedId;
+                doReset(sender, originId, routedId, replyId, traceId, server.authorization);
+                state = McpState.closedReply(state);
             }
         }
 
@@ -970,6 +955,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onClientBegin(
             BeginFW begin)
         {
+            final long originId = server.routedId;
             final long traceId = begin.traceId();
             final OctetsFW extension = begin.extension();
 
@@ -985,7 +971,7 @@ public final class McpProxyFactory implements McpStreamFactory
                 }
             }
 
-            doWindow(sender, server.originId, exitId, replyId, traceId, server.authorization, 0,
+            doWindow(sender, originId, routedId, replyId, traceId, server.authorization, 0,
                 writeBuffer.capacity(), 0);
 
             state = McpState.openedReply(state);
@@ -994,19 +980,28 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onClientEnd(
             EndFW end)
         {
+            final long traceId = end.traceId();
             state = McpState.closedReply(state);
+            doClientEnd(traceId);
+            server.clients.remove(routedId, this);
         }
 
         private void onClientAbort(
             AbortFW abort)
         {
+            final long traceId = abort.traceId();
             state = McpState.closedReply(state);
+            doClientAbort(traceId);
+            server.clients.remove(routedId, this);
         }
 
         private void onClientReset(
             ResetFW reset)
         {
+            final long traceId = reset.traceId();
             state = McpState.closedInitial(state);
+            doClientReset(traceId);
+            server.clients.remove(routedId, this);
         }
     }
 
@@ -1074,7 +1069,7 @@ public final class McpProxyFactory implements McpStreamFactory
             }
             final McpBeginExFW beginEx = builder.build();
 
-            sender = newStream(this::onClientMessage, server.originId, resolvedId, initialId,
+            sender = newStream(this::onClientMessage, server.lifecycle.originId, resolvedId, initialId,
                 traceId, server.authorization, server.affinity, beginEx);
             state = McpState.openingInitial(state);
         }
@@ -1084,7 +1079,7 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (!McpState.initialClosed(state))
             {
-                doEnd(sender, server.originId, resolvedId, initialId,
+                doEnd(sender, server.lifecycle.originId, resolvedId, initialId,
                     traceId, server.authorization);
                 state = McpState.closedInitial(state);
             }
@@ -1095,7 +1090,7 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (!McpState.initialClosed(state))
             {
-                doAbort(sender, server.originId, resolvedId, initialId,
+                doAbort(sender, server.lifecycle.originId, resolvedId, initialId,
                     traceId, server.authorization);
                 state = McpState.closedInitial(state);
             }
@@ -1106,7 +1101,7 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (!McpState.replyClosed(state))
             {
-                doReset(sender, server.originId, resolvedId, replyId,
+                doReset(sender, server.lifecycle.originId, resolvedId, replyId,
                     traceId, server.authorization);
                 state = McpState.closedReply(state);
             }
@@ -1152,7 +1147,7 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long traceId = begin.traceId();
             state = McpState.openedInitial(state);
-            doWindow(sender, server.originId, resolvedId, replyId, traceId,
+            doWindow(sender, server.lifecycle.originId, resolvedId, replyId, traceId,
                 server.authorization, 0, writeBuffer.capacity(), 0);
         }
 
@@ -1165,7 +1160,7 @@ public final class McpProxyFactory implements McpStreamFactory
             if (!appended)
             {
                 state = McpState.closedReply(state);
-                server.onClientError(this, traceId);
+                server.onClientError(traceId);
                 return;
             }
             streamItems(traceId);
@@ -1179,7 +1174,7 @@ public final class McpProxyFactory implements McpStreamFactory
             {
                 state = McpState.closedReply(state);
                 cleanupClientSlot();
-                server.onClientClosed(this, traceId);
+                server.onClientClosed(traceId);
             }
         }
 
@@ -1191,7 +1186,7 @@ public final class McpProxyFactory implements McpStreamFactory
             {
                 state = McpState.closedReply(state);
                 cleanupClientSlot();
-                server.onClientError(this, traceId);
+                server.onClientError(traceId);
             }
         }
 
@@ -1203,7 +1198,7 @@ public final class McpProxyFactory implements McpStreamFactory
             if (!McpState.replyClosed(state))
             {
                 state = McpState.closedReply(state);
-                server.onClientError(this, traceId);
+                server.onClientError(traceId);
             }
         }
 
@@ -1441,61 +1436,46 @@ public final class McpProxyFactory implements McpStreamFactory
     private static final JsonParserFactory RESOURCES_LIST_ITEM_PARSER_FACTORY = StreamingJson.createParserFactory(
         Map.of(StreamingJson.PATH_INCLUDES, List.of("/resources/-/uri")));
 
-    private static final byte[] LIST_REPLY_TOOLS_OPEN = "{\"tools\":[".getBytes(StandardCharsets.UTF_8);
-    private static final byte[] LIST_REPLY_PROMPTS_OPEN = "{\"prompts\":[".getBytes(StandardCharsets.UTF_8);
-    private static final byte[] LIST_REPLY_RESOURCES_OPEN = "{\"resources\":[".getBytes(StandardCharsets.UTF_8);
-    private static final byte[] LIST_REPLY_CLOSE = "]}".getBytes(StandardCharsets.UTF_8);
-    private static final byte[] LIST_REPLY_SEPARATOR = ",".getBytes(StandardCharsets.UTF_8);
-
-    private record PendingRoute(
-        long resolvedId,
-        String prefix)
-    {
-    }
+    private static final DirectBuffer LIST_REPLY_TOOLS_OPEN_RO =
+        new UnsafeBuffer("{\"tools\":[".getBytes(StandardCharsets.UTF_8));
+    private static final DirectBuffer LIST_REPLY_PROMPTS_OPEN_RO =
+        new UnsafeBuffer("{\"prompts\":[".getBytes(StandardCharsets.UTF_8));
+    private static final DirectBuffer LIST_REPLY_RESOURCES_OPEN_RO =
+        new UnsafeBuffer("{\"resources\":[".getBytes(StandardCharsets.UTF_8));
+    private static final DirectBuffer LIST_REPLY_CLOSE_RO =
+        new UnsafeBuffer("]}".getBytes(StandardCharsets.UTF_8));
+    private static final DirectBuffer LIST_REPLY_SEPARATOR_RO =
+        new UnsafeBuffer(",".getBytes(StandardCharsets.UTF_8));
 
     private final class McpListServer
     {
-        private final MessageConsumer sender;
-        private final long originId;
-        private final long routedId;
+        private final McpLifecycleServer lifecycle;
+        private final int kind;
         private final long initialId;
         private final long replyId;
         private final long affinity;
         private final long authorization;
-        private final int kind;
-        private final McpLifecycleServer lifecycle;
-        private final Deque<PendingRoute> remaining;
+        private final Deque<McpRoutePrefix> remaining;
 
         private int state;
         private int itemsEmitted;
-        private McpListClient currentClient;
+        private McpListClient client;
 
         private McpListServer(
-            MessageConsumer sender,
-            long originId,
-            long routedId,
+            McpLifecycleServer lifecycle,
+            int kind,
             long initialId,
             long affinity,
             long authorization,
-            int kind,
-            McpLifecycleServer lifecycle,
-            List<McpRouteConfig> routes,
-            McpBeginExFW beginEx)
+            List<McpRoutePrefix> prefixes)
         {
-            this.sender = sender;
-            this.originId = originId;
-            this.routedId = routedId;
+            this.lifecycle = lifecycle;
+            this.kind = kind;
             this.initialId = initialId;
             this.replyId = supplyReplyId.applyAsLong(initialId);
             this.affinity = affinity;
             this.authorization = authorization;
-            this.kind = kind;
-            this.lifecycle = lifecycle;
-            this.remaining = new ArrayDeque<>(routes.size());
-            for (final McpRouteConfig route : routes)
-            {
-                remaining.add(new PendingRoute(route.id, route.prefix(beginEx)));
-            }
+            this.remaining = new ArrayDeque<>(prefixes);
         }
 
         private void onServerMessage(
@@ -1535,11 +1515,11 @@ public final class McpProxyFactory implements McpStreamFactory
             final long traceId = begin.traceId();
             state = McpState.openingInitial(state);
 
-            doWindow(sender, originId, routedId, initialId, traceId, authorization, 0,
+            doWindow(lifecycle.sender, lifecycle.originId, lifecycle.routedId, initialId, traceId, authorization, 0,
                 writeBuffer.capacity(), 0);
 
             doServerBegin(traceId);
-            emitPrelude(traceId);
+            doEncodeBeginItems(traceId);
             onNextClient(traceId);
         }
 
@@ -1549,9 +1529,9 @@ public final class McpProxyFactory implements McpStreamFactory
             final long traceId = end.traceId();
             state = McpState.closedInitial(state);
 
-            if (currentClient != null)
+            if (client != null)
             {
-                currentClient.doClientEnd(traceId);
+                client.doClientEnd(traceId);
             }
         }
 
@@ -1561,9 +1541,9 @@ public final class McpProxyFactory implements McpStreamFactory
             final long traceId = abort.traceId();
             state = McpState.closedInitial(state);
 
-            if (currentClient != null)
+            if (client != null)
             {
-                currentClient.doClientAbort(traceId);
+                client.doClientAbort(traceId);
             }
             remaining.clear();
         }
@@ -1574,26 +1554,24 @@ public final class McpProxyFactory implements McpStreamFactory
             final long traceId = reset.traceId();
             state = McpState.closedReply(state);
 
-            if (currentClient != null)
+            if (client != null)
             {
-                currentClient.doClientReset(traceId);
+                client.doClientReset(traceId);
             }
             remaining.clear();
         }
 
         private void onClientClosed(
-            McpListClient client,
             long traceId)
         {
-            currentClient = null;
+            client = null;
             onNextClient(traceId);
         }
 
         private void onClientError(
-            McpListClient client,
             long traceId)
         {
-            currentClient = null;
+            client = null;
             remaining.clear();
             doServerAbort(traceId);
         }
@@ -1601,17 +1579,17 @@ public final class McpProxyFactory implements McpStreamFactory
         private void onNextClient(
             long traceId)
         {
-            final PendingRoute route = remaining.poll();
+            final McpRoutePrefix route = remaining.poll();
             if (route == null)
             {
-                closeReply(traceId);
+                doEncodeEndItems(traceId);
                 return;
             }
-            currentClient = new McpListClient(this, route.resolvedId(), route.prefix());
-            currentClient.doClientBegin(traceId);
+            client = new McpListClient(this, route.resolvedId(), route.prefix());
+            client.doClientBegin(traceId);
             if (McpState.initialClosed(state))
             {
-                currentClient.doClientEnd(traceId);
+                client.doClientEnd(traceId);
             }
         }
 
@@ -1623,33 +1601,32 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (itemsEmitted > 0)
             {
-                final UnsafeBuffer sep = new UnsafeBuffer(LIST_REPLY_SEPARATOR);
-                doServerData(traceId, 0L, 0x03, sep.capacity(), sep, 0, sep.capacity());
+                doServerData(traceId, 0L, 0x03, LIST_REPLY_SEPARATOR_RO.capacity(),
+                    LIST_REPLY_SEPARATOR_RO, 0, LIST_REPLY_SEPARATOR_RO.capacity());
             }
-            final UnsafeBuffer itemBuffer = new UnsafeBuffer(item, offset, length);
-            doServerData(traceId, 0L, 0x03, length, itemBuffer, 0, length);
+            itemRO.wrap(item, offset, length);
+            doServerData(traceId, 0L, 0x03, length, itemRO, 0, length);
             itemsEmitted++;
         }
 
-        private void emitPrelude(
+        private void doEncodeBeginItems(
             long traceId)
         {
-            final byte[] preludeBytes = switch (kind)
+            final DirectBuffer prelude = switch (kind)
             {
-            case KIND_TOOLS_LIST -> LIST_REPLY_TOOLS_OPEN;
-            case KIND_PROMPTS_LIST -> LIST_REPLY_PROMPTS_OPEN;
-            case KIND_RESOURCES_LIST -> LIST_REPLY_RESOURCES_OPEN;
+            case KIND_TOOLS_LIST -> LIST_REPLY_TOOLS_OPEN_RO;
+            case KIND_PROMPTS_LIST -> LIST_REPLY_PROMPTS_OPEN_RO;
+            case KIND_RESOURCES_LIST -> LIST_REPLY_RESOURCES_OPEN_RO;
             default -> throw new IllegalStateException("unexpected list kind: " + kind);
             };
-            final UnsafeBuffer buf = new UnsafeBuffer(preludeBytes);
-            doServerData(traceId, 0L, 0x03, preludeBytes.length, buf, 0, preludeBytes.length);
+            doServerData(traceId, 0L, 0x03, prelude.capacity(), prelude, 0, prelude.capacity());
         }
 
-        private void closeReply(
+        private void doEncodeEndItems(
             long traceId)
         {
-            final UnsafeBuffer buf = new UnsafeBuffer(LIST_REPLY_CLOSE);
-            doServerData(traceId, 0L, 0x03, buf.capacity(), buf, 0, buf.capacity());
+            doServerData(traceId, 0L, 0x03, LIST_REPLY_CLOSE_RO.capacity(),
+                LIST_REPLY_CLOSE_RO, 0, LIST_REPLY_CLOSE_RO.capacity());
             doServerEnd(traceId);
         }
 
@@ -1669,7 +1646,8 @@ public final class McpProxyFactory implements McpStreamFactory
             }
             final McpBeginExFW beginEx = builder.build();
 
-            doBegin(sender, originId, routedId, replyId, traceId, authorization, affinity, beginEx);
+            doBegin(lifecycle.sender, lifecycle.originId, lifecycle.routedId, replyId, traceId, authorization,
+                affinity, beginEx);
             state = McpState.openedReply(state);
         }
 
@@ -1682,7 +1660,7 @@ public final class McpProxyFactory implements McpStreamFactory
             int offset,
             int length)
         {
-            doData(sender, originId, routedId, replyId, traceId, authorization,
+            doData(lifecycle.sender, lifecycle.originId, lifecycle.routedId, replyId, traceId, authorization,
                 budgetId, flags, reserved, payload, offset, length);
         }
 
@@ -1691,7 +1669,7 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (!McpState.replyClosed(state))
             {
-                doEnd(sender, originId, routedId, replyId, traceId, authorization);
+                doEnd(lifecycle.sender, lifecycle.originId, lifecycle.routedId, replyId, traceId, authorization);
                 state = McpState.closedReply(state);
             }
         }
@@ -1701,7 +1679,7 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (!McpState.replyClosed(state))
             {
-                doAbort(sender, originId, routedId, replyId, traceId, authorization);
+                doAbort(lifecycle.sender, lifecycle.originId, lifecycle.routedId, replyId, traceId, authorization);
                 state = McpState.closedReply(state);
             }
         }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -34,13 +34,7 @@ import java.util.Map;
 import java.util.function.LongUnaryOperator;
 
 import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonArrayBuilder;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonPointer;
-import jakarta.json.JsonReader;
-import jakarta.json.JsonValue;
 import jakarta.json.stream.JsonParser;
 
 import org.agrona.DirectBuffer;
@@ -187,22 +181,19 @@ public final class McpProxyFactory implements McpStreamFactory
                     if (isListKind(beginKind))
                     {
                         final List<McpRouteConfig> routes = binding.resolveAll(beginEx, authorization);
-                        if (!routes.isEmpty())
-                        {
-                            final McpListServer server = new McpListServer(
-                                sender,
-                                originId,
-                                routedId,
-                                initialId,
-                                affinity,
-                                authorization,
-                                beginKind,
-                                sessionId,
-                                session,
-                                routes,
-                                beginEx);
-                            newStream = server::onServerMessage;
-                        }
+                        final McpListServer server = new McpListServer(
+                            sender,
+                            originId,
+                            routedId,
+                            initialId,
+                            affinity,
+                            authorization,
+                            beginKind,
+                            sessionId,
+                            session,
+                            routes,
+                            beginEx);
+                        newStream = server::onServerMessage;
                     }
                     else
                     {
@@ -562,8 +553,6 @@ public final class McpProxyFactory implements McpStreamFactory
         private MessageConsumer sender;
 
         private int state;
-        private int replySlot = NO_SLOT;
-        private int replySlotOffset;
 
         private McpClient(
             McpServer server,
@@ -779,15 +768,8 @@ public final class McpProxyFactory implements McpStreamFactory
 
             if (payload != null)
             {
-                if (transformsList())
-                {
-                    bufferReplyPayload(payload);
-                }
-                else
-                {
-                    server.doServerData(traceId, budgetId, flags, reserved,
-                        payload.buffer(), payload.offset(), payload.sizeof());
-                }
+                server.doServerData(traceId, budgetId, flags, reserved,
+                    payload.buffer(), payload.offset(), payload.sizeof());
             }
         }
 
@@ -795,16 +777,7 @@ public final class McpProxyFactory implements McpStreamFactory
             EndFW end)
         {
             final long traceId = end.traceId();
-
             state = McpState.closedReply(state);
-
-            if (transformsList() && replySlot != NO_SLOT)
-            {
-                emitTransformedListReply(traceId);
-            }
-
-            cleanupReplySlot();
-
             server.doServerEnd(traceId);
         }
 
@@ -812,56 +785,8 @@ public final class McpProxyFactory implements McpStreamFactory
             AbortFW abort)
         {
             final long traceId = abort.traceId();
-
             state = McpState.closedReply(state);
-
-            cleanupReplySlot();
-
             server.doServerAbort(traceId);
-        }
-
-        private boolean transformsList()
-        {
-            return !server.prefix.isEmpty() && isListKind(server.beginKind);
-        }
-
-        private void bufferReplyPayload(
-            OctetsFW payload)
-        {
-            if (replySlot == NO_SLOT)
-            {
-                replySlot = bufferPool.acquire(initialId);
-            }
-
-            if (replySlot != NO_SLOT)
-            {
-                final MutableDirectBuffer buffer = bufferPool.buffer(replySlot);
-                buffer.putBytes(replySlotOffset, payload.buffer(), payload.offset(), payload.sizeof());
-                replySlotOffset += payload.sizeof();
-            }
-        }
-
-        private void emitTransformedListReply(
-            long traceId)
-        {
-            final byte[] inputBytes = new byte[replySlotOffset];
-            bufferPool.buffer(replySlot).getBytes(0, inputBytes);
-
-            final byte[] outputBytes = applyListPrefix(server.prefix, server.beginKind, inputBytes);
-
-            final UnsafeBuffer outputBuffer = new UnsafeBuffer(outputBytes);
-            server.doServerData(traceId, 0L, 0x03, outputBytes.length,
-                outputBuffer, 0, outputBytes.length);
-        }
-
-        private void cleanupReplySlot()
-        {
-            if (replySlot != NO_SLOT)
-            {
-                bufferPool.release(replySlot);
-                replySlot = NO_SLOT;
-                replySlotOffset = 0;
-            }
         }
 
         private void onClientWindow(
@@ -1868,146 +1793,6 @@ public final class McpProxyFactory implements McpStreamFactory
                 }
             }
         }
-    }
-
-    private static byte[] applyListPrefix(
-        String prefix,
-        int beginKind,
-        byte[] jsonBytes)
-    {
-        final String arrayKey = switch (beginKind)
-        {
-        case KIND_TOOLS_LIST -> "tools";
-        case KIND_PROMPTS_LIST -> "prompts";
-        case KIND_RESOURCES_LIST -> "resources";
-        default -> null;
-        };
-        if (prefix.isEmpty() || arrayKey == null)
-        {
-            return jsonBytes;
-        }
-        final String idKey = beginKind == KIND_RESOURCES_LIST ? "uri" : "name";
-        final JsonPointer idPath = Json.createPointer("/" + arrayKey + "/-/" + idKey);
-        final Map<String, ?> config = Map.of(
-            StreamingJson.PATH_INCLUDES, List.of(idPath),
-            StreamingJson.TOKEN_MAX_BYTES, jsonBytes.length);
-
-        final ByteArrayOutputStream out = new ByteArrayOutputStream(jsonBytes.length + 64);
-        final byte[] prefixBytes = prefix.getBytes(StandardCharsets.UTF_8);
-        int lastEmitted = 0;
-        boolean awaitingIdValue = false;
-        int depth = 0;
-        int targetItemDepth = -1;
-
-        final BufferedInputStream in = new BufferedInputStream(new ByteArrayInputStream(jsonBytes));
-        try (JsonParser parser = StreamingJson.createParser(in, config))
-        {
-            while (true)
-            {
-                final long beforeOffset = parser.getLocation().getStreamOffset();
-                if (!parser.hasNext())
-                {
-                    break;
-                }
-                final long afterOffset = parser.getLocation().getStreamOffset();
-                final JsonParser.Event ev = parser.next();
-                switch (ev)
-                {
-                case START_OBJECT:
-                case START_ARRAY:
-                    depth++;
-                    break;
-                case END_OBJECT:
-                case END_ARRAY:
-                    depth--;
-                    break;
-                case KEY_NAME:
-                    final String key = parser.getString();
-                    if (depth == 1 && arrayKey.equals(key))
-                    {
-                        // next event will be START_ARRAY of the items array; items live at depth == 3
-                        targetItemDepth = 3;
-                    }
-                    else if (depth == targetItemDepth && idKey.equals(key))
-                    {
-                        awaitingIdValue = true;
-                    }
-                    break;
-                case VALUE_STRING:
-                    if (awaitingIdValue)
-                    {
-                        awaitingIdValue = false;
-                        // bytes [beforeOffset..afterOffset) span ":<ws>\"<content>\"" — find opening quote
-                        int openingQuote = (int) beforeOffset;
-                        while (openingQuote < (int) afterOffset && jsonBytes[openingQuote] != '"')
-                        {
-                            openingQuote++;
-                        }
-                        final int contentStart = openingQuote + 1;
-                        // emit verbatim up to and including opening quote
-                        out.write(jsonBytes, lastEmitted, contentStart - lastEmitted);
-                        // splice prefix
-                        out.write(prefixBytes, 0, prefixBytes.length);
-                        // continue with original content + closing quote
-                        out.write(jsonBytes, contentStart, (int) afterOffset - contentStart);
-                        lastEmitted = (int) afterOffset;
-                    }
-                    break;
-                default:
-                    break;
-                }
-            }
-        }
-        // emit any trailing bytes (typically empty for well-formed JSON)
-        out.write(jsonBytes, lastEmitted, jsonBytes.length - lastEmitted);
-        return out.toByteArray();
-    }
-
-    private static byte[] mergeListReplies(
-        int beginKind,
-        byte[][] parts)
-    {
-        if (parts.length == 1 && parts[0] != null)
-        {
-            return parts[0];
-        }
-
-        final String arrayKey = switch (beginKind)
-        {
-        case KIND_TOOLS_LIST -> "tools";
-        case KIND_PROMPTS_LIST -> "prompts";
-        case KIND_RESOURCES_LIST -> "resources";
-        default -> null;
-        };
-
-        if (arrayKey == null)
-        {
-            return new byte[0];
-        }
-
-        final JsonArrayBuilder merged = Json.createArrayBuilder();
-        for (byte[] part : parts)
-        {
-            if (part != null)
-            {
-                try (JsonReader reader = Json.createReader(new ByteArrayInputStream(part)))
-                {
-                    final JsonObject root = reader.readObject();
-                    final JsonArray items = root.getJsonArray(arrayKey);
-                    if (items != null)
-                    {
-                        for (JsonValue item : items)
-                        {
-                            merged.add(item);
-                        }
-                    }
-                }
-            }
-        }
-
-        final JsonObjectBuilder rootBuilder = Json.createObjectBuilder();
-        rootBuilder.add(arrayKey, merged.build());
-        return rootBuilder.build().toString().getBytes(StandardCharsets.UTF_8);
     }
 
     private MessageConsumer newStream(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -76,6 +76,7 @@ public final class McpProxyFactory implements McpStreamFactory
     private final McpBeginExFW mcpBeginExRO = new McpBeginExFW();
     private final OctetsFW emptyRO = new OctetsFW().wrap(new UnsafeBuffer(), 0, 0);
     private final UnsafeBuffer itemRO = new UnsafeBuffer(0, 0);
+    private final DirectBufferInputStreamEx inputRO = new DirectBufferInputStreamEx();
 
     private final BeginFW.Builder beginRW = new BeginFW.Builder();
     private final DataFW.Builder dataRW = new DataFW.Builder();
@@ -1021,14 +1022,13 @@ public final class McpProxyFactory implements McpStreamFactory
         private int replySlotOffset;
 
         // streaming JSON state — built lazily on first DATA frame
-        private JsonParser parser;
-        private DirectBufferInputStreamEx jsonInput;
+        private JsonParser decodableJson;
         private ByteArrayOutputStream itemOut;
         private byte[] itemTransferBuffer;
-        private long parserBaseOffset;       // absolute streamOffset of slot[0]
-        private int depth;
-        private int itemDepth = -1;          // depth at which target items live, set on START_ARRAY
-        private boolean awaitingArrayValue;
+        private long parserBaseOffset;            // absolute streamOffset of buffer[offset] passed to decode
+        private int decodeDepth;                  // JSON nesting depth in the reply envelope
+        private int decodeItemDepth;              // JSON nesting depth within the current item
+        private int decodeSkipDepth;              // JSON nesting depth within a skipped value
         private boolean awaitingIdValue;
         private long itemStartStreamOffset = -1;
         private long itemLastEmittedStreamOffset = -1;
@@ -1155,15 +1155,33 @@ public final class McpProxyFactory implements McpStreamFactory
             DataFW data)
         {
             final long traceId = data.traceId();
+            final long authorization = data.authorization();
+            final long budgetId = data.budgetId();
+            final int reserved = data.reserved();
             final OctetsFW payload = data.payload();
-            final boolean appended = appendToSlot(payload);
-            if (!appended)
+
+            DirectBuffer buffer = payload.buffer();
+            int offset = payload.offset();
+            int limit = payload.limit();
+
+            if (replySlot != NO_SLOT)
             {
-                state = McpState.closedReply(state);
-                server.onClientError(traceId);
-                return;
+                final MutableDirectBuffer slot = bufferPool.buffer(replySlot);
+                if (replySlotOffset + (limit - offset) > slot.capacity())
+                {
+                    state = McpState.closedReply(state);
+                    server.onClientError(traceId);
+                    return;
+                }
+                slot.putBytes(replySlotOffset, buffer, offset, limit - offset);
+                replySlotOffset += limit - offset;
+
+                buffer = slot;
+                offset = 0;
+                limit = replySlotOffset;
             }
-            streamItems(traceId);
+
+            decode(traceId, authorization, budgetId, reserved, buffer, offset, limit);
         }
 
         private void onClientEnd(
@@ -1202,31 +1220,16 @@ public final class McpProxyFactory implements McpStreamFactory
             }
         }
 
-        private boolean appendToSlot(
-            OctetsFW payload)
+        private void decode(
+            long traceId,
+            long authorization,
+            long budgetId,
+            int reserved,
+            DirectBuffer buffer,
+            int offset,
+            int limit)
         {
-            if (replySlot == NO_SLOT)
-            {
-                replySlot = bufferPool.acquire(initialId);
-            }
-            if (replySlot == NO_SLOT)
-            {
-                return false;
-            }
-            final MutableDirectBuffer buf = bufferPool.buffer(replySlot);
-            if (replySlotOffset + payload.sizeof() > buf.capacity())
-            {
-                return false;
-            }
-            buf.putBytes(replySlotOffset, payload.buffer(), payload.offset(), payload.sizeof());
-            replySlotOffset += payload.sizeof();
-            return true;
-        }
-
-        private void streamItems(
-            long traceId)
-        {
-            if (parser == null)
+            if (decodableJson == null)
             {
                 final JsonParserFactory parserFactory = switch (server.kind)
                 {
@@ -1239,8 +1242,7 @@ public final class McpProxyFactory implements McpStreamFactory
                 {
                     return;
                 }
-                jsonInput = new DirectBufferInputStreamEx();
-                parser = parserFactory.createParser(jsonInput);
+                decodableJson = parserFactory.createParser(inputRO);
                 itemOut = new ByteArrayOutputStream(256);
                 itemTransferBuffer = new byte[bufferPool.slotCapacity()];
                 arrayKey = switch (server.kind)
@@ -1251,40 +1253,59 @@ public final class McpProxyFactory implements McpStreamFactory
                 default -> null;
                 };
                 idKey = server.kind == KIND_RESOURCES_LIST ? "uri" : "name";
-                decoder = decodeListBeforeItems;
+                decoder = decodeReply;
             }
 
-            final MutableDirectBuffer slotBuffer = bufferPool.buffer(replySlot);
-            final int parserPosInSlot = (int) (parser.getLocation().getStreamOffset() - parserBaseOffset);
-            jsonInput.wrap(slotBuffer, parserPosInSlot, replySlotOffset - parserPosInSlot);
+            final int delta = (int) (decodableJson.getLocation().getStreamOffset() - parserBaseOffset);
+            inputRO.wrap(buffer, offset + delta, limit - offset - delta);
 
-            while (true)
+            McpListClientDecoder previous = null;
+            int progress = offset;
+            while (progress <= limit && previous != decoder)
             {
-                final long beforeStreamOffset = parser.getLocation().getStreamOffset();
-                if (!parser.hasNext())
-                {
-                    break;
-                }
-                final long afterStreamOffset = parser.getLocation().getStreamOffset();
-                final JsonParser.Event ev = parser.next();
-                decoder.decode(this, ev, traceId, beforeStreamOffset, afterStreamOffset, slotBuffer);
+                previous = decoder;
+                progress = decoder.decode(this, traceId, authorization, budgetId, reserved,
+                    buffer, offset, progress, limit);
             }
 
-            // Compact slot: drop bytes that are no longer needed (consumed and not part of an in-progress item)
-            final int compactBoundaryInSlot;
+            final int compactBoundaryInBuf;
             if (itemStartStreamOffset >= 0)
             {
-                compactBoundaryInSlot = (int) (itemStartStreamOffset - parserBaseOffset);
+                compactBoundaryInBuf = offset + (int) (itemStartStreamOffset - parserBaseOffset);
             }
             else
             {
-                compactBoundaryInSlot = (int) (parser.getLocation().getStreamOffset() - parserBaseOffset);
+                compactBoundaryInBuf = offset + (int) (decodableJson.getLocation().getStreamOffset() - parserBaseOffset);
             }
-            if (compactBoundaryInSlot > 0)
+
+            if (compactBoundaryInBuf < limit)
             {
-                slotBuffer.putBytes(0, slotBuffer, compactBoundaryInSlot, replySlotOffset - compactBoundaryInSlot);
-                replySlotOffset -= compactBoundaryInSlot;
-                parserBaseOffset += compactBoundaryInSlot;
+                final int retained = limit - compactBoundaryInBuf;
+                if (replySlot == NO_SLOT)
+                {
+                    replySlot = bufferPool.acquire(initialId);
+                    if (replySlot == NO_SLOT)
+                    {
+                        state = McpState.closedReply(state);
+                        server.onClientError(traceId);
+                        return;
+                    }
+                }
+                final MutableDirectBuffer slot = bufferPool.buffer(replySlot);
+                if (retained > slot.capacity())
+                {
+                    state = McpState.closedReply(state);
+                    server.onClientError(traceId);
+                    return;
+                }
+                slot.putBytes(0, buffer, compactBoundaryInBuf, retained);
+                replySlotOffset = retained;
+                parserBaseOffset += compactBoundaryInBuf - offset;
+            }
+            else
+            {
+                cleanupClientSlot();
+                parserBaseOffset += compactBoundaryInBuf - offset;
             }
         }
 
@@ -1302,131 +1323,296 @@ public final class McpProxyFactory implements McpStreamFactory
     @FunctionalInterface
     private interface McpListClientDecoder
     {
-        void decode(
+        int decode(
             McpListClient client,
-            JsonParser.Event event,
             long traceId,
-            long beforeOffset,
-            long afterOffset,
-            MutableDirectBuffer slotBuffer);
+            long authorization,
+            long budgetId,
+            int reserved,
+            DirectBuffer buffer,
+            int offset,
+            int progress,
+            int limit);
     }
 
-    private final McpListClientDecoder decodeListBeforeItems = this::decodeListBeforeItems;
-    private final McpListClientDecoder decodeListWithinItems = this::decodeListWithinItems;
+    private final McpListClientDecoder decodeReply = this::decodeReply;
+    private final McpListClientDecoder decodeItemsKey = this::decodeItemsKey;
+    private final McpListClientDecoder decodeSkipObject = this::decodeSkipObject;
+    private final McpListClientDecoder decodeItems = this::decodeItems;
+    private final McpListClientDecoder decodeItem = this::decodeItem;
+    private final McpListClientDecoder decodeIgnore = this::decodeIgnore;
 
-    private void decodeListBeforeItems(
+    private int decodeReply(
         McpListClient client,
-        JsonParser.Event event,
         long traceId,
-        long beforeOffset,
-        long afterOffset,
-        MutableDirectBuffer slotBuffer)
+        long authorization,
+        long budgetId,
+        int reserved,
+        DirectBuffer buffer,
+        int offset,
+        int progress,
+        int limit)
     {
-        switch (event)
+        final JsonParser parser = client.decodableJson;
+
+        decode:
+        while (parser.hasNext())
         {
-        case START_OBJECT:
-        case START_ARRAY:
-            client.depth++;
-            if (event == JsonParser.Event.START_ARRAY && client.awaitingArrayValue)
+            final JsonParser.Event event = parser.next();
+            if (event == JsonParser.Event.START_OBJECT)
             {
-                client.awaitingArrayValue = false;
-                client.itemDepth = client.depth + 1;
-                client.decoder = decodeListWithinItems;
+                client.decodeDepth = 1;
+                client.decoder = decodeItemsKey;
+                break decode;
             }
-            break;
-        case END_OBJECT:
-        case END_ARRAY:
-            client.depth--;
-            break;
-        case KEY_NAME:
-            if (client.depth == 1 && client.arrayKey.equals(client.parser.getString()))
-            {
-                client.awaitingArrayValue = true;
-            }
-            break;
-        default:
-            break;
         }
+
+        return offset + (int) (parser.getLocation().getStreamOffset() - client.parserBaseOffset);
     }
 
-    private void decodeListWithinItems(
+    private int decodeItemsKey(
         McpListClient client,
-        JsonParser.Event event,
         long traceId,
-        long beforeOffset,
-        long afterOffset,
-        MutableDirectBuffer slotBuffer)
+        long authorization,
+        long budgetId,
+        int reserved,
+        DirectBuffer buffer,
+        int offset,
+        int progress,
+        int limit)
     {
-        final int afterInSlot = (int) (afterOffset - client.parserBaseOffset);
-        final int beforeInSlot = (int) (beforeOffset - client.parserBaseOffset);
-        switch (event)
+        final JsonParser parser = client.decodableJson;
+
+        decode:
+        while (parser.hasNext())
         {
-        case START_OBJECT:
-            client.depth++;
-            if (client.depth == client.itemDepth)
+            final JsonParser.Event event = parser.next();
+            switch (event)
             {
-                client.itemStartStreamOffset = afterOffset - 1;
-                client.itemLastEmittedStreamOffset = client.itemStartStreamOffset;
-                client.itemOut.reset();
-            }
-            break;
-        case START_ARRAY:
-            client.depth++;
-            break;
-        case END_OBJECT:
-            if (client.depth == client.itemDepth && client.itemStartStreamOffset >= 0)
-            {
-                final int itemLastEmittedInSlot =
-                    (int) (client.itemLastEmittedStreamOffset - client.parserBaseOffset);
-                slotBuffer.getBytes(itemLastEmittedInSlot, client.itemTransferBuffer,
-                    0, afterInSlot - itemLastEmittedInSlot);
-                client.itemOut.write(client.itemTransferBuffer, 0, afterInSlot - itemLastEmittedInSlot);
-                client.server.streamItem(client.itemOut.toByteArray(), 0, client.itemOut.size(), traceId);
-                client.itemStartStreamOffset = -1;
-                client.itemLastEmittedStreamOffset = -1;
-            }
-            client.depth--;
-            break;
-        case END_ARRAY:
-            client.depth--;
-            if (client.depth + 1 == client.itemDepth - 1)
-            {
-                client.itemDepth = -1;
-                client.decoder = decodeListBeforeItems;
-            }
-            break;
-        case KEY_NAME:
-            if (client.depth == client.itemDepth && client.idKey.equals(client.parser.getString()))
-            {
-                client.awaitingIdValue = true;
-            }
-            break;
-        case VALUE_STRING:
-            if (client.awaitingIdValue && client.itemStartStreamOffset >= 0 && client.prefixBytes.length > 0)
-            {
-                client.awaitingIdValue = false;
-                int openingQuote = beforeInSlot;
-                while (openingQuote < afterInSlot && slotBuffer.getByte(openingQuote) != (byte) '"')
+            case KEY_NAME:
+                if (client.decodeDepth == 1)
                 {
-                    openingQuote++;
+                    final String key = parser.getString();
+                    if (client.arrayKey.equals(key))
+                    {
+                        client.decoder = decodeItems;
+                    }
+                    else
+                    {
+                        client.decodeSkipDepth = 0;
+                        client.decoder = decodeSkipObject;
+                    }
+                    break decode;
                 }
-                final int contentStart = openingQuote + 1;
-                final int itemLastEmittedInSlot =
-                    (int) (client.itemLastEmittedStreamOffset - client.parserBaseOffset);
-                slotBuffer.getBytes(itemLastEmittedInSlot, client.itemTransferBuffer,
-                    0, contentStart - itemLastEmittedInSlot);
-                client.itemOut.write(client.itemTransferBuffer, 0, contentStart - itemLastEmittedInSlot);
-                client.itemOut.write(client.prefixBytes, 0, client.prefixBytes.length);
-                client.itemLastEmittedStreamOffset = client.parserBaseOffset + contentStart;
+                break;
+            case END_OBJECT:
+                client.decodeDepth--;
+                if (client.decodeDepth == 0)
+                {
+                    client.decoder = decodeIgnore;
+                    break decode;
+                }
+                break;
+            default:
+                break;
             }
-            else if (client.awaitingIdValue)
-            {
-                client.awaitingIdValue = false;
-            }
-            break;
-        default:
-            break;
         }
+
+        return offset + (int) (parser.getLocation().getStreamOffset() - client.parserBaseOffset);
+    }
+
+    private int decodeSkipObject(
+        McpListClient client,
+        long traceId,
+        long authorization,
+        long budgetId,
+        int reserved,
+        DirectBuffer buffer,
+        int offset,
+        int progress,
+        int limit)
+    {
+        final JsonParser parser = client.decodableJson;
+
+        decode:
+        while (parser.hasNext())
+        {
+            final JsonParser.Event event = parser.next();
+            switch (event)
+            {
+            case START_OBJECT:
+            case START_ARRAY:
+                client.decodeSkipDepth++;
+                break;
+            case END_OBJECT:
+            case END_ARRAY:
+                client.decodeSkipDepth--;
+                if (client.decodeSkipDepth == 0)
+                {
+                    client.decoder = decodeItemsKey;
+                    break decode;
+                }
+                break;
+            case VALUE_STRING:
+            case VALUE_NUMBER:
+            case VALUE_TRUE:
+            case VALUE_FALSE:
+            case VALUE_NULL:
+                if (client.decodeSkipDepth == 0)
+                {
+                    client.decoder = decodeItemsKey;
+                    break decode;
+                }
+                break;
+            default:
+                break;
+            }
+        }
+
+        return offset + (int) (parser.getLocation().getStreamOffset() - client.parserBaseOffset);
+    }
+
+    private int decodeItems(
+        McpListClient client,
+        long traceId,
+        long authorization,
+        long budgetId,
+        int reserved,
+        DirectBuffer buffer,
+        int offset,
+        int progress,
+        int limit)
+    {
+        final JsonParser parser = client.decodableJson;
+
+        decode:
+        while (parser.hasNext())
+        {
+            final JsonParser.Event event = parser.next();
+            if (event == JsonParser.Event.START_ARRAY)
+            {
+                client.decodeItemDepth = 0;
+                client.decoder = decodeItem;
+                break decode;
+            }
+        }
+
+        return offset + (int) (parser.getLocation().getStreamOffset() - client.parserBaseOffset);
+    }
+
+    private int decodeItem(
+        McpListClient client,
+        long traceId,
+        long authorization,
+        long budgetId,
+        int reserved,
+        DirectBuffer buffer,
+        int offset,
+        int progress,
+        int limit)
+    {
+        final JsonParser parser = client.decodableJson;
+
+        decode:
+        while (true)
+        {
+            final long beforeStreamOffset = parser.getLocation().getStreamOffset();
+            if (!parser.hasNext())
+            {
+                break decode;
+            }
+            final long afterStreamOffset = parser.getLocation().getStreamOffset();
+            final JsonParser.Event event = parser.next();
+            switch (event)
+            {
+            case START_OBJECT:
+                if (client.decodeItemDepth == 0)
+                {
+                    client.itemStartStreamOffset = afterStreamOffset - 1;
+                    client.itemLastEmittedStreamOffset = client.itemStartStreamOffset;
+                    client.itemOut.reset();
+                }
+                client.decodeItemDepth++;
+                break;
+            case START_ARRAY:
+                client.decodeItemDepth++;
+                break;
+            case END_OBJECT:
+                client.decodeItemDepth--;
+                if (client.decodeItemDepth == 0 && client.itemStartStreamOffset >= 0)
+                {
+                    final int afterInBuf = offset + (int) (afterStreamOffset - client.parserBaseOffset);
+                    final int lastEmittedInBuf =
+                        offset + (int) (client.itemLastEmittedStreamOffset - client.parserBaseOffset);
+                    final int len = afterInBuf - lastEmittedInBuf;
+                    buffer.getBytes(lastEmittedInBuf, client.itemTransferBuffer, 0, len);
+                    client.itemOut.write(client.itemTransferBuffer, 0, len);
+                    client.server.streamItem(client.itemOut.toByteArray(), 0, client.itemOut.size(), traceId);
+                    client.itemStartStreamOffset = -1;
+                    client.itemLastEmittedStreamOffset = -1;
+                }
+                break;
+            case END_ARRAY:
+                client.decodeItemDepth--;
+                if (client.decodeItemDepth < 0)
+                {
+                    client.decodeDepth--;
+                    client.decoder = decodeItemsKey;
+                    break decode;
+                }
+                break;
+            case KEY_NAME:
+                if (client.decodeItemDepth == 1 && client.idKey.equals(parser.getString()))
+                {
+                    client.awaitingIdValue = true;
+                }
+                break;
+            case VALUE_STRING:
+                if (client.awaitingIdValue && client.itemStartStreamOffset >= 0 && client.prefixBytes.length > 0)
+                {
+                    client.awaitingIdValue = false;
+                    final int beforeInBuf = offset + (int) (beforeStreamOffset - client.parserBaseOffset);
+                    final int afterInBuf = offset + (int) (afterStreamOffset - client.parserBaseOffset);
+                    int openingQuote = beforeInBuf;
+                    while (openingQuote < afterInBuf && buffer.getByte(openingQuote) != (byte) '"')
+                    {
+                        openingQuote++;
+                    }
+                    final int contentStart = openingQuote + 1;
+                    final int lastEmittedInBuf =
+                        offset + (int) (client.itemLastEmittedStreamOffset - client.parserBaseOffset);
+                    final int len = contentStart - lastEmittedInBuf;
+                    buffer.getBytes(lastEmittedInBuf, client.itemTransferBuffer, 0, len);
+                    client.itemOut.write(client.itemTransferBuffer, 0, len);
+                    client.itemOut.write(client.prefixBytes, 0, client.prefixBytes.length);
+                    client.itemLastEmittedStreamOffset =
+                        client.parserBaseOffset + (long) (contentStart - offset);
+                }
+                else if (client.awaitingIdValue)
+                {
+                    client.awaitingIdValue = false;
+                }
+                break;
+            default:
+                break;
+            }
+        }
+
+        return offset + (int) (parser.getLocation().getStreamOffset() - client.parserBaseOffset);
+    }
+
+    private int decodeIgnore(
+        McpListClient client,
+        long traceId,
+        long authorization,
+        long budgetId,
+        int reserved,
+        DirectBuffer buffer,
+        int offset,
+        int progress,
+        int limit)
+    {
+        return limit;
     }
 
     private static final JsonParserFactory TOOLS_LIST_ITEM_PARSER_FACTORY = StreamingJson.createParserFactory(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -29,6 +29,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
+import java.util.function.LongConsumer;
 import java.util.function.LongUnaryOperator;
 
 import jakarta.json.stream.JsonParser;
@@ -247,11 +248,10 @@ public final class McpProxyFactory implements McpStreamFactory
         }
     }
 
-    private interface McpPending
+    private record PendingAction(
+        LongConsumer onProceed,
+        LongConsumer onReset)
     {
-        void proceed(long traceId);
-
-        void doServerReset(long traceId);
     }
 
     private final class McpExit
@@ -261,7 +261,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private static final int OPENED = 2;
 
         private final long exitId;
-        private final Deque<McpPending> pending;
+        private final Deque<PendingAction> pending;
 
         private int state;
         private String sessionId;
@@ -275,7 +275,7 @@ public final class McpProxyFactory implements McpStreamFactory
         }
     }
 
-    private final class McpServer implements McpPending
+    private final class McpServer
     {
         private final MessageConsumer sender;
         private final long originId;
@@ -383,7 +383,7 @@ public final class McpProxyFactory implements McpStreamFactory
             }
             else
             {
-                exit.pending.add(this);
+                exit.pending.add(new PendingAction(this::proceed, this::doServerReset));
                 if (exit.state == McpExit.UNINITIALIZED)
                 {
                     exit.state = McpExit.OPENING;
@@ -393,7 +393,7 @@ public final class McpProxyFactory implements McpStreamFactory
             }
         }
 
-        public void proceed(
+        private void proceed(
             long traceId)
         {
             this.client = new McpClient(this, resolvedId, traceId);
@@ -522,7 +522,7 @@ public final class McpProxyFactory implements McpStreamFactory
             doWindow(sender, originId, routedId, initialId, traceId, authorization, budgetId, credit, padding);
         }
 
-        public void doServerReset(
+        private void doServerReset(
             long traceId)
         {
             if (!McpState.initialClosed(state))
@@ -938,9 +938,9 @@ public final class McpProxyFactory implements McpStreamFactory
                 {
                     exit.lifecycle.doClientEnd(traceId);
                 }
-                for (McpPending pending : exit.pending)
+                for (PendingAction pending : exit.pending)
                 {
-                    pending.doServerReset(traceId);
+                    pending.onReset().accept(traceId);
                 }
                 exit.pending.clear();
             }
@@ -1055,7 +1055,7 @@ public final class McpProxyFactory implements McpStreamFactory
             exit.state = McpExit.OPENED;
             while (!exit.pending.isEmpty())
             {
-                exit.pending.poll().proceed(traceId);
+                exit.pending.poll().onProceed().accept(traceId);
             }
         }
 
@@ -1094,12 +1094,12 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             while (!exit.pending.isEmpty())
             {
-                exit.pending.poll().doServerReset(traceId);
+                exit.pending.poll().onReset().accept(traceId);
             }
         }
     }
 
-    private final class McpListClient implements McpPending
+    private final class McpListClient
     {
         private final McpListServer server;
         private final McpExit exit;
@@ -1141,8 +1141,7 @@ public final class McpProxyFactory implements McpStreamFactory
             this.prefixBytes = prefix.getBytes(StandardCharsets.UTF_8);
         }
 
-        @Override
-        public void proceed(
+        private void proceed(
             long traceId)
         {
             doClientBegin(traceId);
@@ -1152,8 +1151,7 @@ public final class McpProxyFactory implements McpStreamFactory
             }
         }
 
-        @Override
-        public void doServerReset(
+        private void doServerReset(
             long traceId)
         {
             if (!McpState.replyClosed(state))
@@ -1680,7 +1678,7 @@ public final class McpProxyFactory implements McpStreamFactory
             }
             else
             {
-                exit.pending.add(currentClient);
+                exit.pending.add(new PendingAction(currentClient::proceed, currentClient::doServerReset));
                 if (exit.state == McpExit.UNINITIALIZED)
                 {
                     exit.state = McpExit.OPENING;

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -527,8 +527,6 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             initialId = supplyInitialId.applyAsLong(resolvedId);
             replyId = supplyReplyId.applyAsLong(initialId);
-            sender = streamFactory.newStream(BeginFW.TYPE_ID, writeBuffer, 0, 0, this::onClientMessage);
-            assert sender != null;
 
             final String identifier = server.identifier;
             final int capabilities = server.capabilities;
@@ -559,7 +557,7 @@ public final class McpProxyFactory implements McpStreamFactory
             }
             final McpBeginExFW beginEx = builder.build();
 
-            doBegin(sender, server.originId, resolvedId, initialId,
+            sender = openStream(this::onClientMessage, server.originId, resolvedId, initialId,
                 traceId, server.authorization, server.affinity, beginEx);
             state = McpState.openingInitial(state);
         }
@@ -954,9 +952,6 @@ public final class McpProxyFactory implements McpStreamFactory
         private void doClientBegin(
             long traceId)
         {
-            sender = streamFactory.newStream(BeginFW.TYPE_ID, writeBuffer, 0, 0, this::onClientMessage);
-            assert sender != null;
-
             final String sid = session.sessionId;
             final int clientCapabilities = session.clientCapabilities;
             final McpBeginExFW beginEx = mcpBeginExRW
@@ -965,8 +960,8 @@ public final class McpProxyFactory implements McpStreamFactory
                 .lifecycle(l -> l.sessionId(sid).capabilities(clientCapabilities))
                 .build();
 
-            doBegin(sender, session.originId, exit.exitId, initialId, traceId,
-                session.authorization, session.affinity, beginEx);
+            sender = openStream(this::onClientMessage, session.originId, exit.exitId, initialId,
+                traceId, session.authorization, session.affinity, beginEx);
             state = McpState.openingInitial(state);
         }
 
@@ -1123,6 +1118,35 @@ public final class McpProxyFactory implements McpStreamFactory
             .build();
 
         receiver.accept(begin.typeId(), begin.buffer(), begin.offset(), begin.sizeof());
+    }
+
+    private MessageConsumer openStream(
+        MessageConsumer sender,
+        long originId,
+        long routedId,
+        long streamId,
+        long traceId,
+        long authorization,
+        long affinity,
+        Flyweight extension)
+    {
+        final BeginFW begin = beginRW.wrap(writeBuffer, 0, writeBuffer.capacity())
+            .originId(originId)
+            .routedId(routedId)
+            .streamId(streamId)
+            .sequence(0)
+            .acknowledge(0)
+            .maximum(0)
+            .traceId(traceId)
+            .authorization(authorization)
+            .affinity(affinity)
+            .extension(extension.buffer(), extension.offset(), extension.sizeof())
+            .build();
+
+        final MessageConsumer receiver = streamFactory.newStream(
+            begin.typeId(), begin.buffer(), begin.offset(), begin.sizeof(), sender);
+        receiver.accept(begin.typeId(), begin.buffer(), begin.offset(), begin.sizeof());
+        return receiver;
     }
 
     private void doData(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -28,7 +28,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
@@ -1200,7 +1199,6 @@ public final class McpProxyFactory implements McpStreamFactory
         private final McpExit exit;
         private final long resolvedId;
         private final String prefix;
-        private final int clientIndex;
 
         private long initialId;
         private long replyId;
@@ -1214,14 +1212,12 @@ public final class McpProxyFactory implements McpStreamFactory
             McpListServer server,
             McpExit exit,
             long resolvedId,
-            String prefix,
-            int clientIndex)
+            String prefix)
         {
             this.server = server;
             this.exit = exit;
             this.resolvedId = resolvedId;
             this.prefix = prefix;
-            this.clientIndex = clientIndex;
         }
 
         @Override
@@ -1366,9 +1362,9 @@ public final class McpProxyFactory implements McpStreamFactory
             if (!completed)
             {
                 completed = true;
-                final byte[] transformed = transformedClientReply();
+                final byte[] reply = bufferedClientReply();
                 cleanupClientSlot();
-                server.clientDone(this, transformed, traceId);
+                server.clientDone(this, reply, traceId);
             }
         }
 
@@ -1412,7 +1408,7 @@ public final class McpProxyFactory implements McpStreamFactory
             }
         }
 
-        private byte[] transformedClientReply()
+        private byte[] bufferedClientReply()
         {
             if (replySlot == NO_SLOT || replySlotOffset == 0)
             {
@@ -1420,8 +1416,7 @@ public final class McpProxyFactory implements McpStreamFactory
             }
             final byte[] inputBytes = new byte[replySlotOffset];
             bufferPool.buffer(replySlot).getBytes(0, inputBytes);
-            return prefix.isEmpty() ? inputBytes :
-                applyListPrefix(prefix, server.beginKind, inputBytes);
+            return inputBytes;
         }
 
         private void cleanupClientSlot()
@@ -1435,6 +1430,12 @@ public final class McpProxyFactory implements McpStreamFactory
         }
     }
 
+    private static final byte[] LIST_REPLY_TOOLS_OPEN = "{\"tools\":[".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] LIST_REPLY_PROMPTS_OPEN = "{\"prompts\":[".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] LIST_REPLY_RESOURCES_OPEN = "{\"resources\":[".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] LIST_REPLY_CLOSE = "]}".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] LIST_REPLY_SEPARATOR = ",".getBytes(StandardCharsets.UTF_8);
+
     private final class McpListServer
     {
         private final MessageConsumer sender;
@@ -1447,13 +1448,12 @@ public final class McpProxyFactory implements McpStreamFactory
         private final int beginKind;
         private final String sessionId;
         private final McpSession session;
-        private final List<McpListClient> clients;
-        private final byte[][] clientReplies;
+        private final Deque<McpListClient> remaining;
 
         private int state;
         private boolean endReceived;
-        private int doneClients;
-        private int failedClients;
+        private int itemsEmitted;
+        private McpListClient currentClient;
 
         private McpListServer(
             MessageConsumer sender,
@@ -1478,15 +1478,13 @@ public final class McpProxyFactory implements McpStreamFactory
             this.beginKind = beginKind;
             this.sessionId = sessionId;
             this.session = session;
-            this.clients = new ArrayList<>(routes.size());
-            for (int i = 0; i < routes.size(); i++)
+            this.remaining = new ArrayDeque<>(routes.size());
+            for (final McpRouteConfig route : routes)
             {
-                final McpRouteConfig route = routes.get(i);
                 final McpExit exit = session.supplyExit(route.id);
                 final String prefix = route.prefix(beginEx);
-                clients.add(new McpListClient(this, exit, route.id, prefix, i));
+                remaining.add(new McpListClient(this, exit, route.id, prefix));
             }
-            this.clientReplies = new byte[clients.size()][];
         }
 
         private void onServerMessage(
@@ -1529,24 +1527,9 @@ public final class McpProxyFactory implements McpStreamFactory
             doWindow(sender, originId, routedId, initialId, traceId, authorization, 0,
                 writeBuffer.capacity(), 0);
 
-            for (McpListClient client : clients)
-            {
-                final McpExit exit = client.exit;
-                if (exit.state == McpExit.OPENED)
-                {
-                    client.proceed(traceId);
-                }
-                else
-                {
-                    exit.pending.add(client);
-                    if (exit.state == McpExit.UNINITIALIZED)
-                    {
-                        exit.state = McpExit.OPENING;
-                        exit.lifecycle = new McpLifecycleClient(exit, session);
-                        exit.lifecycle.doClientBegin(traceId);
-                    }
-                }
-            }
+            doServerBegin(traceId);
+            emitPrelude(traceId);
+            startNextRoute(traceId);
         }
 
         private void onServerEnd(
@@ -1556,12 +1539,9 @@ public final class McpProxyFactory implements McpStreamFactory
             state = McpState.closedInitial(state);
             endReceived = true;
 
-            for (McpListClient client : clients)
+            if (currentClient != null && McpState.initialOpened(currentClient.state))
             {
-                if (McpState.initialOpened(client.state))
-                {
-                    client.doClientEnd(traceId);
-                }
+                currentClient.doClientEnd(traceId);
             }
         }
 
@@ -1572,10 +1552,15 @@ public final class McpProxyFactory implements McpStreamFactory
             state = McpState.closedInitial(state);
             endReceived = true;
 
-            for (McpListClient client : clients)
+            if (currentClient != null)
             {
-                client.doClientAbort(traceId);
+                currentClient.doClientAbort(traceId);
             }
+            for (final McpListClient queued : remaining)
+            {
+                queued.doClientAbort(traceId);
+            }
+            remaining.clear();
         }
 
         private void onServerReset(
@@ -1584,10 +1569,15 @@ public final class McpProxyFactory implements McpStreamFactory
             final long traceId = reset.traceId();
             state = McpState.closedReply(state);
 
-            for (McpListClient client : clients)
+            if (currentClient != null)
             {
-                client.doClientReset(traceId);
+                currentClient.doClientReset(traceId);
             }
+            for (final McpListClient queued : remaining)
+            {
+                queued.doClientReset(traceId);
+            }
+            remaining.clear();
         }
 
         private void clientDone(
@@ -1595,46 +1585,88 @@ public final class McpProxyFactory implements McpStreamFactory
             byte[] data,
             long traceId)
         {
-            clientReplies[client.clientIndex] = data;
-            doneClients++;
-
-            if (doneClients + failedClients == clients.size())
+            if (data != null)
             {
-                emitMergedReply(traceId);
+                forEachListItem(data, beginKind, client.prefix, traceId, this::streamItem);
             }
+            currentClient = null;
+            startNextRoute(traceId);
         }
 
         private void clientFailed(
             McpListClient client,
             long traceId)
         {
-            failedClients++;
-
-            for (McpListClient other : clients)
+            currentClient = null;
+            for (final McpListClient queued : remaining)
             {
-                if (other != client && !other.completed)
-                {
-                    other.completed = true;
-                    other.doClientAbort(traceId);
-                }
+                queued.doClientAbort(traceId);
             }
+            remaining.clear();
+            doServerAbort(traceId);
+        }
 
-            if (doneClients + failedClients == clients.size())
+        private void startNextRoute(
+            long traceId)
+        {
+            if (remaining.isEmpty())
             {
-                doServerAbort(traceId);
+                closeReply(traceId);
+                return;
+            }
+            currentClient = remaining.poll();
+            final McpExit exit = currentClient.exit;
+            if (exit.state == McpExit.OPENED)
+            {
+                currentClient.proceed(traceId);
+            }
+            else
+            {
+                exit.pending.add(currentClient);
+                if (exit.state == McpExit.UNINITIALIZED)
+                {
+                    exit.state = McpExit.OPENING;
+                    exit.lifecycle = new McpLifecycleClient(exit, session);
+                    exit.lifecycle.doClientBegin(traceId);
+                }
             }
         }
 
-        private void emitMergedReply(
+        private void streamItem(
+            byte[] item,
+            int offset,
+            int length,
             long traceId)
         {
-            final byte[] mergedJson = mergeListReplies(beginKind, clientReplies);
+            if (itemsEmitted > 0)
+            {
+                final UnsafeBuffer sep = new UnsafeBuffer(LIST_REPLY_SEPARATOR);
+                doServerData(traceId, 0L, 0x03, sep.capacity(), sep, 0, sep.capacity());
+            }
+            final UnsafeBuffer itemBuffer = new UnsafeBuffer(item, offset, length);
+            doServerData(traceId, 0L, 0x03, length, itemBuffer, 0, length);
+            itemsEmitted++;
+        }
 
-            doServerBegin(traceId);
+        private void emitPrelude(
+            long traceId)
+        {
+            final byte[] preludeBytes = switch (beginKind)
+            {
+            case KIND_TOOLS_LIST -> LIST_REPLY_TOOLS_OPEN;
+            case KIND_PROMPTS_LIST -> LIST_REPLY_PROMPTS_OPEN;
+            case KIND_RESOURCES_LIST -> LIST_REPLY_RESOURCES_OPEN;
+            default -> throw new IllegalStateException("unexpected list kind: " + beginKind);
+            };
+            final UnsafeBuffer buf = new UnsafeBuffer(preludeBytes);
+            doServerData(traceId, 0L, 0x03, preludeBytes.length, buf, 0, preludeBytes.length);
+        }
 
-            final UnsafeBuffer outputBuffer = new UnsafeBuffer(mergedJson);
-            doServerData(traceId, 0L, 0x03, mergedJson.length, outputBuffer, 0, mergedJson.length);
-
+        private void closeReply(
+            long traceId)
+        {
+            final UnsafeBuffer buf = new UnsafeBuffer(LIST_REPLY_CLOSE);
+            doServerData(traceId, 0L, 0x03, buf.capacity(), buf, 0, buf.capacity());
             doServerEnd(traceId);
         }
 
@@ -1712,6 +1744,130 @@ public final class McpProxyFactory implements McpStreamFactory
         case KIND_RESOURCES_READ -> beginEx.resourcesRead().sessionId().asString();
         default -> null;
         };
+    }
+
+    @FunctionalInterface
+    private interface ListItemEmitter
+    {
+        void emit(byte[] item, int offset, int length, long traceId);
+    }
+
+    /**
+     * Walks a single route's list reply (e.g. {@code {"tools":[{...},{...}]}}) and emits each
+     * item one at a time via {@code emitter}. The idKey value in each item is spliced with
+     * {@code prefix} during the walk; remaining bytes flow through verbatim. Non-conforming
+     * replies (no matching arrayKey) result in zero emitted items.
+     */
+    private static void forEachListItem(
+        byte[] jsonBytes,
+        int beginKind,
+        String prefix,
+        long traceId,
+        ListItemEmitter emitter)
+    {
+        final String arrayKey = switch (beginKind)
+        {
+        case KIND_TOOLS_LIST -> "tools";
+        case KIND_PROMPTS_LIST -> "prompts";
+        case KIND_RESOURCES_LIST -> "resources";
+        default -> null;
+        };
+        if (arrayKey == null)
+        {
+            return;
+        }
+        final String idKey = beginKind == KIND_RESOURCES_LIST ? "uri" : "name";
+        final JsonPointer idPath = Json.createPointer("/" + arrayKey + "/-/" + idKey);
+        final Map<String, ?> config = Map.of(
+            StreamingJson.PATH_INCLUDES, List.of(idPath),
+            StreamingJson.TOKEN_MAX_BYTES, jsonBytes.length);
+        final byte[] prefixBytes = prefix.getBytes(StandardCharsets.UTF_8);
+
+        final ByteArrayOutputStream itemOut = new ByteArrayOutputStream(256);
+        int depth = 0;
+        int targetItemDepth = -1;
+        int itemStart = -1;
+        int itemLastEmitted = -1;
+        boolean awaitingIdValue = false;
+
+        final BufferedInputStream in = new BufferedInputStream(new ByteArrayInputStream(jsonBytes));
+        try (JsonParser parser = StreamingJson.createParser(in, config))
+        {
+            while (true)
+            {
+                final long beforeOffset = parser.getLocation().getStreamOffset();
+                if (!parser.hasNext())
+                {
+                    break;
+                }
+                final long afterOffset = parser.getLocation().getStreamOffset();
+                final JsonParser.Event ev = parser.next();
+                switch (ev)
+                {
+                case START_OBJECT:
+                    depth++;
+                    if (depth == targetItemDepth)
+                    {
+                        // first byte of the item is the `{` at afterOffset - 1
+                        itemStart = (int) (afterOffset - 1);
+                        itemLastEmitted = itemStart;
+                        itemOut.reset();
+                    }
+                    break;
+                case START_ARRAY:
+                    depth++;
+                    break;
+                case END_OBJECT:
+                    if (depth == targetItemDepth && itemStart >= 0)
+                    {
+                        // emit any tail since the last splice through the closing `}`
+                        itemOut.write(jsonBytes, itemLastEmitted, (int) afterOffset - itemLastEmitted);
+                        emitter.emit(itemOut.toByteArray(), 0, itemOut.size(), traceId);
+                        itemStart = -1;
+                        itemLastEmitted = -1;
+                    }
+                    depth--;
+                    break;
+                case END_ARRAY:
+                    depth--;
+                    break;
+                case KEY_NAME:
+                    final String key = parser.getString();
+                    if (depth == 1 && arrayKey.equals(key))
+                    {
+                        // upcoming START_ARRAY at depth 2; items are at depth 3
+                        targetItemDepth = 3;
+                    }
+                    else if (depth == targetItemDepth && idKey.equals(key))
+                    {
+                        awaitingIdValue = true;
+                    }
+                    break;
+                case VALUE_STRING:
+                    if (awaitingIdValue)
+                    {
+                        awaitingIdValue = false;
+                        if (itemStart >= 0 && prefixBytes.length > 0)
+                        {
+                            int openingQuote = (int) beforeOffset;
+                            while (openingQuote < (int) afterOffset && jsonBytes[openingQuote] != '"')
+                            {
+                                openingQuote++;
+                            }
+                            final int contentStart = openingQuote + 1;
+                            // emit bytes from item start up to and including opening quote
+                            itemOut.write(jsonBytes, itemLastEmitted, contentStart - itemLastEmitted);
+                            // splice in the prefix
+                            itemOut.write(prefixBytes, 0, prefixBytes.length);
+                            itemLastEmitted = contentStart;
+                        }
+                    }
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
     }
 
     private static byte[] applyListPrefix(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -984,7 +984,6 @@ public final class McpProxyFactory implements McpStreamFactory
 
             doServerBegin(traceId, beginEx);
 
-            initialMax = writeBuffer.capacity();
             doServerWindow(traceId, 0L, 0);
         }
 
@@ -1274,7 +1273,6 @@ public final class McpProxyFactory implements McpStreamFactory
                 sessionId = beginEx.lifecycle().sessionId().asString();
             }
 
-            replyMax = writeBuffer.capacity();
             doClientWindow(traceId, 0L, 0);
 
             state = McpState.openedReply(state);
@@ -2168,7 +2166,6 @@ public final class McpProxyFactory implements McpStreamFactory
 
             state = McpState.openingInitial(state);
 
-            initialMax = writeBuffer.capacity();
             doServerWindow(traceId, 0L, 0);
 
             doServerBegin(traceId);

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -14,15 +14,25 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
 
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_LIFECYCLE;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_GET;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_READ;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_CALL;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
+
 import java.util.function.LongUnaryOperator;
 
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.Long2ObjectHashMap;
+import org.agrona.concurrent.UnsafeBuffer;
 
 import io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration;
 import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpBindingConfig;
 import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpRouteConfig;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.Flyweight;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.OctetsFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.AbortFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.BeginFW;
@@ -56,8 +66,10 @@ public final class McpProxyFactory implements McpStreamFactory
     private final AbortFW.Builder abortRW = new AbortFW.Builder();
     private final WindowFW.Builder windowRW = new WindowFW.Builder();
     private final ResetFW.Builder resetRW = new ResetFW.Builder();
+    private final McpBeginExFW.Builder mcpBeginExRW = new McpBeginExFW.Builder();
 
     private final MutableDirectBuffer writeBuffer;
+    private final MutableDirectBuffer codecBuffer;
     private final BindingHandler streamFactory;
     private final LongUnaryOperator supplyInitialId;
     private final LongUnaryOperator supplyReplyId;
@@ -70,6 +82,7 @@ public final class McpProxyFactory implements McpStreamFactory
         EngineContext context)
     {
         this.writeBuffer = context.writeBuffer();
+        this.codecBuffer = new UnsafeBuffer(new byte[context.writeBuffer().capacity()]);
         this.streamFactory = context.streamFactory();
         this.supplyInitialId = context::supplyInitialId;
         this.supplyReplyId = context::supplyReplyId;
@@ -133,7 +146,10 @@ public final class McpProxyFactory implements McpStreamFactory
                     initialId,
                     route.id,
                     affinity,
-                    authorization)::onServerMessage;
+                    authorization,
+                    beginEx.kind(),
+                    sessionId(beginEx),
+                    route.strip(beginEx))::onServerMessage;
             }
         }
 
@@ -150,6 +166,9 @@ public final class McpProxyFactory implements McpStreamFactory
         private final long affinity;
         private final long authorization;
         private final McpClient client;
+        private final int beginKind;
+        private final String sessionId;
+        private final String identifier;
 
         private int state;
 
@@ -160,7 +179,10 @@ public final class McpProxyFactory implements McpStreamFactory
             long initialId,
             long resolvedId,
             long affinity,
-            long authorization)
+            long authorization,
+            int beginKind,
+            String sessionId,
+            String identifier)
         {
             this.sender = sender;
             this.originId = originId;
@@ -169,6 +191,9 @@ public final class McpProxyFactory implements McpStreamFactory
             this.replyId = supplyReplyId.applyAsLong(initialId);
             this.affinity = affinity;
             this.authorization = authorization;
+            this.beginKind = beginKind;
+            this.sessionId = sessionId;
+            this.identifier = identifier;
             this.client = new McpClient(this, resolvedId);
         }
 
@@ -296,9 +321,10 @@ public final class McpProxyFactory implements McpStreamFactory
         }
 
         private void doServerBeginReply(
-            long traceId)
+            long traceId,
+            OctetsFW extension)
         {
-            doBegin(sender, originId, routedId, replyId, traceId, authorization, affinity);
+            doBegin(sender, originId, routedId, replyId, traceId, authorization, affinity, extension);
             state = McpState.openedReply(state);
         }
 
@@ -382,8 +408,10 @@ public final class McpProxyFactory implements McpStreamFactory
             sender = streamFactory.newStream(BeginFW.TYPE_ID, writeBuffer, 0, 0, this::onClientMessage);
             assert sender != null;
 
+            final McpBeginExFW beginEx = buildBeginEx(server.beginKind, server.sessionId, server.identifier);
+
             doBegin(sender, server.originId, resolvedId, initialId,
-                traceId, server.authorization, server.affinity);
+                traceId, server.authorization, server.affinity, beginEx);
             state = McpState.openingInitial(state);
         }
 
@@ -487,10 +515,11 @@ public final class McpProxyFactory implements McpStreamFactory
             BeginFW begin)
         {
             final long traceId = begin.traceId();
+            final OctetsFW extension = begin.extension();
 
             state = McpState.openedInitial(state);
 
-            server.doServerBeginReply(traceId);
+            server.doServerBeginReply(traceId, extension);
         }
 
         private void onClientData(
@@ -551,6 +580,58 @@ public final class McpProxyFactory implements McpStreamFactory
         }
     }
 
+    private static String sessionId(
+        McpBeginExFW beginEx)
+    {
+        return switch (beginEx.kind())
+        {
+        case KIND_LIFECYCLE -> beginEx.lifecycle().sessionId().asString();
+        case KIND_TOOLS_LIST -> beginEx.toolsList().sessionId().asString();
+        case KIND_TOOLS_CALL -> beginEx.toolsCall().sessionId().asString();
+        case KIND_PROMPTS_LIST -> beginEx.promptsList().sessionId().asString();
+        case KIND_PROMPTS_GET -> beginEx.promptsGet().sessionId().asString();
+        case KIND_RESOURCES_LIST -> beginEx.resourcesList().sessionId().asString();
+        case KIND_RESOURCES_READ -> beginEx.resourcesRead().sessionId().asString();
+        default -> null;
+        };
+    }
+
+    private McpBeginExFW buildBeginEx(
+        int kind,
+        String sessionId,
+        String identifier)
+    {
+        final McpBeginExFW.Builder builder = mcpBeginExRW
+            .wrap(codecBuffer, 0, codecBuffer.capacity())
+            .typeId(mcpTypeId);
+
+        return switch (kind)
+        {
+        case KIND_LIFECYCLE -> builder
+            .lifecycle(l -> l.sessionId(sessionId))
+            .build();
+        case KIND_TOOLS_LIST -> builder
+            .toolsList(t -> t.sessionId(sessionId))
+            .build();
+        case KIND_TOOLS_CALL -> builder
+            .toolsCall(t -> t.sessionId(sessionId).name(identifier))
+            .build();
+        case KIND_PROMPTS_LIST -> builder
+            .promptsList(p -> p.sessionId(sessionId))
+            .build();
+        case KIND_PROMPTS_GET -> builder
+            .promptsGet(p -> p.sessionId(sessionId).name(identifier))
+            .build();
+        case KIND_RESOURCES_LIST -> builder
+            .resourcesList(r -> r.sessionId(sessionId))
+            .build();
+        case KIND_RESOURCES_READ -> builder
+            .resourcesRead(r -> r.sessionId(sessionId).uri(identifier))
+            .build();
+        default -> null;
+        };
+    }
+
     private void doBegin(
         MessageConsumer receiver,
         long originId,
@@ -558,9 +639,10 @@ public final class McpProxyFactory implements McpStreamFactory
         long streamId,
         long traceId,
         long authorization,
-        long affinity)
+        long affinity,
+        Flyweight extension)
     {
-        final BeginFW begin = beginRW.wrap(writeBuffer, 0, writeBuffer.capacity())
+        final BeginFW.Builder builder = beginRW.wrap(writeBuffer, 0, writeBuffer.capacity())
             .originId(originId)
             .routedId(routedId)
             .streamId(streamId)
@@ -569,8 +651,14 @@ public final class McpProxyFactory implements McpStreamFactory
             .maximum(0)
             .traceId(traceId)
             .authorization(authorization)
-            .affinity(affinity)
-            .build();
+            .affinity(affinity);
+
+        if (extension != null && extension.sizeof() > 0)
+        {
+            builder.extension(extension.buffer(), extension.offset(), extension.sizeof());
+        }
+
+        final BeginFW begin = builder.build();
 
         receiver.accept(begin.typeId(), begin.buffer(), begin.offset(), begin.sizeof());
     }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -1412,7 +1412,6 @@ public final class McpProxyFactory implements McpStreamFactory
         private int decodeDepth;                  // JSON nesting depth in the reply envelope
         private int decodeItemDepth;              // JSON nesting depth within the current item
         private int decodeSkipDepth;              // JSON nesting depth within a skipped value
-        private boolean awaitingIdValue;
         private long itemStartStreamOffset = -1;
         private long itemEmittedStreamOffset = -1;
         private McpListClientDecoder decoder = decodeInit;
@@ -1816,7 +1815,9 @@ public final class McpProxyFactory implements McpStreamFactory
     private final McpListClientDecoder decodeItemsKey = this::decodeItemsKey;
     private final McpListClientDecoder decodeSkipObject = this::decodeSkipObject;
     private final McpListClientDecoder decodeItems = this::decodeItems;
-    private final McpListClientDecoder decodeItem = this::decodeItem;
+    private final McpListClientDecoder decodeItemStart = this::decodeItemStart;
+    private final McpListClientDecoder decodeItemBody = this::decodeItemBody;
+    private final McpListClientDecoder decodeItemId = this::decodeItemId;
     private final McpListClientDecoder decodeItemFinalize = this::decodeItemFinalize;
     private final McpListClientDecoder decodeIgnore = this::decodeIgnore;
 
@@ -2010,7 +2011,7 @@ public final class McpProxyFactory implements McpStreamFactory
             if (event == JsonParser.Event.START_ARRAY)
             {
                 client.decodeItemDepth = 0;
-                client.decoder = decodeItem;
+                client.decoder = decodeItemStart;
                 break decode;
             }
         }
@@ -2018,7 +2019,46 @@ public final class McpProxyFactory implements McpStreamFactory
         return offset + (int) (parser.getLocation().getStreamOffset() - client.decodedParserProgress);
     }
 
-    private int decodeItem(
+    private int decodeItemStart(
+        McpListClient client,
+        long traceId,
+        long authorization,
+        long budgetId,
+        int reserved,
+        DirectBuffer buffer,
+        int offset,
+        int progress,
+        int limit)
+    {
+        final JsonParser parser = client.decodableJson;
+
+        decode:
+        while (parser.hasNext())
+        {
+            final long afterStreamOffset = parser.getLocation().getStreamOffset();
+            final JsonParser.Event event = parser.next();
+            switch (event)
+            {
+            case START_OBJECT:
+                client.itemStartStreamOffset = afterStreamOffset - 1;
+                client.itemEmittedStreamOffset = client.itemStartStreamOffset;
+                client.server.streamItemBegin(traceId);
+                client.decodeItemDepth = 1;
+                client.decoder = decodeItemBody;
+                break decode;
+            case END_ARRAY:
+                client.decodeDepth--;
+                client.decoder = decodeItemsKey;
+                break decode;
+            default:
+                break;
+            }
+        }
+
+        return offset + (int) (parser.getLocation().getStreamOffset() - client.decodedParserProgress);
+    }
+
+    private int decodeItemBody(
         McpListClient client,
         long traceId,
         long authorization,
@@ -2034,25 +2074,21 @@ public final class McpProxyFactory implements McpStreamFactory
         decode:
         while (true)
         {
-            if (client.itemStartStreamOffset >= 0)
+            final long parserStreamOffset = parser.getLocation().getStreamOffset();
+            if (client.itemEmittedStreamOffset < parserStreamOffset)
             {
-                final long parserStreamOffset = parser.getLocation().getStreamOffset();
-                if (client.itemEmittedStreamOffset < parserStreamOffset)
+                final int emittedInBuf =
+                    offset + (int) (client.itemEmittedStreamOffset - client.decodedParserProgress);
+                final int parserInBuf = offset + (int) (parserStreamOffset - client.decodedParserProgress);
+                final int chunkLen = parserInBuf - emittedInBuf;
+                final int emitted = client.server.streamItemChunk(buffer, emittedInBuf, chunkLen, traceId);
+                client.itemEmittedStreamOffset += emitted;
+                if (emitted < chunkLen)
                 {
-                    final int emittedInBuf =
-                        offset + (int) (client.itemEmittedStreamOffset - client.decodedParserProgress);
-                    final int parserInBuf = offset + (int) (parserStreamOffset - client.decodedParserProgress);
-                    final int chunkLen = parserInBuf - emittedInBuf;
-                    final int emitted = client.server.streamItemChunk(buffer, emittedInBuf, chunkLen, traceId);
-                    client.itemEmittedStreamOffset += emitted;
-                    if (emitted < chunkLen)
-                    {
-                        break decode;
-                    }
+                    break decode;
                 }
             }
 
-            final long beforeStreamOffset = parser.getLocation().getStreamOffset();
             if (!parser.hasNext())
             {
                 break decode;
@@ -2062,20 +2098,12 @@ public final class McpProxyFactory implements McpStreamFactory
             switch (event)
             {
             case START_OBJECT:
-                if (client.decodeItemDepth == 0)
-                {
-                    client.itemStartStreamOffset = afterStreamOffset - 1;
-                    client.itemEmittedStreamOffset = client.itemStartStreamOffset;
-                    client.server.streamItemBegin(traceId);
-                }
-                client.decodeItemDepth++;
-                break;
             case START_ARRAY:
                 client.decodeItemDepth++;
                 break;
             case END_OBJECT:
                 client.decodeItemDepth--;
-                if (client.decodeItemDepth == 0 && client.itemStartStreamOffset >= 0)
+                if (client.decodeItemDepth == 0)
                 {
                     final int afterInBuf = offset + (int) (afterStreamOffset - client.decodedParserProgress);
                     final int emittedInBuf =
@@ -2091,50 +2119,81 @@ public final class McpProxyFactory implements McpStreamFactory
                     client.server.streamItemEnd(traceId);
                     client.itemStartStreamOffset = -1;
                     client.itemEmittedStreamOffset = -1;
+                    client.decoder = decodeItemStart;
+                    break decode;
                 }
                 break;
             case END_ARRAY:
                 client.decodeItemDepth--;
-                if (client.decodeItemDepth < 0)
-                {
-                    client.decodeDepth--;
-                    client.decoder = decodeItemsKey;
-                    break decode;
-                }
                 break;
             case KEY_NAME:
-                if (client.decodeItemDepth == 1 && client.idKey.equals(parser.getString()))
+                if (client.decodeItemDepth == 1 &&
+                    client.prefixBytes.length > 0 &&
+                    client.idKey.equals(parser.getString()))
                 {
-                    client.awaitingIdValue = true;
-                }
-                break;
-            case VALUE_STRING:
-                if (client.awaitingIdValue && client.itemStartStreamOffset >= 0 && client.prefixBytes.length > 0)
-                {
-                    client.awaitingIdValue = false;
-                    final int beforeInBuf = offset + (int) (beforeStreamOffset - client.decodedParserProgress);
-                    final int afterInBuf = offset + (int) (afterStreamOffset - client.decodedParserProgress);
-                    int openingQuote = beforeInBuf;
-                    while (openingQuote < afterInBuf && buffer.getByte(openingQuote) != (byte) '"')
-                    {
-                        openingQuote++;
-                    }
-                    final int contentStart = openingQuote + 1;
-                    final int emittedInBuf =
-                        offset + (int) (client.itemEmittedStreamOffset - client.decodedParserProgress);
-                    client.server.streamItemChunk(buffer, emittedInBuf, contentStart - emittedInBuf, traceId);
-                    client.server.streamItemChunk(client.prefixBufferRO, 0, client.prefixBytes.length, traceId);
-                    client.itemEmittedStreamOffset =
-                        client.decodedParserProgress + (long) (contentStart - offset);
-                }
-                else if (client.awaitingIdValue)
-                {
-                    client.awaitingIdValue = false;
+                    client.decoder = decodeItemId;
+                    break decode;
                 }
                 break;
             default:
                 break;
             }
+        }
+
+        return offset + (int) (parser.getLocation().getStreamOffset() - client.decodedParserProgress);
+    }
+
+    private int decodeItemId(
+        McpListClient client,
+        long traceId,
+        long authorization,
+        long budgetId,
+        int reserved,
+        DirectBuffer buffer,
+        int offset,
+        int progress,
+        int limit)
+    {
+        final JsonParser parser = client.decodableJson;
+
+        final long parserStreamOffset = parser.getLocation().getStreamOffset();
+        if (client.itemEmittedStreamOffset < parserStreamOffset)
+        {
+            final int emittedInBuf =
+                offset + (int) (client.itemEmittedStreamOffset - client.decodedParserProgress);
+            final int parserInBuf = offset + (int) (parserStreamOffset - client.decodedParserProgress);
+            final int chunkLen = parserInBuf - emittedInBuf;
+            final int emitted = client.server.streamItemChunk(buffer, emittedInBuf, chunkLen, traceId);
+            client.itemEmittedStreamOffset += emitted;
+            if (emitted < chunkLen)
+            {
+                return offset + (int) (client.itemEmittedStreamOffset - client.decodedParserProgress);
+            }
+        }
+
+        final long beforeStreamOffset = parser.getLocation().getStreamOffset();
+        if (parser.hasNext())
+        {
+            final long afterStreamOffset = parser.getLocation().getStreamOffset();
+            final JsonParser.Event event = parser.next();
+            if (event == JsonParser.Event.VALUE_STRING)
+            {
+                final int beforeInBuf = offset + (int) (beforeStreamOffset - client.decodedParserProgress);
+                final int afterInBuf = offset + (int) (afterStreamOffset - client.decodedParserProgress);
+                int openingQuote = beforeInBuf;
+                while (openingQuote < afterInBuf && buffer.getByte(openingQuote) != (byte) '"')
+                {
+                    openingQuote++;
+                }
+                final int contentStart = openingQuote + 1;
+                final int emittedInBuf =
+                    offset + (int) (client.itemEmittedStreamOffset - client.decodedParserProgress);
+                client.server.streamItemChunk(buffer, emittedInBuf, contentStart - emittedInBuf, traceId);
+                client.server.streamItemChunk(client.prefixBufferRO, 0, client.prefixBytes.length, traceId);
+                client.itemEmittedStreamOffset =
+                    client.decodedParserProgress + (long) (contentStart - offset);
+            }
+            client.decoder = decodeItemBody;
         }
 
         return offset + (int) (parser.getLocation().getStreamOffset() - client.decodedParserProgress);
@@ -2171,7 +2230,7 @@ public final class McpProxyFactory implements McpStreamFactory
         client.server.streamItemEnd(traceId);
         client.itemStartStreamOffset = -1;
         client.itemEmittedStreamOffset = -1;
-        client.decoder = decodeItem;
+        client.decoder = decodeItemStart;
 
         return offset + (int) (parserStreamOffset - client.decodedParserProgress);
     }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -336,8 +336,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
             client.doClientBegin(traceId);
 
-            initialMax = writeBuffer.capacity();
-            doServerWindow(traceId, 0L, 0);
+            flushServerWindow(traceId, 0L, 0, 0L, 0);
         }
 
         private void onServerData(
@@ -430,7 +429,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
             assert replyAck <= replySeq;
 
-            client.doClientWindow(traceId, budgetId, padding);
+            client.flushClientWindow(traceId, budgetId, padding, replySeq - replyAck, replyMax);
         }
 
         private void onServerReset(
@@ -501,8 +500,27 @@ public final class McpProxyFactory implements McpStreamFactory
             long budgetId,
             int padding)
         {
+            state = McpState.openedInitial(state);
             doWindow(sender, originId, routedId, initialId, initialSeq, initialAck, initialMax, traceId, authorization,
                 budgetId, padding);
+        }
+
+        private void flushServerWindow(
+            long traceId,
+            long budgetId,
+            int padding,
+            long minInitialNoAck,
+            int minInitialMax)
+        {
+            final long newInitialAck = Math.max(initialAck, initialSeq - minInitialNoAck);
+            final int newInitialMax = Math.max(initialMax, minInitialMax);
+
+            if (newInitialAck > initialAck || newInitialMax > initialMax || !McpState.initialOpened(state))
+            {
+                initialAck = newInitialAck;
+                initialMax = newInitialMax;
+                doServerWindow(traceId, budgetId, padding);
+            }
         }
 
         private void doServerReset(
@@ -625,8 +643,27 @@ public final class McpProxyFactory implements McpStreamFactory
             long budgetId,
             int padding)
         {
+            state = McpState.openedReply(state);
             doWindow(sender, server.lifecycle.originId, resolvedId, replyId,
                 replySeq, replyAck, replyMax, traceId, server.authorization, budgetId, padding);
+        }
+
+        private void flushClientWindow(
+            long traceId,
+            long budgetId,
+            int padding,
+            long minReplyNoAck,
+            int minReplyMax)
+        {
+            final long newReplyAck = Math.max(replyAck, replySeq - minReplyNoAck);
+            final int newReplyMax = Math.max(replyMax, minReplyMax);
+
+            if (newReplyAck > replyAck || newReplyMax > replyMax || !McpState.replyOpened(state))
+            {
+                replyAck = newReplyAck;
+                replyMax = newReplyMax;
+                doClientWindow(traceId, budgetId, padding);
+            }
         }
 
         private void doClientReset(
@@ -697,8 +734,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
             server.doServerBegin(traceId, replyExtension);
 
-            replyMax = writeBuffer.capacity();
-            doClientWindow(traceId, 0L, 0);
+            flushClientWindow(traceId, 0L, 0, 0L, 0);
         }
 
         private Flyweight rewriteReplyBeginEx(
@@ -812,7 +848,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
             assert initialAck <= initialSeq;
 
-            server.doServerWindow(traceId, budgetId, padding);
+            server.flushServerWindow(traceId, budgetId, padding, initialSeq - initialAck, initialMax);
         }
 
         private void onClientReset(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -1415,7 +1415,6 @@ public final class McpProxyFactory implements McpStreamFactory
         private boolean awaitingIdValue;
         private long itemStartStreamOffset = -1;
         private long itemEmittedStreamOffset = -1;
-        private boolean pendingFinalize;
         private McpListClientDecoder decoder = decodeInit;
         private String arrayKey;
         private String idKey;
@@ -1776,7 +1775,7 @@ public final class McpProxyFactory implements McpStreamFactory
             }
         }
 
-        private void decodeFromSlot(
+        private void decode(
             long traceId)
         {
             if (replySlot != NO_SLOT)
@@ -1818,6 +1817,7 @@ public final class McpProxyFactory implements McpStreamFactory
     private final McpListClientDecoder decodeSkipObject = this::decodeSkipObject;
     private final McpListClientDecoder decodeItems = this::decodeItems;
     private final McpListClientDecoder decodeItem = this::decodeItem;
+    private final McpListClientDecoder decodeItemFinalize = this::decodeItemFinalize;
     private final McpListClientDecoder decodeIgnore = this::decodeIgnore;
 
     private int decodeInit(
@@ -2050,14 +2050,6 @@ public final class McpProxyFactory implements McpStreamFactory
                         break decode;
                     }
                 }
-
-                if (client.pendingFinalize)
-                {
-                    client.server.streamItemEnd(traceId);
-                    client.itemStartStreamOffset = -1;
-                    client.itemEmittedStreamOffset = -1;
-                    client.pendingFinalize = false;
-                }
             }
 
             final long beforeStreamOffset = parser.getLocation().getStreamOffset();
@@ -2093,7 +2085,7 @@ public final class McpProxyFactory implements McpStreamFactory
                     client.itemEmittedStreamOffset += emitted;
                     if (emitted < chunkLen)
                     {
-                        client.pendingFinalize = true;
+                        client.decoder = decodeItemFinalize;
                         break decode;
                     }
                     client.server.streamItemEnd(traceId);
@@ -2146,6 +2138,42 @@ public final class McpProxyFactory implements McpStreamFactory
         }
 
         return offset + (int) (parser.getLocation().getStreamOffset() - client.decodedParserProgress);
+    }
+
+    private int decodeItemFinalize(
+        McpListClient client,
+        long traceId,
+        long authorization,
+        long budgetId,
+        int reserved,
+        DirectBuffer buffer,
+        int offset,
+        int progress,
+        int limit)
+    {
+        final JsonParser parser = client.decodableJson;
+        final long parserStreamOffset = parser.getLocation().getStreamOffset();
+
+        if (client.itemEmittedStreamOffset < parserStreamOffset)
+        {
+            final int emittedInBuf =
+                offset + (int) (client.itemEmittedStreamOffset - client.decodedParserProgress);
+            final int parserInBuf = offset + (int) (parserStreamOffset - client.decodedParserProgress);
+            final int chunkLen = parserInBuf - emittedInBuf;
+            final int emitted = client.server.streamItemChunk(buffer, emittedInBuf, chunkLen, traceId);
+            client.itemEmittedStreamOffset += emitted;
+            if (emitted < chunkLen)
+            {
+                return offset + (int) (client.itemEmittedStreamOffset - client.decodedParserProgress);
+            }
+        }
+
+        client.server.streamItemEnd(traceId);
+        client.itemStartStreamOffset = -1;
+        client.itemEmittedStreamOffset = -1;
+        client.decoder = decodeItem;
+
+        return offset + (int) (parserStreamOffset - client.decodedParserProgress);
     }
 
     private int decodeIgnore(
@@ -2325,7 +2353,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
             if (client != null)
             {
-                client.decodeFromSlot(traceId);
+                client.decode(traceId);
                 client.flushClientWindow(traceId, budgetId, padding, replySeq - replyAck, replyMax);
             }
         }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -26,7 +26,9 @@ import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
+import java.util.List;
 import java.util.Map;
 import java.util.function.LongUnaryOperator;
 
@@ -156,14 +158,13 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final McpBeginExFW beginEx = mcpBeginExRO.wrap(
                 extension.buffer(), extension.offset(), extension.limit());
-            final McpRouteConfig route = binding.resolve(beginEx, authorization);
+            final int beginKind = beginEx.kind();
+            final String sessionId = sessionId(beginEx);
 
-            if (route != null)
+            if (beginKind == KIND_LIFECYCLE)
             {
-                final int beginKind = beginEx.kind();
-                final String sessionId = sessionId(beginEx);
-
-                if (beginKind == KIND_LIFECYCLE)
+                final McpRouteConfig route = binding.resolve(beginEx, authorization);
+                if (route != null)
                 {
                     final McpSession session = sessions.computeIfAbsent(sessionId, McpSession::new);
                     session.originId = originId;
@@ -177,30 +178,80 @@ public final class McpProxyFactory implements McpStreamFactory
                     session.lifecycle = lifecycle;
                     newStream = lifecycle::onServerMessage;
                 }
-                else
+            }
+            else
+            {
+                final McpSession session = sessions.get(sessionId);
+                if (session != null)
                 {
-                    final McpSession session = sessions.get(sessionId);
-                    if (session != null)
+                    if (isListKind(beginKind))
                     {
-                        final McpExit exit = session.supplyExit(route.id);
-                        final String identifier = route.strip(beginEx);
-                        final String prefix = route.prefix(beginEx);
+                        final List<McpRouteConfig> routes = binding.resolveAll(beginEx, authorization);
+                        if (routes.size() > 1)
+                        {
+                            final McpListServer listServer = new McpListServer(
+                                sender,
+                                originId,
+                                routedId,
+                                initialId,
+                                affinity,
+                                authorization,
+                                beginKind,
+                                sessionId,
+                                session,
+                                routes,
+                                beginEx);
+                            newStream = listServer::onServerMessage;
+                        }
+                        else if (!routes.isEmpty())
+                        {
+                            final McpRouteConfig route = routes.get(0);
+                            final McpExit exit = session.supplyExit(route.id);
+                            final String identifier = route.strip(beginEx);
+                            final String prefix = route.prefix(beginEx);
 
-                        newStream = new McpServer(
-                            sender,
-                            originId,
-                            routedId,
-                            initialId,
-                            route.id,
-                            affinity,
-                            authorization,
-                            beginKind,
-                            sessionId,
-                            identifier,
-                            prefix,
-                            0,
-                            session,
-                            exit)::onServerMessage;
+                            newStream = new McpServer(
+                                sender,
+                                originId,
+                                routedId,
+                                initialId,
+                                route.id,
+                                affinity,
+                                authorization,
+                                beginKind,
+                                sessionId,
+                                identifier,
+                                prefix,
+                                0,
+                                session,
+                                exit)::onServerMessage;
+                        }
+                    }
+                    else
+                    {
+                        final McpRouteConfig route = binding.resolve(beginEx, authorization);
+                        if (route != null)
+                        {
+                            final McpExit exit = session.supplyExit(route.id);
+                            final String identifier = route.strip(beginEx);
+                            final String prefix = route.prefix(beginEx);
+
+                            newStream = new McpServer(
+                                sender,
+                                originId,
+                                routedId,
+                                initialId,
+                                route.id,
+                                affinity,
+                                authorization,
+                                beginKind,
+                                sessionId,
+                                identifier,
+                                prefix,
+                                0,
+                                session,
+                                exit)::onServerMessage;
+                        }
                     }
                 }
             }
@@ -235,6 +286,13 @@ public final class McpProxyFactory implements McpStreamFactory
         }
     }
 
+    private interface McpPending
+    {
+        void proceed(long traceId);
+
+        void doServerReset(long traceId);
+    }
+
     private final class McpExit
     {
         private static final int UNINITIALIZED = 0;
@@ -242,7 +300,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private static final int OPENED = 2;
 
         private final long exitId;
-        private final Deque<McpServer> pending;
+        private final Deque<McpPending> pending;
 
         private int state;
         private String exitSessionId;
@@ -256,7 +314,7 @@ public final class McpProxyFactory implements McpStreamFactory
         }
     }
 
-    private final class McpServer
+    private final class McpServer implements McpPending
     {
         private final MessageConsumer sender;
         private final long originId;
@@ -373,7 +431,7 @@ public final class McpProxyFactory implements McpStreamFactory
             }
         }
 
-        private void proceed(
+        public void proceed(
             long traceId)
         {
             client.doClientBegin(traceId);
@@ -511,7 +569,7 @@ public final class McpProxyFactory implements McpStreamFactory
             doWindow(sender, originId, routedId, initialId, traceId, authorization, budgetId, credit, padding);
         }
 
-        private void doServerReset(
+        public void doServerReset(
             long traceId)
         {
             if (!McpState.initialClosed(state))
@@ -792,10 +850,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
         private boolean transformsList()
         {
-            return !server.prefix.isEmpty() &&
-                (server.beginKind == KIND_TOOLS_LIST ||
-                 server.beginKind == KIND_PROMPTS_LIST ||
-                 server.beginKind == KIND_RESOURCES_LIST);
+            return !server.prefix.isEmpty() && isListKind(server.beginKind);
         }
 
         private void bufferReplyPayload(
@@ -1004,7 +1059,7 @@ public final class McpProxyFactory implements McpStreamFactory
                 {
                     exit.lifecycle.doClientEnd(traceId);
                 }
-                for (McpServer pending : exit.pending)
+                for (McpPending pending : exit.pending)
                 {
                     pending.doServerReset(traceId);
                 }
@@ -1162,6 +1217,510 @@ public final class McpProxyFactory implements McpStreamFactory
         }
     }
 
+    private final class McpListLeg implements McpPending
+    {
+        private final McpListServer listServer;
+        private final McpExit exit;
+        private final long resolvedId;
+        private final String prefix;
+        private final int legIndex;
+
+        private long initialId;
+        private long replyId;
+        private MessageConsumer sender;
+        private int state;
+        private int replySlot = NO_SLOT;
+        private int replySlotOffset;
+        private boolean completed;
+
+        private McpListLeg(
+            McpListServer listServer,
+            McpExit exit,
+            long resolvedId,
+            String prefix,
+            int legIndex)
+        {
+            this.listServer = listServer;
+            this.exit = exit;
+            this.resolvedId = resolvedId;
+            this.prefix = prefix;
+            this.legIndex = legIndex;
+        }
+
+        @Override
+        public void proceed(
+            long traceId)
+        {
+            doClientBegin(traceId);
+            if (listServer.endReceived)
+            {
+                doClientEnd(traceId);
+            }
+        }
+
+        @Override
+        public void doServerReset(
+            long traceId)
+        {
+            if (!completed)
+            {
+                completed = true;
+                listServer.legFailed(this, traceId);
+            }
+        }
+
+        private void doClientBegin(
+            long traceId)
+        {
+            initialId = supplyInitialId.applyAsLong(resolvedId);
+            replyId = supplyReplyId.applyAsLong(initialId);
+
+            final String sid = exit.exitSessionId != null
+                ? exit.exitSessionId : listServer.sessionId;
+            final McpBeginExFW.Builder builder = mcpBeginExRW
+                .wrap(codecBuffer, 0, codecBuffer.capacity())
+                .typeId(mcpTypeId);
+            switch (listServer.beginKind)
+            {
+            case KIND_TOOLS_LIST -> builder.toolsList(t -> t.sessionId(sid));
+            case KIND_PROMPTS_LIST -> builder.promptsList(p -> p.sessionId(sid));
+            case KIND_RESOURCES_LIST -> builder.resourcesList(r -> r.sessionId(sid));
+            default -> throw new IllegalStateException("unexpected list kind: " + listServer.beginKind);
+            }
+            final McpBeginExFW beginEx = builder.build();
+
+            sender = newStream(this::onClientMessage, listServer.originId, resolvedId, initialId,
+                traceId, listServer.authorization, listServer.affinity, beginEx);
+            state = McpState.openingInitial(state);
+        }
+
+        private void doClientEnd(
+            long traceId)
+        {
+            if (sender != null && !McpState.initialClosed(state))
+            {
+                doEnd(sender, listServer.originId, resolvedId, initialId,
+                    traceId, listServer.authorization);
+                state = McpState.closedInitial(state);
+            }
+        }
+
+        private void doClientAbort(
+            long traceId)
+        {
+            if (sender != null && !McpState.initialClosed(state))
+            {
+                doAbort(sender, listServer.originId, resolvedId, initialId,
+                    traceId, listServer.authorization);
+                state = McpState.closedInitial(state);
+            }
+        }
+
+        private void doClientReset(
+            long traceId)
+        {
+            if (sender != null && !McpState.replyClosed(state))
+            {
+                doReset(sender, listServer.originId, resolvedId, replyId,
+                    traceId, listServer.authorization);
+                state = McpState.closedReply(state);
+            }
+        }
+
+        private void onClientMessage(
+            int msgTypeId,
+            DirectBuffer buffer,
+            int index,
+            int length)
+        {
+            switch (msgTypeId)
+            {
+            case BeginFW.TYPE_ID:
+                final BeginFW begin = beginRO.wrap(buffer, index, index + length);
+                onClientBegin(begin);
+                break;
+            case DataFW.TYPE_ID:
+                final DataFW data = dataRO.wrap(buffer, index, index + length);
+                onClientData(data);
+                break;
+            case EndFW.TYPE_ID:
+                final EndFW end = endRO.wrap(buffer, index, index + length);
+                onClientEnd(end);
+                break;
+            case AbortFW.TYPE_ID:
+                final AbortFW abort = abortRO.wrap(buffer, index, index + length);
+                onClientAbort(abort);
+                break;
+            case WindowFW.TYPE_ID:
+                break;
+            case ResetFW.TYPE_ID:
+                final ResetFW reset = resetRO.wrap(buffer, index, index + length);
+                onClientReset(reset);
+                break;
+            default:
+                break;
+            }
+        }
+
+        private void onClientBegin(
+            BeginFW begin)
+        {
+            final long traceId = begin.traceId();
+            state = McpState.openedInitial(state);
+            doWindow(sender, listServer.originId, resolvedId, replyId, traceId,
+                listServer.authorization, 0, writeBuffer.capacity(), 0);
+        }
+
+        private void onClientData(
+            DataFW data)
+        {
+            final OctetsFW payload = data.payload();
+            if (payload != null)
+            {
+                bufferLegPayload(payload);
+            }
+        }
+
+        private void onClientEnd(
+            EndFW end)
+        {
+            final long traceId = end.traceId();
+            state = McpState.closedReply(state);
+            if (!completed)
+            {
+                completed = true;
+                final byte[] transformed = transformedLegReply();
+                cleanupLegSlot();
+                listServer.legDone(this, transformed, traceId);
+            }
+        }
+
+        private void onClientAbort(
+            AbortFW abort)
+        {
+            final long traceId = abort.traceId();
+            state = McpState.closedReply(state);
+            cleanupLegSlot();
+            if (!completed)
+            {
+                completed = true;
+                listServer.legFailed(this, traceId);
+            }
+        }
+
+        private void onClientReset(
+            ResetFW reset)
+        {
+            final long traceId = reset.traceId();
+            state = McpState.closedInitial(state);
+            if (!completed)
+            {
+                completed = true;
+                listServer.legFailed(this, traceId);
+            }
+        }
+
+        private void bufferLegPayload(
+            OctetsFW payload)
+        {
+            if (replySlot == NO_SLOT)
+            {
+                replySlot = bufferPool.acquire(initialId);
+            }
+            if (replySlot != NO_SLOT)
+            {
+                final MutableDirectBuffer buf = bufferPool.buffer(replySlot);
+                buf.putBytes(replySlotOffset, payload.buffer(), payload.offset(), payload.sizeof());
+                replySlotOffset += payload.sizeof();
+            }
+        }
+
+        private byte[] transformedLegReply()
+        {
+            if (replySlot == NO_SLOT || replySlotOffset == 0)
+            {
+                return null;
+            }
+            final byte[] inputBytes = new byte[replySlotOffset];
+            bufferPool.buffer(replySlot).getBytes(0, inputBytes);
+            return prefix.isEmpty() ? inputBytes :
+                applyListPrefix(prefix, listServer.beginKind, inputBytes);
+        }
+
+        private void cleanupLegSlot()
+        {
+            if (replySlot != NO_SLOT)
+            {
+                bufferPool.release(replySlot);
+                replySlot = NO_SLOT;
+                replySlotOffset = 0;
+            }
+        }
+    }
+
+    private final class McpListServer
+    {
+        private final MessageConsumer sender;
+        private final long originId;
+        private final long routedId;
+        private final long initialId;
+        private final long replyId;
+        private final long affinity;
+        private final long authorization;
+        private final int beginKind;
+        private final String sessionId;
+        private final McpSession session;
+        private final List<McpListLeg> legs;
+        private final byte[][] legResults;
+
+        private int state;
+        private boolean endReceived;
+        private int doneLegs;
+        private int failedLegs;
+
+        private McpListServer(
+            MessageConsumer sender,
+            long originId,
+            long routedId,
+            long initialId,
+            long affinity,
+            long authorization,
+            int beginKind,
+            String sessionId,
+            McpSession session,
+            List<McpRouteConfig> routes,
+            McpBeginExFW beginEx)
+        {
+            this.sender = sender;
+            this.originId = originId;
+            this.routedId = routedId;
+            this.initialId = initialId;
+            this.replyId = supplyReplyId.applyAsLong(initialId);
+            this.affinity = affinity;
+            this.authorization = authorization;
+            this.beginKind = beginKind;
+            this.sessionId = sessionId;
+            this.session = session;
+            this.legs = new ArrayList<>(routes.size());
+            for (int i = 0; i < routes.size(); i++)
+            {
+                final McpRouteConfig route = routes.get(i);
+                final McpExit exit = session.supplyExit(route.id);
+                final String prefix = route.prefix(beginEx);
+                legs.add(new McpListLeg(this, exit, route.id, prefix, i));
+            }
+            this.legResults = new byte[legs.size()][];
+        }
+
+        private void onServerMessage(
+            int msgTypeId,
+            DirectBuffer buffer,
+            int index,
+            int length)
+        {
+            switch (msgTypeId)
+            {
+            case BeginFW.TYPE_ID:
+                final BeginFW begin = beginRO.wrap(buffer, index, index + length);
+                onServerBegin(begin);
+                break;
+            case EndFW.TYPE_ID:
+                final EndFW end = endRO.wrap(buffer, index, index + length);
+                onServerEnd(end);
+                break;
+            case AbortFW.TYPE_ID:
+                final AbortFW abort = abortRO.wrap(buffer, index, index + length);
+                onServerAbort(abort);
+                break;
+            case WindowFW.TYPE_ID:
+                break;
+            case ResetFW.TYPE_ID:
+                final ResetFW reset = resetRO.wrap(buffer, index, index + length);
+                onServerReset(reset);
+                break;
+            default:
+                break;
+            }
+        }
+
+        private void onServerBegin(
+            BeginFW begin)
+        {
+            final long traceId = begin.traceId();
+            state = McpState.openingInitial(state);
+
+            doWindow(sender, originId, routedId, initialId, traceId, authorization, 0,
+                writeBuffer.capacity(), 0);
+
+            for (McpListLeg leg : legs)
+            {
+                final McpExit exit = leg.exit;
+                if (exit.state == McpExit.OPENED)
+                {
+                    leg.proceed(traceId);
+                }
+                else
+                {
+                    exit.pending.add(leg);
+                    if (exit.state == McpExit.UNINITIALIZED)
+                    {
+                        exit.state = McpExit.OPENING;
+                        exit.lifecycle = new McpLifecycleClient(exit, session);
+                        exit.lifecycle.doClientBegin(traceId);
+                    }
+                }
+            }
+        }
+
+        private void onServerEnd(
+            EndFW end)
+        {
+            final long traceId = end.traceId();
+            state = McpState.closedInitial(state);
+            endReceived = true;
+
+            for (McpListLeg leg : legs)
+            {
+                if (McpState.initialOpened(leg.state))
+                {
+                    leg.doClientEnd(traceId);
+                }
+            }
+        }
+
+        private void onServerAbort(
+            AbortFW abort)
+        {
+            final long traceId = abort.traceId();
+            state = McpState.closedInitial(state);
+            endReceived = true;
+
+            for (McpListLeg leg : legs)
+            {
+                leg.doClientAbort(traceId);
+            }
+        }
+
+        private void onServerReset(
+            ResetFW reset)
+        {
+            final long traceId = reset.traceId();
+            state = McpState.closedReply(state);
+
+            for (McpListLeg leg : legs)
+            {
+                leg.doClientReset(traceId);
+            }
+        }
+
+        private void legDone(
+            McpListLeg leg,
+            byte[] data,
+            long traceId)
+        {
+            legResults[leg.legIndex] = data;
+            doneLegs++;
+
+            if (doneLegs + failedLegs == legs.size())
+            {
+                emitMergedReply(traceId);
+            }
+        }
+
+        private void legFailed(
+            McpListLeg leg,
+            long traceId)
+        {
+            failedLegs++;
+
+            for (McpListLeg other : legs)
+            {
+                if (other != leg && !other.completed)
+                {
+                    other.completed = true;
+                    other.doClientAbort(traceId);
+                }
+            }
+
+            if (doneLegs + failedLegs == legs.size())
+            {
+                doServerAbort(traceId);
+            }
+        }
+
+        private void emitMergedReply(
+            long traceId)
+        {
+            final byte[] mergedJson = mergeListReplies(beginKind, legResults);
+
+            doServerBegin(traceId);
+
+            final UnsafeBuffer outputBuffer = new UnsafeBuffer(mergedJson);
+            doServerData(traceId, 0L, 0x03, mergedJson.length, outputBuffer, 0, mergedJson.length);
+
+            doServerEnd(traceId);
+        }
+
+        private void doServerBegin(
+            long traceId)
+        {
+            final String sid = sessionId;
+            final McpBeginExFW.Builder builder = mcpBeginExRW
+                .wrap(codecBuffer, 0, codecBuffer.capacity())
+                .typeId(mcpTypeId);
+            switch (beginKind)
+            {
+            case KIND_TOOLS_LIST -> builder.toolsList(t -> t.sessionId(sid));
+            case KIND_PROMPTS_LIST -> builder.promptsList(p -> p.sessionId(sid));
+            case KIND_RESOURCES_LIST -> builder.resourcesList(r -> r.sessionId(sid));
+            default -> throw new IllegalStateException("unexpected list kind: " + beginKind);
+            }
+            final McpBeginExFW beginEx = builder.build();
+
+            doBegin(sender, originId, routedId, replyId, traceId, authorization, affinity, beginEx);
+            state = McpState.openedReply(state);
+        }
+
+        private void doServerData(
+            long traceId,
+            long budgetId,
+            int flags,
+            int reserved,
+            DirectBuffer payload,
+            int offset,
+            int length)
+        {
+            doData(sender, originId, routedId, replyId, traceId, authorization,
+                budgetId, flags, reserved, payload, offset, length);
+        }
+
+        private void doServerEnd(
+            long traceId)
+        {
+            if (!McpState.replyClosed(state))
+            {
+                doEnd(sender, originId, routedId, replyId, traceId, authorization);
+                state = McpState.closedReply(state);
+            }
+        }
+
+        private void doServerAbort(
+            long traceId)
+        {
+            if (!McpState.replyClosed(state))
+            {
+                doAbort(sender, originId, routedId, replyId, traceId, authorization);
+                state = McpState.closedReply(state);
+            }
+        }
+    }
+
+    private static boolean isListKind(
+        int kind)
+    {
+        return kind == KIND_TOOLS_LIST || kind == KIND_PROMPTS_LIST || kind == KIND_RESOURCES_LIST;
+    }
+
     private static String sessionId(
         McpBeginExFW beginEx)
     {
@@ -1221,6 +1780,48 @@ public final class McpProxyFactory implements McpStreamFactory
         }
 
         return result;
+    }
+
+    private static byte[] mergeListReplies(
+        int beginKind,
+        byte[][] parts)
+    {
+        final String arrayKey = switch (beginKind)
+        {
+        case KIND_TOOLS_LIST -> "tools";
+        case KIND_PROMPTS_LIST -> "prompts";
+        case KIND_RESOURCES_LIST -> "resources";
+        default -> null;
+        };
+
+        if (arrayKey == null)
+        {
+            return new byte[0];
+        }
+
+        final JsonArrayBuilder merged = Json.createArrayBuilder();
+        for (byte[] part : parts)
+        {
+            if (part != null)
+            {
+                try (JsonReader reader = Json.createReader(new ByteArrayInputStream(part)))
+                {
+                    final JsonObject root = reader.readObject();
+                    final JsonArray items = root.getJsonArray(arrayKey);
+                    if (items != null)
+                    {
+                        for (JsonValue item : items)
+                        {
+                            merged.add(item);
+                        }
+                    }
+                }
+            }
+        }
+
+        final JsonObjectBuilder rootBuilder = Json.createObjectBuilder();
+        rootBuilder.add(arrayKey, merged.build());
+        return rootBuilder.build().toString().getBytes(StandardCharsets.UTF_8);
     }
 
     private MessageConsumer newStream(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -2176,12 +2176,8 @@ public final class McpProxyFactory implements McpStreamFactory
             {
                 final int decodedKeyOffset = offset + (int) (decodedKeyProgress - client.decodedParserProgress);
                 final int decodedValueOffset = offset + (int) (decodedValueProgress - client.decodedParserProgress);
-                int openingQuote = decodedKeyOffset;
-                while (openingQuote < decodedValueOffset && buffer.getByte(openingQuote) != (byte) '"')
-                {
-                    openingQuote++;
-                }
-                final int decodedContent = openingQuote + 1;
+                final int openingQuote = indexOfByte(buffer, decodedKeyOffset, decodedValueOffset, (byte) '"');
+                final int decodedContent = (openingQuote != -1 ? openingQuote : decodedValueOffset) + 1;
                 final int decodedOffset =
                     offset + (int) (client.decodedItemProgress - client.decodedParserProgress);
                 client.server.streamItemChunk(buffer, decodedOffset, decodedContent - decodedOffset, traceId);
@@ -2613,6 +2609,23 @@ public final class McpProxyFactory implements McpStreamFactory
         int kind)
     {
         return kind == KIND_TOOLS_LIST || kind == KIND_PROMPTS_LIST || kind == KIND_RESOURCES_LIST;
+    }
+
+    private static int indexOfByte(
+        DirectBuffer buffer,
+        int offset,
+        int limit,
+        byte value)
+    {
+        for (int cursor = offset; cursor < limit; cursor++)
+        {
+            if (buffer.getByte(cursor) == value)
+            {
+                return cursor;
+            }
+        }
+
+        return -1;
     }
 
     private static String sessionId(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -93,7 +93,7 @@ public final class McpProxyFactory implements McpStreamFactory
     private final int mcpTypeId;
 
     private final Long2ObjectHashMap<McpBindingConfig> bindings;
-    private final Map<String, McpSession> sessions;
+    private final Map<String, McpLifecycleServer> sessions;
 
     public McpProxyFactory(
         McpConfiguration config,
@@ -163,19 +163,18 @@ public final class McpProxyFactory implements McpStreamFactory
                 final McpRouteConfig route = binding.resolve(beginEx, authorization);
                 if (route != null)
                 {
-                    final McpSession session = sessions.computeIfAbsent(sessionId, McpSession::new);
                     final int clientCapabilities = beginEx.lifecycle().capabilities();
                     final McpLifecycleServer lifecycle = new McpLifecycleServer(
                         sender, originId, routedId, initialId, affinity, authorization,
-                        clientCapabilities, session);
-                    session.lifecycle = lifecycle;
+                        clientCapabilities, sessionId);
+                    sessions.put(sessionId, lifecycle);
                     newStream = lifecycle::onServerMessage;
                 }
             }
             else
             {
-                final McpSession session = sessions.get(sessionId);
-                if (session != null)
+                final McpLifecycleServer lifecycle = sessions.get(sessionId);
+                if (lifecycle != null)
                 {
                     if (isListKind(kind))
                     {
@@ -188,8 +187,7 @@ public final class McpProxyFactory implements McpStreamFactory
                             affinity,
                             authorization,
                             kind,
-                            sessionId,
-                            session,
+                            lifecycle,
                             routes,
                             beginEx);
                         newStream = server::onServerMessage;
@@ -199,7 +197,6 @@ public final class McpProxyFactory implements McpStreamFactory
                         final McpRouteConfig route = binding.resolve(beginEx, authorization);
                         if (route != null)
                         {
-                            final McpExit exit = session.supplyExit(route.id);
                             final String identifier = route.strip(beginEx);
                             final String prefix = route.prefix(beginEx);
 
@@ -212,12 +209,10 @@ public final class McpProxyFactory implements McpStreamFactory
                                 affinity,
                                 authorization,
                                 kind,
-                                sessionId,
                                 identifier,
                                 prefix,
                                 0,
-                                session,
-                                exit)::onServerMessage;
+                                lifecycle)::onServerMessage;
                         }
                     }
                 }
@@ -227,52 +222,10 @@ public final class McpProxyFactory implements McpStreamFactory
         return newStream;
     }
 
-    private final class McpSession
-    {
-        private final String sessionId;
-        private final Long2ObjectHashMap<McpExit> exits;
-
-        private McpLifecycleServer lifecycle;
-
-        private McpSession(
-            String sessionId)
-        {
-            this.sessionId = sessionId;
-            this.exits = new Long2ObjectHashMap<>();
-        }
-
-        private McpExit supplyExit(
-            long exitId)
-        {
-            return exits.computeIfAbsent(exitId, McpExit::new);
-        }
-    }
-
     private record PendingAction(
         LongConsumer onProceed,
         LongConsumer onReset)
     {
-    }
-
-    private final class McpExit
-    {
-        private static final int UNINITIALIZED = 0;
-        private static final int OPENING = 1;
-        private static final int OPENED = 2;
-
-        private final long exitId;
-        private final Deque<PendingAction> pending;
-
-        private int state;
-        private String sessionId;
-        private McpLifecycleClient lifecycle;
-
-        private McpExit(
-            long exitId)
-        {
-            this.exitId = exitId;
-            this.pending = new ArrayDeque<>();
-        }
     }
 
     private final class McpServer
@@ -287,12 +240,10 @@ public final class McpProxyFactory implements McpStreamFactory
         private final long resolvedId;
         private final int kind;
         private McpClient client;
-        private final String sessionId;
         private final String identifier;
         private final String prefix;
         private final int capabilities;
-        private final McpSession session;
-        private final McpExit exit;
+        private final McpLifecycleServer lifecycle;
 
         private int state;
 
@@ -305,12 +256,10 @@ public final class McpProxyFactory implements McpStreamFactory
             long affinity,
             long authorization,
             int kind,
-            String sessionId,
             String identifier,
             String prefix,
             int capabilities,
-            McpSession session,
-            McpExit exit)
+            McpLifecycleServer lifecycle)
         {
             this.sender = sender;
             this.originId = originId;
@@ -321,12 +270,15 @@ public final class McpProxyFactory implements McpStreamFactory
             this.affinity = affinity;
             this.authorization = authorization;
             this.kind = kind;
-            this.sessionId = sessionId;
             this.identifier = identifier;
             this.prefix = prefix;
             this.capabilities = capabilities;
-            this.session = session;
-            this.exit = exit;
+            this.lifecycle = lifecycle;
+        }
+
+        private String sessionId()
+        {
+            return lifecycle.sessionId;
         }
 
         private void onServerMessage(
@@ -377,20 +329,8 @@ public final class McpProxyFactory implements McpStreamFactory
 
             state = McpState.openingInitial(state);
 
-            if (exit.state == McpExit.OPENED)
-            {
-                proceed(traceId);
-            }
-            else
-            {
-                exit.pending.add(new PendingAction(this::proceed, this::doServerReset));
-                if (exit.state == McpExit.UNINITIALIZED)
-                {
-                    exit.state = McpExit.OPENING;
-                    exit.lifecycle = new McpLifecycleClient(exit, session);
-                    exit.lifecycle.doClientBegin(traceId);
-                }
-            }
+            lifecycle.proceedOrQueue(resolvedId, traceId,
+                new PendingAction(this::proceed, this::doServerReset));
         }
 
         private void proceed(
@@ -426,7 +366,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
             if (kind == KIND_LIFECYCLE)
             {
-                sessions.remove(session.sessionId);
+                sessions.remove(lifecycle.sessionId);
             }
         }
 
@@ -441,7 +381,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
             if (kind == KIND_LIFECYCLE)
             {
-                sessions.remove(session.sessionId);
+                sessions.remove(lifecycle.sessionId);
             }
         }
 
@@ -557,9 +497,11 @@ public final class McpProxyFactory implements McpStreamFactory
             final String identifier = server.identifier;
             final int capabilities = server.capabilities;
             final boolean lifecycle = server.kind == KIND_LIFECYCLE;
-            final String outboundSessionId = lifecycle || server.exit.sessionId == null
-                ? server.sessionId
-                : server.exit.sessionId;
+            final McpLifecycleClient upstream = server.lifecycle.exits.get(server.resolvedId);
+            final String upstreamSessionId = upstream != null ? upstream.sessionId : null;
+            final String outboundSessionId = lifecycle || upstreamSessionId == null
+                ? server.sessionId()
+                : upstreamSessionId;
             final McpBeginExFW.Builder builder = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId);
@@ -703,7 +645,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private Flyweight rewriteReplyBeginEx(
             McpBeginExFW beginEx)
         {
-            final String sid = server.sessionId;
+            final String sid = server.sessionId();
             final McpBeginExFW.Builder builder = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId);
@@ -802,7 +744,8 @@ public final class McpProxyFactory implements McpStreamFactory
         private final long affinity;
         private final long authorization;
         private final int clientCapabilities;
-        private final McpSession session;
+        private final String sessionId;
+        private final Long2ObjectHashMap<McpLifecycleClient> exits;
 
         private int state;
 
@@ -814,7 +757,7 @@ public final class McpProxyFactory implements McpStreamFactory
             long affinity,
             long authorization,
             int clientCapabilities,
-            McpSession session)
+            String sessionId)
         {
             this.sender = sender;
             this.originId = originId;
@@ -824,7 +767,30 @@ public final class McpProxyFactory implements McpStreamFactory
             this.affinity = affinity;
             this.authorization = authorization;
             this.clientCapabilities = clientCapabilities;
-            this.session = session;
+            this.sessionId = sessionId;
+            this.exits = new Long2ObjectHashMap<>();
+        }
+
+        private void proceedOrQueue(
+            long exitId,
+            long traceId,
+            PendingAction action)
+        {
+            McpLifecycleClient upstream = exits.get(exitId);
+            if (upstream != null && McpState.replyOpened(upstream.state))
+            {
+                action.onProceed().accept(traceId);
+            }
+            else
+            {
+                if (upstream == null)
+                {
+                    upstream = new McpLifecycleClient(this, exitId);
+                    exits.put(exitId, upstream);
+                    upstream.doClientBegin(traceId);
+                }
+                upstream.pending.add(action);
+            }
         }
 
         private void onServerMessage(
@@ -871,7 +837,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
             final McpBindingConfig binding = bindings.get(routedId);
             final int serverCapabilities = binding.serverCapabilities(authorization);
-            final String sid = session.sessionId;
+            final String sid = sessionId;
             final McpBeginExFW beginEx = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId)
@@ -930,48 +896,47 @@ public final class McpProxyFactory implements McpStreamFactory
         private void cleanup(
             long traceId)
         {
-            sessions.remove(session.sessionId);
+            sessions.remove(sessionId);
 
-            for (McpExit exit : session.exits.values())
+            for (McpLifecycleClient upstream : exits.values())
             {
-                if (exit.lifecycle != null)
-                {
-                    exit.lifecycle.doClientEnd(traceId);
-                }
-                for (PendingAction pending : exit.pending)
+                upstream.doClientEnd(traceId);
+                for (PendingAction pending : upstream.pending)
                 {
                     pending.onReset().accept(traceId);
                 }
-                exit.pending.clear();
+                upstream.pending.clear();
             }
         }
     }
 
     private final class McpLifecycleClient
     {
-        private final McpExit exit;
-        private final McpSession session;
+        private final McpLifecycleServer server;
+        private final long exitId;
         private final long initialId;
         private final long replyId;
-        private MessageConsumer sender;
+        private final Deque<PendingAction> pending;
 
+        private MessageConsumer sender;
         private int state;
+        private String sessionId;        // upstream-provided session id, set on BEGIN reply
 
         private McpLifecycleClient(
-            McpExit exit,
-            McpSession session)
+            McpLifecycleServer server,
+            long exitId)
         {
-            this.exit = exit;
-            this.session = session;
-            this.initialId = supplyInitialId.applyAsLong(exit.exitId);
+            this.server = server;
+            this.exitId = exitId;
+            this.initialId = supplyInitialId.applyAsLong(exitId);
             this.replyId = supplyReplyId.applyAsLong(initialId);
+            this.pending = new ArrayDeque<>();
         }
 
         private void doClientBegin(
             long traceId)
         {
-            final String sid = session.sessionId;
-            final McpLifecycleServer server = session.lifecycle;
+            final String sid = server.sessionId;
             final int clientCapabilities = server.clientCapabilities;
             final McpBeginExFW beginEx = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
@@ -979,7 +944,7 @@ public final class McpProxyFactory implements McpStreamFactory
                 .lifecycle(l -> l.sessionId(sid).capabilities(clientCapabilities))
                 .build();
 
-            sender = newStream(this::onClientMessage, server.originId, exit.exitId, initialId,
+            sender = newStream(this::onClientMessage, server.originId, exitId, initialId,
                 traceId, server.authorization, server.affinity, beginEx);
             state = McpState.openingInitial(state);
         }
@@ -989,8 +954,7 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (!McpState.initialClosed(state))
             {
-                final McpLifecycleServer server = session.lifecycle;
-                doEnd(sender, server.originId, exit.exitId, initialId, traceId, server.authorization);
+                doEnd(sender, server.originId, exitId, initialId, traceId, server.authorization);
                 state = McpState.closedInitial(state);
             }
         }
@@ -1044,18 +1008,17 @@ public final class McpProxyFactory implements McpStreamFactory
                     extension.buffer(), extension.offset(), extension.limit());
                 if (beginEx.kind() == KIND_LIFECYCLE)
                 {
-                    exit.sessionId = beginEx.lifecycle().sessionId().asString();
+                    sessionId = beginEx.lifecycle().sessionId().asString();
                 }
             }
 
-            final McpLifecycleServer server = session.lifecycle;
-            doWindow(sender, server.originId, exit.exitId, replyId, traceId, server.authorization, 0,
+            doWindow(sender, server.originId, exitId, replyId, traceId, server.authorization, 0,
                 writeBuffer.capacity(), 0);
 
-            exit.state = McpExit.OPENED;
-            while (!exit.pending.isEmpty())
+            state = McpState.openedReply(state);
+            while (!pending.isEmpty())
             {
-                exit.pending.poll().onProceed().accept(traceId);
+                pending.poll().onProceed().accept(traceId);
             }
         }
 
@@ -1092,9 +1055,9 @@ public final class McpProxyFactory implements McpStreamFactory
         private void failPending(
             long traceId)
         {
-            while (!exit.pending.isEmpty())
+            while (!pending.isEmpty())
             {
-                exit.pending.poll().onReset().accept(traceId);
+                pending.poll().onReset().accept(traceId);
             }
         }
     }
@@ -1102,7 +1065,6 @@ public final class McpProxyFactory implements McpStreamFactory
     private final class McpListClient
     {
         private final McpListServer server;
-        private final McpExit exit;
         private final long resolvedId;
         private final String prefix;
         private final byte[] prefixBytes;
@@ -1130,12 +1092,10 @@ public final class McpProxyFactory implements McpStreamFactory
 
         private McpListClient(
             McpListServer server,
-            McpExit exit,
             long resolvedId,
             String prefix)
         {
             this.server = server;
-            this.exit = exit;
             this.resolvedId = resolvedId;
             this.prefix = prefix;
             this.prefixBytes = prefix.getBytes(StandardCharsets.UTF_8);
@@ -1167,8 +1127,9 @@ public final class McpProxyFactory implements McpStreamFactory
             initialId = supplyInitialId.applyAsLong(resolvedId);
             replyId = supplyReplyId.applyAsLong(initialId);
 
-            final String sid = exit.sessionId != null
-                ? exit.sessionId : server.sessionId;
+            final McpLifecycleClient upstream = server.lifecycle.exits.get(resolvedId);
+            final String upstreamSessionId = upstream != null ? upstream.sessionId : null;
+            final String sid = upstreamSessionId != null ? upstreamSessionId : server.lifecycle.sessionId;
             final McpBeginExFW.Builder builder = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId);
@@ -1516,8 +1477,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private final long affinity;
         private final long authorization;
         private final int kind;
-        private final String sessionId;
-        private final McpSession session;
+        private final McpLifecycleServer lifecycle;
         private final Deque<McpListClient> remaining;
 
         private int state;
@@ -1532,8 +1492,7 @@ public final class McpProxyFactory implements McpStreamFactory
             long affinity,
             long authorization,
             int kind,
-            String sessionId,
-            McpSession session,
+            McpLifecycleServer lifecycle,
             List<McpRouteConfig> routes,
             McpBeginExFW beginEx)
         {
@@ -1545,14 +1504,12 @@ public final class McpProxyFactory implements McpStreamFactory
             this.affinity = affinity;
             this.authorization = authorization;
             this.kind = kind;
-            this.sessionId = sessionId;
-            this.session = session;
+            this.lifecycle = lifecycle;
             this.remaining = new ArrayDeque<>(routes.size());
             for (final McpRouteConfig route : routes)
             {
-                final McpExit exit = session.supplyExit(route.id);
                 final String prefix = route.prefix(beginEx);
-                remaining.add(new McpListClient(this, exit, route.id, prefix));
+                remaining.add(new McpListClient(this, route.id, prefix));
             }
         }
 
@@ -1671,21 +1628,8 @@ public final class McpProxyFactory implements McpStreamFactory
                 return;
             }
             currentClient = remaining.poll();
-            final McpExit exit = currentClient.exit;
-            if (exit.state == McpExit.OPENED)
-            {
-                currentClient.proceed(traceId);
-            }
-            else
-            {
-                exit.pending.add(new PendingAction(currentClient::proceed, currentClient::doServerReset));
-                if (exit.state == McpExit.UNINITIALIZED)
-                {
-                    exit.state = McpExit.OPENING;
-                    exit.lifecycle = new McpLifecycleClient(exit, session);
-                    exit.lifecycle.doClientBegin(traceId);
-                }
-            }
+            lifecycle.proceedOrQueue(currentClient.resolvedId, traceId,
+                new PendingAction(currentClient::proceed, currentClient::doServerReset));
         }
 
         private void streamItem(
@@ -1729,7 +1673,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private void doServerBegin(
             long traceId)
         {
-            final String sid = sessionId;
+            final String sid = lifecycle.sessionId;
             final McpBeginExFW.Builder builder = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId);

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -167,14 +167,10 @@ public final class McpProxyFactory implements McpStreamFactory
                 if (route != null)
                 {
                     final McpSession session = sessions.computeIfAbsent(sessionId, McpSession::new);
-                    session.originId = originId;
-                    session.routedId = routedId;
-                    session.authorization = authorization;
-                    session.affinity = affinity;
-                    session.clientCapabilities = beginEx.lifecycle().capabilities();
-
+                    final int clientCapabilities = beginEx.lifecycle().capabilities();
                     final McpLifecycleServer lifecycle = new McpLifecycleServer(
-                        sender, originId, routedId, initialId, affinity, authorization, session, binding);
+                        sender, originId, routedId, initialId, affinity, authorization,
+                        clientCapabilities, session);
                     session.lifecycle = lifecycle;
                     newStream = lifecycle::onServerMessage;
                 }
@@ -187,9 +183,9 @@ public final class McpProxyFactory implements McpStreamFactory
                     if (isListKind(beginKind))
                     {
                         final List<McpRouteConfig> routes = binding.resolveAll(beginEx, authorization);
-                        if (routes.size() > 1)
+                        if (!routes.isEmpty())
                         {
-                            final McpListServer listServer = new McpListServer(
+                            final McpListServer server = new McpListServer(
                                 sender,
                                 originId,
                                 routedId,
@@ -201,30 +197,7 @@ public final class McpProxyFactory implements McpStreamFactory
                                 session,
                                 routes,
                                 beginEx);
-                            newStream = listServer::onServerMessage;
-                        }
-                        else if (!routes.isEmpty())
-                        {
-                            final McpRouteConfig route = routes.get(0);
-                            final McpExit exit = session.supplyExit(route.id);
-                            final String identifier = route.strip(beginEx);
-                            final String prefix = route.prefix(beginEx);
-
-                            newStream = new McpServer(
-                                sender,
-                                originId,
-                                routedId,
-                                initialId,
-                                route.id,
-                                affinity,
-                                authorization,
-                                beginKind,
-                                sessionId,
-                                identifier,
-                                prefix,
-                                0,
-                                session,
-                                exit)::onServerMessage;
+                            newStream = server::onServerMessage;
                         }
                     }
                     else
@@ -265,11 +238,6 @@ public final class McpProxyFactory implements McpStreamFactory
         private final String sessionId;
         private final Long2ObjectHashMap<McpExit> exits;
 
-        private long originId;
-        private long routedId;
-        private long authorization;
-        private long affinity;
-        private int clientCapabilities;
         private McpLifecycleServer lifecycle;
 
         private McpSession(
@@ -303,7 +271,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private final Deque<McpPending> pending;
 
         private int state;
-        private String exitSessionId;
+        private String sessionId;
         private McpLifecycleClient lifecycle;
 
         private McpExit(
@@ -610,9 +578,9 @@ public final class McpProxyFactory implements McpStreamFactory
             final String identifier = server.identifier;
             final int capabilities = server.capabilities;
             final boolean lifecycle = server.beginKind == KIND_LIFECYCLE;
-            final String outboundSessionId = lifecycle || server.exit.exitSessionId == null
+            final String outboundSessionId = lifecycle || server.exit.sessionId == null
                 ? server.sessionId
-                : server.exit.exitSessionId;
+                : server.exit.sessionId;
             final McpBeginExFW.Builder builder = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId);
@@ -923,8 +891,8 @@ public final class McpProxyFactory implements McpStreamFactory
         private final long replyId;
         private final long affinity;
         private final long authorization;
+        private final int clientCapabilities;
         private final McpSession session;
-        private final McpBindingConfig binding;
 
         private int state;
 
@@ -935,8 +903,8 @@ public final class McpProxyFactory implements McpStreamFactory
             long initialId,
             long affinity,
             long authorization,
-            McpSession session,
-            McpBindingConfig binding)
+            int clientCapabilities,
+            McpSession session)
         {
             this.sender = sender;
             this.originId = originId;
@@ -945,8 +913,8 @@ public final class McpProxyFactory implements McpStreamFactory
             this.replyId = supplyReplyId.applyAsLong(initialId);
             this.affinity = affinity;
             this.authorization = authorization;
+            this.clientCapabilities = clientCapabilities;
             this.session = session;
-            this.binding = binding;
         }
 
         private void onServerMessage(
@@ -991,6 +959,7 @@ public final class McpProxyFactory implements McpStreamFactory
 
             state = McpState.openingInitial(state);
 
+            final McpBindingConfig binding = bindings.get(routedId);
             final int serverCapabilities = binding.serverCapabilities(authorization);
             final String sid = session.sessionId;
             final McpBeginExFW beginEx = mcpBeginExRW
@@ -1092,15 +1061,16 @@ public final class McpProxyFactory implements McpStreamFactory
             long traceId)
         {
             final String sid = session.sessionId;
-            final int clientCapabilities = session.clientCapabilities;
+            final McpLifecycleServer server = session.lifecycle;
+            final int clientCapabilities = server.clientCapabilities;
             final McpBeginExFW beginEx = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId)
                 .lifecycle(l -> l.sessionId(sid).capabilities(clientCapabilities))
                 .build();
 
-            sender = newStream(this::onClientMessage, session.originId, exit.exitId, initialId,
-                traceId, session.authorization, session.affinity, beginEx);
+            sender = newStream(this::onClientMessage, server.originId, exit.exitId, initialId,
+                traceId, server.authorization, server.affinity, beginEx);
             state = McpState.openingInitial(state);
         }
 
@@ -1109,7 +1079,8 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (sender != null && !McpState.initialClosed(state))
             {
-                doEnd(sender, session.originId, exit.exitId, initialId, traceId, session.authorization);
+                final McpLifecycleServer server = session.lifecycle;
+                doEnd(sender, server.originId, exit.exitId, initialId, traceId, server.authorization);
                 state = McpState.closedInitial(state);
             }
         }
@@ -1163,11 +1134,12 @@ public final class McpProxyFactory implements McpStreamFactory
                     extension.buffer(), extension.offset(), extension.limit());
                 if (beginEx.kind() == KIND_LIFECYCLE)
                 {
-                    exit.exitSessionId = beginEx.lifecycle().sessionId().asString();
+                    exit.sessionId = beginEx.lifecycle().sessionId().asString();
                 }
             }
 
-            doWindow(sender, session.originId, exit.exitId, replyId, traceId, session.authorization, 0,
+            final McpLifecycleServer server = session.lifecycle;
+            doWindow(sender, server.originId, exit.exitId, replyId, traceId, server.authorization, 0,
                 writeBuffer.capacity(), 0);
 
             exit.state = McpExit.OPENED;
@@ -1217,13 +1189,13 @@ public final class McpProxyFactory implements McpStreamFactory
         }
     }
 
-    private final class McpListLeg implements McpPending
+    private final class McpListClient implements McpPending
     {
-        private final McpListServer listServer;
+        private final McpListServer server;
         private final McpExit exit;
         private final long resolvedId;
         private final String prefix;
-        private final int legIndex;
+        private final int clientIndex;
 
         private long initialId;
         private long replyId;
@@ -1233,18 +1205,18 @@ public final class McpProxyFactory implements McpStreamFactory
         private int replySlotOffset;
         private boolean completed;
 
-        private McpListLeg(
-            McpListServer listServer,
+        private McpListClient(
+            McpListServer server,
             McpExit exit,
             long resolvedId,
             String prefix,
-            int legIndex)
+            int clientIndex)
         {
-            this.listServer = listServer;
+            this.server = server;
             this.exit = exit;
             this.resolvedId = resolvedId;
             this.prefix = prefix;
-            this.legIndex = legIndex;
+            this.clientIndex = clientIndex;
         }
 
         @Override
@@ -1252,7 +1224,7 @@ public final class McpProxyFactory implements McpStreamFactory
             long traceId)
         {
             doClientBegin(traceId);
-            if (listServer.endReceived)
+            if (server.endReceived)
             {
                 doClientEnd(traceId);
             }
@@ -1265,7 +1237,7 @@ public final class McpProxyFactory implements McpStreamFactory
             if (!completed)
             {
                 completed = true;
-                listServer.legFailed(this, traceId);
+                server.clientFailed(this, traceId);
             }
         }
 
@@ -1275,22 +1247,22 @@ public final class McpProxyFactory implements McpStreamFactory
             initialId = supplyInitialId.applyAsLong(resolvedId);
             replyId = supplyReplyId.applyAsLong(initialId);
 
-            final String sid = exit.exitSessionId != null
-                ? exit.exitSessionId : listServer.sessionId;
+            final String sid = exit.sessionId != null
+                ? exit.sessionId : server.sessionId;
             final McpBeginExFW.Builder builder = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId);
-            switch (listServer.beginKind)
+            switch (server.beginKind)
             {
             case KIND_TOOLS_LIST -> builder.toolsList(t -> t.sessionId(sid));
             case KIND_PROMPTS_LIST -> builder.promptsList(p -> p.sessionId(sid));
             case KIND_RESOURCES_LIST -> builder.resourcesList(r -> r.sessionId(sid));
-            default -> throw new IllegalStateException("unexpected list kind: " + listServer.beginKind);
+            default -> throw new IllegalStateException("unexpected list kind: " + server.beginKind);
             }
             final McpBeginExFW beginEx = builder.build();
 
-            sender = newStream(this::onClientMessage, listServer.originId, resolvedId, initialId,
-                traceId, listServer.authorization, listServer.affinity, beginEx);
+            sender = newStream(this::onClientMessage, server.originId, resolvedId, initialId,
+                traceId, server.authorization, server.affinity, beginEx);
             state = McpState.openingInitial(state);
         }
 
@@ -1299,8 +1271,8 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (sender != null && !McpState.initialClosed(state))
             {
-                doEnd(sender, listServer.originId, resolvedId, initialId,
-                    traceId, listServer.authorization);
+                doEnd(sender, server.originId, resolvedId, initialId,
+                    traceId, server.authorization);
                 state = McpState.closedInitial(state);
             }
         }
@@ -1310,8 +1282,8 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (sender != null && !McpState.initialClosed(state))
             {
-                doAbort(sender, listServer.originId, resolvedId, initialId,
-                    traceId, listServer.authorization);
+                doAbort(sender, server.originId, resolvedId, initialId,
+                    traceId, server.authorization);
                 state = McpState.closedInitial(state);
             }
         }
@@ -1321,8 +1293,8 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             if (sender != null && !McpState.replyClosed(state))
             {
-                doReset(sender, listServer.originId, resolvedId, replyId,
-                    traceId, listServer.authorization);
+                doReset(sender, server.originId, resolvedId, replyId,
+                    traceId, server.authorization);
                 state = McpState.closedReply(state);
             }
         }
@@ -1367,8 +1339,8 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long traceId = begin.traceId();
             state = McpState.openedInitial(state);
-            doWindow(sender, listServer.originId, resolvedId, replyId, traceId,
-                listServer.authorization, 0, writeBuffer.capacity(), 0);
+            doWindow(sender, server.originId, resolvedId, replyId, traceId,
+                server.authorization, 0, writeBuffer.capacity(), 0);
         }
 
         private void onClientData(
@@ -1377,7 +1349,7 @@ public final class McpProxyFactory implements McpStreamFactory
             final OctetsFW payload = data.payload();
             if (payload != null)
             {
-                bufferLegPayload(payload);
+                bufferClientPayload(payload);
             }
         }
 
@@ -1389,9 +1361,9 @@ public final class McpProxyFactory implements McpStreamFactory
             if (!completed)
             {
                 completed = true;
-                final byte[] transformed = transformedLegReply();
-                cleanupLegSlot();
-                listServer.legDone(this, transformed, traceId);
+                final byte[] transformed = transformedClientReply();
+                cleanupClientSlot();
+                server.clientDone(this, transformed, traceId);
             }
         }
 
@@ -1400,11 +1372,11 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             final long traceId = abort.traceId();
             state = McpState.closedReply(state);
-            cleanupLegSlot();
+            cleanupClientSlot();
             if (!completed)
             {
                 completed = true;
-                listServer.legFailed(this, traceId);
+                server.clientFailed(this, traceId);
             }
         }
 
@@ -1416,11 +1388,11 @@ public final class McpProxyFactory implements McpStreamFactory
             if (!completed)
             {
                 completed = true;
-                listServer.legFailed(this, traceId);
+                server.clientFailed(this, traceId);
             }
         }
 
-        private void bufferLegPayload(
+        private void bufferClientPayload(
             OctetsFW payload)
         {
             if (replySlot == NO_SLOT)
@@ -1435,7 +1407,7 @@ public final class McpProxyFactory implements McpStreamFactory
             }
         }
 
-        private byte[] transformedLegReply()
+        private byte[] transformedClientReply()
         {
             if (replySlot == NO_SLOT || replySlotOffset == 0)
             {
@@ -1444,10 +1416,10 @@ public final class McpProxyFactory implements McpStreamFactory
             final byte[] inputBytes = new byte[replySlotOffset];
             bufferPool.buffer(replySlot).getBytes(0, inputBytes);
             return prefix.isEmpty() ? inputBytes :
-                applyListPrefix(prefix, listServer.beginKind, inputBytes);
+                applyListPrefix(prefix, server.beginKind, inputBytes);
         }
 
-        private void cleanupLegSlot()
+        private void cleanupClientSlot()
         {
             if (replySlot != NO_SLOT)
             {
@@ -1470,13 +1442,13 @@ public final class McpProxyFactory implements McpStreamFactory
         private final int beginKind;
         private final String sessionId;
         private final McpSession session;
-        private final List<McpListLeg> legs;
-        private final byte[][] legResults;
+        private final List<McpListClient> clients;
+        private final byte[][] clientReplies;
 
         private int state;
         private boolean endReceived;
-        private int doneLegs;
-        private int failedLegs;
+        private int doneClients;
+        private int failedClients;
 
         private McpListServer(
             MessageConsumer sender,
@@ -1501,15 +1473,15 @@ public final class McpProxyFactory implements McpStreamFactory
             this.beginKind = beginKind;
             this.sessionId = sessionId;
             this.session = session;
-            this.legs = new ArrayList<>(routes.size());
+            this.clients = new ArrayList<>(routes.size());
             for (int i = 0; i < routes.size(); i++)
             {
                 final McpRouteConfig route = routes.get(i);
                 final McpExit exit = session.supplyExit(route.id);
                 final String prefix = route.prefix(beginEx);
-                legs.add(new McpListLeg(this, exit, route.id, prefix, i));
+                clients.add(new McpListClient(this, exit, route.id, prefix, i));
             }
-            this.legResults = new byte[legs.size()][];
+            this.clientReplies = new byte[clients.size()][];
         }
 
         private void onServerMessage(
@@ -1552,16 +1524,16 @@ public final class McpProxyFactory implements McpStreamFactory
             doWindow(sender, originId, routedId, initialId, traceId, authorization, 0,
                 writeBuffer.capacity(), 0);
 
-            for (McpListLeg leg : legs)
+            for (McpListClient client : clients)
             {
-                final McpExit exit = leg.exit;
+                final McpExit exit = client.exit;
                 if (exit.state == McpExit.OPENED)
                 {
-                    leg.proceed(traceId);
+                    client.proceed(traceId);
                 }
                 else
                 {
-                    exit.pending.add(leg);
+                    exit.pending.add(client);
                     if (exit.state == McpExit.UNINITIALIZED)
                     {
                         exit.state = McpExit.OPENING;
@@ -1579,11 +1551,11 @@ public final class McpProxyFactory implements McpStreamFactory
             state = McpState.closedInitial(state);
             endReceived = true;
 
-            for (McpListLeg leg : legs)
+            for (McpListClient client : clients)
             {
-                if (McpState.initialOpened(leg.state))
+                if (McpState.initialOpened(client.state))
                 {
-                    leg.doClientEnd(traceId);
+                    client.doClientEnd(traceId);
                 }
             }
         }
@@ -1595,9 +1567,9 @@ public final class McpProxyFactory implements McpStreamFactory
             state = McpState.closedInitial(state);
             endReceived = true;
 
-            for (McpListLeg leg : legs)
+            for (McpListClient client : clients)
             {
-                leg.doClientAbort(traceId);
+                client.doClientAbort(traceId);
             }
         }
 
@@ -1607,42 +1579,42 @@ public final class McpProxyFactory implements McpStreamFactory
             final long traceId = reset.traceId();
             state = McpState.closedReply(state);
 
-            for (McpListLeg leg : legs)
+            for (McpListClient client : clients)
             {
-                leg.doClientReset(traceId);
+                client.doClientReset(traceId);
             }
         }
 
-        private void legDone(
-            McpListLeg leg,
+        private void clientDone(
+            McpListClient client,
             byte[] data,
             long traceId)
         {
-            legResults[leg.legIndex] = data;
-            doneLegs++;
+            clientReplies[client.clientIndex] = data;
+            doneClients++;
 
-            if (doneLegs + failedLegs == legs.size())
+            if (doneClients + failedClients == clients.size())
             {
                 emitMergedReply(traceId);
             }
         }
 
-        private void legFailed(
-            McpListLeg leg,
+        private void clientFailed(
+            McpListClient client,
             long traceId)
         {
-            failedLegs++;
+            failedClients++;
 
-            for (McpListLeg other : legs)
+            for (McpListClient other : clients)
             {
-                if (other != leg && !other.completed)
+                if (other != client && !other.completed)
                 {
                     other.completed = true;
                     other.doClientAbort(traceId);
                 }
             }
 
-            if (doneLegs + failedLegs == legs.size())
+            if (doneClients + failedClients == clients.size())
             {
                 doServerAbort(traceId);
             }
@@ -1651,7 +1623,7 @@ public final class McpProxyFactory implements McpStreamFactory
         private void emitMergedReply(
             long traceId)
         {
-            final byte[] mergedJson = mergeListReplies(beginKind, legResults);
+            final byte[] mergedJson = mergeListReplies(beginKind, clientReplies);
 
             doServerBegin(traceId);
 
@@ -1786,6 +1758,11 @@ public final class McpProxyFactory implements McpStreamFactory
         int beginKind,
         byte[][] parts)
     {
+        if (parts.length == 1 && parts[0] != null)
+        {
+            return parts[0];
+        }
+
         final String arrayKey = switch (beginKind)
         {
         case KIND_TOOLS_LIST -> "tools";

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -33,9 +33,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.LongUnaryOperator;
 
-import jakarta.json.Json;
-import jakarta.json.JsonPointer;
 import jakarta.json.stream.JsonParser;
+import jakarta.json.stream.JsonParserFactory;
 
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -1690,10 +1689,10 @@ public final class McpProxyFactory implements McpStreamFactory
             return;
         }
         final String idKey = beginKind == KIND_RESOURCES_LIST ? "uri" : "name";
-        final JsonPointer idPath = Json.createPointer("/" + arrayKey + "/-/" + idKey);
-        final Map<String, ?> config = Map.of(
+        final String idPath = "/" + arrayKey + "/-/" + idKey;
+        final JsonParserFactory factory = StreamingJson.createParserFactory(Map.of(
             StreamingJson.PATH_INCLUDES, List.of(idPath),
-            StreamingJson.TOKEN_MAX_BYTES, jsonBytes.length);
+            StreamingJson.TOKEN_MAX_BYTES, jsonBytes.length));
         final byte[] prefixBytes = prefix.getBytes(StandardCharsets.UTF_8);
 
         final ByteArrayOutputStream itemOut = new ByteArrayOutputStream(256);
@@ -1704,7 +1703,7 @@ public final class McpProxyFactory implements McpStreamFactory
         boolean awaitingIdValue = false;
 
         final BufferedInputStream in = new BufferedInputStream(new ByteArrayInputStream(jsonBytes));
-        try (JsonParser parser = StreamingJson.createParser(in, config))
+        try (JsonParser parser = factory.createParser(in))
         {
             while (true)
             {

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -359,7 +359,7 @@ public final class McpProxyFactory implements McpStreamFactory
         {
             client.doClientBegin(traceId);
 
-            doWindow(sender, originId, routedId, replyId, traceId, authorization, 0,
+            doWindow(sender, originId, routedId, initialId, traceId, authorization, 0,
                 writeBuffer.capacity(), 0);
         }
 
@@ -865,7 +865,7 @@ public final class McpProxyFactory implements McpStreamFactory
             doBegin(sender, originId, routedId, replyId, traceId, authorization, affinity, beginEx);
             state = McpState.openedReply(state);
 
-            doWindow(sender, originId, routedId, replyId, traceId, authorization, 0,
+            doWindow(sender, originId, routedId, initialId, traceId, authorization, 0,
                 writeBuffer.capacity(), 0);
         }
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -242,10 +242,12 @@ public final class McpProxyFactory implements McpStreamFactory
         private long initialSeq;
         private long initialAck;
         private int initialMax;
+        private int initialPad;
 
         private long replySeq;
         private long replyAck;
         private int replyMax;
+        private int replyPad;
 
         private McpServer(
             McpLifecycleServer lifecycle,
@@ -420,10 +422,11 @@ public final class McpProxyFactory implements McpStreamFactory
             assert acknowledge <= sequence;
             assert sequence <= replySeq;
             assert acknowledge >= replyAck;
-            assert maximum >= replyMax;
+            assert maximum + acknowledge >= replyMax + replyAck;
 
             replyAck = acknowledge;
             replyMax = maximum;
+            replyPad = padding;
 
             assert replyAck <= replySeq;
 
@@ -529,10 +532,12 @@ public final class McpProxyFactory implements McpStreamFactory
         private long initialSeq;
         private long initialAck;
         private int initialMax;
+        private int initialPad;
 
         private long replySeq;
         private long replyAck;
         private int replyMax;
+        private int replyPad;
 
         private McpClient(
             McpServer server,
@@ -799,10 +804,11 @@ public final class McpProxyFactory implements McpStreamFactory
             assert acknowledge <= sequence;
             assert sequence <= initialSeq;
             assert acknowledge >= initialAck;
-            assert maximum >= initialMax;
+            assert maximum + acknowledge >= initialMax + initialAck;
 
             initialAck = acknowledge;
             initialMax = maximum;
+            initialPad = padding;
 
             assert initialAck <= initialSeq;
 
@@ -848,10 +854,12 @@ public final class McpProxyFactory implements McpStreamFactory
         private long initialSeq;
         private long initialAck;
         private int initialMax;
+        private int initialPad;
 
         private long replySeq;
         private long replyAck;
         private int replyMax;
+        private int replyPad;
 
         private McpLifecycleServer(
             MessageConsumer sender,
@@ -994,14 +1002,16 @@ public final class McpProxyFactory implements McpStreamFactory
             final long sequence = window.sequence();
             final long acknowledge = window.acknowledge();
             final int maximum = window.maximum();
+            final int padding = window.padding();
 
             assert acknowledge <= sequence;
             assert sequence <= replySeq;
             assert acknowledge >= replyAck;
-            assert maximum >= replyMax;
+            assert maximum + acknowledge >= replyMax + replyAck;
 
             replyAck = acknowledge;
             replyMax = maximum;
+            replyPad = padding;
 
             assert replyAck <= replySeq;
         }
@@ -1090,10 +1100,12 @@ public final class McpProxyFactory implements McpStreamFactory
         private long initialSeq;
         private long initialAck;
         private int initialMax;
+        private int initialPad;
 
         private long replySeq;
         private long replyAck;
         private int replyMax;
+        private int replyPad;
 
         private McpLifecycleClient(
             McpLifecycleServer server,
@@ -1282,14 +1294,16 @@ public final class McpProxyFactory implements McpStreamFactory
             final long sequence = window.sequence();
             final long acknowledge = window.acknowledge();
             final int maximum = window.maximum();
+            final int padding = window.padding();
 
             assert acknowledge <= sequence;
             assert sequence <= initialSeq;
             assert acknowledge >= initialAck;
-            assert maximum >= initialMax;
+            assert maximum + acknowledge >= initialMax + initialAck;
 
             initialAck = acknowledge;
             initialMax = maximum;
+            initialPad = padding;
 
             assert initialAck <= initialSeq;
         }
@@ -1333,10 +1347,12 @@ public final class McpProxyFactory implements McpStreamFactory
         private long initialSeq;
         private long initialAck;
         private int initialMax;
+        private int initialPad;
 
         private long replySeq;
         private long replyAck;
         private int replyMax;
+        private int replyPad;
 
         // streaming JSON state — built lazily on first DATA frame
         private JsonParser decodableJson;
@@ -1584,14 +1600,16 @@ public final class McpProxyFactory implements McpStreamFactory
             final long sequence = window.sequence();
             final long acknowledge = window.acknowledge();
             final int maximum = window.maximum();
+            final int padding = window.padding();
 
             assert acknowledge <= sequence;
             assert sequence <= initialSeq;
             assert acknowledge >= initialAck;
-            assert maximum >= initialMax;
+            assert maximum + acknowledge >= initialMax + initialAck;
 
             initialAck = acknowledge;
             initialMax = maximum;
+            initialPad = padding;
 
             assert initialAck <= initialSeq;
         }
@@ -2049,10 +2067,12 @@ public final class McpProxyFactory implements McpStreamFactory
         private long initialSeq;
         private long initialAck;
         private int initialMax;
+        private int initialPad;
 
         private long replySeq;
         private long replyAck;
         private int replyMax;
+        private int replyPad;
 
         private McpListServer(
             McpLifecycleServer lifecycle,
@@ -2177,14 +2197,16 @@ public final class McpProxyFactory implements McpStreamFactory
             final long sequence = window.sequence();
             final long acknowledge = window.acknowledge();
             final int maximum = window.maximum();
+            final int padding = window.padding();
 
             assert acknowledge <= sequence;
             assert sequence <= replySeq;
             assert acknowledge >= replyAck;
-            assert maximum >= replyMax;
+            assert maximum + acknowledge >= replyMax + replyAck;
 
             replyAck = acknowledge;
             replyMax = maximum;
+            replyPad = padding;
 
             assert replyAck <= replySeq;
         }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -130,7 +130,7 @@ public final class McpServerFactory implements McpStreamFactory
         "/method",
         "/params/name",
         "/params/uri");
-    private final JsonParserFactory jsonParserFactory;
+    private final JsonParserFactory parserFactory;
 
     private final McpServerDecoder decodeJsonRpc = this::decodeJsonRpc;
     private final McpServerDecoder decodeJsonRpcStart = this::decodeJsonRpcStart;
@@ -172,7 +172,7 @@ public final class McpServerFactory implements McpStreamFactory
         this.decodeMax = decodePool.slotCapacity();
         this.encodeMax = encodePool.slotCapacity();
         this.sessions = new Object2ObjectHashMap<>();
-        this.jsonParserFactory = StreamingJson.createParserFactory(Map.of(
+        this.parserFactory = StreamingJson.createParserFactory(Map.of(
             StreamingJson.PATH_INCLUDES, SERVER_JSON_PATH_INCLUDES,
             StreamingJson.TOKEN_MAX_BYTES, decodeMax));
     }
@@ -321,7 +321,7 @@ public final class McpServerFactory implements McpStreamFactory
         server.decodedId = null;
         server.decodedMethod = null;
         server.decodedMethodParam = null;
-        server.decodableJson = jsonParserFactory.createParser(input);
+        server.decodableJson = parserFactory.createParser(input);
         server.decoder = decodeJsonRpcStart;
 
         progress = limit - input.available();

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -19,10 +19,13 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabiliti
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabilities.CLIENT_SAMPLING;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
 
+import java.util.List;
 import java.util.Map;
 import java.util.function.LongUnaryOperator;
 import java.util.function.Supplier;
 
+import jakarta.json.Json;
+import jakarta.json.JsonPointer;
 import jakarta.json.bind.JsonbBuilder;
 import jakarta.json.stream.JsonParser;
 
@@ -122,6 +125,17 @@ public final class McpServerFactory implements McpStreamFactory
 
     private final DirectBufferInputStreamEx inputRO = new DirectBufferInputStreamEx();
 
+    // JSON paths whose values McpServerFactory reads via getString(). Configured on the
+    // StreamingJson parser so non-included values (e.g. /params/arguments contents) are
+    // scanned without scratch accumulation. KEY_NAME tokens are always readable.
+    private static final List<JsonPointer> SERVER_JSON_PATH_INCLUDES = List.of(
+        Json.createPointer("/jsonrpc"),
+        Json.createPointer("/id"),
+        Json.createPointer("/method"),
+        Json.createPointer("/params/name"),
+        Json.createPointer("/params/uri"));
+    private final Map<String, ?> serverJsonConfig;
+
     private final McpServerDecoder decodeJsonRpc = this::decodeJsonRpc;
     private final McpServerDecoder decodeJsonRpcStart = this::decodeJsonRpcStart;
     private final McpServerDecoder decodeJsonRpcNext = this::decodeJsonRpcNext;
@@ -162,6 +176,9 @@ public final class McpServerFactory implements McpStreamFactory
         this.decodeMax = decodePool.slotCapacity();
         this.encodeMax = encodePool.slotCapacity();
         this.sessions = new Object2ObjectHashMap<>();
+        this.serverJsonConfig = Map.of(
+            StreamingJson.PATH_INCLUDES, SERVER_JSON_PATH_INCLUDES,
+            StreamingJson.TOKEN_MAX_BYTES, decodeMax);
     }
 
     @Override
@@ -308,7 +325,7 @@ public final class McpServerFactory implements McpStreamFactory
         server.decodedId = null;
         server.decodedMethod = null;
         server.decodedMethodParam = null;
-        server.decodableJson = StreamingJson.createParser(input);
+        server.decodableJson = StreamingJson.createParser(input, serverJsonConfig);
         server.decoder = decodeJsonRpcStart;
 
         progress = limit - input.available();

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -14,6 +14,9 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
 
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabilities.CLIENT_ELICITATION;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabilities.CLIENT_ROOTS;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabilities.CLIENT_SAMPLING;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
 
 import java.util.Map;
@@ -59,6 +62,9 @@ import io.aklivity.zilla.runtime.engine.config.BindingConfig;
 
 public final class McpServerFactory implements McpStreamFactory
 {
+    private static final int CLIENT_CAPABILITIES =
+        CLIENT_ROOTS.value() | CLIENT_SAMPLING.value() | CLIENT_ELICITATION.value();
+
     private static final String HTTP_TYPE_NAME = "http";
     private static final String MCP_TYPE_NAME = "mcp";
 
@@ -1377,7 +1383,8 @@ public final class McpServerFactory implements McpStreamFactory
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId)
                 .lifecycle(i -> i
-                    .sessionId(session.sessionId))
+                    .sessionId(session.sessionId)
+                    .capabilities(CLIENT_CAPABILITIES))
                 .build();
             session.doAppBegin(traceId, authorization, beginEx);
         }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -24,10 +24,9 @@ import java.util.Map;
 import java.util.function.LongUnaryOperator;
 import java.util.function.Supplier;
 
-import jakarta.json.Json;
-import jakarta.json.JsonPointer;
 import jakarta.json.bind.JsonbBuilder;
 import jakarta.json.stream.JsonParser;
+import jakarta.json.stream.JsonParserFactory;
 
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -125,16 +124,13 @@ public final class McpServerFactory implements McpStreamFactory
 
     private final DirectBufferInputStreamEx inputRO = new DirectBufferInputStreamEx();
 
-    // JSON paths whose values McpServerFactory reads via getString(). Configured on the
-    // StreamingJson parser so non-included values (e.g. /params/arguments contents) are
-    // scanned without scratch accumulation. KEY_NAME tokens are always readable.
-    private static final List<JsonPointer> SERVER_JSON_PATH_INCLUDES = List.of(
-        Json.createPointer("/jsonrpc"),
-        Json.createPointer("/id"),
-        Json.createPointer("/method"),
-        Json.createPointer("/params/name"),
-        Json.createPointer("/params/uri"));
-    private final Map<String, ?> serverJsonConfig;
+    private static final List<String> SERVER_JSON_PATH_INCLUDES = List.of(
+        "/jsonrpc",
+        "/id",
+        "/method",
+        "/params/name",
+        "/params/uri");
+    private final JsonParserFactory jsonParserFactory;
 
     private final McpServerDecoder decodeJsonRpc = this::decodeJsonRpc;
     private final McpServerDecoder decodeJsonRpcStart = this::decodeJsonRpcStart;
@@ -176,9 +172,9 @@ public final class McpServerFactory implements McpStreamFactory
         this.decodeMax = decodePool.slotCapacity();
         this.encodeMax = encodePool.slotCapacity();
         this.sessions = new Object2ObjectHashMap<>();
-        this.serverJsonConfig = Map.of(
+        this.jsonParserFactory = StreamingJson.createParserFactory(Map.of(
             StreamingJson.PATH_INCLUDES, SERVER_JSON_PATH_INCLUDES,
-            StreamingJson.TOKEN_MAX_BYTES, decodeMax);
+            StreamingJson.TOKEN_MAX_BYTES, decodeMax));
     }
 
     @Override
@@ -325,7 +321,7 @@ public final class McpServerFactory implements McpStreamFactory
         server.decodedId = null;
         server.decodedMethod = null;
         server.decodedMethodParam = null;
-        server.decodableJson = StreamingJson.createParser(input, serverJsonConfig);
+        server.decodableJson = jsonParserFactory.createParser(input);
         server.decoder = decodeJsonRpcStart;
 
         progress = limit - input.available();

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpState.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpState.java
@@ -37,6 +37,12 @@ public final class McpState
         return state | INITIAL_OPENED;
     }
 
+    static boolean initialOpening(
+        int state)
+    {
+        return (state & INITIAL_OPENING) != 0;
+    }
+
     static boolean initialOpened(
         int state)
     {

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -41,6 +41,7 @@ public class McpProxyIT
         .countersBufferCapacity(8192)
         .configurationRoot("io/aklivity/zilla/specs/binding/mcp/config")
         .external("app1")
+        .external("app2")
         .clean();
 
     @Rule
@@ -229,6 +230,16 @@ public class McpProxyIT
         "resourcesListReply \"{\\\"resources\\\":[{\\\"uri\\\":\\\"file:///data/readme.txt\\\"," +
             "\\\"mimeType\\\":\\\"text/plain\\\"}]}\"" })
     public void shouldListResourcesWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.toolkit.multi.yaml")
+    @Specification({
+        "${app}/tools.list.toolkit.multi/client",
+        "${app}/tools.list.toolkit.multi/server" })
+    public void shouldListToolsWithToolkitMulti() throws Exception
     {
         k3po.finish();
     }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -47,6 +47,8 @@ public class McpProxyIT
     @Rule
     public final TestRule chain = outerRule(engine).around(k3po).around(timeout);
 
+    // lifecycle ----------------------------------------------------------------
+
     @Test
     @Configuration("proxy.yaml")
     @Specification({
@@ -76,6 +78,8 @@ public class McpProxyIT
         k3po.finish();
     }
 
+    // tools --------------------------------------------------------------------
+
     @Test
     @Configuration("proxy.yaml")
     @Specification({
@@ -83,6 +87,17 @@ public class McpProxyIT
         "${app}/tools.call/server" })
     @ScriptProperty("serverAddress \"zilla://streams/app1\"")
     public void shouldCallTool() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/tools.call.aborted/client",
+        "${app}/tools.call.aborted/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldAbortCallTool() throws Exception
     {
         k3po.finish();
     }
@@ -100,13 +115,35 @@ public class McpProxyIT
     @Test
     @Configuration("proxy.yaml")
     @Specification({
-        "${app}/tools.call.aborted/client",
-        "${app}/tools.call.aborted/server" })
+        "${app}/tools.list/client",
+        "${app}/tools.list/server" })
     @ScriptProperty("serverAddress \"zilla://streams/app1\"")
-    public void shouldAbortCallTool() throws Exception
+    public void shouldListTools() throws Exception
     {
         k3po.finish();
     }
+
+    @Test
+    @Configuration("proxy.toolkit.yaml")
+    @Specification({
+        "${app}/tools.list.toolkit/client",
+        "${app}/tools.list.toolkit/server" })
+    public void shouldListToolsWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.toolkit.multi.yaml")
+    @Specification({
+        "${app}/tools.list.toolkit.multi/client",
+        "${app}/tools.list.toolkit.multi/server" })
+    public void shouldListToolsWithToolkitMulti() throws Exception
+    {
+        k3po.finish();
+    }
+
+    // prompts ------------------------------------------------------------------
 
     @Test
     @Configuration("proxy.yaml")
@@ -115,17 +152,6 @@ public class McpProxyIT
         "${app}/prompts.get/server" })
     @ScriptProperty("serverAddress \"zilla://streams/app1\"")
     public void shouldGetPrompt() throws Exception
-    {
-        k3po.finish();
-    }
-
-    @Test
-    @Configuration("proxy.yaml")
-    @Specification({
-        "${app}/resources.read/client",
-        "${app}/resources.read/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
-    public void shouldReadResource() throws Exception
     {
         k3po.finish();
     }
@@ -141,33 +167,55 @@ public class McpProxyIT
     }
 
     @Test
-    @Configuration("proxy.toolkit.yaml")
-    @Specification({
-        "${app}/resources.read.toolkit/client",
-        "${app}/resources.read.toolkit/server" })
-    public void shouldReadResourceWithToolkit() throws Exception
-    {
-        k3po.finish();
-    }
-
-    @Test
-    @Configuration("proxy.yaml")
-    @Specification({
-        "${app}/tools.list/client",
-        "${app}/tools.list/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
-    public void shouldListTools() throws Exception
-    {
-        k3po.finish();
-    }
-
-    @Test
     @Configuration("proxy.yaml")
     @Specification({
         "${app}/prompts.list/client",
         "${app}/prompts.list/server" })
     @ScriptProperty("serverAddress \"zilla://streams/app1\"")
     public void shouldListPrompts() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.toolkit.yaml")
+    @Specification({
+        "${app}/prompts.list.toolkit/client",
+        "${app}/prompts.list.toolkit/server" })
+    public void shouldListPromptsWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.toolkit.multi.yaml")
+    @Specification({
+        "${app}/prompts.list.toolkit.multi/client",
+        "${app}/prompts.list.toolkit.multi/server" })
+    public void shouldListPromptsWithToolkitMulti() throws Exception
+    {
+        k3po.finish();
+    }
+
+    // resources ----------------------------------------------------------------
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/resources.read/client",
+        "${app}/resources.read/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldReadResource() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.toolkit.yaml")
+    @Specification({
+        "${app}/resources.read.toolkit/client",
+        "${app}/resources.read.toolkit/server" })
+    public void shouldReadResourceWithToolkit() throws Exception
     {
         k3po.finish();
     }
@@ -186,49 +234,9 @@ public class McpProxyIT
     @Test
     @Configuration("proxy.toolkit.yaml")
     @Specification({
-        "${app}/tools.list.toolkit/client",
-        "${app}/tools.list.toolkit/server" })
-    public void shouldListToolsWithToolkit() throws Exception
-    {
-        k3po.finish();
-    }
-
-    @Test
-    @Configuration("proxy.toolkit.yaml")
-    @Specification({
-        "${app}/prompts.list.toolkit/client",
-        "${app}/prompts.list.toolkit/server" })
-    public void shouldListPromptsWithToolkit() throws Exception
-    {
-        k3po.finish();
-    }
-
-    @Test
-    @Configuration("proxy.toolkit.yaml")
-    @Specification({
         "${app}/resources.list.toolkit/client",
         "${app}/resources.list.toolkit/server" })
     public void shouldListResourcesWithToolkit() throws Exception
-    {
-        k3po.finish();
-    }
-
-    @Test
-    @Configuration("proxy.toolkit.multi.yaml")
-    @Specification({
-        "${app}/tools.list.toolkit.multi/client",
-        "${app}/tools.list.toolkit.multi/server" })
-    public void shouldListToolsWithToolkitMulti() throws Exception
-    {
-        k3po.finish();
-    }
-
-    @Test
-    @Configuration("proxy.toolkit.multi.yaml")
-    @Specification({
-        "${app}/prompts.list.toolkit.multi/client",
-        "${app}/prompts.list.toolkit.multi/server" })
-    public void shouldListPromptsWithToolkitMulti() throws Exception
     {
         k3po.finish();
     }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -17,7 +17,6 @@ package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -56,7 +55,6 @@ public class McpProxyIT
         k3po.finish();
     }
 
-    @Ignore("WIP: lazy outbound lifecycle + invocation proceed triggers a JVM crash in engine close; deferred")
     @Test
     @Configuration("proxy.yaml")
     @Specification({

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -157,4 +157,15 @@ public class McpProxyIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/tools.list/client",
+        "${app}/tools.list/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldListTools() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -17,12 +17,14 @@ package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 
+import io.aklivity.k3po.runtime.junit.annotation.ScriptProperty;
 import io.aklivity.k3po.runtime.junit.annotation.Specification;
 import io.aklivity.k3po.runtime.junit.rules.K3poRule;
 import io.aklivity.zilla.runtime.engine.test.EngineRule;
@@ -50,6 +52,18 @@ public class McpProxyIT
     @Specification({
         "${app}/lifecycle.initialize/client" })
     public void shouldInitializeLifecycle() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Ignore("WIP: lazy outbound lifecycle + invocation proceed triggers a JVM crash in engine close; deferred")
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/tools.call/client",
+        "${app}/tools.call/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldCallTool() throws Exception
     {
         k3po.finish();
     }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -308,4 +308,48 @@ public class McpProxyIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/tools.call.10k/client",
+        "${app}/tools.call.10k/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldCallToolWith10kParams() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/tools.call.100k/client",
+        "${app}/tools.call.100k/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldCallToolWith100kParams() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/resources.read.10k/client",
+        "${app}/resources.read.10k/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldReadResourceWith10kContents() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/resources.read.100k/client",
+        "${app}/resources.read.100k/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldReadResourceWith100kContents() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -131,4 +131,30 @@ public class McpProxyIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Configuration("proxy.toolkit.yaml")
+    @Specification({
+        "${app}/prompts.get.toolkit/client",
+        "${app}/prompts.get.toolkit/server" })
+    @ScriptProperty({
+        "serverAddress \"zilla://streams/app1\"",
+        "promptName \"weather_prompt\"" })
+    public void shouldGetPromptWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.toolkit.yaml")
+    @Specification({
+        "${app}/resources.read.toolkit/client",
+        "${app}/resources.read.toolkit/server" })
+    @ScriptProperty({
+        "serverAddress \"zilla://streams/app1\"",
+        "resourceUri \"file:///data/readme.txt\"" })
+    public void shouldReadResourceWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -243,4 +243,24 @@ public class McpProxyIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Configuration("proxy.toolkit.multi.yaml")
+    @Specification({
+        "${app}/prompts.list.toolkit.multi/client",
+        "${app}/prompts.list.toolkit.multi/server" })
+    public void shouldListPromptsWithToolkitMulti() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.toolkit.multi.yaml")
+    @Specification({
+        "${app}/resources.list.toolkit.multi/client",
+        "${app}/resources.list.toolkit.multi/server" })
+    public void shouldListResourcesWithToolkitMulti() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -58,6 +58,26 @@ public class McpProxyIT
     @Test
     @Configuration("proxy.yaml")
     @Specification({
+        "${app}/lifecycle.shutdown/client" })
+    public void shouldShutdownLifecycle() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/lifecycle.shutdown.requests/client",
+        "${app}/lifecycle.shutdown.requests/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldShutdownLifecycleRequests() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
         "${app}/tools.call/client",
         "${app}/tools.call/server" })
     @ScriptProperty("serverAddress \"zilla://streams/app1\"")

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.rules.RuleChain.outerRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+
+import io.aklivity.k3po.runtime.junit.annotation.Specification;
+import io.aklivity.k3po.runtime.junit.rules.K3poRule;
+import io.aklivity.zilla.runtime.engine.test.EngineRule;
+import io.aklivity.zilla.runtime.engine.test.annotation.Configuration;
+
+public class McpProxyIT
+{
+    private final K3poRule k3po = new K3poRule()
+        .addScriptRoot("app", "io/aklivity/zilla/specs/binding/mcp/streams/application");
+
+    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
+
+    private final EngineRule engine = new EngineRule()
+        .directory("target/zilla-itests")
+        .countersBufferCapacity(8192)
+        .configurationRoot("io/aklivity/zilla/specs/binding/mcp/config")
+        .external("app1")
+        .clean();
+
+    @Rule
+    public final TestRule chain = outerRule(engine).around(k3po).around(timeout);
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/lifecycle.initialize/client" })
+    public void shouldInitializeLifecycle() throws Exception
+    {
+        k3po.finish();
+    }
+}

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -47,8 +47,6 @@ public class McpProxyIT
     @Rule
     public final TestRule chain = outerRule(engine).around(k3po).around(timeout);
 
-    // lifecycle ----------------------------------------------------------------
-
     @Test
     @Configuration("proxy.yaml")
     @Specification({
@@ -77,8 +75,6 @@ public class McpProxyIT
     {
         k3po.finish();
     }
-
-    // tools --------------------------------------------------------------------
 
     @Test
     @Configuration("proxy.yaml")
@@ -143,8 +139,6 @@ public class McpProxyIT
         k3po.finish();
     }
 
-    // prompts ------------------------------------------------------------------
-
     @Test
     @Configuration("proxy.yaml")
     @Specification({
@@ -196,8 +190,6 @@ public class McpProxyIT
     {
         k3po.finish();
     }
-
-    // resources ----------------------------------------------------------------
 
     @Test
     @Configuration("proxy.yaml")

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -190,4 +190,46 @@ public class McpProxyIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Configuration("proxy.toolkit.yaml")
+    @Specification({
+        "${app}/tools.list.toolkit/client",
+        "${app}/tools.list.toolkit/server" })
+    @ScriptProperty({
+        "serverAddress \"zilla://streams/app1\"",
+        "toolsListReply \"{\\\"tools\\\":[{\\\"name\\\":\\\"get_weather\\\"," +
+            "\\\"title\\\":\\\"Weather Information Provider\\\"}]}\"" })
+    public void shouldListToolsWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.toolkit.yaml")
+    @Specification({
+        "${app}/prompts.list.toolkit/client",
+        "${app}/prompts.list.toolkit/server" })
+    @ScriptProperty({
+        "serverAddress \"zilla://streams/app1\"",
+        "promptsListReply \"{\\\"prompts\\\":[{\\\"name\\\":\\\"weather_prompt\\\"," +
+            "\\\"description\\\":\\\"Ask about weather\\\"}]}\"" })
+    public void shouldListPromptsWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.toolkit.yaml")
+    @Specification({
+        "${app}/resources.list.toolkit/client",
+        "${app}/resources.list.toolkit/server" })
+    @ScriptProperty({
+        "serverAddress \"zilla://streams/app1\"",
+        "resourcesListReply \"{\\\"resources\\\":[{\\\"uri\\\":\\\"file:///data/readme.txt\\\"," +
+            "\\\"mimeType\\\":\\\"text/plain\\\"}]}\"" })
+    public void shouldListResourcesWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -65,4 +65,15 @@ public class McpProxyIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Configuration("proxy.toolkit.yaml")
+    @Specification({
+        "${app}/tools.call.toolkit/client",
+        "${app}/tools.call.toolkit/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldCallToolForToolkit() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -168,4 +168,26 @@ public class McpProxyIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/prompts.list/client",
+        "${app}/prompts.list/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldListPrompts() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/resources.list/client",
+        "${app}/resources.list/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldListResources() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -71,8 +71,10 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.call.toolkit/client",
         "${app}/tools.call.toolkit/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
-    public void shouldCallToolForToolkit() throws Exception
+    @ScriptProperty({
+        "serverAddress \"zilla://streams/app1\"",
+        "toolName \"get_weather\"" })
+    public void shouldCallToolWithToolkit() throws Exception
     {
         k3po.finish();
     }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -242,4 +242,70 @@ public class McpProxyIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/tools.list.aborted/client",
+        "${app}/tools.list.aborted/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldAbortToolsList() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/tools.list.canceled/client",
+        "${app}/tools.list.canceled/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldListToolsThenCancel() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/prompts.list.aborted/client",
+        "${app}/prompts.list.aborted/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldAbortListPrompts() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/prompts.get.aborted/client",
+        "${app}/prompts.get.aborted/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldAbortGetPrompt() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/resources.list.aborted/client",
+        "${app}/resources.list.aborted/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldAbortListResources() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/resources.read.aborted/client",
+        "${app}/resources.read.aborted/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldAbortReadResource() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -98,4 +98,37 @@ public class McpProxyIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/tools.call.aborted/client",
+        "${app}/tools.call.aborted/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldAbortCallTool() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/prompts.get/client",
+        "${app}/prompts.get/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldGetPrompt() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/resources.read/client",
+        "${app}/resources.read/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldReadResource() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -92,9 +92,6 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.call.toolkit/client",
         "${app}/tools.call.toolkit/server" })
-    @ScriptProperty({
-        "serverAddress \"zilla://streams/app1\"",
-        "toolName \"get_weather\"" })
     public void shouldCallToolWithToolkit() throws Exception
     {
         k3po.finish();
@@ -138,9 +135,6 @@ public class McpProxyIT
     @Specification({
         "${app}/prompts.get.toolkit/client",
         "${app}/prompts.get.toolkit/server" })
-    @ScriptProperty({
-        "serverAddress \"zilla://streams/app1\"",
-        "promptName \"weather_prompt\"" })
     public void shouldGetPromptWithToolkit() throws Exception
     {
         k3po.finish();
@@ -151,9 +145,6 @@ public class McpProxyIT
     @Specification({
         "${app}/resources.read.toolkit/client",
         "${app}/resources.read.toolkit/server" })
-    @ScriptProperty({
-        "serverAddress \"zilla://streams/app1\"",
-        "resourceUri \"file:///data/readme.txt\"" })
     public void shouldReadResourceWithToolkit() throws Exception
     {
         k3po.finish();
@@ -197,10 +188,6 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.list.toolkit/client",
         "${app}/tools.list.toolkit/server" })
-    @ScriptProperty({
-        "serverAddress \"zilla://streams/app1\"",
-        "toolsListReply \"{\\\"tools\\\":[{\\\"name\\\":\\\"get_weather\\\"," +
-            "\\\"title\\\":\\\"Weather Information Provider\\\"}]}\"" })
     public void shouldListToolsWithToolkit() throws Exception
     {
         k3po.finish();
@@ -211,10 +198,6 @@ public class McpProxyIT
     @Specification({
         "${app}/prompts.list.toolkit/client",
         "${app}/prompts.list.toolkit/server" })
-    @ScriptProperty({
-        "serverAddress \"zilla://streams/app1\"",
-        "promptsListReply \"{\\\"prompts\\\":[{\\\"name\\\":\\\"weather_prompt\\\"," +
-            "\\\"description\\\":\\\"Ask about weather\\\"}]}\"" })
     public void shouldListPromptsWithToolkit() throws Exception
     {
         k3po.finish();
@@ -225,10 +208,6 @@ public class McpProxyIT
     @Specification({
         "${app}/resources.list.toolkit/client",
         "${app}/resources.list.toolkit/server" })
-    @ScriptProperty({
-        "serverAddress \"zilla://streams/app1\"",
-        "resourcesListReply \"{\\\"resources\\\":[{\\\"uri\\\":\\\"file:///data/readme.txt\\\"," +
-            "\\\"mimeType\\\":\\\"text/plain\\\"}]}\"" })
     public void shouldListResourcesWithToolkit() throws Exception
     {
         k3po.finish();

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/StreamingJson.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/StreamingJson.java
@@ -65,13 +65,6 @@ public final class StreamingJson
         return new StreamingJsonParser(in, Map.of());
     }
 
-    public static JsonParser createParser(
-        InputStream in,
-        Map<String, ?> config)
-    {
-        return new StreamingJsonParser(in, config);
-    }
-
     /**
      * Mirrors {@link jakarta.json.Json#createParserFactory(Map)}. Construct once per
      * factory class and reuse for the lifetime of the binding to avoid repeating config

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/StreamingJson.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/StreamingJson.java
@@ -18,16 +18,19 @@ import java.io.InputStream;
 import java.util.Map;
 
 import jakarta.json.stream.JsonParser;
+import jakarta.json.stream.JsonParserFactory;
 
 import io.aklivity.zilla.runtime.common.json.internal.StreamingJsonParser;
+import io.aklivity.zilla.runtime.common.json.internal.StreamingJsonParserFactory;
 
 public final class StreamingJson
 {
     /**
-     * Config key whose value is a {@code List<JsonPointer>} identifying document paths
-     * whose values must be readable via {@link JsonParser#getString()} after the
-     * corresponding event. The convention {@code -} as an array-index segment is treated
-     * as a wildcard matching any index (parser-internal extension to RFC 6901).
+     * Config key whose value is a {@code List<String>} of JSON Pointer (RFC 6901) syntax
+     * identifying document paths whose values must be readable via {@link
+     * JsonParser#getString()} after the corresponding event. The convention {@code -} as an
+     * array-index segment is treated as a wildcard matching any index (parser-internal
+     * extension to RFC 6901).
      * <p>
      * Defaults to "every path included" when absent. When specified, only listed paths
      * (minus any matched by {@link #PATH_EXCLUDES}) are readable; values at all other
@@ -36,9 +39,9 @@ public final class StreamingJson
     public static final String PATH_INCLUDES = "io.aklivity.zilla.runtime.common.json.path.includes";
 
     /**
-     * Config key whose value is a {@code List<JsonPointer>} identifying document paths
-     * whose values are NOT required to be readable, even if matched by
-     * {@link #PATH_INCLUDES}. Excludes have final veto.
+     * Config key whose value is a {@code List<String>} of JSON Pointer (RFC 6901) syntax
+     * identifying document paths whose values are NOT required to be readable, even if
+     * matched by {@link #PATH_INCLUDES}. Excludes have final veto.
      */
     public static final String PATH_EXCLUDES = "io.aklivity.zilla.runtime.common.json.path.excludes";
 
@@ -67,5 +70,16 @@ public final class StreamingJson
         Map<String, ?> config)
     {
         return new StreamingJsonParser(in, config);
+    }
+
+    /**
+     * Mirrors {@link jakarta.json.Json#createParserFactory(Map)}. Construct once per
+     * factory class and reuse for the lifetime of the binding to avoid repeating config
+     * resolution on every stream.
+     */
+    public static JsonParserFactory createParserFactory(
+        Map<String, ?> config)
+    {
+        return new StreamingJsonParserFactory(config);
     }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/StreamingJson.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/StreamingJson.java
@@ -15,6 +15,7 @@
 package io.aklivity.zilla.runtime.common.json;
 
 import java.io.InputStream;
+import java.util.Map;
 
 import jakarta.json.stream.JsonParser;
 
@@ -22,6 +23,19 @@ import io.aklivity.zilla.runtime.common.json.internal.StreamingJsonParser;
 
 public final class StreamingJson
 {
+    /**
+     * Config key whose value is a {@code List<JsonPointer>} identifying the document paths
+     * whose values must be readable via {@link JsonParser#getString()} after the corresponding
+     * {@code VALUE_STRING} event. The convention {@code -} as an array-index segment is treated
+     * as a wildcard matching any index (parser-internal extension to RFC 6901).
+     * <p>
+     * Values at non-readable paths are scanned and discarded; calling
+     * {@link JsonParser#getString()} on such a value throws {@link IllegalStateException}.
+     * <p>
+     * Absent or empty: every value is readable (legacy behavior).
+     */
+    public static final String READABLE_PATHS = "io.aklivity.zilla.runtime.common.json.readable.paths";
+
     private StreamingJson()
     {
     }
@@ -29,6 +43,13 @@ public final class StreamingJson
     public static JsonParser createParser(
         InputStream in)
     {
-        return new StreamingJsonParser(in);
+        return new StreamingJsonParser(in, Map.of());
+    }
+
+    public static JsonParser createParser(
+        InputStream in,
+        Map<String, ?> config)
+    {
+        return new StreamingJsonParser(in, config);
     }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/StreamingJson.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/StreamingJson.java
@@ -24,17 +24,33 @@ import io.aklivity.zilla.runtime.common.json.internal.StreamingJsonParser;
 public final class StreamingJson
 {
     /**
-     * Config key whose value is a {@code List<JsonPointer>} identifying the document paths
-     * whose values must be readable via {@link JsonParser#getString()} after the corresponding
-     * {@code VALUE_STRING} event. The convention {@code -} as an array-index segment is treated
+     * Config key whose value is a {@code List<JsonPointer>} identifying document paths
+     * whose values must be readable via {@link JsonParser#getString()} after the
+     * corresponding event. The convention {@code -} as an array-index segment is treated
      * as a wildcard matching any index (parser-internal extension to RFC 6901).
      * <p>
-     * Values at non-readable paths are scanned and discarded; calling
-     * {@link JsonParser#getString()} on such a value throws {@link IllegalStateException}.
-     * <p>
-     * Absent or empty: every value is readable (legacy behavior).
+     * Defaults to "every path included" when absent. When specified, only listed paths
+     * (minus any matched by {@link #PATHS_EXCLUDED}) are readable; values at all other
+     * paths are scanned and discarded, and {@code getString()} on those throws.
      */
-    public static final String READABLE_PATHS = "io.aklivity.zilla.runtime.common.json.readable.paths";
+    public static final String PATHS_INCLUDED = "io.aklivity.zilla.runtime.common.json.paths.included";
+
+    /**
+     * Config key whose value is a {@code List<JsonPointer>} identifying document paths
+     * whose values are NOT required to be readable, even if matched by
+     * {@link #PATHS_INCLUDED}. Excludes have final veto.
+     */
+    public static final String PATHS_EXCLUDED = "io.aklivity.zilla.runtime.common.json.paths.excluded";
+
+    /**
+     * Config key whose value is an {@code Integer} bounding the number of bytes the parser
+     * will scan for a single included value before throwing {@link
+     * jakarta.json.stream.JsonParsingException}. Set to the caller's slot capacity to fail
+     * fast on values that cannot make progress under reset semantics.
+     * <p>
+     * Defaults to unbounded (no enforcement) when absent.
+     */
+    public static final String MAX_TOKEN_BYTES = "io.aklivity.zilla.runtime.common.json.max.token.bytes";
 
     private StreamingJson()
     {

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/StreamingJson.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/StreamingJson.java
@@ -30,17 +30,17 @@ public final class StreamingJson
      * as a wildcard matching any index (parser-internal extension to RFC 6901).
      * <p>
      * Defaults to "every path included" when absent. When specified, only listed paths
-     * (minus any matched by {@link #PATHS_EXCLUDED}) are readable; values at all other
+     * (minus any matched by {@link #PATH_EXCLUDES}) are readable; values at all other
      * paths are scanned and discarded, and {@code getString()} on those throws.
      */
-    public static final String PATHS_INCLUDED = "io.aklivity.zilla.runtime.common.json.paths.included";
+    public static final String PATH_INCLUDES = "io.aklivity.zilla.runtime.common.json.path.includes";
 
     /**
      * Config key whose value is a {@code List<JsonPointer>} identifying document paths
      * whose values are NOT required to be readable, even if matched by
-     * {@link #PATHS_INCLUDED}. Excludes have final veto.
+     * {@link #PATH_INCLUDES}. Excludes have final veto.
      */
-    public static final String PATHS_EXCLUDED = "io.aklivity.zilla.runtime.common.json.paths.excluded";
+    public static final String PATH_EXCLUDES = "io.aklivity.zilla.runtime.common.json.path.excludes";
 
     /**
      * Config key whose value is an {@code Integer} bounding the number of bytes the parser
@@ -50,7 +50,7 @@ public final class StreamingJson
      * <p>
      * Defaults to unbounded (no enforcement) when absent.
      */
-    public static final String MAX_TOKEN_BYTES = "io.aklivity.zilla.runtime.common.json.max.token.bytes";
+    public static final String TOKEN_MAX_BYTES = "io.aklivity.zilla.runtime.common.json.token.max.bytes";
 
     private StreamingJson()
     {

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParser.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParser.java
@@ -48,16 +48,27 @@ public final class StreamingJsonParser implements JsonParser
             throw new IllegalArgumentException("InputStream must support mark/reset");
         }
         this.in = in;
-        this.tokenizer = new StreamingJsonTokenizer(readablePaths(config));
+        this.tokenizer = new StreamingJsonTokenizer(
+            pathList(config, StreamingJson.PATHS_INCLUDED),
+            pathList(config, StreamingJson.PATHS_EXCLUDED),
+            maxTokenBytes(config));
         this.location = new StreamingJsonLocation(tokenizer);
     }
 
     @SuppressWarnings("unchecked")
-    private static List<JsonPointer> readablePaths(
+    private static List<JsonPointer> pathList(
+        Map<String, ?> config,
+        String key)
+    {
+        final Object raw = config.get(key);
+        return raw == null ? List.of() : (List<JsonPointer>) raw;
+    }
+
+    private static int maxTokenBytes(
         Map<String, ?> config)
     {
-        final Object raw = config.get(StreamingJson.READABLE_PATHS);
-        return raw == null ? List.of() : (List<JsonPointer>) raw;
+        final Object raw = config.get(StreamingJson.MAX_TOKEN_BYTES);
+        return raw == null ? Integer.MAX_VALUE : ((Number) raw).intValue();
     }
 
     @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParser.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParser.java
@@ -49,9 +49,9 @@ public final class StreamingJsonParser implements JsonParser
         }
         this.in = in;
         this.tokenizer = new StreamingJsonTokenizer(
-            pathList(config, StreamingJson.PATHS_INCLUDED),
-            pathList(config, StreamingJson.PATHS_EXCLUDED),
-            maxTokenBytes(config));
+            pathList(config, StreamingJson.PATH_INCLUDES),
+            pathList(config, StreamingJson.PATH_EXCLUDES),
+            tokenMaxBytes(config));
         this.location = new StreamingJsonLocation(tokenizer);
     }
 
@@ -64,10 +64,10 @@ public final class StreamingJsonParser implements JsonParser
         return raw == null ? List.of() : (List<JsonPointer>) raw;
     }
 
-    private static int maxTokenBytes(
+    private static int tokenMaxBytes(
         Map<String, ?> config)
     {
-        final Object raw = config.get(StreamingJson.MAX_TOKEN_BYTES);
+        final Object raw = config.get(StreamingJson.TOKEN_MAX_BYTES);
         return raw == null ? Integer.MAX_VALUE : ((Number) raw).intValue();
     }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParser.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParser.java
@@ -103,7 +103,13 @@ public final class StreamingJsonParser implements JsonParser
     @Override
     public String getString()
     {
-        return tokenizer.stringValue();
+        final String value = tokenizer.stringValue();
+        if (value == null && !tokenizer.valueReadable())
+        {
+            throw new IllegalStateException("value not readable; configure path via " +
+                "StreamingJson.PATH_INCLUDES (or remove from PATH_EXCLUDES)");
+        }
+        return value;
     }
 
     @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParser.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParser.java
@@ -17,10 +17,15 @@ package io.aklivity.zilla.runtime.common.json.internal;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
 
+import jakarta.json.JsonPointer;
 import jakarta.json.stream.JsonLocation;
 import jakarta.json.stream.JsonParser;
 import jakarta.json.stream.JsonParsingException;
+
+import io.aklivity.zilla.runtime.common.json.StreamingJson;
 
 public final class StreamingJsonParser implements JsonParser
 {
@@ -31,13 +36,28 @@ public final class StreamingJsonParser implements JsonParser
     public StreamingJsonParser(
         InputStream in)
     {
+        this(in, Map.of());
+    }
+
+    public StreamingJsonParser(
+        InputStream in,
+        Map<String, ?> config)
+    {
         if (!in.markSupported())
         {
             throw new IllegalArgumentException("InputStream must support mark/reset");
         }
         this.in = in;
-        this.tokenizer = new StreamingJsonTokenizer();
+        this.tokenizer = new StreamingJsonTokenizer(readablePaths(config));
         this.location = new StreamingJsonLocation(tokenizer);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<JsonPointer> readablePaths(
+        Map<String, ?> config)
+    {
+        final Object raw = config.get(StreamingJson.READABLE_PATHS);
+        return raw == null ? List.of() : (List<JsonPointer>) raw;
     }
 
     @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParser.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParser.java
@@ -54,22 +54,6 @@ public final class StreamingJsonParser implements JsonParser
         this.location = new StreamingJsonLocation(tokenizer);
     }
 
-    @SuppressWarnings("unchecked")
-    private static List<String> pathList(
-        Map<String, ?> config,
-        String key)
-    {
-        final Object raw = config.get(key);
-        return raw == null ? List.of() : (List<String>) raw;
-    }
-
-    private static int tokenMaxBytes(
-        Map<String, ?> config)
-    {
-        final Object raw = config.get(StreamingJson.TOKEN_MAX_BYTES);
-        return raw == null ? Integer.MAX_VALUE : ((Number) raw).intValue();
-    }
-
     @Override
     public boolean hasNext()
     {
@@ -207,5 +191,21 @@ public final class StreamingJsonParser implements JsonParser
     {
         throw new UnsupportedOperationException("skipArray not yet supported; " +
             "use event-by-event consumption instead");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> pathList(
+        Map<String, ?> config,
+        String key)
+    {
+        final Object raw = config.get(key);
+        return raw == null ? List.of() : (List<String>) raw;
+    }
+
+    private static int tokenMaxBytes(
+        Map<String, ?> config)
+    {
+        final Object raw = config.get(StreamingJson.TOKEN_MAX_BYTES);
+        return raw == null ? Integer.MAX_VALUE : ((Number) raw).intValue();
     }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParser.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParser.java
@@ -20,7 +20,6 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.json.JsonPointer;
 import jakarta.json.stream.JsonLocation;
 import jakarta.json.stream.JsonParser;
 import jakarta.json.stream.JsonParsingException;
@@ -56,12 +55,12 @@ public final class StreamingJsonParser implements JsonParser
     }
 
     @SuppressWarnings("unchecked")
-    private static List<JsonPointer> pathList(
+    private static List<String> pathList(
         Map<String, ?> config,
         String key)
     {
         final Object raw = config.get(key);
-        return raw == null ? List.of() : (List<JsonPointer>) raw;
+        return raw == null ? List.of() : (List<String>) raw;
     }
 
     private static int tokenMaxBytes(

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParserFactory.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParserFactory.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json.internal;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.stream.JsonParser;
+import jakarta.json.stream.JsonParserFactory;
+
+public final class StreamingJsonParserFactory implements JsonParserFactory
+{
+    private final Map<String, ?> config;
+
+    public StreamingJsonParserFactory(
+        Map<String, ?> config)
+    {
+        this.config = config;
+    }
+
+    @Override
+    public JsonParser createParser(
+        Reader reader)
+    {
+        throw new UnsupportedOperationException("StreamingJsonParserFactory only supports InputStream sources");
+    }
+
+    @Override
+    public JsonParser createParser(
+        InputStream in)
+    {
+        return new StreamingJsonParser(in, config);
+    }
+
+    @Override
+    public JsonParser createParser(
+        InputStream in,
+        Charset charset)
+    {
+        return new StreamingJsonParser(in, config);
+    }
+
+    @Override
+    public JsonParser createParser(
+        JsonObject obj)
+    {
+        throw new UnsupportedOperationException("StreamingJsonParserFactory only supports InputStream sources");
+    }
+
+    @Override
+    public JsonParser createParser(
+        JsonArray array)
+    {
+        throw new UnsupportedOperationException("StreamingJsonParserFactory only supports InputStream sources");
+    }
+
+    @Override
+    public Map<String, ?> getConfigInUse()
+    {
+        return config;
+    }
+}

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizer.java
@@ -316,14 +316,14 @@ public final class StreamingJsonTokenizer
         case VALUE_STRING:
             continueStringContent(in);
             pendingEvent = JsonParser.Event.VALUE_STRING;
-            pendingString = takeScratch();
+            pendingString = valueReadable ? takeScratch() : null;
             resumeOp = ResumeOp.NONE;
             afterValueConsumed();
             break;
         case VALUE_NUMBER:
             continueNumberContent(in);
             pendingEvent = JsonParser.Event.VALUE_NUMBER;
-            pendingString = takeScratch();
+            pendingString = valueReadable ? takeScratch() : null;
             resumeOp = ResumeOp.NONE;
             afterValueConsumed();
             break;
@@ -453,7 +453,7 @@ public final class StreamingJsonTokenizer
             resumeOp = ResumeOp.VALUE_STRING;
             continueStringContent(in);
             pendingEvent = JsonParser.Event.VALUE_STRING;
-            pendingString = takeScratch();
+            pendingString = valueReadable ? takeScratch() : null;
             resumeOp = ResumeOp.NONE;
             afterValueConsumed();
             break;
@@ -485,11 +485,14 @@ public final class StreamingJsonTokenizer
             if (c == '-' || c >= '0' && c <= '9')
             {
                 scratch.setLength(0);
-                scratch.append((char) c);
+                if (valueReadable)
+                {
+                    scratch.append((char) c);
+                }
                 resumeOp = ResumeOp.VALUE_NUMBER;
                 continueNumberContent(in);
                 pendingEvent = JsonParser.Event.VALUE_NUMBER;
-                pendingString = takeScratch();
+                pendingString = valueReadable ? takeScratch() : null;
                 resumeOp = ResumeOp.NONE;
                 afterValueConsumed();
             }
@@ -508,6 +511,8 @@ public final class StreamingJsonTokenizer
         {
             throw new JsonParsingException("Expected '\"' for key but got: " + describe(c), null);
         }
+        // keys must always be readable so path matching can compare them
+        valueReadable = true;
         scratch.setLength(0);
         resumeEscape = false;
         resumeUnicodePending = 0;
@@ -621,7 +626,7 @@ public final class StreamingJsonTokenizer
                 resumeUnicodePending--;
                 if (resumeUnicodePending == 0)
                 {
-                    scratch.append((char) resumeUnicodeValue);
+                    appendScratch((char) resumeUnicodeValue);
                 }
                 continue;
             }
@@ -633,22 +638,22 @@ public final class StreamingJsonTokenizer
                 case '"':
                 case '\\':
                 case '/':
-                    scratch.append((char) c);
+                    appendScratch((char) c);
                     break;
                 case 'b':
-                    scratch.append('\b');
+                    appendScratch('\b');
                     break;
                 case 'f':
-                    scratch.append('\f');
+                    appendScratch('\f');
                     break;
                 case 'n':
-                    scratch.append('\n');
+                    appendScratch('\n');
                     break;
                 case 'r':
-                    scratch.append('\r');
+                    appendScratch('\r');
                     break;
                 case 't':
-                    scratch.append('\t');
+                    appendScratch('\t');
                     break;
                 case 'u':
                     resumeUnicodePending = 4;
@@ -673,13 +678,31 @@ public final class StreamingJsonTokenizer
             }
             else if (c < 0x80)
             {
-                scratch.append((char) c);
+                appendScratch((char) c);
             }
             else
             {
                 int codePoint = decodeUtf8(in, c);
-                scratch.appendCodePoint(codePoint);
+                appendCodePointScratch(codePoint);
             }
+        }
+    }
+
+    private void appendScratch(
+        char c)
+    {
+        if (valueReadable)
+        {
+            scratch.append(c);
+        }
+    }
+
+    private void appendCodePointScratch(
+        int codePoint)
+    {
+        if (valueReadable)
+        {
+            scratch.appendCodePoint(codePoint);
         }
     }
 
@@ -752,7 +775,7 @@ public final class StreamingJsonTokenizer
             if (c >= '0' && c <= '9' || c == '.' || c == '-' || c == '+' || c == 'e' || c == 'E')
             {
                 streamOffset++;
-                scratch.append((char) c);
+                appendScratch((char) c);
             }
             else
             {

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizer.java
@@ -21,7 +21,6 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
 
-import jakarta.json.JsonPointer;
 import jakarta.json.stream.JsonParser;
 import jakarta.json.stream.JsonParsingException;
 
@@ -86,8 +85,8 @@ public final class StreamingJsonTokenizer
     }
 
     public StreamingJsonTokenizer(
-        List<JsonPointer> pathIncludes,
-        List<JsonPointer> pathExcludes,
+        List<String> pathIncludes,
+        List<String> pathExcludes,
         int tokenMaxBytes)
     {
         this.pathIncludes = compilePaths(pathIncludes);
@@ -96,16 +95,15 @@ public final class StreamingJsonTokenizer
     }
 
     private static List<String[]> compilePaths(
-        List<JsonPointer> paths)
+        List<String> paths)
     {
         if (paths.isEmpty())
         {
             return List.of();
         }
         final List<String[]> compiled = new java.util.ArrayList<>(paths.size());
-        for (JsonPointer p : paths)
+        for (String s : paths)
         {
-            final String s = p.toString();
             if (s.isEmpty())
             {
                 compiled.add(new String[0]);

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizer.java
@@ -52,14 +52,26 @@ public final class StreamingJsonTokenizer
         VALUE_NULL
     }
 
+    private static final int MAX_DEPTH = 64;
+    private static final String WILDCARD_INDEX = "-";
+
     private final Deque<ParseState> stack = new ArrayDeque<>();
     private final StringBuilder scratch = new StringBuilder();
-    private final List<JsonPointer> readablePaths;
+    private final List<String[]> includedPaths;
+    private final List<String[]> excludedPaths;
+    private final int maxTokenBytes;
+
+    // path tracking — pre-allocated, no per-event allocation
+    private final boolean[] pathInArray = new boolean[MAX_DEPTH];
+    private final String[] pathKey = new String[MAX_DEPTH];
+    private final int[] pathIndex = new int[MAX_DEPTH];
+    private int pathDepth;
 
     private ParseState state = ParseState.DOC_START;
     private JsonParser.Event pendingEvent;
     private String pendingString;
     private long streamOffset;
+    private boolean valueReadable = true;
 
     // scalar resume state (valid when resumeOp != NONE)
     private ResumeOp resumeOp = ResumeOp.NONE;
@@ -70,13 +82,46 @@ public final class StreamingJsonTokenizer
 
     public StreamingJsonTokenizer()
     {
-        this(List.of());
+        this(List.of(), List.of(), Integer.MAX_VALUE);
     }
 
     public StreamingJsonTokenizer(
-        List<JsonPointer> readablePaths)
+        List<JsonPointer> includedPaths,
+        List<JsonPointer> excludedPaths,
+        int maxTokenBytes)
     {
-        this.readablePaths = readablePaths;
+        this.includedPaths = compilePaths(includedPaths);
+        this.excludedPaths = compilePaths(excludedPaths);
+        this.maxTokenBytes = maxTokenBytes;
+    }
+
+    private static List<String[]> compilePaths(
+        List<JsonPointer> paths)
+    {
+        if (paths.isEmpty())
+        {
+            return List.of();
+        }
+        final List<String[]> compiled = new java.util.ArrayList<>(paths.size());
+        for (JsonPointer p : paths)
+        {
+            final String s = p.toString();
+            if (s.isEmpty())
+            {
+                compiled.add(new String[0]);
+            }
+            else
+            {
+                // RFC 6901: leading '/', segments separated by '/', '~1' decodes to '/', '~0' to '~'
+                final String[] parts = s.substring(1).split("/", -1);
+                for (int i = 0; i < parts.length; i++)
+                {
+                    parts[i] = parts[i].replace("~1", "/").replace("~0", "~");
+                }
+                compiled.add(parts);
+            }
+        }
+        return compiled;
     }
 
     public boolean advance(
@@ -129,6 +174,94 @@ public final class StreamingJsonTokenizer
     public long streamOffset()
     {
         return streamOffset;
+    }
+
+    public boolean valueReadable()
+    {
+        return valueReadable;
+    }
+
+    public String currentPath()
+    {
+        if (pathDepth == 0)
+        {
+            return "";
+        }
+        final StringBuilder path = new StringBuilder();
+        for (int i = 0; i < pathDepth; i++)
+        {
+            path.append('/');
+            if (pathInArray[i])
+            {
+                path.append(pathIndex[i]);
+            }
+            else if (pathKey[i] != null)
+            {
+                path.append(pathKey[i].replace("~", "~0").replace("/", "~1"));
+            }
+        }
+        return path.toString();
+    }
+
+    private boolean currentPathReadable()
+    {
+        // include is everything by default; if includedPaths is specified, restrict to those
+        final boolean included = includedPaths.isEmpty() || pathMatchesAny(includedPaths);
+        // excludes have final veto
+        return included && !pathMatchesAny(excludedPaths);
+    }
+
+    private boolean pathMatchesAny(
+        List<String[]> paths)
+    {
+        outer:
+        for (String[] target : paths)
+        {
+            if (target.length != pathDepth)
+            {
+                continue;
+            }
+            for (int i = 0; i < pathDepth; i++)
+            {
+                final String segment = pathInArray[i]
+                    ? Integer.toString(pathIndex[i])
+                    : pathKey[i];
+                final String expected = target[i];
+                if (!WILDCARD_INDEX.equals(expected) && !expected.equals(segment))
+                {
+                    continue outer;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private void pushPath(
+        boolean inArray)
+    {
+        if (pathDepth == MAX_DEPTH)
+        {
+            throw new JsonParsingException("JSON depth exceeds " + MAX_DEPTH, null);
+        }
+        pathInArray[pathDepth] = inArray;
+        pathKey[pathDepth] = null;
+        pathIndex[pathDepth] = 0;
+        pathDepth++;
+    }
+
+    private void popPath()
+    {
+        pathDepth--;
+        pathKey[pathDepth] = null;
+    }
+
+    private void markValueConsumed()
+    {
+        if (pathDepth > 0 && pathInArray[pathDepth - 1])
+        {
+            pathIndex[pathDepth - 1]++;
+        }
     }
 
     private void advanceOne(

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizer.java
@@ -57,9 +57,9 @@ public final class StreamingJsonTokenizer
 
     private final Deque<ParseState> stack = new ArrayDeque<>();
     private final StringBuilder scratch = new StringBuilder();
-    private final List<String[]> includedPaths;
-    private final List<String[]> excludedPaths;
-    private final int maxTokenBytes;
+    private final List<String[]> pathIncludes;
+    private final List<String[]> pathExcludes;
+    private final int tokenMaxBytes;
 
     // path tracking — pre-allocated, no per-event allocation
     private final boolean[] pathInArray = new boolean[MAX_DEPTH];
@@ -86,13 +86,13 @@ public final class StreamingJsonTokenizer
     }
 
     public StreamingJsonTokenizer(
-        List<JsonPointer> includedPaths,
-        List<JsonPointer> excludedPaths,
-        int maxTokenBytes)
+        List<JsonPointer> pathIncludes,
+        List<JsonPointer> pathExcludes,
+        int tokenMaxBytes)
     {
-        this.includedPaths = compilePaths(includedPaths);
-        this.excludedPaths = compilePaths(excludedPaths);
-        this.maxTokenBytes = maxTokenBytes;
+        this.pathIncludes = compilePaths(pathIncludes);
+        this.pathExcludes = compilePaths(pathExcludes);
+        this.tokenMaxBytes = tokenMaxBytes;
     }
 
     private static List<String[]> compilePaths(
@@ -205,10 +205,10 @@ public final class StreamingJsonTokenizer
 
     private boolean currentPathReadable()
     {
-        // include is everything by default; if includedPaths is specified, restrict to those
-        final boolean included = includedPaths.isEmpty() || pathMatchesAny(includedPaths);
+        // include is everything by default; if pathIncludes is specified, restrict to those
+        final boolean included = pathIncludes.isEmpty() || pathMatchesAny(pathIncludes);
         // excludes have final veto
-        return included && !pathMatchesAny(excludedPaths);
+        return included && !pathMatchesAny(pathExcludes);
     }
 
     private boolean pathMatchesAny(

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizer.java
@@ -433,15 +433,18 @@ public final class StreamingJsonTokenizer
         InputStream in,
         int c) throws IOException
     {
+        valueReadable = currentPathReadable();
         switch (c)
         {
         case '{':
             pendingEvent = JsonParser.Event.START_OBJECT;
             pushAndEnter(ParseState.OBJ_AFTER_OPEN);
+            pushPath(false);
             break;
         case '[':
             pendingEvent = JsonParser.Event.START_ARRAY;
             pushAndEnter(ParseState.ARR_AFTER_OPEN);
+            pushPath(true);
             break;
         case '"':
             scratch.setLength(0);
@@ -514,6 +517,10 @@ public final class StreamingJsonTokenizer
         pendingString = takeScratch();
         resumeOp = ResumeOp.NONE;
         state = ParseState.OBJ_AFTER_KEY;
+        if (pathDepth > 0 && !pathInArray[pathDepth - 1])
+        {
+            pathKey[pathDepth - 1] = pendingString;
+        }
     }
 
     private void pushAndEnter(
@@ -556,12 +563,14 @@ public final class StreamingJsonTokenizer
         default:
             throw new JsonParsingException("Unexpected state after value: " + state, null);
         }
+        markValueConsumed();
     }
 
     private void emitEnd(
         JsonParser.Event endEvent)
     {
         pendingEvent = endEvent;
+        popPath();
         if (stack.isEmpty())
         {
             state = ParseState.DOC_DONE;
@@ -570,6 +579,7 @@ public final class StreamingJsonTokenizer
         {
             state = stack.pop();
         }
+        markValueConsumed();
     }
 
     private int skipWhitespace(

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizer.java
@@ -18,6 +18,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 
@@ -101,17 +102,17 @@ public final class StreamingJsonTokenizer
         {
             return List.of();
         }
-        final List<String[]> compiled = new java.util.ArrayList<>(paths.size());
-        for (String s : paths)
+        final List<String[]> compiled = new ArrayList<>(paths.size());
+        for (String path : paths)
         {
-            if (s.isEmpty())
+            if (path.isEmpty())
             {
                 compiled.add(new String[0]);
             }
             else
             {
                 // RFC 6901: leading '/', segments separated by '/', '~1' decodes to '/', '~0' to '~'
-                final String[] parts = s.substring(1).split("/", -1);
+                final String[] parts = path.substring(1).split("/", -1);
                 for (int i = 0; i < parts.length; i++)
                 {
                     parts[i] = parts[i].replace("~1", "/").replace("~0", "~");

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizer.java
@@ -19,7 +19,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.List;
 
+import jakarta.json.JsonPointer;
 import jakarta.json.stream.JsonParser;
 import jakarta.json.stream.JsonParsingException;
 
@@ -52,6 +54,7 @@ public final class StreamingJsonTokenizer
 
     private final Deque<ParseState> stack = new ArrayDeque<>();
     private final StringBuilder scratch = new StringBuilder();
+    private final List<JsonPointer> readablePaths;
 
     private ParseState state = ParseState.DOC_START;
     private JsonParser.Event pendingEvent;
@@ -64,6 +67,17 @@ public final class StreamingJsonTokenizer
     private int resumeUnicodePending;   // hex digits remaining for backslash-u escape
     private int resumeUnicodeValue;
     private int resumeLiteralIndex;     // chars matched so far for true/false/null
+
+    public StreamingJsonTokenizer()
+    {
+        this(List.of());
+    }
+
+    public StreamingJsonTokenizer(
+        List<JsonPointer> readablePaths)
+    {
+        this.readablePaths = readablePaths;
+    }
 
     public boolean advance(
         InputStream in) throws IOException

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizer.java
@@ -374,9 +374,9 @@ public final class StreamingJsonTokenizer
 
     private String takeScratch()
     {
-        String s = scratch.toString();
+        String path = scratch.toString();
         scratch.setLength(0);
-        return s;
+        return path;
     }
 
     private void consumeValue(

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizer.java
@@ -135,9 +135,16 @@ public final class StreamingJsonTokenizer
         pendingEvent = null;
         pendingString = null;
 
-        try
+        while (pendingEvent == null && state != ParseState.DOC_DONE)
         {
-            while (pendingEvent == null && state != ParseState.DOC_DONE)
+            // Snapshot at the start of each iteration. On EOF mid-readable-scalar-scan we rewind
+            // to drop any partial scratch and let the caller retry once more bytes are appended.
+            // For other parse steps (KEY_NAME, structural separators, non-readable values) the
+            // existing internal-resume state carries across frames without needing rewind.
+            final long iterStart = streamOffset;
+            in.mark(tokenMaxBytes == Integer.MAX_VALUE ? Integer.MAX_VALUE : tokenMaxBytes);
+
+            try
             {
                 if (resumeOp != ResumeOp.NONE)
                 {
@@ -148,12 +155,28 @@ public final class StreamingJsonTokenizer
                     advanceOne(in);
                 }
             }
-            return true;
+            catch (EOFException ex)
+            {
+                if (pendingEvent != null)
+                {
+                    return true;
+                }
+                final boolean midReadableScalarScan =
+                    (resumeOp == ResumeOp.VALUE_STRING || resumeOp == ResumeOp.VALUE_NUMBER) && valueReadable;
+                if (midReadableScalarScan)
+                {
+                    in.reset();
+                    streamOffset = iterStart;
+                    scratch.setLength(0);
+                    resumeOp = ResumeOp.NONE;
+                    resumeEscape = false;
+                    resumeUnicodePending = 0;
+                    resumeUnicodeValue = 0;
+                }
+                return false;
+            }
         }
-        catch (EOFException ex)
-        {
-            return pendingEvent != null;
-        }
+        return true;
     }
 
     public JsonParser.Event event()
@@ -794,6 +817,14 @@ public final class StreamingJsonTokenizer
             throw new EOFException();
         }
         streamOffset++;
+        if (valueReadable &&
+            (resumeOp == ResumeOp.VALUE_STRING || resumeOp == ResumeOp.VALUE_NUMBER) &&
+            scratch.length() >= tokenMaxBytes)
+        {
+            throw new JsonParsingException(
+                "value at " + currentPath() + " exceeds max " + tokenMaxBytes + " bytes",
+                null);
+        }
         return c;
     }
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParserFactoryTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParserFactoryTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json.internal;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.stream.JsonParser;
+import jakarta.json.stream.JsonParserFactory;
+
+import org.junit.jupiter.api.Test;
+
+import io.aklivity.zilla.runtime.common.json.StreamingJson;
+
+public class StreamingJsonParserFactoryTest
+{
+    @Test
+    public void shouldCreateParserForInputStreamWithSharedConfig()
+    {
+        final Map<String, Object> config = Map.of(
+            StreamingJson.PATH_INCLUDES, List.of("/jsonrpc"),
+            StreamingJson.TOKEN_MAX_BYTES, 1024);
+        final JsonParserFactory factory = StreamingJson.createParserFactory(config);
+
+        final InputStream in1 = new BufferedInputStream(
+            new ByteArrayInputStream("{\"jsonrpc\":\"2.0\"}".getBytes(UTF_8)));
+        try (JsonParser parser1 = factory.createParser(in1))
+        {
+            assertNotNull(parser1);
+        }
+
+        // factory is reusable
+        final InputStream in2 = new BufferedInputStream(
+            new ByteArrayInputStream("{\"jsonrpc\":\"2.0\"}".getBytes(UTF_8)));
+        try (JsonParser parser2 = factory.createParser(in2))
+        {
+            assertNotNull(parser2);
+        }
+    }
+
+    @Test
+    public void shouldExposeConfigInUse()
+    {
+        final Map<String, Object> config = Map.of(
+            StreamingJson.PATH_INCLUDES, List.of("/jsonrpc"));
+        final JsonParserFactory factory = StreamingJson.createParserFactory(config);
+        assertSame(config, factory.getConfigInUse());
+    }
+
+    @Test
+    public void shouldCreateParserForInputStreamWithCharset()
+    {
+        final JsonParserFactory factory = StreamingJson.createParserFactory(Map.of());
+        final InputStream in = new BufferedInputStream(
+            new ByteArrayInputStream("{}".getBytes(UTF_8)));
+        try (JsonParser parser = factory.createParser(in, UTF_8))
+        {
+            assertEquals(JsonParser.Event.START_OBJECT, parser.next());
+        }
+    }
+
+    @Test
+    public void shouldThrowForReaderSource()
+    {
+        final JsonParserFactory factory = StreamingJson.createParserFactory(Map.of());
+        assertThrows(UnsupportedOperationException.class,
+            () -> factory.createParser(new StringReader("{}")));
+    }
+
+    @Test
+    public void shouldThrowForJsonObjectSource()
+    {
+        final JsonParserFactory factory = StreamingJson.createParserFactory(Map.of());
+        assertThrows(UnsupportedOperationException.class, () -> factory.createParser((JsonObject) null));
+    }
+
+    @Test
+    public void shouldThrowForJsonArraySource()
+    {
+        final JsonParserFactory factory = StreamingJson.createParserFactory(Map.of());
+        assertThrows(UnsupportedOperationException.class, () -> factory.createParser((JsonArray) null));
+    }
+}

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizerPathTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizerPathTest.java
@@ -30,6 +30,7 @@ import jakarta.json.JsonPointer;
 import jakarta.json.JsonStructure;
 import jakarta.json.JsonValue;
 import jakarta.json.stream.JsonParser;
+import jakarta.json.stream.JsonParsingException;
 
 import org.junit.jupiter.api.Test;
 
@@ -244,6 +245,54 @@ class StreamingJsonTokenizerPathTest
         {
             throw new AssertionError("did not reach the non-readable value");
         }
+    }
+
+    @Test
+    void shouldThrowWhenReadableValueExceedsTokenMaxBytes() throws IOException
+    {
+        // Configure PATH_INCLUDES to /payload and TOKEN_MAX_BYTES = 8.
+        // The "payload" string is 20 chars long, so the parser must throw before completing.
+        final List<JsonPointer> includes = List.of(stubPointer("/payload"));
+        final StreamingJsonTokenizer tokenizer =
+            new StreamingJsonTokenizer(includes, List.of(), 8);
+
+        final String json = "{\"payload\":\"abcdefghijklmnopqrst\"}";
+        final InputStream in = new BufferedInputStream(
+            new ByteArrayInputStream(json.getBytes(UTF_8)));
+
+        assertThrows(JsonParsingException.class, () ->
+        {
+            while (tokenizer.advance(in))
+            {
+                tokenizer.clearEvent();
+            }
+        });
+    }
+
+    @Test
+    void shouldNotThrowWhenExcludedValueExceedsTokenMaxBytes() throws IOException
+    {
+        // Same large value but the path is now excluded, so scratch is never populated
+        // and TOKEN_MAX_BYTES does not apply.
+        final List<JsonPointer> excludes = List.of(stubPointer("/payload"));
+        final StreamingJsonTokenizer tokenizer =
+            new StreamingJsonTokenizer(List.of(), excludes, 8);
+
+        final String json = "{\"payload\":\"abcdefghijklmnopqrst\",\"id\":1}";
+        final InputStream in = new BufferedInputStream(
+            new ByteArrayInputStream(json.getBytes(UTF_8)));
+
+        // Walk the entire document without throwing; "id" value should still be readable.
+        Long observedId = null;
+        while (tokenizer.advance(in))
+        {
+            if (tokenizer.event() == JsonParser.Event.VALUE_NUMBER && tokenizer.valueReadable())
+            {
+                observedId = Long.parseLong(tokenizer.stringValue());
+            }
+            tokenizer.clearEvent();
+        }
+        assertEquals(1L, observedId);
     }
 
     @Test

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizerPathTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizerPathTest.java
@@ -26,9 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.json.JsonPointer;
-import jakarta.json.JsonStructure;
-import jakarta.json.JsonValue;
 import jakarta.json.stream.JsonParser;
 import jakarta.json.stream.JsonParsingException;
 
@@ -36,72 +33,51 @@ import org.junit.jupiter.api.Test;
 
 import io.aklivity.zilla.runtime.common.json.StreamingJson;
 
-class StreamingJsonTokenizerPathTest
+public class StreamingJsonTokenizerPathTest
 {
     @Test
-    void shouldTrackPathThroughObjectsAndArrays() throws IOException
+    public void shouldTrackPathThroughObjectsAndArrays() throws IOException
     {
         final String json = "{\"tools\":[{\"name\":\"X\"},{\"name\":\"Y\"}],\"id\":7}";
         final StreamingJsonTokenizer tokenizer = new StreamingJsonTokenizer();
         final InputStream in = new BufferedInputStream(
             new ByteArrayInputStream(json.getBytes(UTF_8)));
 
-        // Capture path observed at each event in the order they fire
         final List<String> pathAtEvent = new ArrayList<>();
         final List<JsonParser.Event> events = new ArrayList<>();
         while (tokenizer.advance(in))
         {
-            // path is recorded immediately after each successful event consumption
             events.add(tokenizer.event());
             pathAtEvent.add(tokenizer.currentPath());
             tokenizer.clearEvent();
         }
 
-        // Sanity check on event sequence
         assertEquals(15, events.size(), "events: " + events);
-
-        // Spot-check key paths:
-        // [0]  START_OBJECT outer  -> "/" (entered outer object; key null)
         assertEquals("/", pathAtEvent.get(0));
-        // [1]  KEY_NAME "tools" -> /tools
         assertEquals("/tools", pathAtEvent.get(1));
-        // [2]  START_ARRAY -> /tools/0 (entered array; index 0)
         assertEquals("/tools/0", pathAtEvent.get(2));
-        // [3]  START_OBJECT item 0 -> /tools/0/ (entered nested object)
         assertEquals("/tools/0/", pathAtEvent.get(3));
-        // [4]  KEY_NAME "name" -> /tools/0/name
         assertEquals("/tools/0/name", pathAtEvent.get(4));
-        // [5]  VALUE_STRING "X" -> still /tools/0/name
         assertEquals("/tools/0/name", pathAtEvent.get(5));
-        // [6]  END_OBJECT closing item 0 -> /tools/1 (popped; index incremented)
         assertEquals("/tools/1", pathAtEvent.get(6));
-        // [7]  START_OBJECT item 1 -> /tools/1/
         assertEquals("/tools/1/", pathAtEvent.get(7));
-        // [8]  KEY_NAME "name"
         assertEquals("/tools/1/name", pathAtEvent.get(8));
-        // [9]  VALUE_STRING "Y"
         assertEquals("/tools/1/name", pathAtEvent.get(9));
-        // [10] END_OBJECT closing item 1 -> /tools/2 (popped; index incremented)
         assertEquals("/tools/2", pathAtEvent.get(10));
-        // [11] END_ARRAY closing tools -> /tools (popped array; outer object's most-recent key remains "tools")
         assertEquals("/tools", pathAtEvent.get(11));
-        // [12] KEY_NAME "id" -> /id
         assertEquals("/id", pathAtEvent.get(12));
-        // [13] VALUE_NUMBER 7 -> still /id
         assertEquals("/id", pathAtEvent.get(13));
-        // [14] END_OBJECT outer -> "" (popped; back at root)
         assertEquals("", pathAtEvent.get(14));
     }
 
     @Test
-    void shouldExposeFullPathForNestedObject() throws IOException
+    public void shouldExposeFullPathForNestedObject() throws IOException
     {
         final String json = "{\"a\":{\"b\":{\"c\":42}}}";
         final StreamingJsonTokenizer tokenizer = new StreamingJsonTokenizer();
         final InputStream in = new BufferedInputStream(
             new ByteArrayInputStream(json.getBytes(UTF_8)));
 
-        // Walk to the VALUE_NUMBER event and check path
         String pathAtNumber = null;
         while (tokenizer.advance(in))
         {
@@ -115,14 +91,14 @@ class StreamingJsonTokenizerPathTest
     }
 
     @Test
-    void shouldCompilePathsAndMatchExpectedValues() throws IOException
+    public void shouldCompilePathsAndMatchExpectedValues() throws IOException
     {
-        final List<JsonPointer> includes = List.of(
-            stubPointer(""),                       // root
-            stubPointer("/tools/-/name"),          // wildcard array index
-            stubPointer("/tools/-/title"));
-        final List<JsonPointer> excludes = List.of(
-            stubPointer("/tools/-/title"));        // excludes win for title
+        final List<String> includes = List.of(
+            "",                       // root
+            "/tools/-/name",          // wildcard array index
+            "/tools/-/title");
+        final List<String> excludes = List.of(
+            "/tools/-/title");        // excludes win for title
 
         final StreamingJsonTokenizer tokenizer =
             new StreamingJsonTokenizer(includes, excludes, 1024);
@@ -131,25 +107,21 @@ class StreamingJsonTokenizerPathTest
         final InputStream in = new BufferedInputStream(
             new ByteArrayInputStream(json.getBytes(UTF_8)));
 
-        // Walk all events; the parser must drive currentPathReadable() at every value
-        // entry, which exercises compilePaths + pathMatchesAny across both lists.
         int eventCount = 0;
         while (tokenizer.advance(in))
         {
             eventCount++;
             tokenizer.clearEvent();
         }
-        // Sanity: parser still emits the same event sequence under config
-        // ({, "tools", [, {, "name", "X", "title", "T", }, {, "name", "Y", }, ], })
         assertEquals(15, eventCount);
     }
 
     @Test
-    void shouldMatchPathSegmentWithEscapedSlashAndTilde() throws IOException
+    public void shouldMatchPathSegmentWithEscapedSlashAndTilde() throws IOException
     {
         // RFC 6901 escapes: "~1" decodes to "/", "~0" decodes to "~"
-        final List<JsonPointer> includes = List.of(
-            stubPointer("/a~1b/c~0d"));            // path of "/a/b" then "c~d"
+        final List<String> includes = List.of(
+            "/a~1b/c~0d");            // path of "/a/b" then "c~d"
 
         final StreamingJsonTokenizer tokenizer =
             new StreamingJsonTokenizer(includes, List.of(), Integer.MAX_VALUE);
@@ -167,15 +139,13 @@ class StreamingJsonTokenizerPathTest
             }
             tokenizer.clearEvent();
         }
-        // currentPath() re-encodes per RFC 6901, so "/" becomes "~1" and "~" becomes "~0"
         assertEquals("/a~1b/c~0d", observedPathAtNumber);
     }
 
     @Test
-    void shouldSuppressScratchForNonReadableValues() throws IOException
+    public void shouldSuppressScratchForNonReadableValues() throws IOException
     {
-        // Only /tools/-/name is readable; everything else is non-readable.
-        final List<JsonPointer> includes = List.of(stubPointer("/tools/-/name"));
+        final List<String> includes = List.of("/tools/-/name");
         final StreamingJsonTokenizer tokenizer =
             new StreamingJsonTokenizer(includes, List.of(), Integer.MAX_VALUE);
 
@@ -183,8 +153,6 @@ class StreamingJsonTokenizerPathTest
         final InputStream in = new BufferedInputStream(
             new ByteArrayInputStream(json.getBytes(UTF_8)));
 
-        // Walk events; stringValue() is non-null only for KEY_NAME (always readable) and
-        // for the readable VALUE_STRING at /tools/0/name.
         final List<String> readableValues = new ArrayList<>();
         final List<JsonParser.Event> nonReadableValueEvents = new ArrayList<>();
         while (tokenizer.advance(in))
@@ -208,32 +176,27 @@ class StreamingJsonTokenizerPathTest
             }
             tokenizer.clearEvent();
         }
-        // Only "X" is readable; "a quite long description" is non-readable
         assertEquals(List.of("X"), readableValues);
         assertEquals(1, nonReadableValueEvents.size());
     }
 
     @Test
-    void shouldThrowFromGetStringForNonReadableValueAtParserLevel() throws IOException
+    public void shouldThrowFromGetStringForNonReadableValueAtParserLevel() throws IOException
     {
-        // Use the parser-level API with PATH_INCLUDES configured so that /tools/-/name is the
-        // only readable value path; everything else throws when getString() is called.
         final String json = "{\"tools\":[{\"name\":\"X\",\"description\":\"a long description\"}]}";
         final BufferedInputStream in = new BufferedInputStream(
             new ByteArrayInputStream(json.getBytes(UTF_8)));
 
         final Map<String, Object> config = Map.of(
-            StreamingJson.PATH_INCLUDES, List.of(stubPointer("/tools/-/name")));
+            StreamingJson.PATH_INCLUDES, List.of("/tools/-/name"));
         final JsonParser parser = StreamingJson.createParser(in, config);
 
-        // Walk to the description value (non-readable) and verify getString throws.
         boolean sawNonReadableValue = false;
         while (parser.hasNext())
         {
             final JsonParser.Event ev = parser.next();
             if (ev == JsonParser.Event.KEY_NAME && "description".equals(parser.getString()))
             {
-                // The next VALUE_STRING event is at /tools/0/description (non-readable).
                 final JsonParser.Event next = parser.next();
                 assertEquals(JsonParser.Event.VALUE_STRING, next);
                 assertThrows(IllegalStateException.class, parser::getString);
@@ -248,11 +211,9 @@ class StreamingJsonTokenizerPathTest
     }
 
     @Test
-    void shouldThrowWhenReadableValueExceedsTokenMaxBytes() throws IOException
+    public void shouldThrowWhenReadableValueExceedsTokenMaxBytes() throws IOException
     {
-        // Configure PATH_INCLUDES to /payload and TOKEN_MAX_BYTES = 8.
-        // The "payload" string is 20 chars long, so the parser must throw before completing.
-        final List<JsonPointer> includes = List.of(stubPointer("/payload"));
+        final List<String> includes = List.of("/payload");
         final StreamingJsonTokenizer tokenizer =
             new StreamingJsonTokenizer(includes, List.of(), 8);
 
@@ -270,11 +231,9 @@ class StreamingJsonTokenizerPathTest
     }
 
     @Test
-    void shouldNotThrowWhenExcludedValueExceedsTokenMaxBytes() throws IOException
+    public void shouldNotThrowWhenExcludedValueExceedsTokenMaxBytes() throws IOException
     {
-        // Same large value but the path is now excluded, so scratch is never populated
-        // and TOKEN_MAX_BYTES does not apply.
-        final List<JsonPointer> excludes = List.of(stubPointer("/payload"));
+        final List<String> excludes = List.of("/payload");
         final StreamingJsonTokenizer tokenizer =
             new StreamingJsonTokenizer(List.of(), excludes, 8);
 
@@ -282,7 +241,6 @@ class StreamingJsonTokenizerPathTest
         final InputStream in = new BufferedInputStream(
             new ByteArrayInputStream(json.getBytes(UTF_8)));
 
-        // Walk the entire document without throwing; "id" value should still be readable.
         Long observedId = null;
         while (tokenizer.advance(in))
         {
@@ -296,7 +254,7 @@ class StreamingJsonTokenizerPathTest
     }
 
     @Test
-    void shouldHandleEmptyConfigAsLegacyBehavior() throws IOException
+    public void shouldHandleEmptyConfigAsLegacyBehavior() throws IOException
     {
         final StreamingJsonTokenizer tokenizer =
             new StreamingJsonTokenizer(List.of(), List.of(), Integer.MAX_VALUE);
@@ -312,60 +270,5 @@ class StreamingJsonTokenizerPathTest
             tokenizer.clearEvent();
         }
         assertEquals(5, events); // [, 1, 2, 3, ]
-    }
-
-    /**
-     * The tokenizer only consults JsonPointer.toString() to compile its match table; we
-     * stub the rest of the interface so tests do not need a JSON-Provider runtime impl
-     * (parsson, joy, etc.) on the test classpath.
-     */
-    private static JsonPointer stubPointer(
-        String s)
-    {
-        return new JsonPointer()
-        {
-            @Override
-            public String toString()
-            {
-                return s;
-            }
-
-            @Override
-            public <T extends JsonStructure> T add(
-                T target,
-                JsonValue value)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public <T extends JsonStructure> T remove(
-                T target)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public <T extends JsonStructure> T replace(
-                T target,
-                JsonValue value)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public boolean containsValue(
-                JsonStructure target)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public JsonValue getValue(
-                JsonStructure target)
-            {
-                throw new UnsupportedOperationException();
-            }
-        };
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizerPathTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizerPathTest.java
@@ -16,6 +16,7 @@ package io.aklivity.zilla.runtime.common.json.internal;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -23,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import jakarta.json.JsonPointer;
 import jakarta.json.JsonStructure;
@@ -30,6 +32,8 @@ import jakarta.json.JsonValue;
 import jakarta.json.stream.JsonParser;
 
 import org.junit.jupiter.api.Test;
+
+import io.aklivity.zilla.runtime.common.json.StreamingJson;
 
 class StreamingJsonTokenizerPathTest
 {
@@ -164,6 +168,82 @@ class StreamingJsonTokenizerPathTest
         }
         // currentPath() re-encodes per RFC 6901, so "/" becomes "~1" and "~" becomes "~0"
         assertEquals("/a~1b/c~0d", observedPathAtNumber);
+    }
+
+    @Test
+    void shouldSuppressScratchForNonReadableValues() throws IOException
+    {
+        // Only /tools/-/name is readable; everything else is non-readable.
+        final List<JsonPointer> includes = List.of(stubPointer("/tools/-/name"));
+        final StreamingJsonTokenizer tokenizer =
+            new StreamingJsonTokenizer(includes, List.of(), Integer.MAX_VALUE);
+
+        final String json = "{\"tools\":[{\"name\":\"X\",\"description\":\"a quite long description\"}]}";
+        final InputStream in = new BufferedInputStream(
+            new ByteArrayInputStream(json.getBytes(UTF_8)));
+
+        // Walk events; stringValue() is non-null only for KEY_NAME (always readable) and
+        // for the readable VALUE_STRING at /tools/0/name.
+        final List<String> readableValues = new ArrayList<>();
+        final List<JsonParser.Event> nonReadableValueEvents = new ArrayList<>();
+        while (tokenizer.advance(in))
+        {
+            final JsonParser.Event ev = tokenizer.event();
+            switch (ev)
+            {
+            case VALUE_STRING:
+            case VALUE_NUMBER:
+                if (tokenizer.valueReadable())
+                {
+                    readableValues.add(tokenizer.stringValue());
+                }
+                else
+                {
+                    nonReadableValueEvents.add(ev);
+                }
+                break;
+            default:
+                break;
+            }
+            tokenizer.clearEvent();
+        }
+        // Only "X" is readable; "a quite long description" is non-readable
+        assertEquals(List.of("X"), readableValues);
+        assertEquals(1, nonReadableValueEvents.size());
+    }
+
+    @Test
+    void shouldThrowFromGetStringForNonReadableValueAtParserLevel() throws IOException
+    {
+        // Use the parser-level API with PATH_INCLUDES configured so that /tools/-/name is the
+        // only readable value path; everything else throws when getString() is called.
+        final String json = "{\"tools\":[{\"name\":\"X\",\"description\":\"a long description\"}]}";
+        final BufferedInputStream in = new BufferedInputStream(
+            new ByteArrayInputStream(json.getBytes(UTF_8)));
+
+        final Map<String, Object> config = Map.of(
+            StreamingJson.PATH_INCLUDES, List.of(stubPointer("/tools/-/name")));
+        final JsonParser parser = StreamingJson.createParser(in, config);
+
+        // Walk to the description value (non-readable) and verify getString throws.
+        boolean sawNonReadableValue = false;
+        while (parser.hasNext())
+        {
+            final JsonParser.Event ev = parser.next();
+            if (ev == JsonParser.Event.KEY_NAME && "description".equals(parser.getString()))
+            {
+                // The next VALUE_STRING event is at /tools/0/description (non-readable).
+                final JsonParser.Event next = parser.next();
+                assertEquals(JsonParser.Event.VALUE_STRING, next);
+                assertThrows(IllegalStateException.class, parser::getString);
+                sawNonReadableValue = true;
+                break;
+            }
+        }
+        if (!sawNonReadableValue)
+        {
+            throw new AssertionError("did not reach the non-readable value");
+        }
     }
 
     @Test

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizerPathTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizerPathTest.java
@@ -24,6 +24,9 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.json.JsonPointer;
+import jakarta.json.JsonStructure;
+import jakarta.json.JsonValue;
 import jakarta.json.stream.JsonParser;
 
 import org.junit.jupiter.api.Test;
@@ -104,5 +107,136 @@ class StreamingJsonTokenizerPathTest
             tokenizer.clearEvent();
         }
         assertEquals("/a/b/c", pathAtNumber);
+    }
+
+    @Test
+    void shouldCompilePathsAndMatchExpectedValues() throws IOException
+    {
+        final List<JsonPointer> includes = List.of(
+            stubPointer(""),                       // root
+            stubPointer("/tools/-/name"),          // wildcard array index
+            stubPointer("/tools/-/title"));
+        final List<JsonPointer> excludes = List.of(
+            stubPointer("/tools/-/title"));        // excludes win for title
+
+        final StreamingJsonTokenizer tokenizer =
+            new StreamingJsonTokenizer(includes, excludes, 1024);
+
+        final String json = "{\"tools\":[{\"name\":\"X\",\"title\":\"T\"},{\"name\":\"Y\"}]}";
+        final InputStream in = new BufferedInputStream(
+            new ByteArrayInputStream(json.getBytes(UTF_8)));
+
+        // Walk all events; the parser must drive currentPathReadable() at every value
+        // entry, which exercises compilePaths + pathMatchesAny across both lists.
+        int eventCount = 0;
+        while (tokenizer.advance(in))
+        {
+            eventCount++;
+            tokenizer.clearEvent();
+        }
+        // Sanity: parser still emits the same event sequence under config
+        // ({, "tools", [, {, "name", "X", "title", "T", }, {, "name", "Y", }, ], })
+        assertEquals(15, eventCount);
+    }
+
+    @Test
+    void shouldMatchPathSegmentWithEscapedSlashAndTilde() throws IOException
+    {
+        // RFC 6901 escapes: "~1" decodes to "/", "~0" decodes to "~"
+        final List<JsonPointer> includes = List.of(
+            stubPointer("/a~1b/c~0d"));            // path of "/a/b" then "c~d"
+
+        final StreamingJsonTokenizer tokenizer =
+            new StreamingJsonTokenizer(includes, List.of(), Integer.MAX_VALUE);
+
+        final String json = "{\"a/b\":{\"c~d\":42}}";
+        final InputStream in = new BufferedInputStream(
+            new ByteArrayInputStream(json.getBytes(UTF_8)));
+
+        String observedPathAtNumber = null;
+        while (tokenizer.advance(in))
+        {
+            if (tokenizer.event() == JsonParser.Event.VALUE_NUMBER)
+            {
+                observedPathAtNumber = tokenizer.currentPath();
+            }
+            tokenizer.clearEvent();
+        }
+        // currentPath() re-encodes per RFC 6901, so "/" becomes "~1" and "~" becomes "~0"
+        assertEquals("/a~1b/c~0d", observedPathAtNumber);
+    }
+
+    @Test
+    void shouldHandleEmptyConfigAsLegacyBehavior() throws IOException
+    {
+        final StreamingJsonTokenizer tokenizer =
+            new StreamingJsonTokenizer(List.of(), List.of(), Integer.MAX_VALUE);
+
+        final String json = "[1,2,3]";
+        final InputStream in = new BufferedInputStream(
+            new ByteArrayInputStream(json.getBytes(UTF_8)));
+
+        int events = 0;
+        while (tokenizer.advance(in))
+        {
+            events++;
+            tokenizer.clearEvent();
+        }
+        assertEquals(5, events); // [, 1, 2, 3, ]
+    }
+
+    /**
+     * The tokenizer only consults JsonPointer.toString() to compile its match table; we
+     * stub the rest of the interface so tests do not need a JSON-Provider runtime impl
+     * (parsson, joy, etc.) on the test classpath.
+     */
+    private static JsonPointer stubPointer(
+        String s)
+    {
+        return new JsonPointer()
+        {
+            @Override
+            public String toString()
+            {
+                return s;
+            }
+
+            @Override
+            public <T extends JsonStructure> T add(
+                T target,
+                JsonValue value)
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <T extends JsonStructure> T remove(
+                T target)
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <T extends JsonStructure> T replace(
+                T target,
+                JsonValue value)
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean containsValue(
+                JsonStructure target)
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public JsonValue getValue(
+                JsonStructure target)
+            {
+                throw new UnsupportedOperationException();
+            }
+        };
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizerPathTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizerPathTest.java
@@ -189,7 +189,7 @@ public class StreamingJsonTokenizerPathTest
 
         final Map<String, Object> config = Map.of(
             StreamingJson.PATH_INCLUDES, List.of("/tools/-/name"));
-        final JsonParser parser = StreamingJson.createParser(in, config);
+        final JsonParser parser = StreamingJson.createParserFactory(config).createParser(in);
 
         boolean sawNonReadableValue = false;
         while (parser.hasNext())

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizerPathTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizerPathTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json.internal;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.json.stream.JsonParser;
+
+import org.junit.jupiter.api.Test;
+
+class StreamingJsonTokenizerPathTest
+{
+    @Test
+    void shouldTrackPathThroughObjectsAndArrays() throws IOException
+    {
+        final String json = "{\"tools\":[{\"name\":\"X\"},{\"name\":\"Y\"}],\"id\":7}";
+        final StreamingJsonTokenizer tokenizer = new StreamingJsonTokenizer();
+        final InputStream in = new BufferedInputStream(
+            new ByteArrayInputStream(json.getBytes(UTF_8)));
+
+        // Capture path observed at each event in the order they fire
+        final List<String> pathAtEvent = new ArrayList<>();
+        final List<JsonParser.Event> events = new ArrayList<>();
+        while (tokenizer.advance(in))
+        {
+            // path is recorded immediately after each successful event consumption
+            events.add(tokenizer.event());
+            pathAtEvent.add(tokenizer.currentPath());
+            tokenizer.clearEvent();
+        }
+
+        // Sanity check on event sequence
+        assertEquals(15, events.size(), "events: " + events);
+
+        // Spot-check key paths:
+        // [0]  START_OBJECT outer  -> "/" (entered outer object; key null)
+        assertEquals("/", pathAtEvent.get(0));
+        // [1]  KEY_NAME "tools" -> /tools
+        assertEquals("/tools", pathAtEvent.get(1));
+        // [2]  START_ARRAY -> /tools/0 (entered array; index 0)
+        assertEquals("/tools/0", pathAtEvent.get(2));
+        // [3]  START_OBJECT item 0 -> /tools/0/ (entered nested object)
+        assertEquals("/tools/0/", pathAtEvent.get(3));
+        // [4]  KEY_NAME "name" -> /tools/0/name
+        assertEquals("/tools/0/name", pathAtEvent.get(4));
+        // [5]  VALUE_STRING "X" -> still /tools/0/name
+        assertEquals("/tools/0/name", pathAtEvent.get(5));
+        // [6]  END_OBJECT closing item 0 -> /tools/1 (popped; index incremented)
+        assertEquals("/tools/1", pathAtEvent.get(6));
+        // [7]  START_OBJECT item 1 -> /tools/1/
+        assertEquals("/tools/1/", pathAtEvent.get(7));
+        // [8]  KEY_NAME "name"
+        assertEquals("/tools/1/name", pathAtEvent.get(8));
+        // [9]  VALUE_STRING "Y"
+        assertEquals("/tools/1/name", pathAtEvent.get(9));
+        // [10] END_OBJECT closing item 1 -> /tools/2 (popped; index incremented)
+        assertEquals("/tools/2", pathAtEvent.get(10));
+        // [11] END_ARRAY closing tools -> /tools (popped array; outer object's most-recent key remains "tools")
+        assertEquals("/tools", pathAtEvent.get(11));
+        // [12] KEY_NAME "id" -> /id
+        assertEquals("/id", pathAtEvent.get(12));
+        // [13] VALUE_NUMBER 7 -> still /id
+        assertEquals("/id", pathAtEvent.get(13));
+        // [14] END_OBJECT outer -> "" (popped; back at root)
+        assertEquals("", pathAtEvent.get(14));
+    }
+
+    @Test
+    void shouldExposeFullPathForNestedObject() throws IOException
+    {
+        final String json = "{\"a\":{\"b\":{\"c\":42}}}";
+        final StreamingJsonTokenizer tokenizer = new StreamingJsonTokenizer();
+        final InputStream in = new BufferedInputStream(
+            new ByteArrayInputStream(json.getBytes(UTF_8)));
+
+        // Walk to the VALUE_NUMBER event and check path
+        String pathAtNumber = null;
+        while (tokenizer.advance(in))
+        {
+            if (tokenizer.event() == JsonParser.Event.VALUE_NUMBER)
+            {
+                pathAtNumber = tokenizer.currentPath();
+            }
+            tokenizer.clearEvent();
+        }
+        assertEquals("/a/b/c", pathAtNumber);
+    }
+}

--- a/specs/binding-mcp.spec/src/main/java/io/aklivity/zilla/specs/binding/mcp/internal/McpFunctions.java
+++ b/specs/binding-mcp.spec/src/main/java/io/aklivity/zilla/specs/binding/mcp/internal/McpFunctions.java
@@ -111,6 +111,7 @@ public final class McpFunctions
         public final class McpLifecycleBeginExBuilder
         {
             private String sessionId;
+            private int capabilities;
 
             public McpLifecycleBeginExBuilder sessionId(
                 String sessionId)
@@ -119,9 +120,16 @@ public final class McpFunctions
                 return this;
             }
 
+            public McpLifecycleBeginExBuilder capabilities(
+                int capabilities)
+            {
+                this.capabilities = capabilities;
+                return this;
+            }
+
             public McpBeginExBuilder build()
             {
-                beginExRW.lifecycle(b -> b.sessionId(sessionId));
+                beginExRW.lifecycle(b -> b.sessionId(sessionId).capabilities(capabilities));
                 return McpBeginExBuilder.this;
             }
         }
@@ -380,11 +388,19 @@ public final class McpFunctions
         public final class McpLifecycleBeginExMatcherBuilder
         {
             private String16FW sessionId;
+            private Integer capabilities;
 
             public McpLifecycleBeginExMatcherBuilder sessionId(
                 String sessionId)
             {
                 this.sessionId = new String16FW(sessionId);
+                return this;
+            }
+
+            public McpLifecycleBeginExMatcherBuilder capabilities(
+                int capabilities)
+            {
+                this.capabilities = capabilities;
                 return this;
             }
 
@@ -397,13 +413,19 @@ public final class McpFunctions
                 McpBeginExFW beginEx)
             {
                 final McpLifecycleBeginExFW lifecycle = beginEx.lifecycle();
-                return matchSessionId(lifecycle);
+                return matchSessionId(lifecycle) && matchCapabilities(lifecycle);
             }
 
             private boolean matchSessionId(
                 McpLifecycleBeginExFW lifecycle)
             {
                 return sessionId == null || sessionId.equals(lifecycle.sessionId());
+            }
+
+            private boolean matchCapabilities(
+                McpLifecycleBeginExFW lifecycle)
+            {
+                return capabilities == null || capabilities == lifecycle.capabilities();
             }
         }
 

--- a/specs/binding-mcp.spec/src/main/resources/META-INF/zilla/mcp.idl
+++ b/specs/binding-mcp.spec/src/main/resources/META-INF/zilla/mcp.idl
@@ -14,6 +14,16 @@
  */
 scope mcp
 {
+    enum McpCapabilities (uint8)
+    {
+        SERVER_TOOLS(1),
+        SERVER_PROMPTS(2),
+        SERVER_RESOURCES(4),
+        CLIENT_ROOTS(8),
+        CLIENT_SAMPLING(16),
+        CLIENT_ELICITATION(32)
+    }
+
     scope stream
     {
         union McpBeginEx switch (uint8) extends core::stream::Extension
@@ -30,6 +40,7 @@ scope mcp
         struct McpLifecycleBeginEx
         {
             string16 sessionId;
+            uint8 capabilities = 0;
         }
 
         struct McpToolsListBeginEx

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.toolkit.multi.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.toolkit.multi.yaml
@@ -25,4 +25,4 @@ bindings:
           - toolkit: bluesky
       - exit: app2
         when:
-          - toolkit: openai
+          - toolkit: quartz

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.toolkit.multi.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.toolkit.multi.yaml
@@ -1,0 +1,28 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    routes:
+      - exit: app1
+        when:
+          - toolkit: bluesky
+      - exit: app2
+        when:
+          - toolkit: openai

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.toolkit.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.toolkit.yaml
@@ -22,4 +22,4 @@ bindings:
     routes:
       - exit: app1
         when:
-          - toolkit: github
+          - toolkit: bluesky

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.toolkit.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.toolkit.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    routes:
+      - exit: app1
+        when:
+          - toolkit: github

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    routes:
+      - exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/mcp.schema.patch.json
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/mcp.schema.patch.json
@@ -88,8 +88,14 @@
                                             "capability":
                                             {
                                                 "title": "Capability",
-                                                "type": "string",
-                                                "enum": [ "tools", "prompts", "resources" ]
+                                                "type": "array",
+                                                "items":
+                                                {
+                                                    "type": "string",
+                                                    "enum": [ "tools", "prompts", "resources" ]
+                                                },
+                                                "minItems": 1,
+                                                "uniqueItems": true
                                             }
                                         },
                                         "additionalProperties": false

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/mcp.schema.patch.json
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/mcp.schema.patch.json
@@ -29,7 +29,7 @@
                     },
                     "kind":
                     {
-                        "enum": [ "server", "client" ]
+                        "enum": [ "server", "client", "proxy" ]
                     },
                     "options":
                     {
@@ -80,11 +80,16 @@
                                         "type": "object",
                                         "properties":
                                         {
-                                            "kind":
+                                            "toolkit":
                                             {
-                                                "title": "Stream Kind",
+                                                "title": "Toolkit",
+                                                "type": "string"
+                                            },
+                                            "capability":
+                                            {
+                                                "title": "Capability",
                                                 "type": "string",
-                                                "enum": [ "server", "proxy", "client", "callback" ]
+                                                "enum": [ "tools", "prompts", "resources" ]
                                             }
                                         },
                                         "additionalProperties": false

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.requests/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.requests/server.rpt
@@ -13,7 +13,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app0"
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown/server.rpt
@@ -13,7 +13,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app0"
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.aborted/server.rpt
@@ -13,7 +13,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app0"
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/client.rpt
@@ -1,0 +1,57 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .promptsGet()
+                               .sessionId("session-1")
+                               .name("bluesky__weather_prompt")
+                               .build()
+                           .build()}
+
+connected
+
+write '{"name":"bluesky__weather_prompt"}'
+write close
+
+read  '{"messages":[{"role":"user","content":{"type":"text","text":"What is the weather like today?"}}]}'
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/server.rpt
@@ -13,10 +13,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-property serverAddress "zilla://streams/app0"
-property promptName "bluesky__weather_prompt"
-
-accept ${serverAddress}
+accept "zilla://streams/app1"
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 
@@ -45,7 +42,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsGet()
                               .sessionId("session-1")
-                              .name(promptName)
+                              .name("weather_prompt")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/server.rpt
@@ -1,0 +1,62 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+property promptName "bluesky__weather_prompt"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .promptsGet()
+                              .sessionId("session-1")
+                              .name(promptName)
+                              .build()
+                          .build()}
+
+connected
+
+read  '{"name":"bluesky__weather_prompt"}'
+read closed
+
+write flush
+
+write '{"messages":[{"role":"user","content":{"type":"text","text":"What is the weather like today?"}}]}'
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get/server.rpt
@@ -13,7 +13,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app0"
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.aborted/server.rpt
@@ -13,7 +13,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app0"
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/client.rpt
@@ -1,0 +1,60 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .promptsList()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+write close
+
+read  '{"prompts":'
+        '['
+          '{"name":"bluesky__weather_prompt"},'
+          '{"name":"openai__generate_text"}'
+        ']'
+      '}'
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/client.rpt
@@ -54,7 +54,7 @@ write close
 read  '{"prompts":'
         '['
           '{"name":"bluesky__weather_prompt"},'
-          '{"name":"openai__generate_text"}'
+          '{"name":"quartz__current_time_prompt"}'
         ']'
       '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/server.rpt
@@ -1,0 +1,101 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/app1"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .promptsList()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+read closed
+
+write '{"prompts":[{"name":"weather_prompt"}]}'
+write flush
+
+write close
+
+
+accept "zilla://streams/app2"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .promptsList()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+read closed
+
+write '{"prompts":[{"name":"generate_text"}]}'
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/server.rpt
@@ -95,7 +95,7 @@ write flush
 
 read closed
 
-write '{"prompts":[{"name":"generate_text"}]}'
+write '{"prompts":[{"name":"current_time_prompt"}]}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/client.rpt
@@ -1,0 +1,62 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .promptsList()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+write close
+
+read  '{"prompts":'
+        '['
+          '{'
+            '"name":"bluesky__weather_prompt",'
+            '"description":"Ask about weather"'
+          '}'
+        ']'
+      '}'
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/server.rpt
@@ -1,0 +1,60 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+property promptsListReply "{\"prompts\":[{\"name\":\"bluesky__weather_prompt\",\"description\":\"Ask about weather\"}]}"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .promptsList()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+read closed
+
+write ${promptsListReply}
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/server.rpt
@@ -13,10 +13,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-property serverAddress "zilla://streams/app0"
-property promptsListReply "{\"prompts\":[{\"name\":\"bluesky__weather_prompt\",\"description\":\"Ask about weather\"}]}"
-
-accept ${serverAddress}
+accept "zilla://streams/app1"
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 
@@ -54,7 +51,7 @@ write flush
 
 read closed
 
-write ${promptsListReply}
+write '{"prompts":[{"name":"weather_prompt","description":"Ask about weather"}]}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list/server.rpt
@@ -13,7 +13,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app0"
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.aborted/server.rpt
@@ -13,7 +13,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app0"
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/client.rpt
@@ -54,7 +54,7 @@ write close
 read  '{"resources":'
         '['
           '{"uri":"bluesky+file:///data/readme.txt"},'
-          '{"uri":"openai+file:///data/notes.txt"}'
+          '{"uri":"quartz+file:///data/timezones.txt"}'
         ']'
       '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/client.rpt
@@ -1,0 +1,60 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .resourcesList()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+write close
+
+read  '{"resources":'
+        '['
+          '{"uri":"bluesky+file:///data/readme.txt"},'
+          '{"uri":"openai+file:///data/notes.txt"}'
+        ']'
+      '}'
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/server.rpt
@@ -95,7 +95,7 @@ write flush
 
 read closed
 
-write '{"resources":[{"uri":"file:///data/notes.txt"}]}'
+write '{"resources":[{"uri":"file:///data/timezones.txt"}]}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/server.rpt
@@ -1,0 +1,101 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/app1"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .resourcesList()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+read closed
+
+write '{"resources":[{"uri":"file:///data/readme.txt"}]}'
+write flush
+
+write close
+
+
+accept "zilla://streams/app2"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .resourcesList()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+read closed
+
+write '{"resources":[{"uri":"file:///data/notes.txt"}]}'
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/client.rpt
@@ -1,0 +1,62 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .resourcesList()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+write close
+
+read  '{"resources":'
+        '['
+          '{'
+            '"uri":"bluesky+file:///data/readme.txt",'
+            '"mimeType":"text/plain"'
+          '}'
+        ']'
+      '}'
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/server.rpt
@@ -1,0 +1,60 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+property resourcesListReply "{\"resources\":[{\"uri\":\"bluesky+file:///data/readme.txt\",\"mimeType\":\"text/plain\"}]}"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .resourcesList()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+read closed
+
+write ${resourcesListReply}
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/server.rpt
@@ -13,10 +13,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-property serverAddress "zilla://streams/app0"
-property resourcesListReply "{\"resources\":[{\"uri\":\"bluesky+file:///data/readme.txt\",\"mimeType\":\"text/plain\"}]}"
-
-accept ${serverAddress}
+accept "zilla://streams/app1"
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 
@@ -54,7 +51,7 @@ write flush
 
 read closed
 
-write ${resourcesListReply}
+write '{"resources":[{"uri":"file:///data/readme.txt","mimeType":"text/plain"}]}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list/server.rpt
@@ -13,7 +13,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app0"
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k/server.rpt
@@ -13,7 +13,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app0"
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k/server.rpt
@@ -13,7 +13,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app0"
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.aborted/server.rpt
@@ -13,7 +13,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app0"
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/client.rpt
@@ -1,0 +1,57 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .resourcesRead()
+                               .sessionId("session-1")
+                               .uri("bluesky+file:///data/readme.txt")
+                               .build()
+                           .build()}
+
+connected
+
+write '{"uri":"bluesky+file:///data/readme.txt"}'
+write close
+
+read  '{"contents":[{"uri":"file:///data/readme.txt","mimeType":"text/plain","text":"Hello World"}]}'
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/server.rpt
@@ -1,0 +1,62 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+property resourceUri "bluesky+file:///data/readme.txt"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .resourcesRead()
+                              .sessionId("session-1")
+                              .uri(resourceUri)
+                              .build()
+                          .build()}
+
+connected
+
+read  '{"uri":"bluesky+file:///data/readme.txt"}'
+read closed
+
+write flush
+
+write '{"contents":[{"uri":"file:///data/readme.txt","mimeType":"text/plain","text":"Hello World"}]}'
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/server.rpt
@@ -13,10 +13,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-property serverAddress "zilla://streams/app0"
-property resourceUri "bluesky+file:///data/readme.txt"
-
-accept ${serverAddress}
+accept "zilla://streams/app1"
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 
@@ -45,7 +42,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesRead()
                               .sessionId("session-1")
-                              .uri(resourceUri)
+                              .uri("file:///data/readme.txt")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read/server.rpt
@@ -13,7 +13,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app0"
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k/server.rpt
@@ -13,7 +13,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app0"
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k/server.rpt
@@ -13,7 +13,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app0"
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.aborted/server.rpt
@@ -13,7 +13,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app0"
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/client.rpt
@@ -1,0 +1,72 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsCall()
+                               .sessionId("session-1")
+                               .name("github__get_weather")
+                               .build()
+                           .build()}
+
+connected
+
+write '{'
+        '"name":"github__get_weather",'
+        '"arguments":'
+        '{'
+          '"location": "New York"'
+        '}'
+      '}'
+write close
+
+read  '{'
+        '"content":'
+        '['
+          '{'
+            '"type": "text",'
+            '"text": "Current weather in New York:\\nTemperature: 72°F\\nConditions: Partly cloudy"'
+          '}'
+        '],'
+        '"isError": false'
+      '}'
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/client.rpt
@@ -44,14 +44,14 @@ write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
                                .sessionId("session-1")
-                               .name("github__get_weather")
+                               .name("bluesky__get_weather")
                                .build()
                            .build()}
 
 connected
 
 write '{'
-        '"name":"github__get_weather",'
+        '"name":"bluesky__get_weather",'
         '"arguments":'
         '{'
           '"location": "New York"'

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/server.rpt
@@ -1,0 +1,76 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsCall()
+                              .sessionId("session-1")
+                              .name("get_weather")
+                              .build()
+                          .build()}
+
+connected
+
+read  '{'
+        '"name":"github__get_weather",'
+        '"arguments":'
+        '{'
+          '"location": "New York"'
+        '}'
+      '}'
+read closed
+
+write flush
+
+write '{'
+        '"content":'
+        '['
+          '{'
+            '"type": "text",'
+            '"text": "Current weather in New York:\\nTemperature: 72°F\\nConditions: Partly cloudy"'
+          '}'
+        '],'
+        '"isError": false'
+      '}'
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/server.rpt
@@ -14,6 +14,7 @@
 #
 
 property serverAddress "zilla://streams/app0"
+property toolName "bluesky__get_weather"
 
 accept ${serverAddress}
        option zilla:window 8192
@@ -44,14 +45,14 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
                               .sessionId("session-1")
-                              .name("get_weather")
+                              .name(toolName)
                               .build()
                           .build()}
 
 connected
 
 read  '{'
-        '"name":"github__get_weather",'
+        '"name":"bluesky__get_weather",'
         '"arguments":'
         '{'
           '"location": "New York"'

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/server.rpt
@@ -13,10 +13,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-property serverAddress "zilla://streams/app0"
-property toolName "bluesky__get_weather"
-
-accept ${serverAddress}
+accept "zilla://streams/app1"
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 
@@ -45,7 +42,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
                               .sessionId("session-1")
-                              .name(toolName)
+                              .name("get_weather")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call/server.rpt
@@ -13,7 +13,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app0"
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.aborted/server.rpt
@@ -13,7 +13,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app0"
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.canceled/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.canceled/server.rpt
@@ -13,7 +13,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app0"
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/client.rpt
@@ -54,7 +54,7 @@ write close
 read  '{"tools":'
         '['
           '{"name":"bluesky__get_weather"},'
-          '{"name":"openai__complete"}'
+          '{"name":"quartz__get_current_time"}'
         ']'
       '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/client.rpt
@@ -1,0 +1,60 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+write close
+
+read  '{"tools":'
+        '['
+          '{"name":"bluesky__get_weather"},'
+          '{"name":"openai__complete"}'
+        ']'
+      '}'
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/server.rpt
@@ -95,7 +95,7 @@ write flush
 
 read closed
 
-write '{"tools":[{"name":"complete"}]}'
+write '{"tools":[{"name":"get_current_time"}]}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/server.rpt
@@ -1,0 +1,101 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/app1"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+read closed
+
+write '{"tools":[{"name":"get_weather"}]}'
+write flush
+
+write close
+
+
+accept "zilla://streams/app2"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+read closed
+
+write '{"tools":[{"name":"complete"}]}'
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/client.rpt
@@ -1,0 +1,62 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+write close
+
+read  '{"tools":'
+        '['
+          '{'
+            '"name":"bluesky__get_weather",'
+            '"title":"Weather Information Provider"'
+          '}'
+        ']'
+      '}'
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/server.rpt
@@ -1,0 +1,60 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+property toolsListReply "{\"tools\":[{\"name\":\"bluesky__get_weather\",\"title\":\"Weather Information Provider\"}]}"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+read closed
+
+write ${toolsListReply}
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/server.rpt
@@ -13,10 +13,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-property serverAddress "zilla://streams/app0"
-property toolsListReply "{\"tools\":[{\"name\":\"bluesky__get_weather\",\"title\":\"Weather Information Provider\"}]}"
-
-accept ${serverAddress}
+accept "zilla://streams/app1"
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 
@@ -54,7 +51,7 @@ write flush
 
 read closed
 
-write ${toolsListReply}
+write '{"tools":[{"name":"get_weather","title":"Weather Information Provider"}]}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list/server.rpt
@@ -13,7 +13,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app0"
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
@@ -155,60 +155,6 @@ public class ApplicationIT
 
     @Test
     @Specification({
-        "${app}/tools.call.toolkit/client",
-        "${app}/tools.call.toolkit/server"})
-    public void shouldCallToolWithToolkit() throws Exception
-    {
-        k3po.finish();
-    }
-
-    @Test
-    @Specification({
-        "${app}/prompts.get.toolkit/client",
-        "${app}/prompts.get.toolkit/server"})
-    public void shouldGetPromptWithToolkit() throws Exception
-    {
-        k3po.finish();
-    }
-
-    @Test
-    @Specification({
-        "${app}/resources.read.toolkit/client",
-        "${app}/resources.read.toolkit/server"})
-    public void shouldReadResourceWithToolkit() throws Exception
-    {
-        k3po.finish();
-    }
-
-    @Test
-    @Specification({
-        "${app}/tools.list.toolkit/client",
-        "${app}/tools.list.toolkit/server"})
-    public void shouldListToolsWithToolkit() throws Exception
-    {
-        k3po.finish();
-    }
-
-    @Test
-    @Specification({
-        "${app}/prompts.list.toolkit/client",
-        "${app}/prompts.list.toolkit/server"})
-    public void shouldListPromptsWithToolkit() throws Exception
-    {
-        k3po.finish();
-    }
-
-    @Test
-    @Specification({
-        "${app}/resources.list.toolkit/client",
-        "${app}/resources.list.toolkit/server"})
-    public void shouldListResourcesWithToolkit() throws Exception
-    {
-        k3po.finish();
-    }
-
-    @Test
-    @Specification({
         "${app}/tools.list/client",
         "${app}/tools.list/server"})
     public void shouldListTools() throws Exception

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
@@ -155,6 +155,15 @@ public class ApplicationIT
 
     @Test
     @Specification({
+        "${app}/tools.call.toolkit/client",
+        "${app}/tools.call.toolkit/server"})
+    public void shouldCallToolWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/tools.list/client",
         "${app}/tools.list/server"})
     public void shouldListTools() throws Exception

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
@@ -182,6 +182,33 @@ public class ApplicationIT
 
     @Test
     @Specification({
+        "${app}/tools.list.toolkit/client",
+        "${app}/tools.list.toolkit/server"})
+    public void shouldListToolsWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/prompts.list.toolkit/client",
+        "${app}/prompts.list.toolkit/server"})
+    public void shouldListPromptsWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/resources.list.toolkit/client",
+        "${app}/resources.list.toolkit/server"})
+    public void shouldListResourcesWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/tools.list/client",
         "${app}/tools.list/server"})
     public void shouldListTools() throws Exception

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
@@ -164,6 +164,24 @@ public class ApplicationIT
 
     @Test
     @Specification({
+        "${app}/prompts.get.toolkit/client",
+        "${app}/prompts.get.toolkit/server"})
+    public void shouldGetPromptWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/resources.read.toolkit/client",
+        "${app}/resources.read.toolkit/server"})
+    public void shouldReadResourceWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/tools.list/client",
         "${app}/tools.list/server"})
     public void shouldListTools() throws Exception


### PR DESCRIPTION
## Summary

- Add `McpProxyFactory` implementing the `mcp · proxy` binding kind in `runtime/binding-mcp`
- USe `McpState` utility class for bit-flag state machine (initial/reply open/closed tracking)
- Register `PROXY` kind in `McpBindingContext` alongside existing `SERVER` kind
- Extend `McpConditionConfig`, `McpConditionConfigBuilder`, `McpConditionConfigAdapter` with `toolkit` and `capability` fields for route matching
- Add `resolveRoutes(toolkit, capability)` to `McpBindingConfig` and `matches(toolkit, capability)` predicate to `McpRouteConfig`
- Add stub `pom.xml` files for `binding-mcp.spec`, `binding-mcp-http.spec`, `binding-mcp-openapi.spec`, `binding-mcp-http`, and `binding-mcp-openapi` modules referenced by parent poms

## Architecture

Follows the cross-protocol proxy pattern from CLAUDE.md:
- `McpProxyFactory` holds all `*RO`/`*RW` flyweight fields as non-static factory fields
- `McpServer` inner class handles the inbound MCP side (`onServerMessage`)
- `McpClient` inner class handles the outbound MCP side (`onClientMessage`)
- Bidirectional pass-through: DATA frames forwarded in both directions, END/ABORT/RESET propagated with safety guards using `McpProxyState`

## Test plan

- [ ] Build with `./mvnw install -pl runtime/binding-mcp -am -DskipTests -DskipITs`
- [ ] Verify `kind: proxy` accepted in `zilla.yaml` with toolkit/capability route conditions
- [ ] Verify MCP stream pass-through from server side to client side
- [ ] Verify orderly close propagation (END in both directions)
- [ ] Verify abortive close propagation (ABORT/RESET)
- [ ] Verify flow control (WINDOW credit) forwarded in both directions

Closes #1669

https://claude.ai/code/session_0174raBeXFTgt98bp4DTyRDm