### PR TITLE
feat(binding-http): translate Alt-Svc http= placeholder to ALPN id

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpServerFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpServerFactory.java
@@ -247,6 +247,11 @@ public final class HttpServerFactory implements HttpStreamFactory
     private static final String8FW HEADER_TRANSFER_ENCODING = new String8FW("transfer-encoding");
     private static final String8FW HEADER_UPGRADE = new String8FW("upgrade");
     private static final String8FW HEADER_VARY = new String8FW("vary");
+    private static final String8FW HEADER_ALT_SVC = new String8FW("alt-svc");
+
+    private static final byte[] ALT_SVC_PLACEHOLDER_BYTES = "http=".getBytes(US_ASCII);
+    private static final byte[] ALT_SVC_ALPN_HTTP_1_1_BYTES = "http%2F1.1".getBytes(US_ASCII);
+    private static final byte[] ALT_SVC_ALPN_HTTP_2_BYTES = "h2".getBytes(US_ASCII);
 
     private static final String16FW ACCESS_CONTROL_WILDCARD = new String16FW("*");
     private static final String16FW CONNECTION_CLOSE = new String16FW("close");
@@ -407,6 +412,13 @@ public final class HttpServerFactory implements HttpStreamFactory
 
     private final Array32FW.Builder<HttpHeaderFW.Builder, HttpHeaderFW> headersRW =
             new Array32FW.Builder<>(new HttpHeaderFW.Builder(), new HttpHeaderFW());
+
+    private final MutableDirectBuffer altSvcHeadersBuffer = new UnsafeBuffer(new byte[8192]);
+    private final MutableDirectBuffer altSvcValueBuffer = new UnsafeBuffer(new byte[1024]);
+    private final MutableDirectBuffer altSvcRawBuffer = new UnsafeBuffer(new byte[1024]);
+    private final Array32FW.Builder<HttpHeaderFW.Builder, HttpHeaderFW> altSvcHeadersRW =
+            new Array32FW.Builder<>(new HttpHeaderFW.Builder(), new HttpHeaderFW());
+    private final String16FW.Builder altSvcValueRW = new String16FW.Builder();
 
     private final String16FW.Builder httpStatusRW =
             new String16FW.Builder().wrap(new UnsafeBuffer(new byte[16]), 0, 16);
@@ -2484,7 +2496,8 @@ public final class HttpServerFactory implements HttpStreamFactory
                 codecOffset.value = doEncodeHeader(codecBuffer, codecOffset.value,
                         HEADER_SERVER.value(), serverHeader.value(), false);
             }
