### PR TITLE
fix(binding-tcp): prevent NPE when retrying accept across contexts

### DIFF
--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpBindingController.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpBindingController.java
@@ -130,17 +130,16 @@ final class TcpBindingController implements BindingController
 
                 boolean accepted = false;
                 int contextCount = contexts.size();
-                for (int i = 0; !accepted && i < contextCount; i++)
+                if (contextCount > 0)
                 {
-                    int index = nextIndex.getAndIncrement();
-                    TcpBindingContext context = contexts.get(index);
+                    int base = nextIndex.getAndIncrement();
+                    for (int i = 0; !accepted && i < contextCount; i++)
+                    {
+                        int index = Math.floorMod(base + i, contextCount);
+                        TcpBindingContext context = contexts.get(index);
 
-                    accepted = context.accepted(binding.id, channel, local);
-                }
-
-                if (nextIndex.get() >= contextCount)
-                {
-                    nextIndex.set(0);
+                        accepted = context.accepted(binding.id, channel, local);
+                    }
                 }
 
                 if (!accepted)


### PR DESCRIPTION
## Summary

`TcpBindingController.handleAccept` could throw an `NullPointerException` on the engine boss thread when a worker rejected an accepted connection via `TcpBindingContext.accepted() == false` and the round-robin retried against another context.

The retry loop used `nextIndex.getAndIncrement()` unboundedly inside the loop and only reset `nextIndex` *after* the loop. So once the first try failed, the next iteration could use an index past `contexts.size() - 1`, `contexts.get(index)` returned `null`, and the subsequent `context.accepted(...)` call NPE'd — crashing the boss thread with `AgentTerminationException` and cascading into engine shutdown.

Reproduction sketch: `workerCount=2`, `nextIndex=1` after a previous accept, new connection arrives and worker 1 is at capacity:
- `i=0`: `index=1`, `contexts.get(1)` ✓, rejects (worker full)
- `i=1`: `index=2` (bumped past size), `contexts.get(2)` → **null**
- NPE on line 138

## Fix

Capture `base = nextIndex.getAndIncrement()` once per accepted connection and compute each retry index as `Math.floorMod(base + i, contextCount)`. This keeps indices in range across retries and tolerates counter overflow. The post-loop `nextIndex` reset is no longer needed and is removed. A `contextCount > 0` guard prevents advancing the counter when no contexts have been registered yet.

Round-robin across connections is preserved — consecutive accepts still advance the base by one.

## Test plan

- [x] `./mvnw clean verify -pl runtime/binding-tcp -am` — all 24 unit + 88 integration tests pass
- [x] JaCoCo coverage check passes
- [x] End-to-end validated against `zilla-plus/examples/store.hazelcast` where the NPE was originally observed

🤖 Generated with [Claude Code](https://claude.com/claude-code)