### PR TITLE
feat(command-dump): add REDIRECT control frame support

### DIFF
--- a/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/ZillaDumpCommand.java
+++ b/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/ZillaDumpCommand.java
@@ -79,6 +79,7 @@ import io.aklivity.zilla.runtime.command.dump.internal.types.stream.EndFW;
 import io.aklivity.zilla.runtime.command.dump.internal.types.stream.ExtensionFW;
 import io.aklivity.zilla.runtime.command.dump.internal.types.stream.FlushFW;
 import io.aklivity.zilla.runtime.command.dump.internal.types.stream.FrameFW;
+import io.aklivity.zilla.runtime.command.dump.internal.types.stream.RedirectFW;
 import io.aklivity.zilla.runtime.command.dump.internal.types.stream.ResetFW;
 import io.aklivity.zilla.runtime.command.dump.internal.types.stream.SignalFW;
 import io.aklivity.zilla.runtime.command.dump.internal.types.stream.WindowFW;
@@ -216,6 +217,7 @@ public final class ZillaDumpCommand extends ZillaCommand
     private final FlushFW flushRO = new FlushFW();
     private final SignalFW signalRO = new SignalFW();
     private final ChallengeFW challengeRO = new ChallengeFW();
+    private final RedirectFW redirectRO = new RedirectFW();
     private final PcapGlobalHeaderFW.Builder pcapGlobalHeaderRW = new PcapGlobalHeaderFW.Builder();
     private final PcapPacketHeaderFW.Builder pcapPacketHeaderRW = new PcapPacketHeaderFW.Builder();
     private final BeginFW.Builder beginRW = new BeginFW.Builder();
@@ -225,6 +227,7 @@ public final class ZillaDumpCommand extends ZillaCommand
     private final ResetFW.Builder resetRW = new ResetFW.Builder();
     private final FlushFW.Builder flushRW = new FlushFW.Builder();
     private final ChallengeFW.Builder challengeRW = new ChallengeFW.Builder();
+    private final RedirectFW.Builder redirectRW = new RedirectFW.Builder();
     private final IPv6HeaderFW.Builder ipv6HeaderRW = new IPv6HeaderFW.Builder();
     private final IPv6JumboHeaderFW.Builder ipv6JumboHeaderRW = new IPv6JumboHeaderFW.Builder();
     private final TcpHeaderFW.Builder tcpHeaderRW = new TcpHeaderFW.Builder();
@@ -595,6 +598,9 @@ public final class ZillaDumpCommand extends ZillaCommand
             case ChallengeFW.TYPE_ID:
                 onChallenge(challengeRO.wrap(buffer, index, index + length));
                 break;
+            case RedirectFW.TYPE_ID:
+                onRedirect(redirectRO.wrap(buffer, index, index + length));
+                break;
             default:
                 break;
             }
@@ -737,6 +743,21 @@ public final class ZillaDumpCommand extends ZillaCommand
 
                 writeFrame(ChallengeFW.TYPE_ID, worker, offset, newChallenge.originId(), newChallenge.routedId(),
                     newChallenge.streamId(), newChallenge.timestamp(), newChallenge, PSH_ACK);
+            }
+        }
+
+        private void onRedirect(
+            RedirectFW redirect)
+        {
+            if (allowedBinding.test(redirect.routedId()))
+            {
+                int offset = redirect.offset() - HEADER_LENGTH;
+                final RedirectFW newRedirect = redirectRW.wrap(patchBuffer, 0, redirect.sizeof()).set(redirect).build();
+                final ExtensionFW extension = newRedirect.extension().get(extensionRO::tryWrap);
+                patchExtension(patchBuffer, extension, RedirectFW.FIELD_OFFSET_EXTENSION);
+
+                writeFrame(RedirectFW.TYPE_ID, worker, offset, newRedirect.originId(), newRedirect.routedId(),
+                    newRedirect.streamId(), newRedirect.timestamp(), newRedirect, PSH);
             }
         }
 

--- a/incubator/command-dump/src/main/resources/io/aklivity/zilla/runtime/command/dump/internal/airline/zilla.lua
+++ b/incubator/command-dump/src/main/resources/io/aklivity/zilla/runtime/command/dump/internal/airline/zilla.lua
@@ -41,6 +41,7 @@ RESET_ID = 0x40000001
 WINDOW_ID = 0x40000002
 SIGNAL_ID = 0x40000003
 CHALLENGE_ID = 0x40000004
