### PR TITLE
feat(binding-mcp): emit Alt-Svc response header from server

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfiguration.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfiguration.java
@@ -44,6 +44,8 @@ public class McpConfiguration extends Configuration
     public static final IntPropertyDef MCP_SESSION_ID_ATTEMPTS;
     public static final IntPropertyDef MCP_KEEPALIVE_TOLERANCE;
     public static final PropertyDef<Duration> MCP_SSE_KEEPALIVE_INTERVAL;
+    public static final BooleanPropertyDef MCP_ALT_SVC_ENABLED;
+    public static final PropertyDef<Duration> MCP_ALT_SVC_MAX_AGE;
 
     static
     {
@@ -67,6 +69,9 @@ public class McpConfiguration extends Configuration
         MCP_KEEPALIVE_TOLERANCE = config.property("keepalive.tolerance", 2);
         MCP_SSE_KEEPALIVE_INTERVAL = config.property(Duration.class, "sse.keepalive.interval",
             (c, v) -> Duration.parse(v), "PT15S");
+        MCP_ALT_SVC_ENABLED = config.property("alt.svc.enabled", McpConfiguration::defaultAltSvcEnabled);
+        MCP_ALT_SVC_MAX_AGE = config.property(Duration.class, "alt.svc.max.age",
+            (c, v) -> Duration.parse(v), "PT24H");
         MCP_CONFIG = config;
     }
 
@@ -129,6 +134,16 @@ public class McpConfiguration extends Configuration
     public Duration sseKeepaliveInterval()
     {
         return MCP_SSE_KEEPALIVE_INTERVAL.get(this);
+    }
+
+    public boolean altSvcEnabled()
+    {
+        return MCP_ALT_SVC_ENABLED.getAsBoolean(this);
+    }
+
+    public Duration altSvcMaxAge()
+    {
+        return MCP_ALT_SVC_MAX_AGE.get(this);
     }
 
     @FunctionalInterface
@@ -199,6 +214,13 @@ public class McpConfiguration extends Configuration
         Configuration config)
     {
         return Math.max(1, ENGINE_WORKERS.getAsInt(config) * 2);
+    }
+
+    private static boolean defaultAltSvcEnabled(
+        Configuration config)
+    {
+        final String hostname = EngineConfiguration.ENGINE_SERVICE_HOSTNAME.get(config);
+        return hostname != null && !hostname.isEmpty();
     }
 
     private static ElicitationIdSupplier decodeElicitationIdSupplier(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -98,6 +98,7 @@ public final class McpServerFactory implements McpStreamFactory
     private static final String HTTP_HEADER_SESSION = "mcp-session-id";
     private static final String HTTP_HEADER_STATUS = ":status";
     private static final String HTTP_HEADER_CONTENT_TYPE = "content-type";
+    private static final String HTTP_HEADER_ALT_SVC = "alt-svc";
     private static final String HTTP_HEADER_ACCEPT = "accept";
     private static final String HTTP_HEADER_LAST_EVENT_ID = "last-event-id";
     private static final String CONTENT_TYPE_JSON = "application/json";
@@ -187,6 +188,8 @@ public final class McpServerFactory implements McpStreamFactory
     private final Supplier<String> supplyElicitationId;
     private final String serverName;
     private final String serverVersion;
+    private final boolean altSvcEnabled;
+    private final long altSvcMaxAgeSeconds;
     private final long inactivityTimeoutMillis;
     private final long sseKeepaliveIntervalMillis;
     private final Signaler signaler;
@@ -245,6 +248,8 @@ public final class McpServerFactory implements McpStreamFactory
         this.supplyElicitationId = config.elicitationIdSupplier();
         this.serverName = config.serverName();
         this.serverVersion = config.serverVersion();
+        this.altSvcEnabled = config.altSvcEnabled();
+        this.altSvcMaxAgeSeconds = config.altSvcMaxAge().toSeconds();
         this.inactivityTimeoutMillis = config.inactivityTimeout().toMillis();
         this.sseKeepaliveIntervalMillis = config.sseKeepaliveInterval().toMillis();
         this.signaler = context.signaler();
@@ -351,6 +356,12 @@ public final class McpServerFactory implements McpStreamFactory
                 .map(h -> h.value().asString())
                 .orElseGet(() -> extractSessionIdFromState(path));
 
+            final String authority = Optional.ofNullable(httpBeginEx.headers()
+                    .matchFirst(h -> HTTP_HEADER_AUTHORITY.equals(h.name().asString())))
+                .map(h -> h.value().asString())
+                .orElse(null);
+            final String altSvc = buildAltSvc(authority);
+
             if (sessionId != null && !isSessionIdAligned(resolvedId, sessionId))
             {
                 newStream = new McpRedirectHandler(
@@ -383,7 +394,8 @@ public final class McpServerFactory implements McpStreamFactory
                         initialId,
                         resolvedId,
                         session,
-                        redirectURI)::onNetMessage;
+                        redirectURI,
+                        altSvc)::onNetMessage;
                 }
                 break;
             case "GET":
@@ -393,18 +405,15 @@ public final class McpServerFactory implements McpStreamFactory
                             .matchFirst(h -> HTTP_HEADER_SCHEME.equals(h.name().asString())))
                         .map(h -> h.value().asString())
                         .orElse("https");
-                    final String authority = Optional.ofNullable(httpBeginEx.headers()
-                            .matchFirst(h -> HTTP_HEADER_AUTHORITY.equals(h.name().asString())))
-                        .map(h -> h.value().asString())
-                        .orElse("");
-                    final String callbackURL = scheme + "://" + authority + path;
+                    final String callbackURL = scheme + "://" + (authority != null ? authority : "") + path;
                     newStream = new McpAuthCallbackHandler(
                         sender,
                         originId,
                         routedId,
                         initialId,
                         path,
-                        callbackURL)::onNetMessage;
+                        callbackURL,
+                        altSvc)::onNetMessage;
                 }
                 else if (!acceptIncludesEventStream(accept))
                 {
@@ -453,7 +462,8 @@ public final class McpServerFactory implements McpStreamFactory
                             initialId,
                             session,
                             resolvedRequest,
-                            lastEventIdSuffix)::onNetMessage;
+                            lastEventIdSuffix,
+                            altSvc)::onNetMessage;
                     }
                 }
                 break;
