### PR TITLE
fix(engine): await worker/boss onStart before EngineManager registration

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineBoss.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineBoss.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -59,6 +60,7 @@ public class EngineBoss implements EngineController, Agent
     private final Map<String, BindingController> controllersByType;
     private final int maxSelectMillis;
     private final int maxIdleCount;
+    private final CountDownLatch started = new CountDownLatch(1);
 
     private volatile Thread thread;
     private Set<NamespaceConfig> namespaces;
@@ -129,6 +131,22 @@ public class EngineBoss implements EngineController, Agent
     public void doStart()
     {
         thread = startOnThread(runner, Thread::new);
+
+        try
+        {
+            started.await();
+        }
+        catch (InterruptedException ex)
+        {
+            Thread.currentThread().interrupt();
+            rethrowUnchecked(ex);
+        }
+    }
+
+    @Override
+    public void onStart()
+    {
+        started.countDown();
     }
 
     public void doClose()

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -60,6 +60,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -273,6 +274,8 @@ public class EngineWorker implements EngineContext, Agent
     private long lastReadStreamId;
     private int idleCount;
     private volatile Thread thread;
+
+    private final CountDownLatch started = new CountDownLatch(1);
 
     private Map<String, ModelContext> modelsByType;
     private EngineRegistry registry;
@@ -856,6 +859,16 @@ public class EngineWorker implements EngineContext, Agent
     public void doStart()
     {
         thread = startOnThread(runner, Thread::new);
+
+        try
+        {
+            started.await();
+        }
+        catch (InterruptedException ex)
+        {
+            Thread.currentThread().interrupt();
+            rethrowUnchecked(ex);
+        }
     }
 
     public void doClose()
@@ -915,6 +928,18 @@ public class EngineWorker implements EngineContext, Agent
 
     @Override
     public void onStart()
+    {
+        try
+        {
+            doInit();
+        }
+        finally
+        {
+            started.countDown();
+        }
+    }
+
+    private void doInit()
     {
         this.streamFactory = router.attach(routerConfig);
 


### PR DESCRIPTION
## Summary

Fixes an NPE introduced by #1757 that surfaces in `binding-pgsql-kafka` (`ProxyIT.shouldDropTopic` and others):

```
java.lang.NullPointerException: Cannot invoke "EngineRegistry.attach(NamespaceConfig)" because "this.registry" is null
    at EngineWorker.attach(EngineWorker.java:1086)
    at EngineManager.lambda$register$1(EngineManager.java:588)
```

After #1757, `EngineWorker` builds its `registry` (and the per-worker binding/guard/vault/catalog/store/model/metric contexts) inside `onStart`, on the worker thread, so handler `supply(this)` calls happen on the owning thread. But `EngineWorker.doStart` was fire-and-forget — it returned as soon as `startOnThread` had launched the runner, before the runner had reached `onStart`.

`Engine.start` then proceeded to start `EngineManager`, whose config watch could fire `register` and call `EngineWorker.attach(namespace)` → `registry.attach(namespace)` against a worker whose `onStart` hadn't yet run, producing the NPE. The pre-#1757 code happened to be safe only because all of that initialization ran in the constructor.

The fix makes startup ordering deterministic with a `CountDownLatch` per worker / boss:

- Counted down at the end of `onStart` in a `finally` (so init failures still release the latch — `await` returns and the runner's error handler surfaces the real exception).
- Awaited at the end of `doStart` before returning.

`EngineBoss` currently has no work in `onStart`, but adding the symmetric scaffolding keeps the worker/boss lifecycle consistent and protects against future asymmetric init.

## Test plan
- [x] `./mvnw -pl runtime/engine clean install` — 320 unit + 204 ITs pass; JaCoCo coverage check passes
- [x] `./mvnw -pl incubator/binding-pgsql-kafka clean verify` — `ProxyIT` 5/5 pass (previously 4 run with 3 errors)
- [x] `./mvnw -pl runtime/binding-http -am clean verify` — green
- [x] `./mvnw -pl runtime/engine checkstyle:check` — clean

https://claude.ai/code/session_01RXTcFJG39snE5KhLkMSALD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RN8xhzqGY2rsXGdkaELa42)_