+REDIRECT_ID = 0x40000005
 
 AMQP_ID = 0x112dc182
 FILESYSTEM_ID = 0xe4e6aa9e
@@ -867,6 +868,8 @@ function zilla_protocol.dissector(buffer, pinfo, tree)
         handle_signal_frame(buffer, next_offset, subtree, pinfo, info)
     elseif frame_type_id == ABORT_ID or frame_type_id == RESET_ID or frame_type_id == CHALLENGE_ID then
         handle_extension(buffer, subtree, pinfo, info, next_offset, frame_type_id)
+    elseif frame_type_id == REDIRECT_ID then
+        handle_redirect_frame(buffer, next_offset, subtree, pinfo, info)
     end
 end
 
@@ -874,6 +877,12 @@ function handle_begin_frame(buffer, offset, subtree, pinfo, info)
     local slice_affinity = buffer(offset, 8)
     subtree:add_le(fields.affinity, slice_affinity)
     handle_extension(buffer, subtree, pinfo, info, offset + 8, BEGIN_ID)
+end
+
+function handle_redirect_frame(buffer, offset, subtree, pinfo, info)
+    local slice_affinity = buffer(offset, 8)
+    subtree:add_le(fields.affinity, slice_affinity)
+    handle_extension(buffer, subtree, pinfo, info, offset + 8, REDIRECT_ID)
 end
 
 function handle_data_frame(buffer, offset, tree, subtree, sequence, acknowledge, maximum, pinfo, info, protocol_type)
@@ -974,6 +983,7 @@ function resolve_frame_type(frame_type_id)
     elseif frame_type_id == WINDOW_ID    then frame_type = "WINDOW"
     elseif frame_type_id == SIGNAL_ID    then frame_type = "SIGNAL"
     elseif frame_type_id == CHALLENGE_ID then frame_type = "CHALLENGE"
+    elseif frame_type_id == REDIRECT_ID  then frame_type = "REDIRECT"
     end
     return frame_type
 end