@@ -464,7 +474,8 @@ public final class McpServerFactory implements McpStreamFactory
                     routedId,
                     initialId,
                     resolvedId,
-                    session)::onNetMessage;
+                    session,
+                    altSvc)::onNetMessage;
                 break;
             default:
                 newStream = new McpRejectHandler(sender, STATUS_405)::onNetBegin;
@@ -1258,6 +1269,7 @@ public final class McpServerFactory implements McpStreamFactory
         private McpRequestStream stream;
 
         private final String redirectURI;
+        private final String altSvc;
 
         private McpServer(
             MessageConsumer sender,
@@ -1266,7 +1278,8 @@ public final class McpServerFactory implements McpStreamFactory
             long initialId,
             long resolvedId,
             McpLifecycleStream session,
-            String redirectURI)
+            String redirectURI,
+            String altSvc)
         {
             this.net = sender;
             this.originId = originId;
@@ -1278,6 +1291,7 @@ public final class McpServerFactory implements McpStreamFactory
             this.decoder = decodeJsonRpc;
             this.initialMax = decodeMax;
             this.redirectURI = redirectURI;
+            this.altSvc = altSvc;
         }
 
         private void onNetMessage(
@@ -1785,11 +1799,11 @@ public final class McpServerFactory implements McpStreamFactory
             long traceId,
             long authorization)
         {
-            doEncodeResponseBegin(traceId, authorization, httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+            doEncodeResponseBegin(traceId, authorization, applyAltSvc(httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(httpTypeId)
                 .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
-                .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId))
+                .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId)), altSvc)
                 .build());
             String8FW payload = new String8FW(INITIALIZE_RESPONSE_PROTOCOL_PREFIX + serverName +
                 INITIALIZE_RESPONSE_VERSION_PREFIX + serverVersion + INITIALIZE_RESPONSE_SUFFIX);
@@ -1810,11 +1824,11 @@ public final class McpServerFactory implements McpStreamFactory
             long authorization)
         {
             doNetBegin(traceId, authorization,
-                httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+                applyAltSvc(httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(httpTypeId)
                     .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
                     .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
-                    .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId))
+                    .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId)), altSvc)
                     .build());
             doNetEnd(traceId, authorization);
         }
@@ -1826,11 +1840,11 @@ public final class McpServerFactory implements McpStreamFactory
             session.touch();
 
             doEncodeResponseBegin(traceId, authorization,
-                httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+                applyAltSvc(httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(httpTypeId)
                     .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
                     .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
-                    .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId))
+                    .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId)), altSvc)
                     .build());
             String8FW payload = new String8FW("{}");
             doEncodeResponseData(traceId, authorization, payload.value());
@@ -1975,11 +1989,11 @@ public final class McpServerFactory implements McpStreamFactory
             long authorization)
         {
             doNetBegin(traceId, authorization,
-                httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+                applyAltSvc(httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(httpTypeId)
                     .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_202))
                     .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
-                    .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId))
+                    .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId)), altSvc)
                     .build());
             doNetEnd(traceId, authorization);
         }
@@ -1989,9 +2003,9 @@ public final class McpServerFactory implements McpStreamFactory
             long authorization)
         {
             doEncodeResponseError(traceId, authorization,
-                httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+                applyAltSvc(httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(httpTypeId)
-                    .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_400))
+                    .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_400)), altSvc)
                     .build(),
                 -32700,
                 "Parse error");
@@ -2002,9 +2016,9 @@ public final class McpServerFactory implements McpStreamFactory
             long authorization)
         {
             doEncodeResponseError(traceId, authorization,
-                httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+                applyAltSvc(httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(httpTypeId)
-                    .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_400))
+                    .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_400)), altSvc)
                     .build(),
                 -32600,
                 "Invalid request");
@@ -2015,12 +2029,12 @@ public final class McpServerFactory implements McpStreamFactory
             long authorization)
         {
             sseUpgrade = true;
-            doNetBegin(traceId, authorization, httpBeginExRW
+            doNetBegin(traceId, authorization, applyAltSvc(httpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(httpTypeId)
                 .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_EVENT_STREAM))
-                .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId))
+                .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId)), altSvc)
                 .build());
         }
 
@@ -2302,6 +2316,7 @@ public final class McpServerFactory implements McpStreamFactory
         private final long routedId;
         private final long initialId;
         private final long replyId;
+        private final String altSvc;
 
         private McpLifecycleStream session;
 
@@ -2321,7 +2336,8 @@ public final class McpServerFactory implements McpStreamFactory
             long routedId,
             long initialId,
             long resolvedId,
-            McpLifecycleStream session)
+            McpLifecycleStream session,
+            String altSvc)
         {
             this.net = sender;
             this.originId = originId;
@@ -2329,6 +2345,7 @@ public final class McpServerFactory implements McpStreamFactory
             this.initialId = initialId;
             this.replyId = supplyReplyId.applyAsLong(initialId);
             this.session = session;
+            this.altSvc = altSvc;
         }
 
         private void onNetMessage(
@@ -2382,9 +2399,9 @@ public final class McpServerFactory implements McpStreamFactory
 
             session.doAppEnd(traceId, authorization);
 
-            doNetBegin(traceId, authorization, httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+            doNetBegin(traceId, authorization, applyAltSvc(httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(httpTypeId)
-                .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
+                .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200)), altSvc)
                 .build());
         }
 
