### PR TITLE
feat(engine): drive guard preauthorize from test binding; resolveId on GuardConfig

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/GuardConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/GuardConfig.java
@@ -18,11 +18,14 @@ package io.aklivity.zilla.runtime.engine.config;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 
+import java.util.function.ToLongFunction;
+
 public class GuardConfig
 {
     public transient long id;
     public transient long storeId;
     public transient String qstore;
+    public transient ToLongFunction<String> resolveId;
 
     public final String namespace;
     public final String name;

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineManager.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineManager.java
@@ -374,6 +374,7 @@ public class EngineManager
         for (GuardConfig guard : namespace.guards)
         {
             guard.id = resolver.resolve(guard.name);
+            guard.resolveId = resolver::resolve;
             if (guard.store != null)
             {
                 guard.storeId = resolver.resolve(guard.store);

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/NamespaceRegistry.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/NamespaceRegistry.java
@@ -136,9 +136,9 @@ public class NamespaceRegistry
     public void attach()
     {
         namespace.vaults.forEach(this::attachVault);
+        namespace.stores.forEach(this::attachStore);
         namespace.guards.forEach(this::attachGuard);
         namespace.catalogs.forEach(this::attachCatalog);
-        namespace.stores.forEach(this::attachStore);
         namespace.telemetry.metrics.forEach(this::attachMetric);
         namespace.bindings.forEach(this::attachBinding);
         namespace.telemetry.exporters.forEach(this::attachExporter);
@@ -147,10 +147,10 @@ public class NamespaceRegistry
     public void detach()
     {
         namespace.vaults.forEach(this::detachVault);
+        namespace.bindings.forEach(this::detachBinding);
         namespace.guards.forEach(this::detachGuard);
         namespace.catalogs.forEach(this::detachCatalog);
         namespace.stores.forEach(this::detachStore);
-        namespace.bindings.forEach(this::detachBinding);
         namespace.telemetry.metrics.forEach(this::detachMetric);
         namespace.telemetry.exporters.forEach(this::detachExporter);
     }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
@@ -15,9 +15,13 @@
  */
 package io.aklivity.zilla.runtime.engine.test.internal.binding;
 
+import static io.aklivity.zilla.runtime.engine.guard.GuardHandler.NEEDS_PREAUTHORIZE;
+import static io.aklivity.zilla.runtime.engine.guard.GuardHandler.NOT_AUTHORIZED;
 import static io.aklivity.zilla.runtime.engine.test.internal.binding.config.TestBindingOptionsConfigAdapter.DEFAULT_ASSERTION_SCHEMA;
 import static java.util.Collections.emptyList;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.util.LinkedList;
 import java.util.List;
@@ -38,6 +42,7 @@ import io.aklivity.zilla.runtime.engine.config.BindingConfig;
 import io.aklivity.zilla.runtime.engine.config.CatalogedConfig;
 import io.aklivity.zilla.runtime.engine.config.SchemaConfig;
 import io.aklivity.zilla.runtime.engine.guard.GuardHandler;
+import io.aklivity.zilla.runtime.engine.guard.GuardHandler.LongCompletionCallback;
 import io.aklivity.zilla.runtime.engine.metrics.Metric;
 import io.aklivity.zilla.runtime.engine.model.ConverterHandler;
 import io.aklivity.zilla.runtime.engine.model.function.ValueConsumer;
@@ -101,6 +106,10 @@ final class TestBindingFactory implements BindingHandler
     private List<CatalogAssertion> catalogAssertions;
     private GuardHandler guard;
     private String credentials;
+    private String callbackUri;
+    private Map<String, String> callbackParams;
+    private String expectIdentity;
+    private String expectCredentials;
     private Map<String, String> attributes;
     private List<Event> events;
     private int eventIndex;
@@ -156,6 +165,10 @@ final class TestBindingFactory implements BindingHandler
                 int guardId = context.supplyTypeId(options.authorization.name);
                 this.guard = context.supplyGuard(NamespacedId.id(namespaceId, guardId));
                 this.credentials = options.authorization.credentials;
+                this.callbackUri = options.authorization.callback;
+                this.callbackParams = options.authorization.callbackParams;
+                this.expectIdentity = options.authorization.expectIdentity;
+                this.expectCredentials = options.authorization.expectCredentials;
                 this.attributes = options.authorization.attributes;
             }
 
@@ -219,22 +232,145 @@ final class TestBindingFactory implements BindingHandler
         MessageConsumer newStream =  null;
 
         TestBindingConfig binding = bindings.get(routedId);
-        authorization = begin.authorization();
 
-        if (guard != null)
+        if (guard == null)
         {
-            authorization = guard.reauthorize(begin.traceId(), routedId, 0, credentials);
+            authorization = begin.authorization();
+            TestRouteConfig route = binding != null ? binding.resolve(authorization) : null;
+            if (route != null)
+            {
+                newStream = new TestSource(source, originId, routedId, initialId, replyId, route.id)::onMessage;
+            }
         }
-
-        TestRouteConfig route = binding != null ? binding.resolve(authorization) : null;
-
-        if (route != null)
+        else
         {
-            final long resolvedId = route.id;
-            newStream = new TestSource(source, originId, routedId, initialId, replyId, resolvedId)::onMessage;
+            // Always go through the async overload — sync guards run inline via the default
+            // {@link GuardHandler#reauthorize(long,long,long,String,LongCompletionCallback)}
+            // bridge; only OAuth-style guards actually defer the callback.
+            TestSource deferred = new TestSource(source, originId, routedId, initialId, replyId, 0L);
+            newStream = deferred::onMessage;
+            doAuthorize(begin.traceId(), routedId, deferred, binding);
         }
 
         return newStream;
+    }
+
+    private void doAuthorize(
+        long traceId,
+        long routedId,
+        TestSource deferred,
+        TestBindingConfig binding)
+    {
+        guard.reauthorize(traceId, routedId, 0, credentials, new LongCompletionCallback()
+        {
+            @Override
+            public void completed(
+                long contextId,
+                long sessionId)
+            {
+                if (sessionId == NEEDS_PREAUTHORIZE && callbackUri != null)
+                {
+                    doPreauthorizeAndCallback(traceId, routedId, deferred, binding);
+                }
+                else
+                {
+                    onAuthorized(traceId, routedId, deferred, binding, sessionId);
+                }
+            }
+
+            @Override
+            public void failed(
+                long contextId,
+                Throwable ex)
+            {
+                onAuthorized(traceId, routedId, deferred, binding, NOT_AUTHORIZED);
+            }
+        });
+    }
+
+    private void doPreauthorizeAndCallback(
+        long traceId,
+        long routedId,
+        TestSource deferred,
+        TestBindingConfig binding)
+    {
+        String url = guard.preauthorize(traceId, routedId, 0, callbackUri);
+        if (url == null)
+        {
+            onAuthorized(traceId, routedId, deferred, binding, NOT_AUTHORIZED);
+            return;
+        }
+        // Per the GuardHandler.preauthorize contract, the redirect-callback URL is passed
+        // back to reauthorize as the credentials. Forward whatever query params the guard
+        // embedded in the preauthorize URL verbatim, then append any additional params the
+        // test configured. The test binding stays guard-agnostic — it doesn't interpret any
+        // specific param name.
+        String callbackResponse = buildCallbackResponse(callbackUri, url, callbackParams);
+        guard.reauthorize(traceId, routedId, 0, callbackResponse, new LongCompletionCallback()
+        {
+            @Override
+            public void completed(
+                long contextId,
+                long sessionId)
+            {
+                onAuthorized(traceId, routedId, deferred, binding, sessionId);
+            }
+
+            @Override
+            public void failed(
+                long contextId,
+                Throwable ex)
+            {
+                onAuthorized(traceId, routedId, deferred, binding, NOT_AUTHORIZED);
+            }
+        });
+    }
+
+    private static String buildCallbackResponse(
+        String callbackUri,
+        String preauthorizeUrl,
+        Map<String, String> additionalParams)
+    {
+        StringBuilder builder = new StringBuilder(callbackUri);
+        boolean hasParams = callbackUri.indexOf('?') >= 0;
+        int q = preauthorizeUrl.indexOf('?');
+        if (q >= 0 && q + 1 < preauthorizeUrl.length())
+        {
+            builder.append(hasParams ? '&' : '?');
+            builder.append(preauthorizeUrl, q + 1, preauthorizeUrl.length());
+            hasParams = true;
+        }
+        if (additionalParams != null)
+        {
+            for (Map.Entry<String, String> entry : additionalParams.entrySet())
+            {
+                builder.append(hasParams ? '&' : '?');
+                builder.append(URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8));
+                builder.append('=');
+                builder.append(URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8));
+                hasParams = true;
+            }
+        }
+        return builder.toString();
+    }
+
+    private void onAuthorized(
+        long traceId,
+        long routedId,
+        TestSource deferred,
+        TestBindingConfig binding,
+        long sessionId)
+    {
+        authorization = sessionId;
+        TestRouteConfig route = binding != null ? binding.resolve(authorization) : null;
+        if (route != null)
+        {
+            deferred.onAuthResolved(traceId, route.id);
+        }
+        else
+        {
+            deferred.onAuthRejected(traceId);
+        }
     }
 
     private final class TestSource
