### PR TITLE
mcp: session id alignment + redirect handling and configurable attempts

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfiguration.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfiguration.java
@@ -14,6 +14,8 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal;
 
+import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_WORKERS;
+
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -39,6 +41,7 @@ public class McpConfiguration extends Configuration
     public static final PropertyDef<String> MCP_CLIENT_NAME;
     public static final PropertyDef<String> MCP_CLIENT_VERSION;
     public static final PropertyDef<Duration> MCP_INACTIVITY_TIMEOUT;
+    public static final IntPropertyDef MCP_SESSION_ID_ATTEMPTS;
     public static final IntPropertyDef MCP_KEEPALIVE_TOLERANCE;
     public static final PropertyDef<Duration> MCP_SSE_KEEPALIVE_INTERVAL;
 
@@ -59,6 +62,8 @@ public class McpConfiguration extends Configuration
             McpConfiguration::defaultServerVersion);
         MCP_INACTIVITY_TIMEOUT = config.property(Duration.class, "inactivity.timeout",
             (c, v) -> Duration.parse(v), "PT60S");
+        MCP_SESSION_ID_ATTEMPTS = config.property("session.id.attempts",
+            McpConfiguration::defaultSessionIdAttempts);
         MCP_KEEPALIVE_TOLERANCE = config.property("keepalive.tolerance", 2);
         MCP_SSE_KEEPALIVE_INTERVAL = config.property(Duration.class, "sse.keepalive.interval",
             (c, v) -> Duration.parse(v), "PT15S");
@@ -114,6 +119,11 @@ public class McpConfiguration extends Configuration
     public int keepaliveTolerance()
     {
         return MCP_KEEPALIVE_TOLERANCE.getAsInt(this);
+    }
+
+    public int sessionIdAttempts()
+    {
+        return MCP_SESSION_ID_ATTEMPTS.getAsInt(this);
     }
 
     public Duration sseKeepaliveInterval()
