### PR TITLE
feat(binding-http): derive ProxyBeginEx from :authority for stream-driven routing

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -22,6 +22,7 @@ import static io.aklivity.zilla.runtime.binding.http.internal.hpack.HpackContext
 import static io.aklivity.zilla.runtime.binding.http.internal.hpack.HpackHeaderFieldFW.HeaderFieldType.UNKNOWN;
 import static io.aklivity.zilla.runtime.binding.http.internal.hpack.HpackLiteralHeaderFieldFW.LiteralType.INCREMENTAL_INDEXING;
 import static io.aklivity.zilla.runtime.binding.http.internal.hpack.HpackLiteralHeaderFieldFW.LiteralType.WITHOUT_INDEXING;
+import static io.aklivity.zilla.runtime.binding.http.internal.types.ProxyAddressProtocol.STREAM;
 import static io.aklivity.zilla.runtime.binding.http.internal.util.BufferUtil.limitOfBytes;
 import static io.aklivity.zilla.runtime.engine.budget.BudgetCreditor.NO_CREDITOR_INDEX;
 import static io.aklivity.zilla.runtime.engine.budget.BudgetDebitor.NO_DEBITOR_INDEX;
@@ -151,6 +152,7 @@ public final class HttpClientFactory implements HttpStreamFactory
 
     private final ExtensionFW extensionRO = new ExtensionFW();
     private final ProxyBeginExFW beginProxyExRO = new ProxyBeginExFW();
+    private final ProxyBeginExFW.Builder proxyBeginExRW = new ProxyBeginExFW.Builder();
     private static final Array32FW<HttpHeaderFW> HEADERS_431_REQUEST_TOO_LARGE =
             new Array32FW.Builder<>(new HttpHeaderFW.Builder(), new HttpHeaderFW())
                     .wrap(new UnsafeBuffer(new byte[64]), 0, 64)
@@ -173,6 +175,7 @@ public final class HttpClientFactory implements HttpStreamFactory
     private static final String SCHEME = ":scheme";
     private static final String CACHE_CONTROL = "cache-control";
     private static final String8FW HEADER_AUTHORITY = new String8FW(":authority");
+    private static final String8FW HEADER_SCHEME = new String8FW(":scheme");
     private static final String8FW HEADER_USER_AGENT = new String8FW("user-agent");
     private static final String8FW HEADER_CONNECTION = new String8FW("connection");
     private static final String8FW HEADER_CONTENT_LENGTH = new String8FW("content-length");
@@ -2606,14 +2609,67 @@ public final class HttpClientFactory implements HttpStreamFactory
         private void doNetworkBegin(
             long traceId,
             long authorization,
-            long affinity)
+            long affinity,
+            String authority,
+            String scheme)
         {
             if (!HttpState.initialOpening(state))
             {
                 state = HttpState.openingInitial(state);
 
+                final Flyweight extension;
+
+                if (authority != null && !authority.isEmpty())
+                {
+                    final String host;
+                    final int port;
+
+                    if (authority.startsWith("["))
+                    {
+                        final int closeBracket = authority.indexOf(']');
+                        if (closeBracket != -1 && closeBracket + 1 < authority.length() && authority.charAt(closeBracket + 1) == ':')
+                        {
+                            host = authority.substring(1, closeBracket);
+                            port = parseInt(authority.substring(closeBracket + 2));
+                        }
+                        else
+                        {
+                            host = closeBracket != -1 ? authority.substring(1, closeBracket) : authority;
+                            port = "https".equals(scheme) ? 443 : 80;
+                        }
+                    }
+                    else
+                    {
+                        final int colon = authority.lastIndexOf(':');
+                        if (colon != -1)
+                        {
+                            host = authority.substring(0, colon);
+                            port = parseInt(authority.substring(colon + 1));
+                        }
+                        else
+                        {
+                            host = authority;
+                            port = "https".equals(scheme) ? 443 : 80;
+                        }
+                    }
+
+                    extension = proxyBeginExRW.wrap(extBuffer, 0, extBuffer.capacity())
+                        .typeId(proxyTypeId)
+                        .address(a -> a.inet(i -> i.protocol(p -> p.set(STREAM))
+                                                   .source("0.0.0.0")
+                                                   .destination(host)
+                                                   .sourcePort(0)
+                                                   .destinationPort(port)))
+                        .infos(ii -> ii.item(i -> i.authority(authority)))
+                        .build();
+                }
+                else
+                {
+                    extension = EMPTY_OCTETS;
+                }
+
                 network = newStream(this::onNetwork, originId, routedId, initialId, initialSeq, initialAck,
-                    initialMax, traceId, authorization, affinity, EMPTY_OCTETS);
+                    initialMax, traceId, authorization, affinity, extension);
             }
         }
 