@@ -259,7 +395,9 @@ final class TestBindingFactory implements BindingHandler
         private long replyBud;
         private int replyCap;
 
-        private final TestTarget target;
+        private TestTarget target;
+        private boolean pendingBegin;
+        private long pendingTraceId;
 
         private TestSource(
             MessageConsumer source,
@@ -274,7 +412,25 @@ final class TestBindingFactory implements BindingHandler
             this.routedId = routedId;
             this.initialId = initialId;
             this.replyId = replyId;
+            this.target = resolvedId != 0L ? new TestTarget(routedId, resolvedId) : null;
+        }
+
+        private void onAuthResolved(
+            long traceId,
+            long resolvedId)
+        {
             this.target = new TestTarget(routedId, resolvedId);
+            if (pendingBegin)
+            {
+                pendingBegin = false;
+                runInitialBeginBody(pendingTraceId);
+            }
+        }
+
+        private void onAuthRejected(
+            long traceId)
+        {
+            doInitialReset(traceId);
         }
 
         private void onMessage(
@@ -325,6 +481,18 @@ final class TestBindingFactory implements BindingHandler
         {
             long traceId = begin.traceId();
 
+            if (target == null)
+            {
+                pendingBegin = true;
+                pendingTraceId = traceId;
+                return;
+            }
+            runInitialBeginBody(traceId);
+        }
+
+        private void runInitialBeginBody(
+            long traceId)
+        {
             target.doInitialBegin(traceId);
 
             if (vault != null && vaultAssertion != null)
@@ -426,6 +594,18 @@ final class TestBindingFactory implements BindingHandler
                         doInitialReset(traceId);
                     }
                 }