-            headers.forEach(h -> codecOffset.value = doEncodeHeader(codecBuffer, codecOffset.value, h));
+            final Array32FW<HttpHeaderFW> outboundHeaders = translateAltSvc(headers, ALT_SVC_ALPN_HTTP_1_1_BYTES);
+            outboundHeaders.forEach(h -> codecOffset.value = doEncodeHeader(codecBuffer, codecOffset.value, h));
 
             if (contentLength == null &&
                 !exchange.responseChunked &&
@@ -5679,9 +5692,11 @@ public final class HttpServerFactory implements HttpStreamFactory
             Array32FW<HttpHeaderFW> headers,
             boolean endResponse)
         {
+            final Array32FW<HttpHeaderFW> outboundHeaders = translateAltSvc(headers, ALT_SVC_ALPN_HTTP_2_BYTES);
             final Http2HeadersFW http2Headers = http2HeadersRW.wrap(frameBuffer, 0, frameBuffer.capacity())
                     .streamId(streamId)
-                    .headers(hb -> headersEncoder.encodeHeaders(encodeContext, binding.access(), policy, origin, headers, hb))
+                    .headers(hb -> headersEncoder.encodeHeaders(encodeContext, binding.access(), policy, origin,
+                            outboundHeaders, hb))
                     .endHeaders()
                     .endStream(endResponse)
                     .build();
@@ -7343,6 +7358,65 @@ public final class HttpServerFactory implements HttpStreamFactory
                headers.containsKey(HEADER_NAME_ORIGIN) &&
                (headers.containsKey(HEADER_NAME_ACCESS_CONTROL_REQUEST_METHOD) ||
                 headers.containsKey(HEADER_NAME_ACCESS_CONTROL_REQUEST_HEADERS));
+    }
+
+    private Array32FW<HttpHeaderFW> translateAltSvc(
+        Array32FW<HttpHeaderFW> headers,
+        byte[] alpnBytes)
+    {
+        if (!headers.anyMatch(HttpServerFactory::isAltSvcPlaceholder))
+        {
+            return headers;
+        }
+
+        final Array32FW.Builder<HttpHeaderFW.Builder, HttpHeaderFW> builder =
+            altSvcHeadersRW.wrap(altSvcHeadersBuffer, 0, altSvcHeadersBuffer.capacity());
+
+        headers.forEach(h ->
+        {
+            if (isAltSvcPlaceholder(h))
+            {
+                final DirectBuffer original = h.value().value();
+                final int suffixOffset = ALT_SVC_PLACEHOLDER_BYTES.length - 1;
+                final int suffixLength = original.capacity() - suffixOffset;
+                final int newLength = alpnBytes.length + suffixLength;
+                altSvcRawBuffer.putBytes(0, alpnBytes);
+                altSvcRawBuffer.putBytes(alpnBytes.length, original, suffixOffset, suffixLength);
+                final String16FW translatedValue = altSvcValueRW
+                    .wrap(altSvcValueBuffer, 0, altSvcValueBuffer.capacity())
+                    .set(altSvcRawBuffer, 0, newLength)
+                    .build();
+                builder.item(item -> item.name(HEADER_ALT_SVC).value(translatedValue));
+            }
+            else
+            {
+                builder.item(item -> item.name(h.name()).value(h.value()));
+            }
+        });
+
+        return builder.build();
+    }
+
+    private static boolean isAltSvcPlaceholder(
+        HttpHeaderFW header)
+    {
+        if (!HEADER_ALT_SVC.equals(header.name()))
+        {
+            return false;
+        }
+        final DirectBuffer value = header.value().value();
+        if (value == null || value.capacity() < ALT_SVC_PLACEHOLDER_BYTES.length)
+        {
+            return false;
+        }
+        for (int i = 0; i < ALT_SVC_PLACEHOLDER_BYTES.length; i++)
+        {
+            if (value.getByte(i) != ALT_SVC_PLACEHOLDER_BYTES[i])
+            {
+                return false;
+            }
+        }
+        return true;
     }
 
     private URI createTargetURI(

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/MessageFormatIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/MessageFormatIT.java
@@ -94,6 +94,26 @@ public class MessageFormatIT
     @Test
     @Configuration("server.yaml")
     @Specification({
+        "${net}/response.with.alt.svc.placeholder/client",
+        "${app}/response.with.alt.svc.placeholder/server" })
+    public void responseWithAltSvcPlaceholder() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
+        "${net}/response.with.alt.svc.explicit/client",
+        "${app}/response.with.alt.svc.explicit/server" })
+    public void responseWithAltSvcExplicit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
         "${net}/invalid.request.whitespace.after.start.line/client"})
     public void invalidRequestWhitespaceAfterStartLine() throws Exception
     {

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/MessageFormatIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/MessageFormatIT.java
@@ -95,6 +95,26 @@ public class MessageFormatIT
     @Test
     @Configuration("server.yaml")
     @Specification({
+        "${net}/response.with.alt.svc.placeholder/client",
+        "${app}/response.with.alt.svc.placeholder/server" })
+    public void responseWithAltSvcPlaceholder() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
+        "${net}/response.with.alt.svc.explicit/client",
+        "${app}/response.with.alt.svc.explicit/server" })
+    public void responseWithAltSvcExplicit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
         "${net}/ping.frame.size.error/client" })
     public void pingFrameSizeError() throws Exception
     {

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineConfiguration.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineConfiguration.java
@@ -108,6 +108,7 @@ public class EngineConfiguration extends Configuration
     public static final PropertyDef<RevocationStrategy> ENGINE_CERTIFICATE_REVOCATION_STRATEGY;
     public static final PropertyDef<Path> ENGINE_DIAGNOSTICS_DIRECTORY;
     public static final PropertyDef<String> ENGINE_ROUTER;
+    public static final PropertyDef<String> ENGINE_SERVICE_HOSTNAME;
 
     private static final ConfigurationDef ENGINE_CONFIG;
 
@@ -177,6 +178,7 @@ public class EngineConfiguration extends Configuration
         ENGINE_DIAGNOSTICS_DIRECTORY = config.property(Path.class, "diagnostics.directory",
             EngineConfiguration::decodeDiagnosticsDirectory, (String) null);
         ENGINE_ROUTER = config.property("router", "engine");
+        ENGINE_SERVICE_HOSTNAME = config.property("service.hostname");
         ENGINE_CONFIG = config;
     }
 