@@ -4636,7 +4692,15 @@ public final class HttpClientFactory implements HttpStreamFactory
                 requestContentLength = contentLengthHeader != null ? parseInt(contentLengthHeader.value().asString()) :
                     isBodilessMethod ? 0 : NO_CONTENT_LENGTH;
 
-                client.doNetworkBegin(traceId, authorization, 0);
+                final HttpHeaderFW authorityHeader = headers.matchFirst(header ->
+                    HEADER_AUTHORITY.equals(header.name()));
+                final HttpHeaderFW schemeHeader = headers.matchFirst(header ->
+                    HEADER_SCHEME.equals(header.name()));
+
+                final String authority = authorityHeader != null ? authorityHeader.value().asString() : null;
+                final String scheme = schemeHeader != null ? schemeHeader.value().asString() : null;
+
+                client.doNetworkBegin(traceId, authorization, 0, authority, scheme);
 
                 if (HttpState.replyOpened(client.state))
                 {

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -2632,7 +2632,7 @@ public final class HttpClientFactory implements HttpStreamFactory
                                                    .destination(host)
                                                    .sourcePort(0)
                                                    .destinationPort(port)))
-                        .infos(ii -> ii.item(i -> i.authority(authority)))
+                        .infos(ii -> ii.item(i -> i.authority(host)))
                         .build();
                 }
                 else

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -129,6 +129,7 @@ public final class HttpClientFactory implements HttpStreamFactory
     private static final Pattern VERSION_PATTERN = Pattern.compile("HTTP/1\\.\\d");
     private static final Pattern HEADER_LINE_PATTERN = Pattern.compile("(?<name>[^\\s:]+):\\s*(?<value>[^\r\n]*)\r\n");
     private static final Pattern CONNECTION_CLOSE_PATTERN = Pattern.compile("(^|\\s*,\\s*)close(\\s*,\\s*|$)");
+    private static final Pattern AUTHORITY_PATTERN = Pattern.compile("(?<host>[^:]+):(?<port>\\d+)");
     private static final Map<String, String> EMPTY_HEADERS = Collections.emptyMap();
 
     private static final byte[] HOST_BYTES = "Host".getBytes(US_ASCII);
@@ -175,7 +176,6 @@ public final class HttpClientFactory implements HttpStreamFactory
     private static final String SCHEME = ":scheme";
     private static final String CACHE_CONTROL = "cache-control";
     private static final String8FW HEADER_AUTHORITY = new String8FW(":authority");
-    private static final String8FW HEADER_SCHEME = new String8FW(":scheme");
     private static final String8FW HEADER_USER_AGENT = new String8FW("user-agent");
     private static final String8FW HEADER_CONNECTION = new String8FW("connection");
     private static final String8FW HEADER_CONTENT_LENGTH = new String8FW("content-length");
@@ -338,6 +338,7 @@ public final class HttpClientFactory implements HttpStreamFactory
     private final Matcher versionPart;
     private final Matcher headerLine;
     private final Matcher connectionClose;
+    private final Matcher authorityPart;
     private final int httpTypeId;
     private final int proxyTypeId;
     private final int encodeMax;
@@ -377,6 +378,7 @@ public final class HttpClientFactory implements HttpStreamFactory
         this.headerLine = HEADER_LINE_PATTERN.matcher("");
         this.versionPart = VERSION_PATTERN.matcher("");
         this.connectionClose = CONNECTION_CLOSE_PATTERN.matcher("");
+        this.authorityPart = AUTHORITY_PATTERN.matcher("");
         this.maximumRequestQueueSize = bufferPool.slotCapacity();
 
         this.clientPools = new Long2ObjectHashMap<>();
@@ -2610,8 +2612,7 @@ public final class HttpClientFactory implements HttpStreamFactory
             long traceId,
             long authorization,
             long affinity,