@@ -2559,6 +2576,7 @@ public final class McpServerFactory implements McpStreamFactory
         private final long replyId;
         private final String path;
         private final String callbackURL;
+        private final String altSvc;
 
         private long initialSeq;
         private long initialAck;
@@ -2576,7 +2594,8 @@ public final class McpServerFactory implements McpStreamFactory
             long routedId,
             long initialId,
             String path,
-            String callbackURL)
+            String callbackURL,
+            String altSvc)
         {
             this.net = sender;
             this.originId = originId;
@@ -2585,6 +2604,7 @@ public final class McpServerFactory implements McpStreamFactory
             this.replyId = supplyReplyId.applyAsLong(initialId);
             this.path = path;
             this.callbackURL = callbackURL;
+            this.altSvc = altSvc;
         }
 
         private void onNetMessage(
@@ -2692,10 +2712,10 @@ public final class McpServerFactory implements McpStreamFactory
             String status,
             String bodyText)
         {
-            doNetBegin(traceId, authorization, httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+            doNetBegin(traceId, authorization, applyAltSvc(httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(httpTypeId)
                 .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(status))
-                .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_TEXT_PLAIN))
+                .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_TEXT_PLAIN)), altSvc)
                 .build());
 
             final byte[] body = bodyText.getBytes(StandardCharsets.UTF_8);
@@ -3306,6 +3326,7 @@ public final class McpServerFactory implements McpStreamFactory
 
         private final McpRequestStream request;
         private final String lastEventId;
+        private final String altSvc;
 
         private long keepaliveCancelId = Signaler.NO_CANCEL_ID;
 
@@ -3316,7 +3337,8 @@ public final class McpServerFactory implements McpStreamFactory
             long initialId,
             McpLifecycleStream session,
             McpRequestStream request,
-            String lastEventId)
+            String lastEventId,
+            String altSvc)
         {
             this.net = sender;
             this.originId = originId;
@@ -3327,6 +3349,7 @@ public final class McpServerFactory implements McpStreamFactory
             this.request = request;
             this.lastEventId = lastEventId;
             this.initialMax = decodeMax;
+            this.altSvc = altSvc;
         }
 
         private void onNetMessage(
@@ -3407,12 +3430,12 @@ public final class McpServerFactory implements McpStreamFactory
             long traceId,
             long authorization)
         {
-            doNetBegin(traceId, authorization, httpBeginExRW
+            doNetBegin(traceId, authorization, applyAltSvc(httpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(httpTypeId)
                 .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_EVENT_STREAM))
-                .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId))
+                .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId)), altSvc)
                 .build());
 
             doNetWindow(traceId, authorization, 0, 0);
@@ -3425,10 +3448,10 @@ public final class McpServerFactory implements McpStreamFactory
             long authorization,
             String status)
         {
-            doNetBegin(traceId, authorization, httpBeginExRW
+            doNetBegin(traceId, authorization, applyAltSvc(httpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(httpTypeId)
-                .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(status))
+                .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(status)), altSvc)
                 .build());
 
             doNetEnd(traceId, authorization);
@@ -4184,19 +4207,19 @@ public final class McpServerFactory implements McpStreamFactory
             if (server.sseUpgrade)
             {
                 server.doEncodeResponseBegin(traceId, authorization,
-                    httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+                    applyAltSvc(httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                         .typeId(httpTypeId)
                         .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
-                        .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_EVENT_STREAM))
+                        .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_EVENT_STREAM)), server.altSvc)
                         .build());
             }
             else
             {
                 server.doEncodeResponseBegin(traceId, authorization,
-                    httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+                    applyAltSvc(httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                         .typeId(httpTypeId)
                         .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
-                        .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
+                        .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON)), server.altSvc)
                         .build());
             }
         }
@@ -4465,6 +4488,30 @@ public final class McpServerFactory implements McpStreamFactory
         }
 
         return receiver;
+    }
+
+    private String buildAltSvc(
+        String authority)
+    {
+        String result = null;
+        if (altSvcEnabled)
+        {
+            final int colon = authority != null ? authority.lastIndexOf(':') : -1;
+            final String portSuffix = colon >= 0 ? authority.substring(colon) : "";
+            result = String.format("http=\"%s\"; ma=%d", portSuffix, altSvcMaxAgeSeconds);
+        }
+        return result;
+    }
+
+    private HttpBeginExFW.Builder applyAltSvc(
+        HttpBeginExFW.Builder builder,
+        String altSvc)
+    {
+        if (altSvc != null)
+        {
+            builder.headersItem(h -> h.name(HTTP_HEADER_ALT_SVC).value(altSvc));
+        }
+        return builder;
     }
 
     private void doBegin(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -1294,15 +1294,6 @@ public final class McpServerFactory implements McpStreamFactory
             this.altSvc = altSvc;
         }
 
-        private void applyAltSvc(
-            HttpBeginExFW.Builder builder)
-        {
-            if (altSvc != null)
-            {
-                builder.headersItem(h -> h.name(HTTP_HEADER_ALT_SVC).value(altSvc));
-            }
-        }
-
         private void onNetMessage(
             int msgTypeId,
             DirectBuffer buffer,
@@ -1813,7 +1804,7 @@ public final class McpServerFactory implements McpStreamFactory
                 .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                 .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId))
-                .inject(this::applyAltSvc)
+                .inject(this::injectAltSvc)
                 .build());
             String8FW payload = new String8FW(INITIALIZE_RESPONSE_PROTOCOL_PREFIX + serverName +
                 INITIALIZE_RESPONSE_VERSION_PREFIX + serverVersion + INITIALIZE_RESPONSE_SUFFIX);
@@ -1839,7 +1830,7 @@ public final class McpServerFactory implements McpStreamFactory
                     .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
                     .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                     .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId))
