### PR TITLE
test(engine): add store operation drivers to TestBinding

### DIFF
--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
@@ -48,6 +48,7 @@ import io.aklivity.zilla.runtime.engine.test.internal.binding.config.TestBinding
 import io.aklivity.zilla.runtime.engine.test.internal.binding.config.TestBindingOptionsConfig;
 import io.aklivity.zilla.runtime.engine.test.internal.binding.config.TestBindingOptionsConfig.CatalogAssertion;
 import io.aklivity.zilla.runtime.engine.test.internal.binding.config.TestBindingOptionsConfig.Event;
+import io.aklivity.zilla.runtime.engine.test.internal.binding.config.TestBindingOptionsConfig.StoreAssertion;
 import io.aklivity.zilla.runtime.engine.test.internal.binding.config.TestBindingOptionsConfig.VaultAssertion;
 import io.aklivity.zilla.runtime.engine.test.internal.binding.config.TestRouteConfig;
 import io.aklivity.zilla.runtime.engine.test.internal.event.TestEventContext;
@@ -105,6 +106,8 @@ final class TestBindingFactory implements BindingHandler
     private int eventIndex;
     private VaultHandler vault;
     private VaultAssertion vaultAssertion;
+    private StoreHandler store;
+    private List<StoreAssertion> storeAssertions;
     private long authorization;
 
     TestBindingFactory(
@@ -167,10 +170,12 @@ final class TestBindingFactory implements BindingHandler
             if (options.store != null)
             {
                 int storeId = context.supplyTypeId(options.store);
-                StoreHandler store = context.supplyStore(NamespacedId.id(namespaceId, storeId));
-                if (store != null)
+                this.store = context.supplyStore(NamespacedId.id(namespaceId, storeId));
+                this.storeAssertions = options.storeAssertions != null && !options.storeAssertions.isEmpty() ?
+                    options.storeAssertions.get(0).assertions : null;
+                if (this.store != null && this.storeAssertions == null)
                 {
-                    store.putIfAbsent("init", "", Long.MAX_VALUE, v -> {});
+                    this.store.putIfAbsent("init", "", Long.MAX_VALUE, v -> {});
                 }
             }
 
@@ -419,6 +424,68 @@ final class TestBindingFactory implements BindingHandler
                     if (!entry.getValue().equals(guard.attribute(authorization, entry.getKey())))
                     {
                         doInitialReset(traceId);
+                    }
+                }
+            }
+
+            if (store != null && storeAssertions != null && !storeAssertions.isEmpty())
+            {
+                for (StoreAssertion a : storeAssertions)
+                {
+                    if (a.delay > 0L)
+                    {
+                        try
+                        {
+                            Thread.sleep(a.delay);
+                        }
+                        catch (InterruptedException ex)
+                        {
+                            Thread.currentThread().interrupt();
+                            throw new RuntimeException(ex);
+                        }
+                    }
+                    switch (a.op)
+                    {
+                    case "get":
+                        store.get(a.key, (k, v) ->
+                        {
+                            if (a.hasExpect && !Objects.equals(v, a.expect))
+                            {
+                                doInitialReset(traceId);
+                            }
+                        });
+                        break;
+                    case "put":
+                        store.put(a.key, a.value, a.ttl, v ->
+                        {
+                        });
+                        break;
+                    case "putIfAbsent":
+                        store.putIfAbsent(a.key, a.value, a.ttl, v ->
+                        {
+                            if (a.hasExpect && !Objects.equals(v, a.expect))
+                            {
+                                doInitialReset(traceId);
+                            }
+                        });
+                        break;
+                    case "delete":
+                        store.delete(a.key, v ->
+                        {
+                        });
+                        break;
+                    case "getAndDelete":
+                        store.getAndDelete(a.key, v ->
+                        {
+                            if (a.hasExpect && !Objects.equals(v, a.expect))
+                            {
+                                doInitialReset(traceId);
+                            }
+                        });
+                        break;
+                    default:
+                        doInitialReset(traceId);
+                        break;
                     }
                 }
             }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestBindingOptionsConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestBindingOptionsConfig.java
@@ -34,6 +34,7 @@ public final class TestBindingOptionsConfig extends OptionsConfig
     public final List<CatalogAssertions> catalogAssertions;
     public final VaultAssertion vaultAssertion;
     public final String store;