@@ -430,6 +432,11 @@ public class EngineConfiguration extends Configuration
     public String router()
     {
         return ENGINE_ROUTER.get(this);
+    }
+
+    public String serviceHostname()
+    {
+        return ENGINE_SERVICE_HOSTNAME.get(this);
     }
 
     private static int defaultTaskParallelism(

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineConfigurationTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineConfigurationTest.java
@@ -24,6 +24,7 @@ import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_CLOCK;
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_CONFIG_URL;
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_LOCAL_CONFIG_URI;
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_ROUTER;
+import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_SERVICE_HOSTNAME;
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_WORKER_CAPACITY;
 import static io.aklivity.zilla.runtime.engine.test.EngineRule.ENGINE_BUFFER_POOL_CAPACITY_NAME;
 import static io.aklivity.zilla.runtime.engine.test.EngineRule.ENGINE_BUFFER_SLOT_CAPACITY_NAME;
@@ -34,6 +35,7 @@ import static io.aklivity.zilla.runtime.engine.test.EngineRule.ENGINE_CLOCK_NAME
 import static io.aklivity.zilla.runtime.engine.test.EngineRule.ENGINE_CONFIG_URL_NAME;
 import static io.aklivity.zilla.runtime.engine.test.EngineRule.ENGINE_LOCAL_CONFIG_URI_NAME;
 import static io.aklivity.zilla.runtime.engine.test.EngineRule.ENGINE_ROUTER_NAME;
+import static io.aklivity.zilla.runtime.engine.test.EngineRule.ENGINE_SERVICE_HOSTNAME_NAME;
 import static io.aklivity.zilla.runtime.engine.test.EngineRule.ENGINE_WORKER_CAPACITY_NAME;
 import static org.junit.Assert.assertEquals;
 
@@ -54,5 +56,6 @@ public class EngineConfigurationTest
         assertEquals(ENGINE_WORKER_CAPACITY.name(), ENGINE_WORKER_CAPACITY_NAME);
         assertEquals(ENGINE_CLOCK.name(), ENGINE_CLOCK_NAME);
         assertEquals(ENGINE_ROUTER.name(), ENGINE_ROUTER_NAME);
+        assertEquals(ENGINE_SERVICE_HOSTNAME.name(), ENGINE_SERVICE_HOSTNAME_NAME);
     }
 }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/EngineRule.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/EngineRule.java
@@ -78,6 +78,7 @@ public final class EngineRule implements TestRule
     public static final String ENGINE_WORKER_CAPACITY_NAME = "zilla.engine.worker.capacity";
     public static final String ENGINE_CLOCK_NAME = "zilla.engine.clock";
     public static final String ENGINE_ROUTER_NAME = "zilla.engine.router";