@@ -183,6 +193,12 @@ public class McpConfiguration extends Configuration
     private static String defaultSessionIdSupplier()
     {
         return UUID.randomUUID().toString();
+    }
+
+    private static int defaultSessionIdAttempts(
+        Configuration config)
+    {
+        return Math.max(1, ENGINE_WORKERS.getAsInt(config) * 2);
     }
 
     private static ElicitationIdSupplier decodeElicitationIdSupplier(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -18,7 +18,9 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabiliti
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabilities.CLIENT_ROOTS;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabilities.CLIENT_SAMPLING;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
+import static io.aklivity.zilla.runtime.engine.internal.stream.StreamId.streamIndex;
 
+import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -64,6 +66,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpElicitCrea
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpElicitStatus;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpFlushExFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpProgressFlushExFW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.RedirectFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.ResetFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.SignalFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.WindowFW;
@@ -75,6 +78,7 @@ import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
 import io.aklivity.zilla.runtime.engine.buffer.BufferPool;
 import io.aklivity.zilla.runtime.engine.concurrent.Signaler;
 import io.aklivity.zilla.runtime.engine.config.BindingConfig;
+import io.aklivity.zilla.runtime.engine.util.function.LongLongFunction;
 
 public final class McpServerFactory implements McpStreamFactory
 {
@@ -171,6 +175,7 @@ public final class McpServerFactory implements McpStreamFactory
     private final FlushFW.Builder flushRW = new FlushFW.Builder();
     private final WindowFW.Builder windowRW = new WindowFW.Builder();
     private final ResetFW.Builder resetRW = new ResetFW.Builder();
+    private final RedirectFW.Builder redirectRW = new RedirectFW.Builder();
     private final ChallengeFW.Builder challengeRW = new ChallengeFW.Builder();
     private final HttpBeginExFW.Builder httpBeginExRW = new HttpBeginExFW.Builder();
     private final HttpResetExFW.Builder httpResetExRW = new HttpResetExFW.Builder();
@@ -189,6 +194,7 @@ public final class McpServerFactory implements McpStreamFactory
     private final MutableDirectBuffer codecBuffer;
     private final BindingHandler streamFactory;
     private final LongUnaryOperator supplyInitialId;
+    private final LongLongFunction<Long> supplyInitialIdByHash;
     private final LongUnaryOperator supplyReplyId;
     private final int httpTypeId;
     private final int mcpTypeId;
@@ -196,6 +202,7 @@ public final class McpServerFactory implements McpStreamFactory
     private final BufferPool encodePool;
     private final int decodeMax;
     private final int encodeMax;
+    private final int sessionIdAttempts;
 
     private final DirectBufferInputStreamEx inputRO = new DirectBufferInputStreamEx();
 
@@ -228,6 +235,7 @@ public final class McpServerFactory implements McpStreamFactory
 
     private final Long2ObjectHashMap<McpBindingConfig> bindings;
     private final Map<String, McpServerFactory.McpLifecycleStream> sessions;
+    private final int localIndex;
 
     public McpServerFactory(
         McpConfiguration config,
@@ -244,6 +252,7 @@ public final class McpServerFactory implements McpStreamFactory
         this.codecBuffer = new UnsafeBuffer(new byte[context.writeBuffer().capacity()]);
         this.streamFactory = context.streamFactory();
         this.supplyInitialId = context::supplyInitialId;
+        this.supplyInitialIdByHash = (bindingId, hash) -> context.supplyInitialId(bindingId, (int) hash);
         this.supplyReplyId = context::supplyReplyId;
         this.bindings = new Long2ObjectHashMap<>();
         this.httpTypeId = context.supplyTypeId(HTTP_TYPE_NAME);
@@ -252,7 +261,9 @@ public final class McpServerFactory implements McpStreamFactory
         this.encodePool = context.bufferPool().duplicate();
         this.decodeMax = decodePool.slotCapacity();
         this.encodeMax = encodePool.slotCapacity();
+        this.sessionIdAttempts = config.sessionIdAttempts();
         this.sessions = new Object2ObjectHashMap<>();
+        this.localIndex = context.index();
         this.parserFactory = StreamingJson.createParserFactory(Map.of(
             StreamingJson.PATH_INCLUDES, SERVER_JSON_PATH_INCLUDES,
             StreamingJson.TOKEN_MAX_BYTES, decodeMax));
@@ -334,6 +345,26 @@ public final class McpServerFactory implements McpStreamFactory
                     .matchFirst(h -> HTTP_HEADER_PATH.equals(h.name().asString())))
                 .map(h -> h.value().asString())
                 .orElse(null);
+
+            final String sessionId = Optional.ofNullable(httpBeginEx.headers()
+                    .matchFirst(h -> HTTP_HEADER_SESSION.equals(h.name().asString())))
+                .map(h -> h.value().asString())
+                .orElseGet(() -> extractSessionIdFromState(path));
+
+            if (sessionId != null && !isSessionIdAligned(resolvedId, sessionId))
+            {
+                newStream = new McpRedirectHandler(
+                    sender,
+                    originId,
+                    routedId,
+                    initialId,
+                    initialSeq,
+                    initialAck,
+                    traceId,
+                    extension,
+                    sessionId)::onNetMessage;
+                return newStream;
+            }
 
             switch (method)
             {
@@ -1703,11 +1734,19 @@ public final class McpServerFactory implements McpStreamFactory
             long traceId,
             long authorization)
         {
-            McpLifecycleStream session = new McpLifecycleStream(this);
-            sessions.put(session.sessionId, session);
+            final String sessionId = newSessionId(resolvedId);
+            if (sessionId == null)
+            {
+                doNetReset(traceId, authorization);
+            }
+            else
+            {
+                McpLifecycleStream session = new McpLifecycleStream(this, sessionId);
+                sessions.put(session.sessionId, session);
 
-            assert this.session == null;
-            this.session = session;
+                assert this.session == null;
+                this.session = session;
+            }
         }
 
         private void onLifecycleInitialized(
@@ -2828,9 +2867,10 @@ public final class McpServerFactory implements McpStreamFactory
         private boolean eventsUnsupported;
 
         private McpLifecycleStream(
-            McpServer server)
+            McpServer server,
+            String sessionId)
         {
-            this.sessionId = supplySessionId.get();
+            this.sessionId = sessionId;
             this.requests = new Object2ObjectHashMap<>();
             this.elicitations = new Object2ObjectHashMap<>();
             this.originId = server.routedId;
@@ -4974,4 +5014,150 @@ public final class McpServerFactory implements McpStreamFactory
 
         return progress - offset;
     }
-}
+
+    private void doRedirect(
+        MessageConsumer sender,
+        long originId,
+        long routedId,
+        long streamId,
+        long sequence,
+        long acknowledge,
+        long traceId,
+        long authorization,
+        long affinity,
+        Flyweight extension)
+    {
+        final RedirectFW redirect = redirectRW.wrap(writeBuffer, 0, writeBuffer.capacity())
+            .originId(originId)
+            .routedId(routedId)
+            .streamId(streamId)
+            .sequence(sequence)
+            .acknowledge(acknowledge)
+            .maximum(0)
+            .traceId(traceId)
+            .authorization(authorization)
+            .budgetId(0L)
+            .padding(0)
+            .affinity(affinity)
+            .extension(extension.buffer(), extension.offset(), extension.sizeof())
+            .build();
+
+        sender.accept(redirect.typeId(), redirect.buffer(), redirect.offset(), redirect.sizeof());
+    }
+
+    private String newSessionId(
+        long resolvedId)
+    {
+        String sessionId = null;
+
+        for (int i = 0; i < sessionIdAttempts; i++)
+        {
+            final String candidate = supplySessionId.get();
+            if (isSessionIdAligned(resolvedId, candidate))
+            {
+                sessionId = candidate;
+                break;
+            }
+        }
+
+        return sessionId;
+    }
+
+    private boolean isSessionIdAligned(
+        long resolvedId,
+        String sessionId)
+    {
+        final long initialId = supplyInitialIdByHash.apply(resolvedId, sessionId.hashCode());
+        final int alignedIndex = streamIndex(initialId);
+        return alignedIndex == localIndex;
+    }
+
+    private String extractSessionIdFromState(
+        String path)
+    {
+        String sessionId = null;
+
+        if (path != null)
+        {
+            final Matcher matcher = STATE_PARAM_PATTERN.matcher(path);
+            if (matcher.find())
+            {
+                final String state = URLDecoder.decode(matcher.group(1), StandardCharsets.UTF_8);
+                final int dotAt = state.indexOf('.');
+                if (dotAt > 0)
+                {
+                    sessionId = state.substring(0, dotAt);
+                }
+            }
+        }
+
+        return sessionId;
+    }
+
+    private final class McpRedirectHandler
+    {
+        private final MessageConsumer sender;
+        private final long originId;
+        private final long routedId;
+        private final long streamId;
+        private final long sequence;
+        private final long acknowledge;
+        private final long traceId;
+        private final OctetsFW extension;
+        private final String sessionId;
+
+        private McpRedirectHandler(
+            MessageConsumer sender,
+            long originId,
+            long routedId,
+            long streamId,
+            long sequence,
+            long acknowledge,
+            long traceId,
+            OctetsFW extension,
+            String sessionId)
+        {
+            this.sender = sender;
+            this.originId = originId;
+            this.routedId = routedId;
+            this.streamId = streamId;
+            this.sequence = sequence;
+            this.acknowledge = acknowledge;
+            this.traceId = traceId;
+            this.extension = extension;
+            this.sessionId = sessionId;
+        }
+
+        private void onNetMessage(
+            int msgTypeId,
+            DirectBuffer buffer,
+            int index,
+            int length)
+        {
+            switch (msgTypeId)
+            {
+            case BeginFW.TYPE_ID:
+                final BeginFW begin = beginRO.wrap(buffer, index, index + length);
+                onNetBegin(begin);
+                break;
+            case AbortFW.TYPE_ID:
+            case DataFW.TYPE_ID:
+            case FlushFW.TYPE_ID:
+            case EndFW.TYPE_ID:
+            case ResetFW.TYPE_ID:
+            case WindowFW.TYPE_ID:
+            case ChallengeFW.TYPE_ID:
+                break;
+            default:
+                break;
+            }
+        }
+
+        private void onNetBegin(
+            BeginFW begin)
+        {
+            final long authorization = begin.authorization();
+            doRedirect(sender, originId, routedId, streamId, sequence, acknowledge, traceId, authorization,
+                sessionId.hashCode(), extension);
+        }
+    }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -5036,8 +5036,6 @@ public final class McpServerFactory implements McpStreamFactory
             .maximum(0)
             .traceId(traceId)
             .authorization(authorization)
-            .budgetId(0L)
-            .padding(0)
             .affinity(affinity)
             .extension(extension.buffer(), extension.offset(), extension.sizeof())
             .build();

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -5161,3 +5161,4 @@ public final class McpServerFactory implements McpStreamFactory
                 sessionId.hashCode(), extension);
         }
     }