-            String authority,
-            String scheme)
+            String authority)
         {
             if (!HttpState.initialOpening(state))
             {
@@ -2619,40 +2620,10 @@ public final class HttpClientFactory implements HttpStreamFactory
 
                 final Flyweight extension;
 
-                if (authority != null && !authority.isEmpty())
+                if (authority != null && authorityPart.reset(authority).matches())
                 {
-                    final String host;
-                    final int port;
-
-                    if (authority.startsWith("["))
-                    {
-                        final int closeBracket = authority.indexOf(']');
-                        if (closeBracket != -1 && closeBracket + 1 < authority.length() &&
-                            authority.charAt(closeBracket + 1) == ':')
-                        {
-                            host = authority.substring(1, closeBracket);
-                            port = parseInt(authority.substring(closeBracket + 2));
-                        }
-                        else
-                        {
-                            host = closeBracket != -1 ? authority.substring(1, closeBracket) : authority;
-                            port = "https".equals(scheme) ? 443 : 80;
-                        }
-                    }
-                    else
-                    {
-                        final int colon = authority.lastIndexOf(':');
-                        if (colon != -1)
-                        {
-                            host = authority.substring(0, colon);
-                            port = parseInt(authority.substring(colon + 1));
-                        }
-                        else
-                        {
-                            host = authority;
-                            port = "https".equals(scheme) ? 443 : 80;
-                        }
-                    }
+                    final String host = authorityPart.group("host");
+                    final int port = parseInt(authorityPart.group("port"));
 
                     extension = proxyBeginExRW.wrap(extBuffer, 0, extBuffer.capacity())
                         .typeId(proxyTypeId)
@@ -4697,11 +4668,7 @@ public final class HttpClientFactory implements HttpStreamFactory
                     HEADER_AUTHORITY.equals(header.name()));
                 final String authority = authorityHeader != null ? authorityHeader.value().asString() : null;
 
-                final HttpHeaderFW schemeHeader = headers.matchFirst(header ->
-                    HEADER_SCHEME.equals(header.name()));
-                final String scheme = schemeHeader != null ? schemeHeader.value().asString() : null;
-
-                client.doNetworkBegin(traceId, authorization, 0, authority, scheme);
+                client.doNetworkBegin(traceId, authorization, 0, authority);
 
                 if (HttpState.replyOpened(client.state))
                 {

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -2627,7 +2627,8 @@ public final class HttpClientFactory implements HttpStreamFactory
                     if (authority.startsWith("["))
                     {
                         final int closeBracket = authority.indexOf(']');
-                        if (closeBracket != -1 && closeBracket + 1 < authority.length() && authority.charAt(closeBracket + 1) == ':')
+                        if (closeBracket != -1 && closeBracket + 1 < authority.length() &&
+                            authority.charAt(closeBracket + 1) == ':')
                         {
                             host = authority.substring(1, closeBracket);
                             port = parseInt(authority.substring(closeBracket + 2));
@@ -4694,10 +4695,10 @@ public final class HttpClientFactory implements HttpStreamFactory
 
                 final HttpHeaderFW authorityHeader = headers.matchFirst(header ->
                     HEADER_AUTHORITY.equals(header.name()));
+                final String authority = authorityHeader != null ? authorityHeader.value().asString() : null;
+
                 final HttpHeaderFW schemeHeader = headers.matchFirst(header ->
                     HEADER_SCHEME.equals(header.name()));
-
-                final String authority = authorityHeader != null ? authorityHeader.value().asString() : null;
                 final String scheme = schemeHeader != null ? schemeHeader.value().asString() : null;
 
                 client.doNetworkBegin(traceId, authorization, 0, authority, scheme);

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpBindingConfig.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpBindingConfig.java
@@ -119,10 +119,15 @@ public final class TcpBindingConfig
                 InetAddress[] addresses = options != null ? resolveHost(options.host) : null;
                 resolved = addresses != null ? new InetSocketAddress(addresses[0], port) : null;
             }
-            else if (routes == TcpBindingConfig.DEFAULT_CLIENT_ROUTES)
+            else if (routes == TcpBindingConfig.DEFAULT_CLIENT_ROUTES && options == null)
             {
                 ProxyAddressFW address = beginEx.address();
                 resolved = resolveInetSocketAddress(address);
+            }
+            else if (routes == TcpBindingConfig.DEFAULT_CLIENT_ROUTES)
+            {
+                InetAddress[] addresses = resolveHost(options.host);
+                resolved = addresses != null ? new InetSocketAddress(addresses[0], port) : null;
             }
             else
             {

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsBindingConfig.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsBindingConfig.java
@@ -212,7 +212,7 @@ public final class TlsBindingConfig
             engine.setUseClientMode(true);
 
             List<String> sni = options.sni;
-            if (beginEx != null)
+            if (sni == null && beginEx != null)
             {
                 ProxyInfoFW info = beginEx.infos().matchFirst(a -> a.kind() == AUTHORITY);
 

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.and.abort/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.and.abort/client.rpt
@@ -28,7 +28,7 @@ write zilla:begin.ext ${proxy:beginEx()
                                .destinationPort(8080)
                                .build()
                              .info()
-                               .authority("localhost:8080")
+                               .authority("localhost")
                                .build()
                              .build()}
 connected

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.and.abort/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.and.abort/client.rpt
@@ -17,6 +17,20 @@
 connect "zilla://streams/net0"
   option zilla:window 8192
   option zilla:transmission "duplex"
+
+write zilla:begin.ext ${proxy:beginEx()
+                             .typeId(zilla:id("proxy"))
+                             .addressInet()
+                               .protocol("stream")
+                               .source("0.0.0.0")
+                               .destination("localhost")
+                               .sourcePort(0)
+                               .destinationPort(8080)
+                               .build()
+                             .info()
+                               .authority("localhost:8080")
+                               .build()
+                             .build()}
 connected
 
 # Request 1

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.and.abort/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.and.abort/server.rpt
@@ -18,6 +18,20 @@ accept "zilla://streams/net0"
   option zilla:window 8192
   option zilla:transmission "duplex"
 accepted
+
+read zilla:begin.ext ${proxy:matchBeginEx()
+                            .typeId(zilla:id("proxy"))
+                            .addressInet()
+                              .protocol("stream")
+                              .source("0.0.0.0")
+                              .destination("localhost")
+                              .sourcePort(0)
+                              .destinationPort(8080)
+                              .build()
+                            .info()
+                              .authority("localhost:8080")
+                              .build()
+                            .build()}
 connected
 
 read "GET / HTTP/1.1" "\r\n"

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.and.abort/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.and.abort/server.rpt
@@ -29,7 +29,7 @@ read zilla:begin.ext ${proxy:matchBeginEx()
                               .destinationPort(8080)
                               .build()
                             .info()
-                              .authority("localhost:8080")
+                              .authority("localhost")
                               .build()
                             .build()}
 connected


### PR DESCRIPTION
## Summary

- Extracts `:authority` and `:scheme` headers from `HttpBeginExFW` when opening a new outbound network stream in `HttpClientFactory`
- Parses the authority into `host` and `port` with full IPv6 bracket-notation support (e.g. `[::1]:8443`) and scheme-based port defaults (443 for `https`, 80 for `http`)
- Builds a `ProxyBeginExFW` with `address.inet` (family=INET, protocol=STREAM, source=`0.0.0.0`, destination=host, sourcePort=0, destinationPort=port) and an `infos` entry of type AUTHORITY carrying the full `:authority` value for TLS SNI
- Falls back to `EMPTY_OCTETS` when no authority is present, preserving existing behaviour
- Follows the flyweight-on-factory pattern: `proxyBeginExRW` is a non-static field on `HttpClientFactory`, reused across all streams on the worker thread

## Changes

- `runtime/binding-http/…/stream/HttpClientFactory.java`
  - New static import: `ProxyAddressProtocol.STREAM`
  - New factory field: `ProxyBeginExFW.Builder proxyBeginExRW`
  - New constant: `String8FW HEADER_SCHEME`
  - `HttpClient.doNetworkBegin` — gains `authority` and `scheme` parameters; builds `ProxyBeginExFW` when authority is non-empty
  - `HttpExchange.onRequestBegin` — extracts `:authority` and `:scheme` from headers before calling `doNetworkBegin`

## Test plan

- [ ] Compile `runtime/binding-http` successfully
- [ ] Run `./mvnw test -pl runtime/binding-http -DskipITs` — existing unit tests pass
- [ ] Verify existing spec ITs still pass: `./mvnw verify -pl specs/binding-http.spec`
- [ ] Manually confirm `ProxyBeginExFW` is populated correctly for plain-host, host:port, and IPv6 authorities

Closes #1676