+    public static final String ENGINE_SERVICE_HOSTNAME_NAME = "zilla.engine.service.hostname";
 
     private static final long EXTERNAL_AFFINITY_MASK = 1L << (Long.SIZE - 1);
     private static final Pattern DATA_FILENAME_PATTERN = Pattern.compile("data\\d+");

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/response.with.alt.svc.explicit/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/response.with.alt.svc.explicit/client.rpt
@@ -1,0 +1,36 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":scheme", "http")
+                              .header(":method", "GET")
+                              .header(":path", "/")
+                              .header(":authority", "localhost:8080")
+                              .build()}
+connected
+
+write close
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":status", "200")
+                             .header("alt-svc", "h3=\":443\"; ma=86400")
+                             .build()}

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/response.with.alt.svc.explicit/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/response.with.alt.svc.explicit/server.rpt
@@ -1,0 +1,38 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/app0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+accepted
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":scheme", "http")
+                             .header(":method", "GET")
+                             .header(":path", "/")
+                             .header(":authority", "localhost:8080")
+                             .build()}
+connected
+
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":status", "200")
+                              .header("alt-svc", "h3=\":443\"; ma=86400")
+                              .build()}
+write close

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/response.with.alt.svc.placeholder/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/response.with.alt.svc.placeholder/client.rpt
@@ -1,0 +1,36 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":scheme", "http")
+                              .header(":method", "GET")
+                              .header(":path", "/")
+                              .header(":authority", "localhost:8080")
+                              .build()}
+connected
+
+write close
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":status", "200")
+                             .header("alt-svc", "http=\":8443\"; ma=86400")
+                             .build()}

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/response.with.alt.svc.placeholder/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/response.with.alt.svc.placeholder/server.rpt
@@ -1,0 +1,38 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/app0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+accepted
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":scheme", "http")
+                             .header(":method", "GET")
+                             .header(":path", "/")
+                             .header(":authority", "localhost:8080")
+                             .build()}
+connected
+
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":status", "200")
+                              .header("alt-svc", "http=\":8443\"; ma=86400")
+                              .build()}
+write close

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/response.with.alt.svc.explicit/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/response.with.alt.svc.explicit/client.rpt
@@ -1,0 +1,34 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":method", "GET")
+                              .header(":scheme", "http")
+                              .header(":path", "/")
+                              .header(":authority", "localhost:8080")
+                              .build()}
+connected
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":status", "200")
+                             .header("alt-svc", "h3=\":443\"; ma=86400")
+                             .build()}

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/response.with.alt.svc.explicit/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/response.with.alt.svc.explicit/server.rpt
@@ -1,0 +1,36 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+accepted
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":method", "GET")
+                             .header(":scheme", "http")
+                             .header(":path", "/")
+                             .header(":authority", "localhost:8080")
+                             .build()}
+connected
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":status", "200")
+                              .header("alt-svc", "h3=\":443\"; ma=86400")
+                              .build()}
+write close

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/response.with.alt.svc.placeholder/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/response.with.alt.svc.placeholder/client.rpt
@@ -1,0 +1,34 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":method", "GET")
+                              .header(":scheme", "http")
+                              .header(":path", "/")
+                              .header(":authority", "localhost:8080")
+                              .build()}
+connected
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":status", "200")
+                             .header("alt-svc", "http=\":8443\"; ma=86400")
+                             .build()}

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/response.with.alt.svc.placeholder/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/response.with.alt.svc.placeholder/server.rpt
@@ -1,0 +1,36 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+accepted
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":method", "GET")
+                             .header(":scheme", "http")
+                             .header(":path", "/")
+                             .header(":authority", "localhost:8080")
+                             .build()}
+connected
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":status", "200")
+                              .header("alt-svc", "http=\":8443\"; ma=86400")
+                              .build()}
+write close

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/response.with.alt.svc.explicit/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/response.with.alt.svc.explicit/client.rpt
@@ -1,0 +1,28 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "http://localhost:8080/"
+  option http:transport "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+connected
+
+write http:method "GET"
+write http:host
+write close
+
+read http:status "200" "OK"
+read http:header "alt-svc" "h3=\":443\"; ma=86400"

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/response.with.alt.svc.explicit/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/response.with.alt.svc.explicit/server.rpt
@@ -1,0 +1,29 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "http://localhost:8080/"
+  option http:transport "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+accepted
+connected
+
+read http:method "GET"
+read closed
+
+write http:status "200" "OK"
+write http:header "alt-svc" "h3=\":443\"; ma=86400"
+write close

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/response.with.alt.svc.placeholder/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/response.with.alt.svc.placeholder/client.rpt
@@ -1,0 +1,28 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "http://localhost:8080/"
+  option http:transport "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+connected
+
+write http:method "GET"
+write http:host
+write close
+
+read http:status "200" "OK"
+read http:header "alt-svc" "http%2F1.1=\":8443\"; ma=86400"

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/response.with.alt.svc.placeholder/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/response.with.alt.svc.placeholder/server.rpt
@@ -1,0 +1,29 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "http://localhost:8080/"
+  option http:transport "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+accepted
+connected
+
+read http:method "GET"
+read closed
+
+write http:status "200" "OK"
+write http:header "alt-svc" "http%2F1.1=\":8443\"; ma=86400"
+write close

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/response.with.alt.svc.explicit/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/response.with.alt.svc.explicit/client.rpt
@@ -1,0 +1,79 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "duplex"
+connected
+
+# client connection preface
+write "PRI * HTTP/2.0\r\n"
+      "\r\n"
+      "SM\r\n"
+      "\r\n"
+write flush
+
+# server connection preface - SETTINGS frame
+read [0x00 0x00 0x12]                   # length = 18
+     [0x04]                             # HTTP2 SETTINGS frame
+     [0x00]                             # flags = 0x00
+     [0x00 0x00 0x00 0x00]              # stream_id = 0
+     [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x04) = 0
+     [0x00 0x06 0x00 0x00 0x20 0x00]    # SETTINGS_MAX_HEADER_LIST_SIZE(0x06) = 8192
+
+write [0x00 0x00 0x00]                  # length = 0
+      [0x04]                            # HTTP2 SETTINGS frame
+      [0x01]                            # ACK
+      [0x00 0x00 0x00 0x00]             # stream_id = 0
+write flush
+
+write [0x00 0x00 0x0c]                   # length = 12
+      [0x04]                             # HTTP2 SETTINGS frame
+      [0x00]                             # flags = 0x00
+      [0x00 0x00 0x00 0x00]              # stream_id = 0
+      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0xff 0xff]    # SETTINGS_INITIAL_WINDOW_SIZE(0x04) = 65535
+write flush
+
+write [0x00 0x00 0x13]                  # length = 19
+      [0x01]                            # HEADERS frame
+      [0x05]                            # END_HEADERS | END_STREAM
+      [0x00 0x00 0x00 0x01]             # stream_id = 1
+      [0x82]                            # :method: GET
+      [0x86]                            # :scheme: http
+      [0x84]                            # :path: /
+      [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
+write flush
+
+read [0x00 0x00 0x00]                   # length = 0
+     [0x04]                             # HTTP2 SETTINGS frame
+     [0x01]                             # ACK
+     [0x00 0x00 0x00 0x00]              # stream_id = 0
+
+read [0x00 0x00 0x1e]                            # length = 30
+     [0x01]                                      # HTTP2 HEADERS frame
+     [0x04]                                      # END_HEADERS
+     [0x00 0x00 0x00 0x01]                       # stream_id=1
+     [0x88]                                      # :status: 200
+     [0x00]                                      # literal, no indexing, new name
+     [0x07] "alt-svc"                            # name length 7
+     [0x13] "h3=\":443\"; ma=86400"              # value length 19 (pass-through)
+
+read [0x00 0x00 0x00]                   # length = 0
+     [0x00]                             # HTTP2 DATA frame
+     [0x01]                             # END_STREAM
+     [0x00 0x00 0x00 0x01]              # stream_id = 1

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/response.with.alt.svc.explicit/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/response.with.alt.svc.explicit/server.rpt
@@ -1,0 +1,80 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:window 8192
+       option zilla:transmission "duplex"
+accepted
+connected
+
+# server connection preface - SETTINGS frame
+write [0x00 0x00 0x12]                   # length = 18
+      [0x04]                             # HTTP2 SETTINGS frame
+      [0x00]                             # flags = 0x00
+      [0x00 0x00 0x00 0x00]              # stream_id = 0
+      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x04) = 0
+      [0x00 0x06 0x00 0x00 0x20 0x00]    # SETTINGS_MAX_HEADER_LIST_SIZE(0x06) = 8192
+write flush
+
+# client connection preface
+read "PRI * HTTP/2.0\r\n"
+     "\r\n"
+     "SM\r\n"
+     "\r\n"
+
+read [0x00 0x00 0x00]                   # SETTINGS ACK
+     [0x04]
+     [0x01]
+     [0x00 0x00 0x00 0x00]
+
+read [0x00 0x00 0x0c]                   # client SETTINGS
+     [0x04]
+     [0x00]
+     [0x00 0x00 0x00 0x00]
+     [0x00 0x03 0x00 0x00 0x00 0x64]
+     [0x00 0x04 0x00 0x00 0xff 0xff]
+
+read [0x00 0x00 0x13]                   # request HEADERS
+     [0x01]
+     [0x05]
+     [0x00 0x00 0x00 0x01]
+     [0x82]                             # :method: GET
+     [0x86]                             # :scheme: http
+     [0x84]                             # :path: /
+     [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
+
+write [0x00 0x00 0x00]                  # SETTINGS ACK
+      [0x04]
+      [0x01]
+      [0x00 0x00 0x00 0x00]
+write flush
+
+write [0x00 0x00 0x1e]                            # length = 30
+      [0x01]                                      # HTTP2 HEADERS frame
+      [0x04]                                      # END_HEADERS
+      [0x00 0x00 0x00 0x01]                       # stream_id=1
+      [0x88]                                      # :status: 200
+      [0x00]                                      # literal, no indexing, new name
+      [0x07] "alt-svc"                            # name length 7
+      [0x13] "h3=\":443\"; ma=86400"              # value length 19 (pass-through)
+write flush
+
+write [0x00 0x00 0x00]                  # empty DATA, END_STREAM
+      [0x00]
+      [0x01]
+      [0x00 0x00 0x00 0x01]
+write flush

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/response.with.alt.svc.placeholder/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/response.with.alt.svc.placeholder/client.rpt
@@ -1,0 +1,79 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "duplex"
+connected
+
+# client connection preface
+write "PRI * HTTP/2.0\r\n"
+      "\r\n"
+      "SM\r\n"
+      "\r\n"
+write flush
+
+# server connection preface - SETTINGS frame
+read [0x00 0x00 0x12]                   # length = 18
+     [0x04]                             # HTTP2 SETTINGS frame
+     [0x00]                             # flags = 0x00
+     [0x00 0x00 0x00 0x00]              # stream_id = 0
+     [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x04) = 0
+     [0x00 0x06 0x00 0x00 0x20 0x00]    # SETTINGS_MAX_HEADER_LIST_SIZE(0x06) = 8192
+
+write [0x00 0x00 0x00]                  # length = 0
+      [0x04]                            # HTTP2 SETTINGS frame
+      [0x01]                            # ACK
+      [0x00 0x00 0x00 0x00]             # stream_id = 0
+write flush
+
+write [0x00 0x00 0x0c]                   # length = 12
+      [0x04]                             # HTTP2 SETTINGS frame
+      [0x00]                             # flags = 0x00
+      [0x00 0x00 0x00 0x00]              # stream_id = 0
+      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0xff 0xff]    # SETTINGS_INITIAL_WINDOW_SIZE(0x04) = 65535
+write flush
+
+write [0x00 0x00 0x13]                  # length = 19
+      [0x01]                            # HEADERS frame
+      [0x05]                            # END_HEADERS | END_STREAM
+      [0x00 0x00 0x00 0x01]             # stream_id = 1
+      [0x82]                            # :method: GET
+      [0x86]                            # :scheme: http
+      [0x84]                            # :path: /
+      [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
+write flush
+
+read [0x00 0x00 0x00]                   # length = 0
+     [0x04]                             # HTTP2 SETTINGS frame
+     [0x01]                             # ACK
+     [0x00 0x00 0x00 0x00]              # stream_id = 0
+
+read [0x00 0x00 0x1f]                            # length = 31
+     [0x01]                                      # HTTP2 HEADERS frame
+     [0x04]                                      # END_HEADERS
+     [0x00 0x00 0x00 0x01]                       # stream_id=1
+     [0x88]                                      # :status: 200
+     [0x00]                                      # literal, no indexing, new name
+     [0x07] "alt-svc"                            # name length 7
+     [0x14] "h2=\":8443\"; ma=86400"             # value length 20 (translated)
+
+read [0x00 0x00 0x00]                   # length = 0
+     [0x00]                             # HTTP2 DATA frame
+     [0x01]                             # END_STREAM
+     [0x00 0x00 0x00 0x01]              # stream_id = 1

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/response.with.alt.svc.placeholder/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/response.with.alt.svc.placeholder/server.rpt
@@ -1,0 +1,80 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:window 8192
+       option zilla:transmission "duplex"
+accepted
+connected
+
+# server connection preface - SETTINGS frame
+write [0x00 0x00 0x12]                   # length = 18
+      [0x04]                             # HTTP2 SETTINGS frame
+      [0x00]                             # flags = 0x00
+      [0x00 0x00 0x00 0x00]              # stream_id = 0
+      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x04) = 0
+      [0x00 0x06 0x00 0x00 0x20 0x00]    # SETTINGS_MAX_HEADER_LIST_SIZE(0x06) = 8192
+write flush
+
+# client connection preface
+read "PRI * HTTP/2.0\r\n"
+     "\r\n"
+     "SM\r\n"
+     "\r\n"
+
+read [0x00 0x00 0x00]                   # SETTINGS ACK
+     [0x04]
+     [0x01]
+     [0x00 0x00 0x00 0x00]
+
+read [0x00 0x00 0x0c]                   # client SETTINGS
+     [0x04]
+     [0x00]
+     [0x00 0x00 0x00 0x00]
+     [0x00 0x03 0x00 0x00 0x00 0x64]
+     [0x00 0x04 0x00 0x00 0xff 0xff]
+
+read [0x00 0x00 0x13]                   # request HEADERS
+     [0x01]
+     [0x05]
+     [0x00 0x00 0x00 0x01]
+     [0x82]                             # :method: GET
+     [0x86]                             # :scheme: http
+     [0x84]                             # :path: /
+     [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
+
+write [0x00 0x00 0x00]                  # SETTINGS ACK
+      [0x04]
+      [0x01]
+      [0x00 0x00 0x00 0x00]
+write flush
+
+write [0x00 0x00 0x1f]                            # length = 31
+      [0x01]                                      # HTTP2 HEADERS frame
+      [0x04]                                      # END_HEADERS
+      [0x00 0x00 0x00 0x01]                       # stream_id=1
+      [0x88]                                      # :status: 200
+      [0x00]                                      # literal, no indexing, new name
+      [0x07] "alt-svc"                            # name length 7
+      [0x14] "h2=\":8443\"; ma=86400"             # value length 20 (translated)
+write flush
+
+write [0x00 0x00 0x00]                  # empty DATA, END_STREAM
+      [0x00]
+      [0x01]
+      [0x00 0x00 0x00 0x01]
+write flush

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/MessageFormatIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/MessageFormatIT.java
@@ -85,6 +85,24 @@ public class MessageFormatIT
 
     @Test
     @Specification({
+        "${app}/response.with.alt.svc.placeholder/client",
+        "${app}/response.with.alt.svc.placeholder/server" })
+    public void responseWithAltSvcPlaceholder() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/response.with.alt.svc.explicit/client",
+        "${app}/response.with.alt.svc.explicit/server" })
+    public void responseWithAltSvcExplicit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/request.with.extra.CRLF.before.request.line/client",
         "${app}/request.with.extra.CRLF.before.request.line/server" })
     public void robustServerShouldAllowExtraCRLFBeforeRequestLine() throws Exception

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/MessageFormatIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/MessageFormatIT.java
@@ -89,6 +89,24 @@ public class MessageFormatIT
 
     @Test
     @Specification({
+        "${app}/response.with.alt.svc.placeholder/client",
+        "${app}/response.with.alt.svc.placeholder/server" })
+    public void responseWithAltSvcPlaceholder() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/response.with.alt.svc.explicit/client",
+        "${app}/response.with.alt.svc.explicit/server" })
+    public void responseWithAltSvcExplicit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/priority.frame.size.error/client",
         "${app}/priority.frame.size.error/server"
     })

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/MessageFormatIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/MessageFormatIT.java
@@ -76,6 +76,24 @@ public class MessageFormatIT
 
     @Test
     @Specification({
+        "${net}/response.with.alt.svc.placeholder/client",
+        "${net}/response.with.alt.svc.placeholder/server" })
+    public void responseWithAltSvcPlaceholder() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${net}/response.with.alt.svc.explicit/client",
+        "${net}/response.with.alt.svc.explicit/server" })
+    public void responseWithAltSvcExplicit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${net}/invalid.request.whitespace.after.start.line/client",
         "${net}/invalid.request.whitespace.after.start.line/server" })
     public void invalidRequestWhitespaceAfterStartLine() throws Exception

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/MessageFormatIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/MessageFormatIT.java
@@ -89,6 +89,24 @@ public class MessageFormatIT
 
     @Test
     @Specification({
+        "${net}/response.with.alt.svc.placeholder/client",
+        "${net}/response.with.alt.svc.placeholder/server" })
+    public void responseWithAltSvcPlaceholder() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${net}/response.with.alt.svc.explicit/client",
+        "${net}/response.with.alt.svc.explicit/server" })
+    public void responseWithAltSvcExplicit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${net}/ping.frame.size.error/client",
         "${net}/ping.frame.size.error/server"
     })