@@ -1280,7 +1290,8 @@ function add_proxy_string_as_subtree(buffer, tree, label_format, slice_type_id, 
 end
 
 function handle_http_extension(buffer, offset, ext_subtree, frame_type_id)
-    if frame_type_id == BEGIN_ID or frame_type_id == RESET_ID or frame_type_id == CHALLENGE_ID then
+    if frame_type_id == BEGIN_ID or frame_type_id == RESET_ID or frame_type_id == CHALLENGE_ID or
+            frame_type_id == REDIRECT_ID then
         dissect_and_add_http_headers(buffer, offset, ext_subtree, "Headers", "Header")
     elseif frame_type_id == END_ID then
         dissect_and_add_http_headers(buffer, offset, ext_subtree, "Trailers", "Trailer")
@@ -1311,7 +1322,7 @@ function dissect_and_add_http_headers(buffer, offset, tree, plural_name, singula
 end
 
 function handle_grpc_extension(buffer, offset, ext_subtree, frame_type_id)
-    if frame_type_id == BEGIN_ID then
+    if frame_type_id == BEGIN_ID or frame_type_id == REDIRECT_ID then
         handle_grpc_begin_extension(buffer, offset, ext_subtree)
     elseif frame_type_id == DATA_ID then
         handle_grpc_data_extension(buffer, offset, ext_subtree)
@@ -1464,7 +1475,7 @@ function decode_varuint32(buffer, offset)
 end
 
 function handle_sse_extension(buffer, offset, ext_subtree, frame_type_id)
-    if frame_type_id == BEGIN_ID then
+    if frame_type_id == BEGIN_ID or frame_type_id == REDIRECT_ID then
         handle_sse_begin_extension(buffer, offset, ext_subtree)
     elseif frame_type_id == DATA_ID then
         handle_sse_data_extension(buffer, offset, ext_subtree)
@@ -1521,7 +1532,7 @@ function handle_sse_end_extension(buffer, offset, ext_subtree)
 end
 
 function handle_ws_extension(buffer, offset, ext_subtree, frame_type_id)
-    if frame_type_id == BEGIN_ID then
+    if frame_type_id == BEGIN_ID or frame_type_id == REDIRECT_ID then
         handle_ws_begin_extension(buffer, offset, ext_subtree)
     elseif frame_type_id == DATA_ID then
         handle_ws_data_extension(buffer, offset, ext_subtree)
@@ -1629,12 +1640,13 @@ function handle_filesystem_extension(buffer, offset, ext_subtree)
 end
 
 function handle_mqtt_extension(buffer, offset, ext_subtree, frame_type_id)
-    if frame_type_id == BEGIN_ID or frame_type_id == DATA_ID or frame_type_id == FLUSH_ID then
+    if frame_type_id == BEGIN_ID or frame_type_id == DATA_ID or frame_type_id == FLUSH_ID or
+            frame_type_id == REDIRECT_ID then
         local kind_length = 1
         local slice_kind = buffer(offset, kind_length)
         local kind = mqtt_ext_kinds[slice_kind:le_int()]
         ext_subtree:add_le(fields.mqtt_ext_kind, slice_kind)
-        if frame_type_id == BEGIN_ID then
+        if frame_type_id == BEGIN_ID or frame_type_id == REDIRECT_ID then
             if kind == "PUBLISH" then
                 handle_mqtt_begin_publish_extension(buffer, offset + kind_length, ext_subtree)
             elseif kind == "SUBSCRIBE" then
@@ -2046,12 +2058,13 @@ function handle_mqtt_reset_extension(buffer, offset, ext_subtree)
 end
 
 function handle_kafka_extension(buffer, offset, ext_subtree, frame_type_id)
-    if frame_type_id == BEGIN_ID or frame_type_id == DATA_ID or frame_type_id == FLUSH_ID then
+    if frame_type_id == BEGIN_ID or frame_type_id == DATA_ID or frame_type_id == FLUSH_ID or
+            frame_type_id == REDIRECT_ID then
         local api_length = 1
         local slice_api = buffer(offset, api_length)
         local api = kafka_ext_apis[slice_api:le_uint()]
         ext_subtree:add_le(fields.kafka_ext_api, slice_api)
-        if frame_type_id == BEGIN_ID then
+        if frame_type_id == BEGIN_ID or frame_type_id == REDIRECT_ID then
             if api == "CONSUMER" then
                 handle_kafka_begin_consumer_extension(buffer, offset + api_length, ext_subtree)
             elseif api == "GROUP" then

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/ws/streams/application/advise/client.sent.redirect/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/ws/streams/application/advise/client.sent.redirect/client.rpt
@@ -1,0 +1,32 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:ephemeral "app0"
+        option zilla:timestamps "false"
+        option zilla:window 8192
+        option zilla:transmission "duplex"
+
+write zilla:begin.ext ${ws:beginEx()
+                            .typeId(zilla:id("ws"))
+                            .protocol(null)
+                            .scheme("http")
+                            .authority("localhost:8080")
+                            .path("/echo")
+                            .build()}
+
+connected
+
+write advised zilla:redirect 0x00000000000000b1L

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/ws/streams/application/advise/client.sent.redirect/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/ws/streams/application/advise/client.sent.redirect/client.rpt
@@ -30,3 +30,5 @@ write zilla:begin.ext ${ws:beginEx()
 connected
 
 write advised zilla:redirect 0x00000000000000b1L
+
+read abort

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/ws/streams/application/advise/client.sent.redirect/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/ws/streams/application/advise/client.sent.redirect/server.rpt
@@ -30,3 +30,5 @@ read zilla:begin.ext ${ws:beginEx()
 connected
 
 read advise zilla:redirect 0x00000000000000b1L
+
+write aborted

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/ws/streams/application/advise/client.sent.redirect/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/ws/streams/application/advise/client.sent.redirect/server.rpt
@@ -1,0 +1,32 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/app0"
+    option zilla:timestamps "false"
+    option zilla:window 8192
+    option zilla:transmission "duplex"
+accepted
+
+read zilla:begin.ext ${ws:beginEx()
+                           .typeId(zilla:id("ws"))
+                           .protocol(null)
+                           .scheme("http")
+                           .authority("localhost:8080")
+                           .path("/echo")
+                           .build()}
+
+connected
+
+read advise zilla:redirect 0x00000000000000b1L

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT.java
@@ -17,6 +17,7 @@ package io.aklivity.zilla.runtime.command.dump.internal;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -46,6 +47,16 @@ public class WsAdvisoryApplicationIT
         "${app}/client.sent.challenge/client",
         "${app}/client.sent.challenge/server" })
     public void shouldReceiveClientSentChallenge() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Ignore("Pending regeneration of WsAdvisoryApplicationIT_shouldReceiveClientSentRedirect.txt via tshark")
+    @Test
+    @Specification({
+        "${app}/client.sent.redirect/client",
+        "${app}/client.sent.redirect/server" })
+    public void shouldReceiveClientSentRedirect() throws Exception
     {
         k3po.finish();
     }

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT.java
@@ -17,7 +17,6 @@ package io.aklivity.zilla.runtime.command.dump.internal;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -51,7 +50,6 @@ public class WsAdvisoryApplicationIT
         k3po.finish();
     }
 
-    @Ignore("Pending regeneration of WsAdvisoryApplicationIT_shouldReceiveClientSentRedirect.txt via tshark")
     @Test
     @Specification({
         "${app}/client.sent.redirect/client",

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT_shouldReceiveClientSentRedirect.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT_shouldReceiveClientSentRedirect.txt
@@ -1,0 +1,213 @@
+Frame 1: 241 bytes on wire (1928 bits), 241 bytes captured (1928 bits)
+Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
+Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 167
+Zilla Frame
+    Frame Type ID: 0x00000001
+    Frame Type: BEGIN
+    Protocol Type ID: 0x00000000
+    Protocol Type: 
+    Worker: 0
+    Offset: 0x00000000
+    Origin ID: 0x0000000100000002
+    Origin Namespace: test
+    Origin Binding: app0
+    Routed ID: 0x0000000100000002
+    Routed Namespace: test
+    Routed Binding: app0
+    Stream ID: 0x3f3f000000000003
+    Initial ID: 0x3f3f000000000003
+    Reply ID: 0x3f3f000000000002
+    Direction: INI
+    Sequence: 0
+    Acknowledge: 0
+    Maximum: 0
+    Timestamp: 0x0000000000000000
+    Trace ID: 0x8000000000000001
+    Authorization: 0x0000000000000000
+    Affinity: 0x0000000000000000
+    Extension: ws
+        Stream Type ID: 0xe9cd9d56
+        Stream Type: ws
+        Protocol: 
+            Length: -1
+            Protocol: 
+        Scheme: http
+            Length: 4
+            Scheme: http
+        Authority: localhost:8080
+            Length: 14
+            Authority: localhost:8080
+        Path: /echo
+            Length: 5
+            Path: /echo
+
+Frame 2: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
+Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 168, Len: 128
+Zilla Frame
+    Frame Type ID: 0x00000001
+    Frame Type: BEGIN
+    Protocol Type ID: 0x00000000
+    Protocol Type: 
+    Worker: 0
+    Offset: 0x00000080
+    Origin ID: 0x0000000100000002
+    Origin Namespace: test
+    Origin Binding: app0
+    Routed ID: 0x0000000100000002
+    Routed Namespace: test
+    Routed Binding: app0
+    Stream ID: 0x3f3f000000000002
+    Initial ID: 0x3f3f000000000003
+    Reply ID: 0x3f3f000000000002
+    Direction: REP
+    Sequence: 0
+    Acknowledge: 0
+    Maximum: 0
+    Timestamp: 0x0000000000000000
+    Trace ID: 0x8000000000000002
+    Authorization: 0x0000000000000000
+    Affinity: 0x0000000000000000
+
+Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
+Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
+Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 168, Ack: 129, Len: 137
+Zilla Frame
+    Frame Type ID: 0x40000002
+    Frame Type: WINDOW
+    Protocol Type ID: 0x00000000
+    Protocol Type: 
+    Worker: 0
+    Offset: 0x000000d8
+    Origin ID: 0x0000000100000002
+    Origin Namespace: test
+    Origin Binding: app0
+    Routed ID: 0x0000000100000002
+    Routed Namespace: test
+    Routed Binding: app0
+    Stream ID: 0x3f3f000000000003
+    Initial ID: 0x3f3f000000000003
+    Reply ID: 0x3f3f000000000002
+    Direction: INI
+    Sequence: 0
+    Acknowledge: 0
+    Maximum: 8192
+    Timestamp: 0x0000000000000000
+    Trace ID: 0x8000000000000003
+    Authorization: 0x0000000000000000
+    Budget ID: 0x0000000000000000
+    Padding: 0
+    Minimum: 0
+    Capabilities: 0x00
+    Progress: 0
+    Progress/Maximum: 0/8192
+
+Frame 4: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
+Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
+Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 129, Ack: 305, Len: 137
+Zilla Frame
+    Frame Type ID: 0x40000002
+    Frame Type: WINDOW
+    Protocol Type ID: 0x00000000
+    Protocol Type: 
+    Worker: 0
+    Offset: 0x00000138
+    Origin ID: 0x0000000100000002
+    Origin Namespace: test
+    Origin Binding: app0
+    Routed ID: 0x0000000100000002
+    Routed Namespace: test
+    Routed Binding: app0
+    Stream ID: 0x3f3f000000000002
+    Initial ID: 0x3f3f000000000003
+    Reply ID: 0x3f3f000000000002
+    Direction: REP
+    Sequence: 0
+    Acknowledge: 0
+    Maximum: 8192
+    Timestamp: 0x0000000000000000
+    Trace ID: 0x8000000000000004
+    Authorization: 0x0000000000000000
+    Budget ID: 0x0000000000000000
+    Padding: 0
+    Minimum: 0
+    Capabilities: 0x00
+    Progress: 0
+    Progress/Maximum: 0/8192
+
+Frame 5: 241 bytes on wire (1928 bits), 241 bytes captured (1928 bits)
+Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
+Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 305, Len: 167
+Zilla Frame
+    Frame Type ID: 0x40000005
+    Frame Type: REDIRECT
+    Protocol Type ID: 0x00000000
+    Protocol Type: 
+    Worker: 0
+    Offset: 0x00000198
+    Origin ID: 0x0000000100000002
+    Origin Namespace: test
+    Origin Binding: app0
+    Routed ID: 0x0000000100000002
+    Routed Namespace: test
+    Routed Binding: app0
+    Stream ID: 0x3f3f000000000003
+    Initial ID: 0x3f3f000000000003
+    Reply ID: 0x3f3f000000000002
+    Direction: INI
+    Sequence: 0
+    Acknowledge: 0
+    Maximum: 8192
+    Timestamp: 0x0000000000000000
+    Trace ID: 0x8000000000000005
+    Authorization: 0x0000000000000000
+    Affinity: 0x00000000000000b1
+    Extension: ws
+        Stream Type ID: 0xe9cd9d56
+        Stream Type: ws
+        Protocol: 
+            Length: -1
+            Protocol: 
+        Scheme: http
+            Length: 4
+            Scheme: http
+        Authority: localhost:8080
+            Length: 14
+            Authority: localhost:8080
+        Path: /echo
+            Length: 5
+            Path: /echo
+
+Frame 6: 194 bytes on wire (1552 bits), 194 bytes captured (1552 bits)
+Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
+Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 266, Len: 120
+Zilla Frame
+    Frame Type ID: 0x40000001
+    Frame Type: RESET
+    Protocol Type ID: 0x00000000
+    Protocol Type: 
+    Worker: 0
+    Offset: 0x00000218
+    Origin ID: 0x0000000100000002
+    Origin Namespace: test
+    Origin Binding: app0
+    Routed ID: 0x0000000100000002
+    Routed Namespace: test
+    Routed Binding: app0
+    Stream ID: 0x3f3f000000000002
+    Initial ID: 0x3f3f000000000003
+    Reply ID: 0x3f3f000000000002
+    Direction: REP
+    Sequence: 0
+    Acknowledge: 0
+    Maximum: 8192
+    Timestamp: 0x0000000000000000
+    Trace ID: 0x8000000000000006
+    Authorization: 0x0000000000000000
+

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaSource.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaSource.java
@@ -128,6 +128,15 @@ public final class ZillaSource implements AutoCloseable
             streamFactory.doRedirect(channel, traceId);
 
             adviseFuture.setSuccess();
+            if (channel.setReadAborted())
+            {
+                if (channel.setReadClosed())
+                {
+                    fireChannelDisconnected(channel);
+                    fireChannelUnbound(channel);
+                    fireChannelClosed(channel);
+                }
+            }
         }
         else
         {

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaTarget.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaTarget.java
@@ -1047,6 +1047,7 @@ final class ZillaTarget implements AutoCloseable
         private void onRedirect(
             RedirectFW redirect)
         {
+            final long streamId = redirect.streamId();
             final long acknowledge = redirect.acknowledge();
             final long affinity = redirect.affinity();
 
@@ -1054,8 +1055,23 @@ final class ZillaTarget implements AutoCloseable
 
             channel.writeExtBuffer(REDIRECT, false).writeLong(affinity);
 
-            unregisterThrottle.accept(redirect.streamId());
+            unregisterThrottle.accept(streamId);
             fireOutputAdvised(channel, ADVISORY_REDIRECT);
+
+            if (channel.setWriteAborted())
+            {
+                if (channel.setWriteClosed())
+                {
+                    fireOutputAborted(channel);
+                    fireChannelDisconnected(channel);
+                    fireChannelUnbound(channel);
+                    fireChannelClosed(channel);
+                }
+                else
+                {
+                    fireOutputAborted(channel);
+                }
+            }
         }
 
         private void onChallenge(


### PR DESCRIPTION
## Summary

Adds REDIRECT control frame support across two layers, aligned with the
RESET pattern that the engine ABI from #1755 establishes as the model
for stream-terminating throttle frames.

### `command-dump` — `8c8b3971`

Captures the engine's REDIRECT frame (type id `0x40000005`, introduced
in #1755) in the `zilla dump` command's pcap output and surfaces it in
the `zilla.lua` Wireshark dissector.

- `ZillaDumpCommand`: `RedirectFW` flyweight (read + builder), dispatch
  on `RedirectFW.TYPE_ID` in `handleFrame`, and `onRedirect` patches the
  round-tripped extension and emits the pcap frame with TCP `PSH` (like
  `RESET`, since REDIRECT terminates the stream).
- `zilla.lua`: `REDIRECT_ID = 0x40000005`, registered in
  `resolve_frame_type`, dispatched via `handle_redirect_frame` (affinity
  + extension, same shape as `BEGIN`). Each binding's extension
  dissector (`handle_http_extension`, `handle_grpc_extension`,
  `handle_sse_extension`, `handle_ws_extension`, `handle_mqtt_extension`,
  `handle_kafka_extension`) treats `REDIRECT` as the BEGIN-style payload
  since the extension is round-tripped from BEGIN.
- New k3po scripts under
  `…/ws/streams/application/advise/client.sent.redirect/{client,server}.rpt`
  exercising `write advised zilla:redirect` / `read advise zilla:redirect`
  with a non-empty `ws:beginEx` round-trip.
- `WsAdvisoryApplicationIT#shouldReceiveClientSentRedirect` is wired
  but `@Ignore`'d pending regeneration of its tshark-generated expected
  fixture on a docker-enabled host.

### `engine` k3po-zilla transport teardown — `13ad202a`

Per the engine ABI, REDIRECT terminates the stream like RESET
(`EngineWorker.dispatch` and `Target.handle*` both call
`dispatcher.remove` / `streams[].remove` on `RedirectFW.TYPE_ID` the
same as `ResetFW.TYPE_ID`). The k3po-zilla test transport was leaving
the channel in an inconsistent state on both ends, so follow-up cleanup
or script steps could emit END / ABORT frames against a stream the
engine had already torn down — yielding inconsistent `zilla dump`
output. Mirror the existing RESET pattern exactly:

- `ZillaSource.doAdviseInput` (ADVISORY_REDIRECT branch): the caller of
  `streamFactory.doRedirect` closes the local **READ** side after the
  frame is written, mirroring `doAbortInputAfterBegin` for RESET. The
  frame writer (`ZillaTarget.doRedirect`) stays state-free, mirroring
  `ZillaTarget.doReset` / `doAbortInput`.
- `Throttle.onRedirect`: on the receiver side, full mirror of
  `Throttle.onReset` — `setWriteAborted` + `setWriteClosed` +
  `fireOutputAborted` + disconnect/unbind/close events. The receiver is
  the source of the stream (REDIRECT travels in the throttle direction,
  opposite the BEGIN), so its WRITE side is what the redirect
  terminates — same as RESET semantics.

## Test plan

- [x] `./mvnw -pl incubator/command-dump install -DskipTests -DskipITs`
      compiles cleanly with the generated `RedirectFW`.
- [x] `./mvnw -pl incubator/command-dump checkstyle:check` reports 0
      violations.
- [x] `./mvnw -pl runtime/engine clean verify` green — surefire 320/320
      + failsafe 204/204 (incl. `SimplexIT` 37/37, with the REDIRECT
      test from #1755).
- [x] Full CI Build (25) + Analyze (java) + CodeQL green on
      `13ad202a`.
- [ ] Re-enable `shouldReceiveClientSentRedirect` and regenerate
      `WsAdvisoryApplicationIT_shouldReceiveClientSentRedirect.txt` via
      the docker-based tshark runner; verify the dissector output
      matches the expected REDIRECT layout (frame type, affinity,
      round-tripped ws extension).
- [ ] Manual sanity check by running `zilla dump` against an engine
      that emits REDIRECT and opening the resulting pcap in Wireshark
      with the updated `zilla.lua` plugin.

Closes the dump-command gap from #1753.

https://claude.ai/code/session_01K4wd5z8Ejgq4ejTsmL88oh