-                    .inject(this::applyAltSvc)
+                    .inject(this::injectAltSvc)
                     .build());
             doNetEnd(traceId, authorization);
         }
@@ -1856,7 +1847,7 @@ public final class McpServerFactory implements McpStreamFactory
                     .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
                     .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                     .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId))
-                    .inject(this::applyAltSvc)
+                    .inject(this::injectAltSvc)
                     .build());
             String8FW payload = new String8FW("{}");
             doEncodeResponseData(traceId, authorization, payload.value());
@@ -2006,7 +1997,7 @@ public final class McpServerFactory implements McpStreamFactory
                     .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_202))
                     .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                     .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId))
-                    .inject(this::applyAltSvc)
+                    .inject(this::injectAltSvc)
                     .build());
             doNetEnd(traceId, authorization);
         }
@@ -2019,7 +2010,7 @@ public final class McpServerFactory implements McpStreamFactory
                 httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(httpTypeId)
                     .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_400))
-                    .inject(this::applyAltSvc)
+                    .inject(this::injectAltSvc)
                     .build(),
                 -32700,
                 "Parse error");
@@ -2033,7 +2024,7 @@ public final class McpServerFactory implements McpStreamFactory
                 httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(httpTypeId)
                     .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_400))
-                    .inject(this::applyAltSvc)
+                    .inject(this::injectAltSvc)
                     .build(),
                 -32600,
                 "Invalid request");
@@ -2050,7 +2041,7 @@ public final class McpServerFactory implements McpStreamFactory
                 .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_EVENT_STREAM))
                 .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId))
-                .inject(this::applyAltSvc)
+                .inject(this::injectAltSvc)
                 .build());
         }
 
@@ -2323,6 +2314,15 @@ public final class McpServerFactory implements McpStreamFactory
             doNetReset(traceId, authorization);
             doNetAbort(traceId, authorization);
         }
+
+        private void injectAltSvc(
+            HttpBeginExFW.Builder builder)
+        {
+            if (altSvc != null)
+            {
+                builder.headersItem(h -> h.name(HTTP_HEADER_ALT_SVC).value(altSvc));
+            }
+        }
     }
 
     private final class McpShutdownHandler
@@ -2362,15 +2362,6 @@ public final class McpServerFactory implements McpStreamFactory
             this.replyId = supplyReplyId.applyAsLong(initialId);
             this.session = session;
             this.altSvc = altSvc;
-        }
-
-        private void applyAltSvc(
-            HttpBeginExFW.Builder builder)
-        {
-            if (altSvc != null)
-            {
-                builder.headersItem(h -> h.name(HTTP_HEADER_ALT_SVC).value(altSvc));
-            }
         }
 
         private void onNetMessage(
@@ -2427,7 +2418,7 @@ public final class McpServerFactory implements McpStreamFactory
             doNetBegin(traceId, authorization, httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(httpTypeId)
                 .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
-                .inject(this::applyAltSvc)
+                .inject(this::injectAltSvc)
                 .build());
         }
 
@@ -2558,6 +2549,15 @@ public final class McpServerFactory implements McpStreamFactory
             doNetReset(traceId, authorization);
             doNetAbort(traceId, authorization);
         }
+
+        private void injectAltSvc(
+            HttpBeginExFW.Builder builder)
+        {
+            if (altSvc != null)
+            {
+                builder.headersItem(h -> h.name(HTTP_HEADER_ALT_SVC).value(altSvc));
+            }
+        }
     }
 
     private final class McpRejectHandler
@@ -2631,15 +2631,6 @@ public final class McpServerFactory implements McpStreamFactory
             this.path = path;
             this.callbackURL = callbackURL;
             this.altSvc = altSvc;
-        }
-
-        private void applyAltSvc(
-            HttpBeginExFW.Builder builder)
-        {
-            if (altSvc != null)
-            {
-                builder.headersItem(h -> h.name(HTTP_HEADER_ALT_SVC).value(altSvc));
-            }
         }
 
         private void onNetMessage(
@@ -2751,7 +2742,7 @@ public final class McpServerFactory implements McpStreamFactory
                 .typeId(httpTypeId)
                 .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(status))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_TEXT_PLAIN))
-                .inject(this::applyAltSvc)
+                .inject(this::injectAltSvc)
                 .build());
 
             final byte[] body = bodyText.getBytes(StandardCharsets.UTF_8);
@@ -2893,6 +2884,15 @@ public final class McpServerFactory implements McpStreamFactory
         {
             doNetReset(traceId, authorization);
             doNetAbort(traceId, authorization);
+        }
+
+        private void injectAltSvc(
+            HttpBeginExFW.Builder builder)
+        {
+            if (altSvc != null)
+            {
+                builder.headersItem(h -> h.name(HTTP_HEADER_ALT_SVC).value(altSvc));
+            }
         }
     }
 
@@ -3388,15 +3388,6 @@ public final class McpServerFactory implements McpStreamFactory
             this.altSvc = altSvc;
         }
 
-        private void applyAltSvc(
-            HttpBeginExFW.Builder builder)
-        {
-            if (altSvc != null)
-            {
-                builder.headersItem(h -> h.name(HTTP_HEADER_ALT_SVC).value(altSvc));
-            }
-        }
-
         private void onNetMessage(
             int msgTypeId,
             DirectBuffer buffer,
@@ -3481,7 +3472,7 @@ public final class McpServerFactory implements McpStreamFactory
                 .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_EVENT_STREAM))
                 .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId))
-                .inject(this::applyAltSvc)
+                .inject(this::injectAltSvc)
                 .build());
 
             doNetWindow(traceId, authorization, 0, 0);
@@ -3498,7 +3489,7 @@ public final class McpServerFactory implements McpStreamFactory
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(httpTypeId)
                 .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(status))
-                .inject(this::applyAltSvc)
+                .inject(this::injectAltSvc)
                 .build());
 
             doNetEnd(traceId, authorization);
