### PR TITLE
fix(ci): wrap teardown if-expression entirely in ${{ }}

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,6 +147,6 @@ jobs:
           path: ./logs.tgz
 
       - name: Teardown
-        if: always() && ${{ hashFiles(format('examples/{0}/teardown.sh', matrix.dir)) != '' }}
+        if: ${{ always() && hashFiles(format('examples/{0}/teardown.sh', matrix.dir)) != '' }}
         working-directory: examples/${{ matrix.dir }}
         run: docker compose down --remove-orphans


### PR DESCRIPTION
## Summary

The `Teardown` step in `.github/workflows/build.yml:150` mixes literal text (`always() && `) with a `${{ }}` expression inside an `if:` clause. GitHub Actions now rejects this as a workflow syntax error, failing the `Build (25)` job before any downstream matrix job can run.

Move `always()` inside the single `${{ }}` expression, matching the pattern already used on line 119.

## Test plan

- [ ] CI `Build (25)` job parses the workflow without a syntax error
- [ ] Teardown step still runs when `examples/{matrix.dir}/teardown.sh` exists, including on prior-step failure (behaviour equivalent to `always() && ...`)

https://claude.ai/code/session_0174raBeXFTgt98bp4DTyRDm