+}

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfigurationTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfigurationTest.java
@@ -22,6 +22,7 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration.MC
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration.MCP_SERVER_NAME;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration.MCP_SERVER_VERSION;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration.MCP_SESSION_ID;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration.MCP_SESSION_ID_ATTEMPTS;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration.MCP_SSE_KEEPALIVE_INTERVAL;
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_DETACH_ON_CLOSE;
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_SYNTHETIC_ABORT;
@@ -40,6 +41,7 @@ public class McpConfigurationTest
     public static final String MCP_CLIENT_NAME_NAME = "zilla.binding.mcp.client.name";
     public static final String MCP_CLIENT_VERSION_NAME = "zilla.binding.mcp.client.version";
     public static final String MCP_INACTIVITY_TIMEOUT_NAME = "zilla.binding.mcp.inactivity.timeout";
+    public static final String MCP_SESSION_ID_ATTEMPTS_NAME = "zilla.binding.mcp.session.id.attempts";
     public static final String MCP_KEEPALIVE_TOLERANCE_NAME = "zilla.binding.mcp.keepalive.tolerance";
     public static final String MCP_SSE_KEEPALIVE_INTERVAL_NAME = "zilla.binding.mcp.sse.keepalive.interval";
 
@@ -55,6 +57,7 @@ public class McpConfigurationTest
         assertEquals(MCP_CLIENT_NAME.name(), MCP_CLIENT_NAME_NAME);
         assertEquals(MCP_CLIENT_VERSION.name(), MCP_CLIENT_VERSION_NAME);
         assertEquals(MCP_INACTIVITY_TIMEOUT.name(), MCP_INACTIVITY_TIMEOUT_NAME);