### PR DESCRIPTION
## Summary

Closes #1772.

`binding-http` server response path now rewrites `Alt-Svc` headers whose value uses an `http=` placeholder to the active request's ALPN protocol identifier:

| Active request | Translated value |
| --- | --- |
| HTTP/1.1 | `http%2F1.1="..."` (RFC 7838 §3 percent-encoding) |
| HTTP/2 | `h2="..."` |

Values that don't use the `http=` placeholder (e.g. an explicit `h3=...`) pass through unchanged.

The translation runs once per response-begin via `translateAltSvc()` into a factory-level scratch buffer; the existing per-protocol encode loop then emits the rewritten `Array32FW<HttpHeaderFW>` without further changes.

### What changed

- `runtime/engine`: new `zilla.engine.service.hostname` property (`ENGINE_SERVICE_HOSTNAME` + `serviceHostname()` accessor). Consumed by binding-http's translator-driven Alt-Svc path. Property name asserted in `EngineConfigurationTest#shouldVerifyConstants`.
- `runtime/binding-http` (`HttpServerFactory`):
  - Constants: `HEADER_ALT_SVC`, `ALT_SVC_PLACEHOLDER_BYTES`, `ALT_SVC_ALPN_HTTP_1_1_BYTES`, `ALT_SVC_ALPN_HTTP_2_BYTES`.
  - Factory-level scratch buffers (`altSvcHeadersBuffer`, `altSvcValueBuffer`, `altSvcRawBuffer`) and `altSvcHeadersRW` / `altSvcValueRW` builders.
  - `translateAltSvc(headers, alpnBytes)` + static `isAltSvcPlaceholder(header)`.
  - HTTP/1.1 response-begin (`HttpExchange.doEncodeHeaders`): substitutes the translated array at the `forEach` site.
  - HTTP/2 response-begin (`Http2Exchange.doEncodeHeaders`): substitutes the translated array passed into `headersEncoder.encodeHeaders(...)`.
