### PR TITLE
feat(flyweight-maven-plugin): add inject(Consumer&lt;Builder&gt;) on generated struct + union builders

### DIFF
--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/StructFlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/StructFlyweightGenerator.java
@@ -1575,6 +1575,7 @@ public final class StructFlyweightGenerator extends ClassSpecGenerator
                           .addMethod(wrapMethodWithArray.generate())
                           .addMethod(rewrapMethod())
                           .addMethod(setMethod())
+                          .addMethod(injectMethod())
                           .addMethod(buildMethod())
                           .build();
         }
@@ -1629,6 +1630,18 @@ public final class StructFlyweightGenerator extends ClassSpecGenerator
                 .addStatement("lastFieldSet = FIELD_COUNT - 1")
                 .addStatement("return this")
                 .build();
+        }
+
+        private MethodSpec injectMethod()
+        {
+            ClassName consumerType = ClassName.get(Consumer.class);
+            return methodBuilder("inject")
+                    .addModifiers(PUBLIC)
+                    .returns(thisName)
+                    .addParameter(ParameterizedTypeName.get(consumerType, thisName), "injector")
+                    .addStatement("injector.accept(this)")
+                    .addStatement("return this")
+                    .build();
         }
 
         private static String appendMethodName(

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/UnionFlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/UnionFlyweightGenerator.java
@@ -991,6 +991,7 @@ public final class UnionFlyweightGenerator extends ClassSpecGenerator
             buildMethod.build();
             return builder.addMethod(constructor())
                           .addMethod(wrapMethod.generate())
+                          .addMethod(injectMethod())
                           .build();
         }
 
@@ -999,6 +1000,18 @@ public final class UnionFlyweightGenerator extends ClassSpecGenerator
             return constructorBuilder()
                     .addModifiers(PUBLIC)
                     .addStatement("super(new $T())", unionType)
+                    .build();
+        }
+
+        private MethodSpec injectMethod()
+        {
+            ClassName consumerType = ClassName.get(Consumer.class);
+            return methodBuilder("inject")
+                    .addModifiers(PUBLIC)
+                    .returns(thisName)
+                    .addParameter(ParameterizedTypeName.get(consumerType, thisName), "injector")
+                    .addStatement("injector.accept(this)")
+                    .addStatement("return this")
                     .build();
         }
 

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/FlatFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/FlatFWTest.java
@@ -442,4 +442,32 @@ public class FlatFWTest
         assertEquals("", flatRO.string4().asString());
     }
 
+    @Test
+    public void shouldChainViaInjectPreservingBuilderType() throws Exception
+    {
+        final boolean withFixed4 = true;
+        int limit = flatRW.wrap(buffer, 0, buffer.capacity())
+            .fixed1(10)
+            .fixed2(20)
+            .string1("value1")
+            .fixed3(30)
+            .string2("value2")
+            .inject(b -> b.fixed4(withFixed4 ? 40 : 0))
+            .string3("value3")
+            .fixed5((byte) 50)
+            .string4("value4")
+            .build()
+            .limit();
+        flatRO.wrap(buffer, 0, limit);
+        assertEquals(10, flatRO.fixed1());
+        assertEquals(20, flatRO.fixed2());
+        assertEquals("value1", flatRO.string1().asString());
+        assertEquals(30, flatRO.fixed3());
+        assertEquals("value2", flatRO.string2().asString());
+        assertEquals(40, flatRO.fixed4());
+        assertEquals("value3", flatRO.string3().asString());
+        assertEquals(50, flatRO.fixed5());
+        assertEquals("value4", flatRO.string4().asString());
+    }
+
 }

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/UnionChildFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/UnionChildFWTest.java
@@ -209,4 +209,18 @@ public class UnionChildFWTest
         flyweightRW.wrap(buffer, 0, buffer.capacity())
             .build();
     }
+
+    @Test
+    public void shouldChainViaInjectPreservingBuilderType()
+    {
+        final boolean wide = true;
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .fixed1(10)
+            .inject(b -> b.width16((short) (wide ? 16 : 8)))
+            .build()
+            .limit();
+        UnionChildFW unionChild = flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(16, unionChild.width16());
+        assertEquals(KIND_WIDTH16, unionChild.kind());
+    }
 }


### PR DESCRIPTION
Adds `inject(Consumer<Builder>)` to generated struct and union flyweight builders so conditional mutations can stay inside the fluent chain instead of forcing it to be broken into a temporary variable.

Picks up on the suggestion in #1709 ([discussion thread](https://github.com/aklivity/zilla/pull/1709#discussion_r3141297926)).

## Before

```java
XxxFW.Builder b = builderRW.wrap(buf, 0, capacity).typeId(typeId);
if (cond)
{
    b.someField(value);
}
XxxFW msg = b.build();
```

## After

```java
XxxFW msg = builderRW.wrap(buf, 0, capacity)
    .typeId(typeId)
    .inject(b -> { if (cond) b.someField(value); })
    .build();
```

## Implementation notes

- Wired in via `StructFlyweightGenerator.BuilderClassGenerator.generate` and `UnionFlyweightGenerator.BuilderClassGenerator.generate`.
- Generated method signature is per-subclass: `public Builder inject(Consumer<Builder> injector)`. The lambda parameter receives the concrete builder type without an explicit type witness — Java's inference picks the receiver type directly.
- I prototyped placing this on `Flyweight.Builder<T>` as a generic method `<B extends Builder<T>> B inject(Consumer<B>)` first; that approach forced callers to write `.<XxxFW.Builder>inject(...)` because `B` isn't constrained by the receiver's runtime type. Per-subclass generation gives clean ergonomics without invasive F-bounded changes to the base class (which would have rippled into all hand-written `Flyweight.Builder<T>` subclasses across the bindings).
- Other flyweight shapes (list, map, array, string, bounded-octets, variant) can adopt the same pattern in follow-up commits if needed; this PR covers the cases that unblock the proxy / extension-builder simplification in #1709.

## Test plan

- [x] `./mvnw test -pl build/flyweight-maven-plugin` — all flyweight-maven-plugin tests pass, including new ones below.
- [x] `FlatFWTest.shouldChainViaInjectPreservingBuilderType` — struct case, chain continues after `inject(...)` with subclass methods.
- [x] `UnionChildFWTest.shouldChainViaInjectPreservingBuilderType` — union case, ditto.
- [x] `./mvnw clean install -pl runtime/engine,runtime/binding-mcp -am -DskipTests -DskipITs` — sanity build of a binding consuming the regenerated flyweights succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_0196ranuZwz1vjCEQ9mGHhfW)_