### PR TITLE
Cache Maven repository in release workflow using actions/cache and generated cache key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,10 +125,23 @@ jobs:
       with:
         java-version: 25
         distribution: zulu
-        cache: maven
         server-id: github
         server-username: GITHUB_ACTOR
         server-password: GITHUB_TOKEN
+
+    - name: Create Maven cache key input
+      run: |
+        find . -name pom.xml -print0 \
+          | sort -z \
+          | xargs -0 sed -E '0,/<version>[^<]+<\/version>/s//<version>IGNORED<\/version>/' \
+          > .maven-cache-key
+
+    - name: Cache Maven packages
+      uses: actions/cache@v5
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('.maven-cache-key') }}
+        restore-keys: ${{ runner.os }}-m2-
 
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v3


### PR DESCRIPTION
### Motivation
- Speed up repeated release job runs by caching the local Maven repository across workflow executions.
- Replace the `cache: maven` option on `actions/setup-java@v5` with an explicit cache step that uses a deterministic key based on project POM contents to avoid unnecessary cache misses.

### Description
- Removed the `cache: maven` option from the `Setup JDK` step using `actions/setup-java@v5`.
- Added a `Create Maven cache key input` step that collects all `pom.xml` files, normalizes a version fragment, and writes the combined result to `.maven-cache-key` for hashing.
- Added a `Cache Maven packages` step using `actions/cache@v5` to cache `~/.m2` with a key of `${{ runner.os }}-m2-${{ hashFiles('.maven-cache-key') }}` and a restore prefix of `${{ runner.os }}-m2-`.
- Kept the existing deploy (`./mvnw ... deploy`) and post-deploy cleanup (`rm -fr ~/.m2/repository/...`) steps unchanged.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a025f961bd883228057381627daf664)