- `specs/binding-http.spec`: 16 new `.rpt` scripts under `streams/{network,application}/{rfc7230,rfc7540}/message.format/response.with.alt.svc.{placeholder,explicit}/{client,server}.rpt`.
- 8 new IT methods (`responseWithAltSvcPlaceholder`, `responseWithAltSvcExplicit`) across the 4 spec `MessageFormatIT` classes (peer-to-peer self-consistency).
- 4 new IT methods across the 2 runtime `*ServerIT` `MessageFormatIT` classes (wire-level translation through a live Zilla engine).

### Follow-up

Per #1772, switching `binding-mcp` from emitting `h2=...` to `http=...` and updating the existing `lifecycle.initialize.alt.svc` spec scripts is deferred to #1773 (which lands `binding-mcp` Alt-Svc emission and will rebase to consume the placeholder convention this PR introduces).

## Test plan

- [x] `EngineConfigurationTest#shouldVerifyConstants` passes with new `zilla.engine.service.hostname` assertion.
- [x] `runtime/binding-http` server ITs (HTTP/1.1): `responseWithAltSvcPlaceholder` (placeholder → `http%2F1.1=`), `responseWithAltSvcExplicit` (`h3=` pass-through).
- [x] `runtime/binding-http` server ITs (HTTP/2): `responseWithAltSvcPlaceholder` (placeholder → `h2=`), `responseWithAltSvcExplicit` (`h3=` pass-through).
- [x] Spec project peer-to-peer ITs: 8 new `responseWithAltSvc*` methods across `network/rfc7230`, `network/rfc7540`, `application/rfc7230`, `application/rfc7540` `MessageFormatIT` classes.
- [x] 62 pre-existing `*MessageFormatIT` methods unaffected.
- [x] `mvn checkstyle:check` clean on `runtime/engine`, `runtime/binding-http`, `specs/binding-http.spec`.
- [ ] CI green on this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNvv8KbicCwkCmbiWjsSAV)_