+            }
+
+            if (guard != null && expectIdentity != null &&
+                !expectIdentity.equals(guard.identity(authorization)))
+            {
+                doInitialReset(traceId);
+            }
+
+            if (guard != null && expectCredentials != null &&
+                !expectCredentials.equals(guard.credentials(authorization)))
+            {
+                doInitialReset(traceId);
             }
 
             if (store != null && storeAssertions != null && !storeAssertions.isEmpty())

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
@@ -244,9 +244,6 @@ final class TestBindingFactory implements BindingHandler
         }
         else
         {
-            // Always go through the async overload — sync guards run inline via the default
-            // {@link GuardHandler#reauthorize(long,long,long,String,LongCompletionCallback)}
-            // bridge; only OAuth-style guards actually defer the callback.
             TestSource deferred = new TestSource(source, originId, routedId, initialId, replyId, 0L);
             newStream = deferred::onMessage;
             doAuthorize(begin.traceId(), routedId, deferred, binding);
@@ -300,11 +297,6 @@ final class TestBindingFactory implements BindingHandler
             onAuthorized(traceId, routedId, deferred, binding, NOT_AUTHORIZED);
             return;
         }
-        // Per the GuardHandler.preauthorize contract, the redirect-callback URL is passed
-        // back to reauthorize as the credentials. Forward whatever query params the guard
-        // embedded in the preauthorize URL verbatim, then append any additional params the
-        // test configured. The test binding stays guard-agnostic — it doesn't interpret any
-        // specific param name.
         String callbackResponse = buildCallbackResponse(callbackUri, url, callbackParams);
         guard.reauthorize(traceId, routedId, 0, callbackResponse, new LongCompletionCallback()
         {

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestAuthorizationConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestAuthorizationConfig.java
@@ -21,6 +21,10 @@ public final class TestAuthorizationConfig
 {
     public final String name;
     public final String credentials;
+    public final String callback;
+    public final Map<String, String> callbackParams;
+    public final String expectIdentity;
+    public final String expectCredentials;
     public final Map<String, String> attributes;
 
     public TestAuthorizationConfig(
@@ -28,8 +32,24 @@ public final class TestAuthorizationConfig
         String credentials,
         Map<String, String> attributes)
     {
+        this(name, credentials, null, null, null, null, attributes);
+    }
+
+    public TestAuthorizationConfig(
+        String name,
+        String credentials,
+        String callback,
+        Map<String, String> callbackParams,
+        String expectIdentity,
+        String expectCredentials,
+        Map<String, String> attributes)
+    {
         this.name = name;
         this.credentials = credentials;
+        this.callback = callback;
+        this.callbackParams = callbackParams;
+        this.expectIdentity = expectIdentity;
+        this.expectCredentials = expectCredentials;
         this.attributes = attributes;
     }
 }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestBindingOptionsConfigAdapter.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestBindingOptionsConfigAdapter.java
@@ -46,6 +46,10 @@ public final class TestBindingOptionsConfigAdapter implements OptionsConfigAdapt
     private static final String CATALOG_NAME = "catalog";
     private static final String AUTHORIZATION_NAME = "authorization";
     private static final String CREDENTIALS_NAME = "credentials";
+    private static final String CALLBACK_NAME = "callback";
+    private static final String CALLBACK_PARAMS_NAME = "callbackParams";
+    private static final String EXPECT_IDENTITY_NAME = "expectIdentity";
+    private static final String EXPECT_CREDENTIALS_NAME = "expectCredentials";
     private static final String ATTRIBUTES_NAME = "attributes";
     private static final String EVENTS_NAME = "events";
     private static final String TIMESTAMP_NAME = "timestamp";
@@ -209,6 +213,24 @@ public final class TestBindingOptionsConfigAdapter implements OptionsConfigAdapt
             JsonObjectBuilder credentials = Json.createObjectBuilder();
             TestAuthorizationConfig authorization = testOptions.authorization;
             credentials.add(CREDENTIALS_NAME, authorization.credentials);
+            if (authorization.callback != null)
+            {
+                credentials.add(CALLBACK_NAME, authorization.callback);
+            }
+            if (authorization.callbackParams != null && !authorization.callbackParams.isEmpty())
+            {
+                JsonObjectBuilder paramsJson = Json.createObjectBuilder();
+                authorization.callbackParams.forEach(paramsJson::add);
+                credentials.add(CALLBACK_PARAMS_NAME, paramsJson);
+            }
+            if (authorization.expectIdentity != null)
+            {
+                credentials.add(EXPECT_IDENTITY_NAME, authorization.expectIdentity);
+            }
+            if (authorization.expectCredentials != null)
+            {
+                credentials.add(EXPECT_CREDENTIALS_NAME, authorization.expectCredentials);
+            }
             JsonObjectBuilder authorizationJson = Json.createObjectBuilder();
             authorizationJson.add(authorization.name, credentials);
             if (authorization.attributes != null &&
@@ -360,13 +382,27 @@ public final class TestBindingOptionsConfigAdapter implements OptionsConfigAdapt
                     if (guard.containsKey(CREDENTIALS_NAME))
                     {
                         String credentials = guard.getString(CREDENTIALS_NAME);
+                        String callback = guard.containsKey(CALLBACK_NAME) ? guard.getString(CALLBACK_NAME) : null;
+                        Map<String, String> callbackParams = null;
+                        if (guard.containsKey(CALLBACK_PARAMS_NAME))
+                        {
+                            callbackParams = new HashMap<>();
+                            Map<String, String> sink = callbackParams;
+                            guard.getJsonObject(CALLBACK_PARAMS_NAME)
+                                .forEach((key, value) -> sink.put(key, ((JsonString) value).getString()));
+                        }
+                        String expectIdentity = guard.containsKey(EXPECT_IDENTITY_NAME)
+                            ? guard.getString(EXPECT_IDENTITY_NAME) : null;
+                        String expectCredentials = guard.containsKey(EXPECT_CREDENTIALS_NAME)
+                            ? guard.getString(EXPECT_CREDENTIALS_NAME) : null;
                         Map<String, String> attributes = new HashMap<>();
                         if (guard.containsKey(ATTRIBUTES_NAME))
                         {
                             guard.getJsonObject(ATTRIBUTES_NAME)
                                 .forEach((key, value) -> attributes.put(key, ((JsonString) value).getString()));
                         }
-                        testOptions.authorization(name, credentials, attributes);
+                        testOptions.authorization(name, credentials, callback, callbackParams,
+                            expectIdentity, expectCredentials, attributes);
                     }
                 }
             }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestBindingOptionsConfigBuilder.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestBindingOptionsConfigBuilder.java
@@ -92,6 +92,32 @@ public final class TestBindingOptionsConfigBuilder<T> extends ConfigBuilder<T, T
         return this;
     }
 