+        assertEquals(MCP_SESSION_ID_ATTEMPTS.name(), MCP_SESSION_ID_ATTEMPTS_NAME);
         assertEquals(MCP_KEEPALIVE_TOLERANCE.name(), MCP_KEEPALIVE_TOLERANCE_NAME);
         assertEquals(MCP_SSE_KEEPALIVE_INTERVAL.name(), MCP_SSE_KEEPALIVE_INTERVAL_NAME);
     }


### PR DESCRIPTION
### Motivation

- Ensure MCP session IDs are aligned to the local stream index and provide a redirect when a client-supplied session ID maps to a different index.
- Allow tuning how many candidate session IDs are generated to find an aligned one via configuration.

### Description

- Add configuration property `zilla.binding.mcp.session.id.attempts` with getter `sessionIdAttempts()` and default `ENGINE_WORKERS * 2` in `McpConfiguration` and expose it as `MCP_SESSION_ID_ATTEMPTS`.
- Introduce `supplyInitialIdByHash`, `sessionIdAttempts`, and `localIndex` in `McpServerFactory`, plus a `RedirectFW` builder to support redirect messages.
- Implement session alignment logic: `newSessionId(...)` tries up to configured attempts to obtain an aligned session id, `isSessionIdAligned(...)` checks alignment using `supplyInitialIdByHash` and `streamIndex`, and `extractSessionIdFromState(...)` pulls session id from `state` URL parameter.
- When an incoming HTTP begin contains a session id that is not aligned, construct a `McpRedirectHandler` to send a `RedirectFW` pointing the client to the correct affinity, and create lifecycle sessions with the chosen aligned session id or reset when none found.

### Testing

- Updated unit test `McpConfigurationTest` to include the new property constant and ran the binding-mcp module tests with `mvn -pl runtime/binding-mcp test`, which succeeded.
- Built the module and ran unit tests locally for the modified classes, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a02685dd9d88322abf59ab0d2117e12)

Closes #1761 