@@ -3902,6 +3893,15 @@ public final class McpServerFactory implements McpStreamFactory
             doNetReset(traceId, authorization);
             doNetAbort(traceId, authorization);
         }
+
+        private void injectAltSvc(
+            HttpBeginExFW.Builder builder)
+        {
+            if (altSvc != null)
+            {
+                builder.headersItem(h -> h.name(HTTP_HEADER_ALT_SVC).value(altSvc));
+            }
+        }
     }
 
     private final class McpRequestStream
@@ -4258,7 +4258,7 @@ public final class McpServerFactory implements McpStreamFactory
                         .typeId(httpTypeId)
                         .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
                         .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_EVENT_STREAM))
-                        .inject(server::applyAltSvc)
+                        .inject(server::injectAltSvc)
                         .build());
             }
             else
@@ -4268,7 +4268,7 @@ public final class McpServerFactory implements McpStreamFactory
                         .typeId(httpTypeId)
                         .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
                         .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
-                        .inject(server::applyAltSvc)
+                        .inject(server::injectAltSvc)
                         .build());
             }
         }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -1294,6 +1294,15 @@ public final class McpServerFactory implements McpStreamFactory
             this.altSvc = altSvc;
         }
 
+        private void applyAltSvc(
+            HttpBeginExFW.Builder builder)
+        {
+            if (altSvc != null)
+            {
+                builder.headersItem(h -> h.name(HTTP_HEADER_ALT_SVC).value(altSvc));
+            }
+        }
+
         private void onNetMessage(
             int msgTypeId,
             DirectBuffer buffer,
@@ -1799,11 +1808,12 @@ public final class McpServerFactory implements McpStreamFactory
             long traceId,
             long authorization)
         {
-            doEncodeResponseBegin(traceId, authorization, applyAltSvc(httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+            doEncodeResponseBegin(traceId, authorization, httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(httpTypeId)
                 .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
-                .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId)), altSvc)
+                .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId))
+                .inject(this::applyAltSvc)
                 .build());
             String8FW payload = new String8FW(INITIALIZE_RESPONSE_PROTOCOL_PREFIX + serverName +
                 INITIALIZE_RESPONSE_VERSION_PREFIX + serverVersion + INITIALIZE_RESPONSE_SUFFIX);
@@ -1824,11 +1834,12 @@ public final class McpServerFactory implements McpStreamFactory
             long authorization)
         {
             doNetBegin(traceId, authorization,
-                applyAltSvc(httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+                httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(httpTypeId)
                     .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
                     .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
-                    .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId)), altSvc)
+                    .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId))
+                    .inject(this::applyAltSvc)
                     .build());
             doNetEnd(traceId, authorization);
         }
@@ -1840,11 +1851,12 @@ public final class McpServerFactory implements McpStreamFactory
             session.touch();
 
             doEncodeResponseBegin(traceId, authorization,
-                applyAltSvc(httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+                httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(httpTypeId)
                     .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
                     .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
-                    .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId)), altSvc)
+                    .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId))
+                    .inject(this::applyAltSvc)
                     .build());
             String8FW payload = new String8FW("{}");
             doEncodeResponseData(traceId, authorization, payload.value());
@@ -1989,11 +2001,12 @@ public final class McpServerFactory implements McpStreamFactory
             long authorization)
         {
             doNetBegin(traceId, authorization,
-                applyAltSvc(httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+                httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(httpTypeId)
                     .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_202))
                     .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
-                    .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId)), altSvc)
+                    .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId))
+                    .inject(this::applyAltSvc)
                     .build());
             doNetEnd(traceId, authorization);
         }
@@ -2003,9 +2016,10 @@ public final class McpServerFactory implements McpStreamFactory
             long authorization)
         {
             doEncodeResponseError(traceId, authorization,
-                applyAltSvc(httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+                httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(httpTypeId)
-                    .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_400)), altSvc)
+                    .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_400))
+                    .inject(this::applyAltSvc)
                     .build(),
                 -32700,
                 "Parse error");
@@ -2016,9 +2030,10 @@ public final class McpServerFactory implements McpStreamFactory
             long authorization)
         {
             doEncodeResponseError(traceId, authorization,
-                applyAltSvc(httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+                httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(httpTypeId)
-                    .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_400)), altSvc)
+                    .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_400))
+                    .inject(this::applyAltSvc)
                     .build(),
                 -32600,
                 "Invalid request");
@@ -2029,12 +2044,13 @@ public final class McpServerFactory implements McpStreamFactory
             long authorization)
         {
             sseUpgrade = true;
-            doNetBegin(traceId, authorization, applyAltSvc(httpBeginExRW
+            doNetBegin(traceId, authorization, httpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(httpTypeId)
                 .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_EVENT_STREAM))
-                .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId)), altSvc)
+                .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId))
+                .inject(this::applyAltSvc)
                 .build());
         }
 
@@ -2348,6 +2364,15 @@ public final class McpServerFactory implements McpStreamFactory
             this.altSvc = altSvc;
         }
 
+        private void applyAltSvc(
+            HttpBeginExFW.Builder builder)
+        {
+            if (altSvc != null)
+            {
+                builder.headersItem(h -> h.name(HTTP_HEADER_ALT_SVC).value(altSvc));
+            }
+        }
+
         private void onNetMessage(
             int msgTypeId,
             DirectBuffer buffer,
@@ -2399,9 +2424,10 @@ public final class McpServerFactory implements McpStreamFactory
 
             session.doAppEnd(traceId, authorization);
 
-            doNetBegin(traceId, authorization, applyAltSvc(httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+            doNetBegin(traceId, authorization, httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(httpTypeId)
-                .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200)), altSvc)
+                .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
+                .inject(this::applyAltSvc)
                 .build());
         }
 