+    public final List<StoreAssertions> storeAssertions;
 
     public static TestBindingOptionsConfigBuilder<TestBindingOptionsConfig> builder()
     {
@@ -56,7 +57,8 @@ public final class TestBindingOptionsConfig extends OptionsConfig
         List<Metric> metrics,
         List<CatalogAssertions> catalogAssertions,
         VaultAssertion vaultAssertion,
-        String store)
+        String store,
+        List<StoreAssertions> storeAssertions)
     {
         super(value != null ? List.of(value) : List.of(), List.of());
         this.value = value;
@@ -69,6 +71,7 @@ public final class TestBindingOptionsConfig extends OptionsConfig
         this.catalogAssertions = catalogAssertions;
         this.vaultAssertion = vaultAssertion;
         this.store = store;
+        this.storeAssertions = storeAssertions;
     }
 
     public static final class Event
@@ -150,6 +153,49 @@ public final class TestBindingOptionsConfig extends OptionsConfig
         {
             this.id = id;
             this.schema = schema;
+            this.delay = delay;
+        }
+    }
+
+    public static final class StoreAssertions
+    {
+        public final String name;
+        public final List<StoreAssertion> assertions;
+
+        public StoreAssertions(
+            String name,
+            List<StoreAssertion> assertions)
+        {
+            this.name = name;
+            this.assertions = assertions;
+        }
+    }
+
+    public static final class StoreAssertion
+    {
+        public final String op;
+        public final String key;
+        public final String value;
+        public final long ttl;
+        public final String expect;
+        public final boolean hasExpect;
+        public final long delay;
+
+        public StoreAssertion(
+            String op,
+            String key,
+            String value,
+            long ttl,
+            String expect,
+            boolean hasExpect,
+            long delay)
+        {
+            this.op = op;
+            this.key = key;
+            this.value = value;
+            this.ttl = ttl;
+            this.expect = expect;
+            this.hasExpect = hasExpect;
             this.delay = delay;
         }
     }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestBindingOptionsConfigAdapter.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestBindingOptionsConfigAdapter.java
@@ -64,6 +64,11 @@ public final class TestBindingOptionsConfigAdapter implements OptionsConfigAdapt
     private static final String KIND_NAME = "kind";
     private static final String VALUES_NAME = "values";
     private static final String STORE_NAME = "store";
+    private static final String STORE_OP_NAME = "op";
+    private static final String STORE_KEY_NAME = "key";
+    private static final String STORE_VALUE_NAME = "value";
+    private static final String STORE_TTL_NAME = "ttl";
+    private static final String STORE_EXPECT_NAME = "expect";
 
     private final ModelConfigAdapter model = new ModelConfigAdapter();
 
@@ -115,7 +120,8 @@ public final class TestBindingOptionsConfigAdapter implements OptionsConfigAdapt
         }
 
         if (testOptions.catalogAssertions != null ||
-            testOptions.vaultAssertion != null)
+            testOptions.vaultAssertion != null ||
+            testOptions.storeAssertions != null)
         {
             JsonObjectBuilder assertions = Json.createObjectBuilder();
 
@@ -152,6 +158,47 @@ public final class TestBindingOptionsConfigAdapter implements OptionsConfigAdapt
                 }
 
                 assertions.add(VAULT_NAME, assertion);
+            }
+
+            if (testOptions.storeAssertions != null)
+            {
+                JsonObjectBuilder storeAssertions = Json.createObjectBuilder();
+                for (TestBindingOptionsConfig.StoreAssertions s : testOptions.storeAssertions)
+                {
+                    JsonArrayBuilder array = Json.createArrayBuilder();
+                    for (TestBindingOptionsConfig.StoreAssertion a : s.assertions)
+                    {
+                        JsonObjectBuilder assertion = Json.createObjectBuilder();
+                        assertion.add(STORE_OP_NAME, a.op);
+                        assertion.add(STORE_KEY_NAME, a.key);
+                        if (a.value != null)
+                        {
+                            assertion.add(STORE_VALUE_NAME, a.value);
+                        }
+                        if (a.ttl != Long.MAX_VALUE)
+                        {
+                            assertion.add(STORE_TTL_NAME, a.ttl);
+                        }
+                        if (a.hasExpect)
+                        {
+                            if (a.expect == null)
+                            {
+                                assertion.addNull(STORE_EXPECT_NAME);
+                            }
+                            else
+                            {
+                                assertion.add(STORE_EXPECT_NAME, a.expect);
+                            }
+                        }
+                        if (a.delay != 0L)
+                        {
+                            assertion.add(DELAY_NAME, a.delay);
+                        }
+                        array.add(assertion);
+                    }
+                    storeAssertions.add(s.name, array);
+                }
+                assertions.add(STORE_NAME, storeAssertions);
             }
 
             object.add(ASSERTIONS_NAME, assertions);