+    public TestBindingOptionsConfigBuilder<T> authorization(
+        String name,
+        String credentials,
+        String callback,
+        Map<String, String> callbackParams,
+        Map<String, String> attributes)
+    {
+        this.authorization = new TestAuthorizationConfig(
+            name, credentials, callback, callbackParams, null, null, attributes);
+        return this;
+    }
+
+    public TestBindingOptionsConfigBuilder<T> authorization(
+        String name,
+        String credentials,
+        String callback,
+        Map<String, String> callbackParams,
+        String expectIdentity,
+        String expectCredentials,
+        Map<String, String> attributes)
+    {
+        this.authorization = new TestAuthorizationConfig(
+            name, credentials, callback, callbackParams, expectIdentity, expectCredentials, attributes);
+        return this;
+    }
+
     public TestBindingOptionsConfigBuilder<T> event(
         long timestamp,
         String message)

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/schema/binding/test.schema.patch.json
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/schema/binding/test.schema.patch.json
@@ -171,6 +171,30 @@
                                                 {
                                                     "type": "string"
                                                 },
+                                                "callback":
+                                                {
+                                                    "type": "string"
+                                                },
+                                                "callbackParams":
+                                                {
+                                                    "type": "object",
+                                                    "patternProperties":
+                                                    {
+                                                        "^[a-zA-Z]+[a-zA-Z0-9._-]*$":
+                                                        {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                "expectIdentity":
+                                                {
+                                                    "type": "string"
+                                                },
+                                                "expectCredentials":
+                                                {
+                                                    "type": "string"
+                                                },
                                                 "attributes":
                                                 {
                                                     "type": "object",


### PR DESCRIPTION
## Summary

Two related additions, both about letting guards participate in the config layer the way bindings already do.

### 1. `GuardConfig.resolveId`

Mirror of `BindingConfig.resolveId`. `EngineManager` populates it from the same `NameResolver` used for bindings, so a guard implementation can resolve another guard's name to its namespaced id at attach time.

This unblocks patterns where a guard references another guard — e.g. a `via` reference to an upstream guard that holds an inbound subject credential, so a delegated guard can call `engine.supplyGuard(viaId).credentials(contextId)` to fetch the user's bearer for an upstream exchange.

### 2. Test binding async authorization + preauthorize orchestration

Today the engine's `TestBindingFactory` only invokes the synchronous `reauthorize` overload. Any guard that returns `NEEDS_PREAUTHORIZE` on the first call cannot be driven through the test binding alone. With these additions any guard that overrides `preauthorize` can be exercised end-to-end via `EngineRule` + `@Configuration`.

Per the existing [`GuardHandler.preauthorize` contract](https://github.com/aklivity/zilla/blob/develop/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/guard/GuardHandler.java), the redirect-callback URL (with whatever query params the guard embedded) is passed back to `reauthorize` as the credentials. The test binding stays **guard-agnostic** — it forwards the preauthorize URL's query string verbatim onto the configured callback URL and appends any additional `callbackParams` declared in the test config; it never interprets any specific param name itself.

- **Test binding async authorization** — `TestBindingFactory.newStream` invokes the async `reauthorize` overload on every stream begin and defers route resolution until the callback fires. Stream begin is buffered until the deferred mode resolves; on success the post-auth body runs as before, on failure a reset is sent. Synchronous guards continue to work via the default async-overload bridge that delegates to the synchronous `reauthorize`.

- **Preauthorize orchestration** — when async `reauthorize` resolves with `NEEDS_PREAUTHORIZE` and the authorization config supplies a `callback` URL, the test binding calls `preauthorize`, copies the preauthorize URL's query string onto the callback URL, appends any configured `callbackParams`, and calls `reauthorize` again with the resulting URL as the credentials.

- **`TestAuthorizationConfig` + builder + adapter + schema patch:**
  - `callback` — optional callback URL the guard should embed in its preauthorize URL.
  - `callbackParams` — optional string-to-string map of additional query params to append to the callback response (e.g. an authorization code returned by a simulated upstream).
  - `expectIdentity`, `expectCredentials` — optional assertions; after authorization resolves, the test binding resets the stream if `guard.identity(sessionId)` or `guard.credentials(sessionId)` doesn't match. Mirrors the existing `attributes:` assertion pattern.

### 3. `NamespaceRegistry.attach` order fix

Stores now attach **before** guards. Previously guards attached first, so a guard with a configured `store: …` could not resolve it via `context.supplyStore` at attach time.

## Example

```yaml
stores:
  store0:
    type: test
guards:
  jwt0:
    type: jwt
    options: { ... }
  guard0:
    type: my-pre-authz-guard
    store: store0
    options:
      via: "${guarded['jwt0'].credentials}"
      callback: /cb
      ...
bindings:
  net0:
    type: test
    kind: server
    options:
      authorization:
        guard0:
          credentials: subject-token
          callback: /cb
          callbackParams:
            code: stub-code
          expectCredentials: ACCESS-FROM-IDP
    exit: app0
```

The K3PO connect script triggers `newStream`; the test binding drives `reauthorize → preauthorize → reauthorize(callbackURL)` end-to-end against the guard. After authorization resolves, `expectCredentials` asserts the resulting session's bearer matches the upstream-issued token. The guard implementation, in turn, can use `guard.resolveId.applyAsLong("jwt0")` at attach time to thread the inbound subject credential through to the upstream exchange.

## Test plan

- [ ] `./mvnw clean verify -pl runtime/engine` — engine unit + IT tests pass.
- [ ] Synchronous guards (jwt, azure-ad, identity, etc.) continue to work via the default async-overload bridge.
- [ ] A pre-authorization-capable guard (e.g. an OAuth-style guard in a downstream module) can be exercised declaratively via the new `callback` / `callbackParams` authorization fields and asserted via `expectIdentity` / `expectCredentials`. The guard's `via` reference is resolved through `GuardConfig.resolveId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)