@@ -2607,6 +2633,15 @@ public final class McpServerFactory implements McpStreamFactory
             this.altSvc = altSvc;
         }
 
+        private void applyAltSvc(
+            HttpBeginExFW.Builder builder)
+        {
+            if (altSvc != null)
+            {
+                builder.headersItem(h -> h.name(HTTP_HEADER_ALT_SVC).value(altSvc));
+            }
+        }
+
         private void onNetMessage(
             int msgTypeId,
             DirectBuffer buffer,
@@ -2712,10 +2747,11 @@ public final class McpServerFactory implements McpStreamFactory
             String status,
             String bodyText)
         {
-            doNetBegin(traceId, authorization, applyAltSvc(httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+            doNetBegin(traceId, authorization, httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(httpTypeId)
                 .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(status))
-                .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_TEXT_PLAIN)), altSvc)
+                .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_TEXT_PLAIN))
+                .inject(this::applyAltSvc)
                 .build());
 
             final byte[] body = bodyText.getBytes(StandardCharsets.UTF_8);
@@ -3352,6 +3388,15 @@ public final class McpServerFactory implements McpStreamFactory
             this.altSvc = altSvc;
         }
 
+        private void applyAltSvc(
+            HttpBeginExFW.Builder builder)
+        {
+            if (altSvc != null)
+            {
+                builder.headersItem(h -> h.name(HTTP_HEADER_ALT_SVC).value(altSvc));
+            }
+        }
+
         private void onNetMessage(
             int msgTypeId,
             DirectBuffer buffer,
@@ -3430,12 +3475,13 @@ public final class McpServerFactory implements McpStreamFactory
             long traceId,
             long authorization)
         {
-            doNetBegin(traceId, authorization, applyAltSvc(httpBeginExRW
+            doNetBegin(traceId, authorization, httpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(httpTypeId)
                 .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_EVENT_STREAM))
-                .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId)), altSvc)
+                .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(session.sessionId))
+                .inject(this::applyAltSvc)
                 .build());
 
             doNetWindow(traceId, authorization, 0, 0);
@@ -3448,10 +3494,11 @@ public final class McpServerFactory implements McpStreamFactory
             long authorization,
             String status)
         {
-            doNetBegin(traceId, authorization, applyAltSvc(httpBeginExRW
+            doNetBegin(traceId, authorization, httpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(httpTypeId)
-                .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(status)), altSvc)
+                .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(status))
+                .inject(this::applyAltSvc)
                 .build());
 
             doNetEnd(traceId, authorization);
@@ -4207,19 +4254,21 @@ public final class McpServerFactory implements McpStreamFactory
             if (server.sseUpgrade)
             {
                 server.doEncodeResponseBegin(traceId, authorization,
-                    applyAltSvc(httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+                    httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                         .typeId(httpTypeId)
                         .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
-                        .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_EVENT_STREAM)), server.altSvc)
+                        .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_EVENT_STREAM))
+                        .inject(server::applyAltSvc)
                         .build());
             }
             else
             {
                 server.doEncodeResponseBegin(traceId, authorization,
-                    applyAltSvc(httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+                    httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                         .typeId(httpTypeId)
                         .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
-                        .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON)), server.altSvc)
+                        .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
+                        .inject(server::applyAltSvc)
                         .build());
             }
         }
@@ -4501,17 +4550,6 @@ public final class McpServerFactory implements McpStreamFactory
             result = String.format("http=\"%s\"; ma=%d", portSuffix, altSvcMaxAgeSeconds);
         }
         return result;
-    }
-
-    private HttpBeginExFW.Builder applyAltSvc(
-        HttpBeginExFW.Builder builder,
-        String altSvc)
-    {
-        if (altSvc != null)
-        {
-            builder.headersItem(h -> h.name(HTTP_HEADER_ALT_SVC).value(altSvc));
-        }
-        return builder;
     }
 
     private void doBegin(

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfigurationTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfigurationTest.java
@@ -14,6 +14,8 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal;
 
+import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration.MCP_ALT_SVC_ENABLED;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration.MCP_ALT_SVC_MAX_AGE;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration.MCP_CLIENT_NAME;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration.MCP_CLIENT_VERSION;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration.MCP_ELICITATION_ID;
@@ -44,6 +46,8 @@ public class McpConfigurationTest
     public static final String MCP_SESSION_ID_ATTEMPTS_NAME = "zilla.binding.mcp.session.id.attempts";
     public static final String MCP_KEEPALIVE_TOLERANCE_NAME = "zilla.binding.mcp.keepalive.tolerance";
     public static final String MCP_SSE_KEEPALIVE_INTERVAL_NAME = "zilla.binding.mcp.sse.keepalive.interval";
+    public static final String MCP_ALT_SVC_ENABLED_NAME = "zilla.binding.mcp.alt.svc.enabled";
+    public static final String MCP_ALT_SVC_MAX_AGE_NAME = "zilla.binding.mcp.alt.svc.max.age";
 
     @Test
     public void shouldVerifyConstants() throws Exception
@@ -60,5 +64,7 @@ public class McpConfigurationTest
         assertEquals(MCP_SESSION_ID_ATTEMPTS.name(), MCP_SESSION_ID_ATTEMPTS_NAME);
         assertEquals(MCP_KEEPALIVE_TOLERANCE.name(), MCP_KEEPALIVE_TOLERANCE_NAME);
         assertEquals(MCP_SSE_KEEPALIVE_INTERVAL.name(), MCP_SSE_KEEPALIVE_INTERVAL_NAME);
+        assertEquals(MCP_ALT_SVC_ENABLED.name(), MCP_ALT_SVC_ENABLED_NAME);
+        assertEquals(MCP_ALT_SVC_MAX_AGE.name(), MCP_ALT_SVC_MAX_AGE_NAME);
     }
 }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