@@ -271,6 +318,35 @@ public final class TestBindingOptionsConfigAdapter implements OptionsConfigAdapt
                         vaultJson.getString(VAULT_SIGNER_NAME, null),
                         vaultJson.getString(VAULT_TRUST_NAME, null),
                         vaultJson.getBoolean(VAULT_TRUSTCACERTS_NAME, false)));
+                }
+
+                if (assertionsJson.containsKey(STORE_NAME))
+                {
+                    JsonObject storesJson = assertionsJson.getJsonObject(STORE_NAME);
+                    for (String storeName : storesJson.keySet())
+                    {
+                        JsonArray storeAssertionsJson = storesJson.getJsonArray(storeName);
+                        List<TestBindingOptionsConfig.StoreAssertion> storeAssertions = new LinkedList<>();
+                        for (JsonValue assertion : storeAssertionsJson)
+                        {
+                            JsonObject s = assertion.asJsonObject();
+                            String expect = null;
+                            boolean hasExpect = s.containsKey(STORE_EXPECT_NAME);
+                            if (hasExpect && !s.isNull(STORE_EXPECT_NAME))
+                            {
+                                expect = s.getString(STORE_EXPECT_NAME);
+                            }
+                            storeAssertions.add(new TestBindingOptionsConfig.StoreAssertion(
+                                s.getString(STORE_OP_NAME),
+                                s.getString(STORE_KEY_NAME),
+                                s.getString(STORE_VALUE_NAME, null),
+                                s.containsKey(STORE_TTL_NAME) ? s.getJsonNumber(STORE_TTL_NAME).longValue() : Long.MAX_VALUE,
+                                expect,
+                                hasExpect,
+                                s.containsKey(DELAY_NAME) ? s.getJsonNumber(DELAY_NAME).longValue() : 0L));
+                        }
+                        testOptions.storeAssertions(storeName, storeAssertions);
+                    }
                 }
             }
 

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestBindingOptionsConfigBuilder.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestBindingOptionsConfigBuilder.java
@@ -40,6 +40,7 @@ public final class TestBindingOptionsConfigBuilder<T> extends ConfigBuilder<T, T
     private List<TestBindingOptionsConfig.CatalogAssertions> catalogAssertions;
     private VaultAssertion vaultAssertion;
     private String store;
+    private List<TestBindingOptionsConfig.StoreAssertions> storeAssertions;
 
     TestBindingOptionsConfigBuilder(
         Function<OptionsConfig, T> mapper)
@@ -142,10 +143,22 @@ public final class TestBindingOptionsConfigBuilder<T> extends ConfigBuilder<T, T
         return this;
     }
 
+    public TestBindingOptionsConfigBuilder<T> storeAssertions(
+        String name,
+        List<TestBindingOptionsConfig.StoreAssertion> assertions)
+    {
+        if (this.storeAssertions == null)
+        {
+            this.storeAssertions = new LinkedList<>();
+        }
+        this.storeAssertions.add(new TestBindingOptionsConfig.StoreAssertions(name, assertions));
+        return this;
+    }
+
     @Override
     public T build()
     {
         return mapper.apply(new TestBindingOptionsConfig(value, mode, schema, authorization, catalogs, events,
-                metrics, catalogAssertions, vaultAssertion, store));
+                metrics, catalogAssertions, vaultAssertion, store, storeAssertions));
     }
 }


### PR DESCRIPTION
## Summary
- Add `StoreAssertions` / `StoreAssertion` nested types to `TestBindingOptionsConfig` and wire them through the builder + JSON adapter.
- Extend `TestBindingFactory.onInitialBegin` to execute each assertion against the resolved `StoreHandler` and fail the initial stream (`doInitialReset`) on mismatched expectations.
- Supports the five SPI operations: `get`, `put`, `putIfAbsent`, `delete`, `getAndDelete`, with optional `expect` and `delay`.

## Why
Today the test binding can only smoke-test a store via a hardcoded `putIfAbsent("init", "", MAX_VALUE)` on attach. Store implementations (e.g. the new `store-redis` in zilla-plus) cannot drive per-operation integration tests without each shipping its own test binding.

With this change, any store module can script scenarios declaratively in zilla.yaml:

```yaml
bindings:
  net0:
    type: test
    kind: server
    options:
      store: session_store
      assertions:
        store:
          session_store:
            - op: putIfAbsent
              key: k1
              value: v1
              expect: null
            - op: get
              key: k1
              expect: v1
    exit: app0
```

## Test plan
- [x] Engine compiles
- [ ] Existing engine tests pass (`./mvnw -pl runtime/engine verify`)
- [ ] Consumed by zilla-plus `store-redis` ITs (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)