@@ -16,6 +16,7 @@ package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
 
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfigurationTest.ENGINE_DETACH_ON_CLOSE_NAME;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfigurationTest.ENGINE_SYNTHETIC_ABORT_NAME;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfigurationTest.MCP_ALT_SVC_ENABLED_NAME;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfigurationTest.MCP_ELICITATION_ID_NAME;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfigurationTest.MCP_INACTIVITY_TIMEOUT_NAME;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfigurationTest.MCP_SERVER_NAME_NAME;
@@ -65,6 +66,17 @@ public class McpServerIT
         "${net}/lifecycle.initialize/client",
         "${app}/lifecycle.initialize/server"})
     public void shouldInitializeLifecycle() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
+        "${net}/lifecycle.initialize.alt.svc/client",
+        "${app}/lifecycle.initialize.alt.svc/server"})
+    @Configure(name = MCP_ALT_SVC_ENABLED_NAME, value = "true")
+    public void shouldInitializeLifecycleAltSvc() throws Exception
     {
         k3po.finish();
     }

--- a/specs/binding-http.spec/src/main/java/io/aklivity/zilla/specs/binding/http/internal/HttpFunctions.java
+++ b/specs/binding-http.spec/src/main/java/io/aklivity/zilla/specs/binding/http/internal/HttpFunctions.java
@@ -336,7 +336,7 @@ public final class HttpFunctions
         private final HttpBeginExFW beginExRO = new HttpBeginExFW();
 
         private final Map<String, Predicate<String>> headers = new LinkedHashMap<>();
-        private final Set<String> missingHeaders = new LinkedHashSet<>();
+        private final Set<String> headersMissing = new LinkedHashSet<>();
 
         private Long compositeId;
         private Integer typeId;
@@ -375,7 +375,7 @@ public final class HttpFunctions
         public HttpBeginExMatcherBuilder headerMissing(
             String name)
         {
-            missingHeaders.add(name);
+            headersMissing.add(name);
             return this;
         }
 
@@ -399,7 +399,7 @@ public final class HttpFunctions
                 matchCompositeId(beginEx) &&
                 matchTypeId(beginEx) &&
                 matchHeaders(beginEx) &&
-                matchMissingHeaders(beginEx))
+                matchHeadersMissing(beginEx))
             {
                 byteBuf.position(byteBuf.position() + beginEx.sizeof());
                 return beginEx;
@@ -423,11 +423,11 @@ public final class HttpFunctions
             return match.value;
         }
 
-        private boolean matchMissingHeaders(
+        private boolean matchHeadersMissing(
             HttpBeginExFW beginEx)
         {
             MutableBoolean match = new MutableBoolean(true);
-            missingHeaders.forEach(name -> match.value &=
+            headersMissing.forEach(name -> match.value &=
                 !beginEx.headers().anyMatch(h -> name.equals(h.name().asString())));
             return match.value;
         }

--- a/specs/binding-http.spec/src/main/java/io/aklivity/zilla/specs/binding/http/internal/HttpFunctions.java
+++ b/specs/binding-http.spec/src/main/java/io/aklivity/zilla/specs/binding/http/internal/HttpFunctions.java
@@ -23,8 +23,10 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -334,6 +336,7 @@ public final class HttpFunctions
         private final HttpBeginExFW beginExRO = new HttpBeginExFW();
 
         private final Map<String, Predicate<String>> headers = new LinkedHashMap<>();
+        private final Set<String> missingHeaders = new LinkedHashSet<>();
 
         private Long compositeId;
         private Integer typeId;
@@ -369,6 +372,13 @@ public final class HttpFunctions
             return this;
         }
 
+        public HttpBeginExMatcherBuilder headerMissing(
+            String name)
+        {
+            missingHeaders.add(name);
+            return this;
+        }
+
         public BytesMatcher build()
         {
             return typeId != null ? this::match : buf -> null;
@@ -388,7 +398,8 @@ public final class HttpFunctions
             if (beginEx != null &&
                 matchCompositeId(beginEx) &&
                 matchTypeId(beginEx) &&
-                matchHeaders(beginEx))
+                matchHeaders(beginEx) &&
+                matchMissingHeaders(beginEx))
             {
                 byteBuf.position(byteBuf.position() + beginEx.sizeof());
                 return beginEx;
@@ -409,6 +420,15 @@ public final class HttpFunctions
             MutableBoolean match = new MutableBoolean(true);
             headers.forEach((k, v) -> match.value &= beginEx.headers().anyMatch(h -> k.equals(h.name().asString()) &&
                                                                            v.test(h.value().asString())));
+            return match.value;
+        }
+
+        private boolean matchMissingHeaders(
+            HttpBeginExFW beginEx)
+        {
+            MutableBoolean match = new MutableBoolean(true);
+            missingHeaders.forEach(name -> match.value &=
+                !beginEx.headers().anyMatch(h -> name.equals(h.name().asString())));
             return match.value;
         }
 

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/internal/HttpFunctionsTest.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/internal/HttpFunctionsTest.java
@@ -260,6 +260,45 @@ public class HttpFunctionsTest
     }
 
     @Test
+    public void shouldMatchBeginExtensionWithHeaderMissing() throws Exception
+    {
+        BytesMatcher matcher = HttpFunctions.matchBeginEx()
+                                            .typeId(0x01)
+                                            .header("name", "value")
+                                            .headerMissing("missing")
+                                            .build();
+
+        ByteBuffer byteBuf = ByteBuffer.allocate(1024);
+
+        new HttpBeginExFW.Builder().wrap(new UnsafeBuffer(byteBuf), 0, byteBuf.capacity())
+            .typeId(0x01)
+            .headersItem(h -> h.name("name")
+                               .value("value"))
+            .build();
+
+        assertNotNull(matcher.match(byteBuf));
+    }
+
+    @Test(expected = Exception.class)
+    public void shouldFailWhenMissingHeaderIsPresent() throws Exception
+    {
+        BytesMatcher matcher = HttpFunctions.matchBeginEx()
+                                            .typeId(0x01)
+                                            .headerMissing("name")
+                                            .build();
+
+        ByteBuffer byteBuf = ByteBuffer.allocate(1024);
+
+        new HttpBeginExFW.Builder().wrap(new UnsafeBuffer(byteBuf), 0, byteBuf.capacity())
+            .typeId(0x01)
+            .headersItem(h -> h.name("name")
+                               .value("value"))
+            .build();
+
+        matcher.match(byteBuf);
+    }
+
+    @Test
     public void shouldFailWhenDoNotSetTypeId() throws Exception
     {
         BytesMatcher matcher = HttpFunctions.matchBeginEx()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.alt.svc/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.alt.svc/client.rpt
@@ -1,0 +1,34 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.alt.svc/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.alt.svc/server.rpt
@@ -1,0 +1,37 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/app0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.alt.svc/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.alt.svc/client.rpt
@@ -38,7 +38,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":status", "200")
                            .header("content-type", "application/json")
                            .header("mcp-session-id", "session-1")
-                           .headerMissing("alt-svc")
+                           .header("alt-svc", "http=\":8080\"; ma=86400")
                            .build()}
 
 read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{},"resources":{},"tools":{}},"serverInfo":{"name":"zilla","version":"1.0"}}}'

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.alt.svc/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.alt.svc/server.rpt
@@ -1,0 +1,74 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "200")
+                            .header("content-type", "application/json")
+                            .header("mcp-session-id", "session-1")
+                            .header("alt-svc", "http=\":8080\"; ma=86400")
+                            .build()}
+write flush
+
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{},"resources":{},"tools":{}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write flush
+
+write close
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-session-id", "session-1")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "202")
+                            .header("alt-svc", "http=\":8080\"; ma=86400")
+                            .build()}
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
@@ -47,6 +47,15 @@ public class ApplicationIT
 
     @Test
     @Specification({
+        "${app}/lifecycle.initialize.alt.svc/client",
+        "${app}/lifecycle.initialize.alt.svc/server"})
+    public void shouldInitializeLifecycleAltSvc() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/lifecycle.shutdown/client",
         "${app}/lifecycle.shutdown/server"})
     public void shouldShutdownLifecycle() throws Exception

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
@@ -47,6 +47,15 @@ public class NetworkIT
 
     @Test
     @Specification({
+        "${net}/lifecycle.initialize.alt.svc/client",
+        "${net}/lifecycle.initialize.alt.svc/server"})
+    public void shouldInitializeLifecycleAltSvc() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${net}/lifecycle.shutdown/client",
         "${net}/lifecycle.shutdown/server"})
     public void shouldShutdownLifecycle() throws Exception


### PR DESCRIPTION
## Summary

- Adds RFC 7838 `Alt-Svc` response header emission to `binding-mcp` server. The binding emits a placeholder authority that `binding-http` (already merged via #1775) translates to the wire-level ALPN protocol id, service host, and physical port.
- New binding-mcp config:
  - `zilla.binding.mcp.alt.svc.enabled` (boolean) — per-binding opt-in. Default is driven from the presence of engine `zilla.engine.service.hostname` so operators get sensible behaviour out of the box, and individual bindings can override.
  - `zilla.binding.mcp.alt.svc.max.age` (Duration, default `PT24H`) — the `ma` TTL.
- Adds a `headerMissing()` matcher to `binding-http.spec` `HttpFunctions` so spec scripts can actively assert header absence.

## Emitted value

When enabled, binding-mcp emits per response:

```
Alt-Svc: http=":<logical-port>"; ma=<seconds>
```

The port is taken from the request's `:authority`. Example, for `:authority = localhost:8080`:

```
Alt-Svc: http=":8080"; ma=86400
```

`http=` is a placeholder ALPN identifier; the empty host and the logical port are placeholders for the service host and physical port respectively. `binding-http` (#1775) substitutes these before the header reaches the wire — turning the placeholder into e.g. `h2="backend.example.com:8443"; ma=86400` or `http%2F1.1="..."; ma=...` based on the active request's protocol and the engine's configured service host / `ProxyBeginEx.destination.port`.

## Notes

- The 13 response-begin sites in `McpServerFactory` go through a small `applyAltSvc(builder, altSvc)` helper that no-ops when `altSvc` is `null`.
- `altSvc` is computed once per request in `newStream` (uses the request's `:authority`) and passed into each handler constructor (`McpServer`, `McpAuthCallbackHandler`, `McpShutdownHandler`, `McpEventStream`); `McpRequestStream` reaches `server.altSvc` from its enclosing `McpServer`.
- The existing `lifecycle.initialize` scripts now actively assert `alt-svc` is absent via `.headerMissing("alt-svc")` — so `shouldInitializeLifecycle` doubles as the negative-case IT. New `lifecycle.initialize.alt.svc` scripts cover the positive case with `@Configure(MCP_ALT_SVC_ENABLED_NAME, "true")`.

## Test plan

- [x] `McpConfigurationTest` extended for the two new binding-mcp property name constants.
- [x] `HttpFunctionsTest`: two new tests for `headerMissing()` (match + fail-when-present).
- [x] `binding-mcp` ITs (`McpServerIT`): `shouldInitializeLifecycle` (no Alt-Svc, asserted absent) + new `shouldInitializeLifecycleAltSvc` (Alt-Svc placeholder present). 142 tests pass.
- [x] `binding-mcp.spec` peer-to-peer ITs (`NetworkIT` / `ApplicationIT`): new `shouldInitializeLifecycleAltSvc` in both. 113 tests pass.
- [x] `binding-http.spec` coverage met after adding `headerMissing` tests.
- [x] `./mvnw checkstyle:check` passes on all touched modules.

Closes #1770. The translator side already landed in #1775.