### PR TITLE
Add MCP lifecycle and toolkit integration tests

### DIFF
--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -101,11 +101,9 @@ public class McpProxyIT
     @Test
     @Configuration("proxy.toolkit.yaml")
     @Specification({
-        "${app}/tools.call.toolkit/client",
+        "${app}/tools.call.toolkit.prefixed/client",
         "${app}/tools.call.toolkit/server" })
-    @ScriptProperty({
-        "serverAddress \"zilla://streams/app1\"",
-        "toolName \"get_weather\""})
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
     public void shouldCallToolWithToolkit() throws Exception
     {
         k3po.finish();
@@ -125,11 +123,9 @@ public class McpProxyIT
     @Test
     @Configuration("proxy.toolkit.yaml")
     @Specification({
-        "${app}/tools.list.toolkit/client",
+        "${app}/tools.list.toolkit.prefixed/client",
         "${app}/tools.list.toolkit/server" })
-    @ScriptProperty({
-        "serverAddress \"zilla://streams/app1\"",
-        "toolName \"get_weather\""})
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
     public void shouldListToolsWithToolkit() throws Exception
     {
         k3po.finish();
@@ -138,7 +134,7 @@ public class McpProxyIT
     @Test
     @Configuration("proxy.toolkit.multi.yaml")
     @Specification({
-        "${app}/tools.list.toolkit.multi/client",
+        "${app}/tools.list.toolkit.multi.prefixed/client",
         "${app}/tools.list.toolkit.multi/server" })
     public void shouldListToolsWithToolkitMulti() throws Exception
     {
@@ -159,11 +155,9 @@ public class McpProxyIT
     @Test
     @Configuration("proxy.toolkit.yaml")
     @Specification({
-        "${app}/prompts.get.toolkit/client",
+        "${app}/prompts.get.toolkit.prefixed/client",
         "${app}/prompts.get.toolkit/server" })
-    @ScriptProperty({
-        "serverAddress \"zilla://streams/app1\"",
-        "promptName \"weather_prompt\""})
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
     public void shouldGetPromptWithToolkit() throws Exception
     {
         k3po.finish();
@@ -183,11 +177,9 @@ public class McpProxyIT
     @Test
     @Configuration("proxy.toolkit.yaml")
     @Specification({
-        "${app}/prompts.list.toolkit/client",
+        "${app}/prompts.list.toolkit.prefixed/client",
         "${app}/prompts.list.toolkit/server" })
-    @ScriptProperty({
-        "serverAddress \"zilla://streams/app1\"",
-        "promptName \"weather_prompt\""})
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
     public void shouldListPromptsWithToolkit() throws Exception
     {
         k3po.finish();
@@ -196,7 +188,7 @@ public class McpProxyIT
     @Test
     @Configuration("proxy.toolkit.multi.yaml")
     @Specification({
-        "${app}/prompts.list.toolkit.multi/client",
+        "${app}/prompts.list.toolkit.multi.prefixed/client",
         "${app}/prompts.list.toolkit.multi/server" })
     public void shouldListPromptsWithToolkitMulti() throws Exception
     {
@@ -217,11 +209,9 @@ public class McpProxyIT
     @Test
     @Configuration("proxy.toolkit.yaml")
     @Specification({
-        "${app}/resources.read.toolkit/client",
+        "${app}/resources.read.toolkit.prefixed/client",
         "${app}/resources.read.toolkit/server" })
-    @ScriptProperty({
-        "serverAddress \"zilla://streams/app1\"",
-        "resourceUri \"file:///data/readme.txt\""})
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
     public void shouldReadResourceWithToolkit() throws Exception
     {
         k3po.finish();
@@ -241,11 +231,9 @@ public class McpProxyIT
     @Test
     @Configuration("proxy.toolkit.yaml")
     @Specification({
-        "${app}/resources.list.toolkit/client",
+        "${app}/resources.list.toolkit.prefixed/client",
         "${app}/resources.list.toolkit/server" })
-    @ScriptProperty({
-        "serverAddress \"zilla://streams/app1\"",
-        "resourceUri \"file:///data/readme.txt\""})
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
     public void shouldListResourcesWithToolkit() throws Exception
     {
         k3po.finish();
@@ -254,7 +242,7 @@ public class McpProxyIT
     @Test
     @Configuration("proxy.toolkit.multi.yaml")
     @Specification({
-        "${app}/resources.list.toolkit.multi/client",
+        "${app}/resources.list.toolkit.multi.prefixed/client",
         "${app}/resources.list.toolkit.multi/server" })
     public void shouldListResourcesWithToolkitMulti() throws Exception
     {
@@ -385,11 +373,9 @@ public class McpProxyIT
     @Test
     @Configuration("proxy.toolkit.yaml")
     @Specification({
-        "${app}/tools.call.toolkit.with.progress/client",
+        "${app}/tools.call.toolkit.with.progress.prefixed/client",
         "${app}/tools.call.toolkit.with.progress/server" })
-    @ScriptProperty({
-        "serverAddress \"zilla://streams/app1\"",
-        "toolName \"get_weather\""})
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
     public void shouldCallToolWithToolkitWithProgress() throws Exception
     {
         k3po.finish();

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -103,6 +103,9 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.call.toolkit/client",
         "${app}/tools.call.toolkit/server" })
+    @ScriptProperty({
+        "serverAddress \"zilla://streams/app1\"",
+        "toolName \"get_weather\""})
     public void shouldCallToolWithToolkit() throws Exception
     {
         k3po.finish();
@@ -124,6 +127,9 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.list.toolkit/client",
         "${app}/tools.list.toolkit/server" })
+    @ScriptProperty({
+        "serverAddress \"zilla://streams/app1\"",
+        "toolName \"get_weather\""})
     public void shouldListToolsWithToolkit() throws Exception
     {
         k3po.finish();
@@ -155,6 +161,9 @@ public class McpProxyIT
     @Specification({
         "${app}/prompts.get.toolkit/client",
         "${app}/prompts.get.toolkit/server" })
+    @ScriptProperty({
+        "serverAddress \"zilla://streams/app1\"",
+        "promptName \"weather_prompt\""})
     public void shouldGetPromptWithToolkit() throws Exception
     {
         k3po.finish();
@@ -176,6 +185,9 @@ public class McpProxyIT
     @Specification({
         "${app}/prompts.list.toolkit/client",
         "${app}/prompts.list.toolkit/server" })
+    @ScriptProperty({
+        "serverAddress \"zilla://streams/app1\"",
+        "promptName \"weather_prompt\""})
     public void shouldListPromptsWithToolkit() throws Exception
     {
         k3po.finish();
@@ -207,6 +219,9 @@ public class McpProxyIT
     @Specification({
         "${app}/resources.read.toolkit/client",
         "${app}/resources.read.toolkit/server" })
+    @ScriptProperty({
+        "serverAddress \"zilla://streams/app1\"",
+        "resourceUri \"file:///data/readme.txt\""})
     public void shouldReadResourceWithToolkit() throws Exception
     {
         k3po.finish();
@@ -228,6 +243,9 @@ public class McpProxyIT
     @Specification({
         "${app}/resources.list.toolkit/client",
         "${app}/resources.list.toolkit/server" })
+    @ScriptProperty({
+        "serverAddress \"zilla://streams/app1\"",
+        "resourceUri \"file:///data/readme.txt\""})
     public void shouldListResourcesWithToolkit() throws Exception
     {
         k3po.finish();
@@ -369,6 +387,9 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.call.toolkit.with.progress/client",
         "${app}/tools.call.toolkit.with.progress/server" })
+    @ScriptProperty({
+        "serverAddress \"zilla://streams/app1\"",
+        "toolName \"get_weather\""})
     public void shouldCallToolWithToolkitWithProgress() throws Exception
     {
         k3po.finish();

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.evict/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.evict/client.rpt
@@ -1,0 +1,58 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read advise zilla:challenge ${mcp:challengeEx()
+                                  .typeId(zilla:id("mcp"))
+                                  .resume()
+                                      .build()
+                                  .build()}
+
+read advised zilla:flush ${mcp:matchFlushEx()
+                               .typeId(zilla:id("mcp"))
+                               .resumable()
+                                   .build()
+                               .build()}
+
+read advise zilla:challenge ${mcp:challengeEx()
+                                  .typeId(zilla:id("mcp"))
+                                  .resume()
+                                      .build()
+                                  .build()}
+
+read advised zilla:flush ${mcp:matchFlushEx()
+                               .typeId(zilla:id("mcp"))
+                               .resumable()
+                                   .build()
+                               .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.keepalive/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.keepalive/client.rpt
@@ -13,14 +13,18 @@
 # specific language governing permissions and limitations under the License.
 #
 
-property serverAddress "zilla://streams/app0"
-property toolName "bluesky__get_weather"
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
 
-accept ${serverAddress}
-       option zilla:window 8192
-       option zilla:transmission "half-duplex"
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
 
-accepted
+connected
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
@@ -29,49 +33,14 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
-connected
+read advise zilla:challenge ${mcp:challengeEx()
+                                  .typeId(zilla:id("mcp"))
+                                  .resume()
+                                      .build()
+                                  .build()}
 
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .lifecycle()
-                               .sessionId("session-1")
-                               .build()
-                           .build()}
-write flush
-
-accepted
-
-read zilla:begin.ext ${mcp:matchBeginEx()
-                          .typeId(zilla:id("mcp"))
-                          .toolsCall()
-                              .sessionId("session-1")
-                              .name(toolName)
-                              .build()
-                          .build()}
-
-connected
-
-read  '{'
-        '"name":"bluesky__get_weather",'
-        '"arguments":'
-        '{'
-          '"location": "New York"'
-        '}'
-      '}'
-read closed
-
-write flush
-
-write '{'
-        '"content":'
-        '['
-          '{'
-            '"type": "text",'
-            '"text": "Current weather in New York:\\nTemperature: 72°F\\nConditions: Partly cloudy"'
-          '}'
-        '],'
-        '"isError": false'
-      '}'
-write flush
-
-write close
+read advised zilla:flush ${mcp:matchFlushEx()
+                               .typeId(zilla:id("mcp"))
+                               .resumable()
+                                   .build()
+                               .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.ping/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.ping/server.rpt
@@ -14,7 +14,6 @@
 #
 
 property serverAddress "zilla://streams/app0"
-property toolName "bluesky__get_weather"
 
 accept ${serverAddress}
        option zilla:window 8192
@@ -39,39 +38,4 @@ write zilla:begin.ext ${mcp:beginEx()
                            .build()}
 write flush
 
-accepted
-
-read zilla:begin.ext ${mcp:matchBeginEx()
-                          .typeId(zilla:id("mcp"))
-                          .toolsCall()
-                              .sessionId("session-1")
-                              .name(toolName)
-                              .build()
-                          .build()}
-
-connected
-
-read  '{'
-        '"name":"bluesky__get_weather",'
-        '"arguments":'
-        '{'
-          '"location": "New York"'
-        '}'
-      '}'
-read closed
-
-write flush
-
-write '{'
-        '"content":'
-        '['
-          '{'
-            '"type": "text",'
-            '"text": "Current weather in New York:\\nTemperature: 72°F\\nConditions: Partly cloudy"'
-          '}'
-        '],'
-        '"isError": false'
-      '}'
-write flush
-
-write close
+write notify KEEPALIVE_COMPLETE

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit.prefixed/client.rpt
@@ -50,8 +50,21 @@ write zilla:begin.ext ${mcp:beginEx()
 
 connected
 
-write '{"name":"bluesky__weather_prompt"}'
+write '{'
+        '"name":"bluesky__weather_prompt"'
+      '}'
 write close
 
-read  '{"messages":[{"role":"user","content":{"type":"text","text":"What is the weather like today?"}}]}'
+read  '{"messages":'
+        '['
+          '{'
+            '"role":"user",'
+            '"content":'
+            '{'
+              '"type":"text",'
+              '"text":"What is the weather like today?"'
+            '}'
+          '}'
+        ']'
+      '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit.prefixed/client.rpt
@@ -42,54 +42,16 @@ connect await LIFECYCLE_INITIALIZED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .toolsCall()
+                           .promptsGet()
                                .sessionId("session-1")
-                               .name("get_weather")
+                               .name("bluesky__weather_prompt")
                                .build()
                            .build()}
 
 connected
 
-write '{'
-        '"name":"bluesky__get_weather",'
-        '"arguments":'
-        '{'
-          '"location": "New York"'
-        '},'
-        '"_meta":'
-        '{'
-          '"progressToken":"abc123"'
-        '}'
-      '}'
+write '{"name":"bluesky__weather_prompt"}'
 write close
 
-read advised zilla:flush ${mcp:matchFlushEx()
-                               .typeId(zilla:id("mcp"))
-                               .resumable()
-                                   .id("0")
-                                   .build()
-                               .build()}
-
-read advised zilla:flush ${mcp:matchFlushEx()
-                               .typeId(zilla:id("mcp"))
-                               .progress()
-                                   .id("1")
-                                   .token("abc123")
-                                   .progress(50)
-                                   .total(100)
-                                   .message("Checking if Lady Liberty needs an umbrella...")
-                                   .build()
-                               .build()}
-
-read '{'
-      '"content":'
-      '['
-        '{'
-          '"type": "text",'
-          '"text": "Current weather in New York:\\nTemperature: 72°F\\nConditions: Partly cloudy"'
-        '}'
-      '],'
-      '"isError": false'
-    '}'
-
+read  '{"messages":[{"role":"user","content":{"type":"text","text":"What is the weather like today?"}}]}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit.prefixed/server.rpt
@@ -13,18 +13,13 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+property serverAddress "zilla://streams/app0"
 
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .lifecycle()
-                               .sessionId("session-1")
-                               .build()
-                           .build()}
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
 
-connected
+accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
@@ -33,23 +28,34 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
-read notify LIFECYCLE_INITIALIZED
-
-connect await LIFECYCLE_INITIALIZED
-        "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+connected
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .promptsList()
+                           .lifecycle()
                                .sessionId("session-1")
                                .build()
                            .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .promptsGet()
+                              .sessionId("session-1")
+                              .name("bluesky__weather_prompt")
+                              .build()
+                          .build()}
 
 connected
 
-write close
-
-read  '{"prompts":[{"name":"weather_prompt","description":"Ask about weather"}]}'
+read  '{"name":"bluesky__weather_prompt"}'
 read closed
+
+write flush
+
+write '{"messages":[{"role":"user","content":{"type":"text","text":"What is the weather like today?"}}]}'
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit.prefixed/server.rpt
@@ -50,12 +50,25 @@ read zilla:begin.ext ${mcp:matchBeginEx()
 
 connected
 
-read  '{"name":"bluesky__weather_prompt"}'
+read  '{'
+        '"name":"bluesky__weather_prompt"'
+      '}'
 read closed
 
 write flush
 
-write '{"messages":[{"role":"user","content":{"type":"text","text":"What is the weather like today?"}}]}'
+write '{"messages":'
+        '['
+          '{'
+            '"role":"user",'
+            '"content":'
+            '{'
+              '"type":"text",'
+              '"text":"What is the weather like today?"'
+            '}'
+          '}'
+        ']'
+      '}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/client.rpt
@@ -50,8 +50,21 @@ write zilla:begin.ext ${mcp:beginEx()
 
 connected
 
-write '{"name":"bluesky__weather_prompt"}'
+write '{'
+        '"name":"bluesky__weather_prompt"'
+      '}'
 write close
 
-read  '{"messages":[{"role":"user","content":{"type":"text","text":"What is the weather like today?"}}]}'
+read  '{"messages":'
+        '['
+          '{'
+            '"role":"user",'
+            '"content":'
+            '{'
+              '"type":"text",'
+              '"text":"What is the weather like today?"'
+            '}'
+          '}'
+        ']'
+      '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/client.rpt
@@ -44,7 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsGet()
                                .sessionId("session-1")
-                               .name("bluesky__weather_prompt")
+                               .name("weather_prompt")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/server.rpt
@@ -14,7 +14,6 @@
 #
 
 property serverAddress "zilla://streams/app0"
-property promptName "bluesky__weather_prompt"
 
 accept ${serverAddress}
        option zilla:window 8192
@@ -45,7 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsGet()
                               .sessionId("session-1")
-                              .name(promptName)
+                              .name("weather_prompt")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/server.rpt
@@ -13,7 +13,10 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app1"
+property serverAddress "zilla://streams/app0"
+property promptName "bluesky__weather_prompt"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 
@@ -42,7 +45,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsGet()
                               .sessionId("session-1")
-                              .name("weather_prompt")
+                              .name(promptName)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/server.rpt
@@ -50,12 +50,25 @@ read zilla:begin.ext ${mcp:matchBeginEx()
 
 connected
 
-read  '{"name":"bluesky__weather_prompt"}'
+read  '{'
+        '"name":"bluesky__weather_prompt"'
+      '}'
 read closed
 
 write flush
 
-write '{"messages":[{"role":"user","content":{"type":"text","text":"What is the weather like today?"}}]}'
+write '{"messages":'
+        '['
+          '{'
+            '"role":"user",'
+            '"content":'
+            '{'
+              '"type":"text",'
+              '"text":"What is the weather like today?"'
+            '}'
+          '}'
+        ']'
+      '}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi.prefixed/client.rpt
@@ -13,7 +13,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/app1"
+connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
 
@@ -33,16 +33,16 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
-read notify LIFECYCLE_INITIALIZED_1
+read notify LIFECYCLE_INITIALIZED
 
-connect await LIFECYCLE_INITIALIZED_1
-        "zilla://streams/app1"
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .toolsList()
+                           .promptsList()
                                .sessionId("session-1")
                                .build()
                            .build()}
@@ -51,50 +51,10 @@ connected
 
 write close
 
-read '{"tools":[{"name":"get_weather"}]}'
-read closed
-
-read notify SERVER_1_DONE
-
-
-connect await SERVER_1_DONE
-        "zilla://streams/app2"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
-
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .lifecycle()
-                               .sessionId("session-1")
-                               .build()
-                           .build()}
-
-connected
-
-read zilla:begin.ext ${mcp:matchBeginEx()
-                          .typeId(zilla:id("mcp"))
-                          .lifecycle()
-                              .sessionId("session-1")
-                              .build()
-                          .build()}
-
-read notify LIFECYCLE_INITIALIZED_2
-
-connect await LIFECYCLE_INITIALIZED_2
-        "zilla://streams/app2"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
-
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .toolsList()
-                               .sessionId("session-1")
-                               .build()
-                           .build()}
-
-connected
-
-write close
-
-read '{"tools":[{"name":"get_current_time"}]}'
+read  '{"prompts":'
+        '['
+          '{"name":"bluesky__weather_prompt"},'
+          '{"name":"quartz__current_time_prompt"}'
+        ']'
+      '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi.prefixed/server.rpt
@@ -13,18 +13,13 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+property serverAddress "zilla://streams/app0"
 
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .lifecycle()
-                               .sessionId("session-1")
-                               .build()
-                           .build()}
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
 
-connected
+accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
@@ -33,23 +28,32 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
-read notify LIFECYCLE_INITIALIZED
-
-connect await LIFECYCLE_INITIALIZED
-        "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+connected
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .promptsList()
+                           .lifecycle()
                                .sessionId("session-1")
                                .build()
                            .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .promptsList()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
 
 connected
 
-write close
+write flush
 
-read  '{"prompts":[{"name":"weather_prompt","description":"Ask about weather"}]}'
 read closed
+
+write '{"prompts":[{"name":"bluesky__weather_prompt"},{"name":"quartz__current_time_prompt"}]}'
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi.prefixed/server.rpt
@@ -53,7 +53,12 @@ write flush
 
 read closed
 
-write '{"prompts":[{"name":"bluesky__weather_prompt"},{"name":"quartz__current_time_prompt"}]}'
+write '{"prompts":'
+        '['
+          '{"name":"bluesky__weather_prompt"},'
+          '{"name":"quartz__current_time_prompt"}'
+        ']'
+      '}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/client.peer.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/client.peer.rpt
@@ -1,0 +1,100 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app1"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED_1
+
+connect await LIFECYCLE_INITIALIZED_1
+        "zilla://streams/app1"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .promptsList()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+write close
+
+read '{"prompts":[{"name":"weather_prompt"}]}'
+read closed
+
+read notify SERVER_1_DONE
+
+
+connect await SERVER_1_DONE
+        "zilla://streams/app2"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED_2
+
+connect await LIFECYCLE_INITIALIZED_2
+        "zilla://streams/app2"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .promptsList()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+write close
+
+read '{"prompts":[{"name":"current_time_prompt"}]}'
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/client.rpt
@@ -51,7 +51,11 @@ connected
 
 write close
 
-read '{"prompts":[{"name":"weather_prompt"}]}'
+read  '{"prompts":'
+        '['
+          '{"name":"weather_prompt"}'
+        ']'
+      '}'
 read closed
 
 read notify SERVER_1_DONE
@@ -96,5 +100,9 @@ connected
 
 write close
 
-read '{"prompts":[{"name":"current_time_prompt"}]}'
+read  '{"prompts":'
+        '['
+          '{"name":"current_time_prompt"}'
+        ']'
+      '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/client.rpt
@@ -13,7 +13,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/app0"
+connect "zilla://streams/app1"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
 
@@ -33,10 +33,10 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
-read notify LIFECYCLE_INITIALIZED
+read notify LIFECYCLE_INITIALIZED_1
 
-connect await LIFECYCLE_INITIALIZED
-        "zilla://streams/app0"
+connect await LIFECYCLE_INITIALIZED_1
+        "zilla://streams/app1"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
 
@@ -51,10 +51,50 @@ connected
 
 write close
 
-read  '{"prompts":'
-        '['
-          '{"name":"bluesky__weather_prompt"},'
-          '{"name":"quartz__current_time_prompt"}'
-        ']'
-      '}'
+read '{"prompts":[{"name":"weather_prompt"}]}'
+read closed
+
+read notify SERVER_1_DONE
+
+
+connect await SERVER_1_DONE
+        "zilla://streams/app2"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED_2
+
+connect await LIFECYCLE_INITIALIZED_2
+        "zilla://streams/app2"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .promptsList()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+write close
+
+read '{"prompts":[{"name":"current_time_prompt"}]}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/server.rpt
@@ -51,7 +51,11 @@ write flush
 
 read closed
 
-write '{"prompts":[{"name":"weather_prompt"}]}'
+write '{"prompts":'
+        '['
+          '{"name":"weather_prompt"}'
+        ']'
+      '}'
 write flush
 
 write close
@@ -95,7 +99,11 @@ write flush
 
 read closed
 
-write '{"prompts":[{"name":"current_time_prompt"}]}'
+write '{"prompts":'
+        '['
+          '{"name":"current_time_prompt"}'
+        ']'
+      '}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.prefixed/client.rpt
@@ -42,54 +42,21 @@ connect await LIFECYCLE_INITIALIZED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .toolsCall()
+                           .promptsList()
                                .sessionId("session-1")
-                               .name("get_weather")
                                .build()
                            .build()}
 
 connected
 
-write '{'
-        '"name":"bluesky__get_weather",'
-        '"arguments":'
-        '{'
-          '"location": "New York"'
-        '},'
-        '"_meta":'
-        '{'
-          '"progressToken":"abc123"'
-        '}'
-      '}'
 write close
 
-read advised zilla:flush ${mcp:matchFlushEx()
-                               .typeId(zilla:id("mcp"))
-                               .resumable()
-                                   .id("0")
-                                   .build()
-                               .build()}
-
-read advised zilla:flush ${mcp:matchFlushEx()
-                               .typeId(zilla:id("mcp"))
-                               .progress()
-                                   .id("1")
-                                   .token("abc123")
-                                   .progress(50)
-                                   .total(100)
-                                   .message("Checking if Lady Liberty needs an umbrella...")
-                                   .build()
-                               .build()}
-
-read '{'
-      '"content":'
-      '['
-        '{'
-          '"type": "text",'
-          '"text": "Current weather in New York:\\nTemperature: 72°F\\nConditions: Partly cloudy"'
-        '}'
-      '],'
-      '"isError": false'
-    '}'
-
+read  '{"prompts":'
+        '['
+          '{'
+            '"name":"bluesky__weather_prompt",'
+            '"description":"Ask about weather"'
+          '}'
+        ']'
+      '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.prefixed/server.rpt
@@ -53,7 +53,14 @@ write flush
 
 read closed
 
-write '{"prompts":[{"name":"bluesky__weather_prompt","description":"Ask about weather"}]}'
+write '{"prompts":'
+        '['
+          '{'
+            '"name":"bluesky__weather_prompt",'
+            '"description":"Ask about weather"'
+          '}'
+        ']'
+      '}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.prefixed/server.rpt
@@ -13,18 +13,13 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+property serverAddress "zilla://streams/app0"
 
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .lifecycle()
-                               .sessionId("session-1")
-                               .build()
-                           .build()}
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
 
-connected
+accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
@@ -33,23 +28,32 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
-read notify LIFECYCLE_INITIALIZED
-
-connect await LIFECYCLE_INITIALIZED
-        "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+connected
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .promptsList()
+                           .lifecycle()
                                .sessionId("session-1")
                                .build()
                            .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .promptsList()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
 
 connected
 
-write close
+write flush
 
-read  '{"prompts":[{"name":"weather_prompt","description":"Ask about weather"}]}'
 read closed
+
+write '{"prompts":[{"name":"bluesky__weather_prompt","description":"Ask about weather"}]}'
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/client.rpt
@@ -51,5 +51,12 @@ connected
 
 write close
 
-read  '{"prompts":[{"name":"weather_prompt","description":"Ask about weather"}]}'
+read  '{"prompts":'
+        '['
+          '{'
+            '"name":"weather_prompt",'
+            '"description":"Ask about weather"'
+          '}'
+        ']'
+      '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/server.rpt
@@ -53,7 +53,14 @@ write flush
 
 read closed
 
-write '{"prompts":[{"name":"weather_prompt","description":"Ask about weather"}]}'
+write '{"prompts":'
+        '['
+          '{'
+            '"name":"weather_prompt",'
+            '"description":"Ask about weather"'
+          '}'
+        ']'
+      '}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/server.rpt
@@ -13,7 +13,10 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app1"
+property serverAddress "zilla://streams/app0"
+property promptName "bluesky__weather_prompt"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 
@@ -51,7 +54,7 @@ write flush
 
 read closed
 
-write '{"prompts":[{"name":"weather_prompt","description":"Ask about weather"}]}'
+write '{"prompts":[{"name":"' ${promptName} '","description":"Ask about weather"}]}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi.prefixed/client.rpt
@@ -42,54 +42,19 @@ connect await LIFECYCLE_INITIALIZED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .toolsCall()
+                           .resourcesList()
                                .sessionId("session-1")
-                               .name("get_weather")
                                .build()
                            .build()}
 
 connected
 
-write '{'
-        '"name":"bluesky__get_weather",'
-        '"arguments":'
-        '{'
-          '"location": "New York"'
-        '},'
-        '"_meta":'
-        '{'
-          '"progressToken":"abc123"'
-        '}'
-      '}'
 write close
 
-read advised zilla:flush ${mcp:matchFlushEx()
-                               .typeId(zilla:id("mcp"))
-                               .resumable()
-                                   .id("0")
-                                   .build()
-                               .build()}
-
-read advised zilla:flush ${mcp:matchFlushEx()
-                               .typeId(zilla:id("mcp"))
-                               .progress()
-                                   .id("1")
-                                   .token("abc123")
-                                   .progress(50)
-                                   .total(100)
-                                   .message("Checking if Lady Liberty needs an umbrella...")
-                                   .build()
-                               .build()}
-
-read '{'
-      '"content":'
-      '['
-        '{'
-          '"type": "text",'
-          '"text": "Current weather in New York:\\nTemperature: 72°F\\nConditions: Partly cloudy"'
-        '}'
-      '],'
-      '"isError": false'
-    '}'
-
+read  '{"resources":'
+        '['
+          '{"uri":"bluesky+file:///data/readme.txt"},'
+          '{"uri":"quartz+file:///data/timezones.txt"}'
+        ']'
+      '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi.prefixed/server.rpt
@@ -53,7 +53,12 @@ write flush
 
 read closed
 
-write '{"resources":[{"uri":"bluesky+file:///data/readme.txt"},{"uri":"quartz+file:///data/timezones.txt"}]}'
+write '{"resources":'
+        '['
+          '{"uri":"bluesky+file:///data/readme.txt"},'
+          '{"uri":"quartz+file:///data/timezones.txt"}'
+        ']'
+      '}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi.prefixed/server.rpt
@@ -13,18 +13,13 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+property serverAddress "zilla://streams/app0"
 
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .lifecycle()
-                               .sessionId("session-1")
-                               .build()
-                           .build()}
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
 
-connected
+accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
@@ -33,23 +28,32 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
-read notify LIFECYCLE_INITIALIZED
-
-connect await LIFECYCLE_INITIALIZED
-        "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+connected
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .promptsList()
+                           .lifecycle()
                                .sessionId("session-1")
                                .build()
                            .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .resourcesList()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
 
 connected
 
-write close
+write flush
 
-read  '{"prompts":[{"name":"weather_prompt","description":"Ask about weather"}]}'
 read closed
+
+write '{"resources":[{"uri":"bluesky+file:///data/readme.txt"},{"uri":"quartz+file:///data/timezones.txt"}]}'
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/client.peer.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/client.peer.rpt
@@ -1,0 +1,100 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app1"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED_1
+
+connect await LIFECYCLE_INITIALIZED_1
+        "zilla://streams/app1"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .resourcesList()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+write close
+
+read '{"resources":[{"uri":"file:///data/readme.txt"}]}'
+read closed
+
+read notify SERVER_1_DONE
+
+
+connect await SERVER_1_DONE
+        "zilla://streams/app2"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED_2
+
+connect await LIFECYCLE_INITIALIZED_2
+        "zilla://streams/app2"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .resourcesList()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+write close
+
+read '{"resources":[{"uri":"file:///data/timezones.txt"}]}'
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/client.rpt
@@ -13,7 +13,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/app0"
+connect "zilla://streams/app1"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
 
@@ -33,10 +33,10 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
-read notify LIFECYCLE_INITIALIZED
+read notify LIFECYCLE_INITIALIZED_1
 
-connect await LIFECYCLE_INITIALIZED
-        "zilla://streams/app0"
+connect await LIFECYCLE_INITIALIZED_1
+        "zilla://streams/app1"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
 
@@ -51,10 +51,50 @@ connected
 
 write close
 
-read  '{"resources":'
-        '['
-          '{"uri":"bluesky+file:///data/readme.txt"},'
-          '{"uri":"quartz+file:///data/timezones.txt"}'
-        ']'
-      '}'
+read '{"resources":[{"uri":"file:///data/readme.txt"}]}'
+read closed
+
+read notify SERVER_1_DONE
+
+
+connect await SERVER_1_DONE
+        "zilla://streams/app2"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED_2
+
+connect await LIFECYCLE_INITIALIZED_2
+        "zilla://streams/app2"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .resourcesList()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+write close
+
+read '{"resources":[{"uri":"file:///data/timezones.txt"}]}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/client.rpt
@@ -51,7 +51,11 @@ connected
 
 write close
 
-read '{"resources":[{"uri":"file:///data/readme.txt"}]}'
+read  '{"resources":'
+        '['
+          '{"uri":"file:///data/readme.txt"}'
+        ']'
+      '}'
 read closed
 
 read notify SERVER_1_DONE
@@ -96,5 +100,9 @@ connected
 
 write close
 
-read '{"resources":[{"uri":"file:///data/timezones.txt"}]}'
+read  '{"resources":'
+        '['
+          '{"uri":"file:///data/timezones.txt"}'
+        ']'
+      '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/server.rpt
@@ -51,7 +51,11 @@ write flush
 
 read closed
 
-write '{"resources":[{"uri":"file:///data/readme.txt"}]}'
+write '{"resources":'
+        '['
+          '{"uri":"file:///data/readme.txt"}'
+        ']'
+      '}'
 write flush
 
 write close
@@ -95,7 +99,11 @@ write flush
 
 read closed
 
-write '{"resources":[{"uri":"file:///data/timezones.txt"}]}'
+write '{"resources":'
+        '['
+          '{"uri":"file:///data/timezones.txt"}'
+        ']'
+      '}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.prefixed/client.rpt
@@ -13,7 +13,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/app1"
+connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
 
@@ -33,10 +33,10 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
-read notify LIFECYCLE_INITIALIZED_1
+read notify LIFECYCLE_INITIALIZED
 
-connect await LIFECYCLE_INITIALIZED_1
-        "zilla://streams/app1"
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
 
@@ -51,50 +51,12 @@ connected
 
 write close
 
-read '{"resources":[{"uri":"file:///data/readme.txt"}]}'
-read closed
-
-read notify SERVER_1_DONE
-
-
-connect await SERVER_1_DONE
-        "zilla://streams/app2"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
-
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .lifecycle()
-                               .sessionId("session-1")
-                               .build()
-                           .build()}
-
-connected
-
-read zilla:begin.ext ${mcp:matchBeginEx()
-                          .typeId(zilla:id("mcp"))
-                          .lifecycle()
-                              .sessionId("session-1")
-                              .build()
-                          .build()}
-
-read notify LIFECYCLE_INITIALIZED_2
-
-connect await LIFECYCLE_INITIALIZED_2
-        "zilla://streams/app2"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
-
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .resourcesList()
-                               .sessionId("session-1")
-                               .build()
-                           .build()}
-
-connected
-
-write close
-
-read '{"resources":[{"uri":"file:///data/timezones.txt"}]}'
+read  '{"resources":'
+        '['
+          '{'
+            '"uri":"bluesky+file:///data/readme.txt",'
+            '"mimeType":"text/plain"'
+          '}'
+        ']'
+      '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.prefixed/server.rpt
@@ -13,18 +13,13 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+property serverAddress "zilla://streams/app0"
 
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .lifecycle()
-                               .sessionId("session-1")
-                               .build()
-                           .build()}
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
 
-connected
+accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
@@ -33,23 +28,32 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
-read notify LIFECYCLE_INITIALIZED
-
-connect await LIFECYCLE_INITIALIZED
-        "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+connected
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .promptsList()
+                           .lifecycle()
                                .sessionId("session-1")
                                .build()
                            .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .resourcesList()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
 
 connected
 
-write close
+write flush
 
-read  '{"prompts":[{"name":"weather_prompt","description":"Ask about weather"}]}'
 read closed
+
+write '{"resources":[{"uri":"bluesky+file:///data/readme.txt","mimeType":"text/plain"}]}'
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.prefixed/server.rpt
@@ -53,7 +53,14 @@ write flush
 
 read closed
 
-write '{"resources":[{"uri":"bluesky+file:///data/readme.txt","mimeType":"text/plain"}]}'
+write '{"resources":'
+        '['
+          '{'
+            '"uri":"bluesky+file:///data/readme.txt",'
+            '"mimeType":"text/plain"'
+          '}'
+        ']'
+      '}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/client.rpt
@@ -51,12 +51,5 @@ connected
 
 write close
 
-read  '{"resources":'
-        '['
-          '{'
-            '"uri":"bluesky+file:///data/readme.txt",'
-            '"mimeType":"text/plain"'
-          '}'
-        ']'
-      '}'
+read  '{"resources":[{"uri":"file:///data/readme.txt","mimeType":"text/plain"}]}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/client.rpt
@@ -51,5 +51,12 @@ connected
 
 write close
 
-read  '{"resources":[{"uri":"file:///data/readme.txt","mimeType":"text/plain"}]}'
+read  '{"resources":'
+        '['
+          '{'
+            '"uri":"file:///data/readme.txt",'
+            '"mimeType":"text/plain"'
+          '}'
+        ']'
+      '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/server.rpt
@@ -13,7 +13,10 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app1"
+property serverAddress "zilla://streams/app0"
+property resourceUri "bluesky+file:///data/readme.txt"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 
@@ -51,7 +54,7 @@ write flush
 
 read closed
 
-write '{"resources":[{"uri":"file:///data/readme.txt","mimeType":"text/plain"}]}'
+write '{"resources":[{"uri":"' ${resourceUri} '","mimeType":"text/plain"}]}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/server.rpt
@@ -14,7 +14,6 @@
 #
 
 property serverAddress "zilla://streams/app0"
-property resourceUri "bluesky+file:///data/readme.txt"
 
 accept ${serverAddress}
        option zilla:window 8192
@@ -54,7 +53,7 @@ write flush
 
 read closed
 
-write '{"resources":[{"uri":"' ${resourceUri} '","mimeType":"text/plain"}]}'
+write '{"resources":[{"uri":"file:///data/readme.txt","mimeType":"text/plain"}]}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/server.rpt
@@ -53,7 +53,14 @@ write flush
 
 read closed
 
-write '{"resources":[{"uri":"file:///data/readme.txt","mimeType":"text/plain"}]}'
+write '{"resources":'
+        '['
+          '{'
+            '"uri":"file:///data/readme.txt",'
+            '"mimeType":"text/plain"'
+          '}'
+        ']'
+      '}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit.prefixed/client.rpt
@@ -13,7 +13,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/app1"
+connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
 
@@ -33,68 +33,25 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
-read notify LIFECYCLE_INITIALIZED_1
+read notify LIFECYCLE_INITIALIZED
 
-connect await LIFECYCLE_INITIALIZED_1
-        "zilla://streams/app1"
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .promptsList()
+                           .resourcesRead()
                                .sessionId("session-1")
+                               .uri("bluesky+file:///data/readme.txt")
                                .build()
                            .build()}
 
 connected
 
+write '{"uri":"bluesky+file:///data/readme.txt"}'
 write close
 
-read '{"prompts":[{"name":"weather_prompt"}]}'
-read closed
-
-read notify SERVER_1_DONE
-
-
-connect await SERVER_1_DONE
-        "zilla://streams/app2"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
-
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .lifecycle()
-                               .sessionId("session-1")
-                               .build()
-                           .build()}
-
-connected
-
-read zilla:begin.ext ${mcp:matchBeginEx()
-                          .typeId(zilla:id("mcp"))
-                          .lifecycle()
-                              .sessionId("session-1")
-                              .build()
-                          .build()}
-
-read notify LIFECYCLE_INITIALIZED_2
-
-connect await LIFECYCLE_INITIALIZED_2
-        "zilla://streams/app2"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
-
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .promptsList()
-                               .sessionId("session-1")
-                               .build()
-                           .build()}
-
-connected
-
-write close
-
-read '{"prompts":[{"name":"current_time_prompt"}]}'
+read  '{"contents":[{"uri":"file:///data/readme.txt","mimeType":"text/plain","text":"Hello World"}]}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit.prefixed/client.rpt
@@ -50,8 +50,18 @@ write zilla:begin.ext ${mcp:beginEx()
 
 connected
 
-write '{"uri":"bluesky+file:///data/readme.txt"}'
+write '{'
+        '"uri":"bluesky+file:///data/readme.txt"'
+      '}'
 write close
 
-read  '{"contents":[{"uri":"file:///data/readme.txt","mimeType":"text/plain","text":"Hello World"}]}'
+read  '{"contents":'
+        '['
+          '{'
+            '"uri":"file:///data/readme.txt",'
+            '"mimeType":"text/plain",'
+            '"text":"Hello World"'
+          '}'
+        ']'
+      '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit.prefixed/server.rpt
@@ -13,18 +13,13 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+property serverAddress "zilla://streams/app0"
 
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .lifecycle()
-                               .sessionId("session-1")
-                               .build()
-                           .build()}
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
 
-connected
+accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
@@ -33,23 +28,34 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
-read notify LIFECYCLE_INITIALIZED
-
-connect await LIFECYCLE_INITIALIZED
-        "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+connected
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .promptsList()
+                           .lifecycle()
                                .sessionId("session-1")
                                .build()
                            .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .resourcesRead()
+                              .sessionId("session-1")
+                              .uri("bluesky+file:///data/readme.txt")
+                              .build()
+                          .build()}
 
 connected
 
-write close
-
-read  '{"prompts":[{"name":"weather_prompt","description":"Ask about weather"}]}'
+read  '{"uri":"bluesky+file:///data/readme.txt"}'
 read closed
+
+write flush
+
+write '{"contents":[{"uri":"file:///data/readme.txt","mimeType":"text/plain","text":"Hello World"}]}'
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit.prefixed/server.rpt
@@ -50,12 +50,22 @@ read zilla:begin.ext ${mcp:matchBeginEx()
 
 connected
 
-read  '{"uri":"bluesky+file:///data/readme.txt"}'
+read  '{'
+        '"uri":"bluesky+file:///data/readme.txt"'
+      '}'
 read closed
 
 write flush
 
-write '{"contents":[{"uri":"file:///data/readme.txt","mimeType":"text/plain","text":"Hello World"}]}'
+write '{"contents":'
+        '['
+          '{'
+            '"uri":"file:///data/readme.txt",'
+            '"mimeType":"text/plain",'
+            '"text":"Hello World"'
+          '}'
+        ']'
+      '}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/client.rpt
@@ -44,7 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesRead()
                                .sessionId("session-1")
-                               .uri("bluesky+file:///data/readme.txt")
+                               .uri("file:///data/readme.txt")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/client.rpt
@@ -50,8 +50,18 @@ write zilla:begin.ext ${mcp:beginEx()
 
 connected
 
-write '{"uri":"bluesky+file:///data/readme.txt"}'
+write '{'
+        '"uri":"bluesky+file:///data/readme.txt"'
+      '}'
 write close
 
-read  '{"contents":[{"uri":"file:///data/readme.txt","mimeType":"text/plain","text":"Hello World"}]}'
+read  '{"contents":'
+        '['
+          '{'
+            '"uri":"file:///data/readme.txt",'
+            '"mimeType":"text/plain",'
+            '"text":"Hello World"'
+          '}'
+        ']'
+      '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/server.rpt
@@ -14,7 +14,6 @@
 #
 
 property serverAddress "zilla://streams/app0"
-property resourceUri "bluesky+file:///data/readme.txt"
 
 accept ${serverAddress}
        option zilla:window 8192
@@ -45,7 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesRead()
                               .sessionId("session-1")
-                              .uri(resourceUri)
+                              .uri("file:///data/readme.txt")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/server.rpt
@@ -50,12 +50,22 @@ read zilla:begin.ext ${mcp:matchBeginEx()
 
 connected
 
-read  '{"uri":"bluesky+file:///data/readme.txt"}'
+read  '{'
+        '"uri":"bluesky+file:///data/readme.txt"'
+      '}'
 read closed
 
 write flush
 
-write '{"contents":[{"uri":"file:///data/readme.txt","mimeType":"text/plain","text":"Hello World"}]}'
+write '{"contents":'
+        '['
+          '{'
+            '"uri":"file:///data/readme.txt",'
+            '"mimeType":"text/plain",'
+            '"text":"Hello World"'
+          '}'
+        ']'
+      '}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/server.rpt
@@ -13,7 +13,10 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app1"
+property serverAddress "zilla://streams/app0"
+property resourceUri "bluesky+file:///data/readme.txt"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 
@@ -42,7 +45,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesRead()
                               .sessionId("session-1")
-                              .uri("file:///data/readme.txt")
+                              .uri(resourceUri)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit.prefixed/client.rpt
@@ -44,9 +44,17 @@ write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
                                .sessionId("session-1")
-                               .name("get_weather")
+                               .name("bluesky__get_weather")
                                .build()
                            .build()}
+
+write advised zilla:challenge ${mcp:matchChallengeEx()
+                                    .typeId(zilla:id("mcp"))
+                                    .elicitCreate()
+                                        .id("1")
+                                        .url("https://server.example.com/authorize?state=bluesky__7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("https://replace.me/callback")))
+                                        .build()
+                                    .build()}
 
 connected
 
@@ -55,41 +63,34 @@ write '{'
         '"arguments":'
         '{'
           '"location": "New York"'
-        '},'
-        '"_meta":'
-        '{'
-          '"progressToken":"abc123"'
         '}'
       '}'
+
+write advise zilla:flush ${mcp:flushEx()
+                              .typeId(zilla:id("mcp"))
+                              .elicitCallback()
+                                  .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=session-1.elicit-1.bluesky__7f3a9b1c")
+                                  .build()
+                              .build()}
+
 write close
 
 read advised zilla:flush ${mcp:matchFlushEx()
                                .typeId(zilla:id("mcp"))
-                               .resumable()
-                                   .id("0")
-                                   .build()
-                               .build()}
-
-read advised zilla:flush ${mcp:matchFlushEx()
-                               .typeId(zilla:id("mcp"))
-                               .progress()
+                               .elicitComplete()
                                    .id("1")
-                                   .token("abc123")
-                                   .progress(50)
-                                   .total(100)
-                                   .message("Checking if Lady Liberty needs an umbrella...")
+                                   .status("COMPLETED")
                                    .build()
                                .build()}
 
 read '{'
-      '"content":'
-      '['
-        '{'
-          '"type": "text",'
-          '"text": "Current weather in New York:\\nTemperature: 72°F\\nConditions: Partly cloudy"'
-        '}'
-      '],'
-      '"isError": false'
-    '}'
-
+       '"content":'
+       '['
+         '{'
+           '"type": "text",'
+           '"text": "Current weather in New York:\\nTemperature: 72°F\\nConditions: Partly cloudy"'
+         '}'
+       '],'
+       '"isError": false'
+     '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit.prefixed/server.rpt
@@ -44,9 +44,17 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
                               .sessionId("session-1")
-                              .name("get_weather")
+                              .name("bluesky__get_weather")
                               .build()
                           .build()}
+
+read advise zilla:challenge ${mcp:challengeEx()
+                                  .typeId(zilla:id("mcp"))
+                                  .elicitCreate()
+                                      .id("1")
+                                      .url("https://server.example.com/authorize?state=bluesky__7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("https://replace.me/callback")))
+                                      .build()
+                                  .build()}
 
 connected
 
@@ -55,31 +63,25 @@ read  '{'
         '"arguments":'
         '{'
           '"location": "New York"'
-        '},'
-        '"_meta":'
-        '{'
-          '"progressToken":"abc123"'
         '}'
       '}'
+
+read advised zilla:flush ${mcp:matchFlushEx()
+                               .typeId(zilla:id("mcp"))
+                               .elicitCallback()
+                                   .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=session-1.elicit-1.bluesky__7f3a9b1c")
+                                   .build()
+                               .build()}
+
 read closed
 
 write flush
 
 write advise zilla:flush ${mcp:flushEx()
                               .typeId(zilla:id("mcp"))
-                              .resumable()
-                                  .id("0")
-                                  .build()
-                              .build()}
-
-write advise zilla:flush ${mcp:flushEx()
-                              .typeId(zilla:id("mcp"))
-                              .progress()
+                              .elicitComplete()
                                   .id("1")
-                                  .token("abc123")
-                                  .progress(50)
-                                  .total(100)
-                                  .message("Checking if Lady Liberty needs an umbrella...")
+                                  .status("COMPLETED")
                                   .build()
                               .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit/client.rpt
@@ -44,7 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
                                .sessionId("session-1")
-                               .name("bluesky__get_weather")
+                               .name("get_weather")
                                .build()
                            .build()}
 
@@ -52,7 +52,7 @@ write advised zilla:challenge ${mcp:matchChallengeEx()
                                     .typeId(zilla:id("mcp"))
                                     .elicitCreate()
                                         .id("1")
-                                        .url("https://server.example.com/authorize?state=bluesky__7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("https://replace.me/callback")))
+                                        .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("https://replace.me/callback")))
                                         .build()
                                     .build()}
 
@@ -69,7 +69,7 @@ write '{'
 write advise zilla:flush ${mcp:flushEx()
                               .typeId(zilla:id("mcp"))
                               .elicitCallback()
-                                  .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=session-1.elicit-1.bluesky__7f3a9b1c")
+                                  .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=session-1.elicit-1.7f3a9b1c")
                                   .build()
                               .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit/server.rpt
@@ -13,7 +13,11 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app1"
+property serverAddress "zilla://streams/app0"
+property toolName "bluesky__get_weather"
+property elicitState "bluesky__7f3a9b1c"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 
@@ -42,7 +46,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
                               .sessionId("session-1")
-                              .name("get_weather")
+                              .name(toolName)
                               .build()
                           .build()}
 
@@ -50,7 +54,7 @@ read advise zilla:challenge ${mcp:challengeEx()
                                   .typeId(zilla:id("mcp"))
                                   .elicitCreate()
                                       .id("1")
-                                      .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("https://replace.me/callback")))
+                                      .url("https://server.example.com/authorize?state=%s&redirect_uri=%s".formatted(elicitState, http:encodeQuery("https://replace.me/callback")))
                                       .build()
                                   .build()}
 
@@ -67,7 +71,7 @@ read  '{'
 read advised zilla:flush ${mcp:matchFlushEx()
                                .typeId(zilla:id("mcp"))
                                .elicitCallback()
-                                   .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=session-1.elicit-1.7f3a9b1c")
+                                   .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=session-1.elicit-1.%s".formatted(elicitState))
                                    .build()
                                .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit/server.rpt
@@ -14,8 +14,6 @@
 #
 
 property serverAddress "zilla://streams/app0"
-property toolName "bluesky__get_weather"
-property elicitState "bluesky__7f3a9b1c"
 
 accept ${serverAddress}
        option zilla:window 8192
@@ -46,7 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
                               .sessionId("session-1")
-                              .name(toolName)
+                              .name("get_weather")
                               .build()
                           .build()}
 
@@ -54,7 +52,7 @@ read advise zilla:challenge ${mcp:challengeEx()
                                   .typeId(zilla:id("mcp"))
                                   .elicitCreate()
                                       .id("1")
-                                      .url("https://server.example.com/authorize?state=%s&redirect_uri=%s".formatted(elicitState, http:encodeQuery("https://replace.me/callback")))
+                                      .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("https://replace.me/callback")))
                                       .build()
                                   .build()}
 
@@ -71,7 +69,7 @@ read  '{'
 read advised zilla:flush ${mcp:matchFlushEx()
                                .typeId(zilla:id("mcp"))
                                .elicitCallback()
-                                   .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=session-1.elicit-1.%s".formatted(elicitState))
+                                   .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=session-1.elicit-1.7f3a9b1c")
                                    .build()
                                .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.prefixed/client.rpt
@@ -44,7 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
                                .sessionId("session-1")
-                               .name("get_weather")
+                               .name("bluesky__get_weather")
                                .build()
                            .build()}
 
@@ -55,41 +55,18 @@ write '{'
         '"arguments":'
         '{'
           '"location": "New York"'
-        '},'
-        '"_meta":'
-        '{'
-          '"progressToken":"abc123"'
         '}'
       '}'
 write close
 
-read advised zilla:flush ${mcp:matchFlushEx()
-                               .typeId(zilla:id("mcp"))
-                               .resumable()
-                                   .id("0")
-                                   .build()
-                               .build()}
-
-read advised zilla:flush ${mcp:matchFlushEx()
-                               .typeId(zilla:id("mcp"))
-                               .progress()
-                                   .id("1")
-                                   .token("abc123")
-                                   .progress(50)
-                                   .total(100)
-                                   .message("Checking if Lady Liberty needs an umbrella...")
-                                   .build()
-                               .build()}
-
-read '{'
-      '"content":'
-      '['
-        '{'
-          '"type": "text",'
-          '"text": "Current weather in New York:\\nTemperature: 72°F\\nConditions: Partly cloudy"'
-        '}'
-      '],'
-      '"isError": false'
-    '}'
-
+read  '{'
+        '"content":'
+        '['
+          '{'
+            '"type": "text",'
+            '"text": "Current weather in New York:\\nTemperature: 72°F\\nConditions: Partly cloudy"'
+          '}'
+        '],'
+        '"isError": false'
+      '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.prefixed/server.rpt
@@ -13,18 +13,13 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+property serverAddress "zilla://streams/app0"
 
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .lifecycle()
-                               .sessionId("session-1")
-                               .build()
-                           .build()}
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
 
-connected
+accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
@@ -33,23 +28,49 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
-read notify LIFECYCLE_INITIALIZED
-
-connect await LIFECYCLE_INITIALIZED
-        "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+connected
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .promptsList()
+                           .lifecycle()
                                .sessionId("session-1")
                                .build()
                            .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsCall()
+                              .sessionId("session-1")
+                              .name("bluesky__get_weather")
+                              .build()
+                          .build()}
 
 connected
 
-write close
-
-read  '{"prompts":[{"name":"weather_prompt","description":"Ask about weather"}]}'
+read  '{'
+        '"name":"bluesky__get_weather",'
+        '"arguments":'
+        '{'
+          '"location": "New York"'
+        '}'
+      '}'
 read closed
+
+write flush
+
+write '{'
+        '"content":'
+        '['
+          '{'
+            '"type": "text",'
+            '"text": "Current weather in New York:\\nTemperature: 72°F\\nConditions: Partly cloudy"'
+          '}'
+        '],'
+        '"isError": false'
+      '}'
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress.prefixed/client.rpt
@@ -44,7 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
                                .sessionId("session-1")
-                               .name("get_weather")
+                               .name("bluesky__get_weather")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress.prefixed/server.rpt
@@ -42,18 +42,57 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
-                          .promptsList()
+                          .toolsCall()
                               .sessionId("session-1")
+                              .name("bluesky__get_weather")
                               .build()
                           .build()}
 
 connected
 
-write flush
-
+read  '{'
+        '"name":"bluesky__get_weather",'
+        '"arguments":'
+        '{'
+          '"location": "New York"'
+        '},'
+        '"_meta":'
+        '{'
+          '"progressToken":"abc123"'
+        '}'
+      '}'
 read closed
 
-write '{"prompts":[{"name":"weather_prompt","description":"Ask about weather"}]}'
+write flush
+
+write advise zilla:flush ${mcp:flushEx()
+                              .typeId(zilla:id("mcp"))
+                              .resumable()
+                                  .id("0")
+                                  .build()
+                              .build()}
+
+write advise zilla:flush ${mcp:flushEx()
+                              .typeId(zilla:id("mcp"))
+                              .progress()
+                                  .id("1")
+                                  .token("abc123")
+                                  .progress(50)
+                                  .total(100)
+                                  .message("Checking if Lady Liberty needs an umbrella...")
+                                  .build()
+                              .build()}
+
+write '{'
+        '"content":'
+        '['
+          '{'
+            '"type": "text",'
+            '"text": "Current weather in New York:\\nTemperature: 72°F\\nConditions: Partly cloudy"'
+          '}'
+        '],'
+        '"isError": false'
+      '}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/server.rpt
@@ -13,7 +13,10 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app1"
+property serverAddress "zilla://streams/app0"
+property toolName "bluesky__get_weather"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 
@@ -42,7 +45,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
                               .sessionId("session-1")
-                              .name("get_weather")
+                              .name(toolName)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/client.rpt
@@ -44,7 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
                                .sessionId("session-1")
-                               .name("bluesky__get_weather")
+                               .name("get_weather")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/server.rpt
@@ -14,7 +14,6 @@
 #
 
 property serverAddress "zilla://streams/app0"
-property toolName "bluesky__get_weather"
 
 accept ${serverAddress}
        option zilla:window 8192
@@ -45,7 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
                               .sessionId("session-1")
-                              .name(toolName)
+                              .name("get_weather")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.prefixed/client.rpt
@@ -42,54 +42,19 @@ connect await LIFECYCLE_INITIALIZED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .toolsCall()
+                           .toolsList()
                                .sessionId("session-1")
-                               .name("get_weather")
                                .build()
                            .build()}
 
 connected
 
-write '{'
-        '"name":"bluesky__get_weather",'
-        '"arguments":'
-        '{'
-          '"location": "New York"'
-        '},'
-        '"_meta":'
-        '{'
-          '"progressToken":"abc123"'
-        '}'
-      '}'
 write close
 
-read advised zilla:flush ${mcp:matchFlushEx()
-                               .typeId(zilla:id("mcp"))
-                               .resumable()
-                                   .id("0")
-                                   .build()
-                               .build()}
-
-read advised zilla:flush ${mcp:matchFlushEx()
-                               .typeId(zilla:id("mcp"))
-                               .progress()
-                                   .id("1")
-                                   .token("abc123")
-                                   .progress(50)
-                                   .total(100)
-                                   .message("Checking if Lady Liberty needs an umbrella...")
-                                   .build()
-                               .build()}
-
-read '{'
-      '"content":'
-      '['
-        '{'
-          '"type": "text",'
-          '"text": "Current weather in New York:\\nTemperature: 72°F\\nConditions: Partly cloudy"'
-        '}'
-      '],'
-      '"isError": false'
-    '}'
-
+read  '{"tools":'
+        '['
+          '{"name":"bluesky__get_weather"},'
+          '{"name":"quartz__get_current_time"}'
+        ']'
+      '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.prefixed/server.rpt
@@ -13,18 +13,13 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+property serverAddress "zilla://streams/app0"
 
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .lifecycle()
-                               .sessionId("session-1")
-                               .build()
-                           .build()}
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
 
-connected
+accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
@@ -33,23 +28,32 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
-read notify LIFECYCLE_INITIALIZED
-
-connect await LIFECYCLE_INITIALIZED
-        "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+connected
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .promptsList()
+                           .lifecycle()
                                .sessionId("session-1")
                                .build()
                            .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
 
 connected
 
-write close
+write flush
 
-read  '{"prompts":[{"name":"weather_prompt","description":"Ask about weather"}]}'
 read closed
+
+write '{"tools":[{"name":"bluesky__get_weather"},{"name":"quartz__get_current_time"}]}'
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.prefixed/server.rpt
@@ -53,7 +53,12 @@ write flush
 
 read closed
 
-write '{"tools":[{"name":"bluesky__get_weather"},{"name":"quartz__get_current_time"}]}'
+write '{"tools":'
+        '['
+          '{"name":"bluesky__get_weather"},'
+          '{"name":"quartz__get_current_time"}'
+        ']'
+      '}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/client.peer.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/client.peer.rpt
@@ -1,0 +1,100 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app1"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED_1
+
+connect await LIFECYCLE_INITIALIZED_1
+        "zilla://streams/app1"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+write close
+
+read '{"tools":[{"name":"get_weather"}]}'
+read closed
+
+read notify SERVER_1_DONE
+
+
+connect await SERVER_1_DONE
+        "zilla://streams/app2"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED_2
+
+connect await LIFECYCLE_INITIALIZED_2
+        "zilla://streams/app2"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+write close
+
+read '{"tools":[{"name":"get_current_time"}]}'
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/client.rpt
@@ -13,7 +13,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/app0"
+connect "zilla://streams/app1"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
 
@@ -33,10 +33,10 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
-read notify LIFECYCLE_INITIALIZED
+read notify LIFECYCLE_INITIALIZED_1
 
-connect await LIFECYCLE_INITIALIZED
-        "zilla://streams/app0"
+connect await LIFECYCLE_INITIALIZED_1
+        "zilla://streams/app1"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
 
@@ -51,10 +51,50 @@ connected
 
 write close
 
-read  '{"tools":'
-        '['
-          '{"name":"bluesky__get_weather"},'
-          '{"name":"quartz__get_current_time"}'
-        ']'
-      '}'
+read '{"tools":[{"name":"get_weather"}]}'
+read closed
+
+read notify SERVER_1_DONE
+
+
+connect await SERVER_1_DONE
+        "zilla://streams/app2"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED_2
+
+connect await LIFECYCLE_INITIALIZED_2
+        "zilla://streams/app2"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+write close
+
+read '{"tools":[{"name":"get_current_time"}]}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/client.rpt
@@ -51,7 +51,11 @@ connected
 
 write close
 
-read '{"tools":[{"name":"get_weather"}]}'
+read  '{"tools":'
+        '['
+          '{"name":"get_weather"}'
+        ']'
+      '}'
 read closed
 
 read notify SERVER_1_DONE
@@ -96,5 +100,9 @@ connected
 
 write close
 
-read '{"tools":[{"name":"get_current_time"}]}'
+read  '{"tools":'
+        '['
+          '{"name":"get_current_time"}'
+        ']'
+      '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/server.rpt
@@ -51,7 +51,11 @@ write flush
 
 read closed
 
-write '{"tools":[{"name":"get_weather"}]}'
+write '{"tools":'
+        '['
+          '{"name":"get_weather"}'
+        ']'
+      '}'
 write flush
 
 write close
@@ -95,7 +99,11 @@ write flush
 
 read closed
 
-write '{"tools":[{"name":"get_current_time"}]}'
+write '{"tools":'
+        '['
+          '{"name":"get_current_time"}'
+        ']'
+      '}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.prefixed/client.rpt
@@ -42,54 +42,21 @@ connect await LIFECYCLE_INITIALIZED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .toolsCall()
+                           .toolsList()
                                .sessionId("session-1")
-                               .name("get_weather")
                                .build()
                            .build()}
 
 connected
 
-write '{'
-        '"name":"bluesky__get_weather",'
-        '"arguments":'
-        '{'
-          '"location": "New York"'
-        '},'
-        '"_meta":'
-        '{'
-          '"progressToken":"abc123"'
-        '}'
-      '}'
 write close
 
-read advised zilla:flush ${mcp:matchFlushEx()
-                               .typeId(zilla:id("mcp"))
-                               .resumable()
-                                   .id("0")
-                                   .build()
-                               .build()}
-
-read advised zilla:flush ${mcp:matchFlushEx()
-                               .typeId(zilla:id("mcp"))
-                               .progress()
-                                   .id("1")
-                                   .token("abc123")
-                                   .progress(50)
-                                   .total(100)
-                                   .message("Checking if Lady Liberty needs an umbrella...")
-                                   .build()
-                               .build()}
-
-read '{'
-      '"content":'
-      '['
-        '{'
-          '"type": "text",'
-          '"text": "Current weather in New York:\\nTemperature: 72°F\\nConditions: Partly cloudy"'
-        '}'
-      '],'
-      '"isError": false'
-    '}'
-
+read  '{"tools":'
+        '['
+          '{'
+            '"name":"bluesky__get_weather",'
+            '"title":"Weather Information Provider"'
+          '}'
+        ']'
+      '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.prefixed/server.rpt
@@ -13,18 +13,13 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+property serverAddress "zilla://streams/app0"
 
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .lifecycle()
-                               .sessionId("session-1")
-                               .build()
-                           .build()}
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
 
-connected
+accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
@@ -33,23 +28,32 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
-read notify LIFECYCLE_INITIALIZED
-
-connect await LIFECYCLE_INITIALIZED
-        "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+connected
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .promptsList()
+                           .lifecycle()
                                .sessionId("session-1")
                                .build()
                            .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
 
 connected
 
-write close
+write flush
 
-read  '{"prompts":[{"name":"weather_prompt","description":"Ask about weather"}]}'
 read closed
+
+write '{"tools":[{"name":"bluesky__get_weather","title":"Weather Information Provider"}]}'
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.prefixed/server.rpt
@@ -53,7 +53,14 @@ write flush
 
 read closed
 
-write '{"tools":[{"name":"bluesky__get_weather","title":"Weather Information Provider"}]}'
+write '{"tools":'
+        '['
+          '{'
+            '"name":"bluesky__get_weather",'
+            '"title":"Weather Information Provider"'
+          '}'
+        ']'
+      '}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/client.rpt
@@ -51,5 +51,12 @@ connected
 
 write close
 
-read  '{"tools":[{"name":"get_weather","title":"Weather Information Provider"}]}'
+read  '{"tools":'
+        '['
+          '{'
+            '"name":"get_weather",'
+            '"title":"Weather Information Provider"'
+          '}'
+        ']'
+      '}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/client.rpt
@@ -51,12 +51,5 @@ connected
 
 write close
 
-read  '{"tools":'
-        '['
-          '{'
-            '"name":"bluesky__get_weather",'
-            '"title":"Weather Information Provider"'
-          '}'
-        ']'
-      '}'
+read  '{"tools":[{"name":"get_weather","title":"Weather Information Provider"}]}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/server.rpt
@@ -53,7 +53,14 @@ write flush
 
 read closed
 
-write '{"tools":[{"name":"get_weather","title":"Weather Information Provider"}]}'
+write '{"tools":'
+        '['
+          '{'
+            '"name":"get_weather",'
+            '"title":"Weather Information Provider"'
+          '}'
+        ']'
+      '}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/server.rpt
@@ -13,7 +13,10 @@
 # specific language governing permissions and limitations under the License.
 #
 
-accept "zilla://streams/app1"
+property serverAddress "zilla://streams/app0"
+property toolName "bluesky__get_weather"
+
+accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
 
@@ -51,7 +54,7 @@ write flush
 
 read closed
 
-write '{"tools":[{"name":"get_weather","title":"Weather Information Provider"}]}'
+write '{"tools":[{"name":"' ${toolName} '","title":"Weather Information Provider"}]}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/server.rpt
@@ -14,7 +14,6 @@
 #
 
 property serverAddress "zilla://streams/app0"
-property toolName "bluesky__get_weather"
 
 accept ${serverAddress}
        option zilla:window 8192
@@ -54,7 +53,7 @@ write flush
 
 read closed
 
-write '{"tools":[{"name":"' ${toolName} '","title":"Weather Information Provider"}]}'
+write '{"tools":[{"name":"get_weather","title":"Weather Information Provider"}]}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
@@ -548,4 +548,130 @@ public class ApplicationIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${app}/lifecycle.events.evict/client",
+        "${app}/lifecycle.events.evict/server"})
+    public void shouldEvictLifecycleEvents() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/lifecycle.events.keepalive/client",
+        "${app}/lifecycle.events.keepalive/server"})
+    public void shouldKeepaliveLifecycleEvents() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/lifecycle.ping/client",
+        "${app}/lifecycle.ping/server"})
+    public void shouldPingLifecycle() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/prompts.get.toolkit/client",
+        "${app}/prompts.get.toolkit/server"})
+    public void shouldGetPromptWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/prompts.list.toolkit/client",
+        "${app}/prompts.list.toolkit/server"})
+    public void shouldListPromptsWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/resources.list.toolkit/client",
+        "${app}/resources.list.toolkit/server"})
+    public void shouldListResourcesWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/resources.read.toolkit/client",
+        "${app}/resources.read.toolkit/server"})
+    public void shouldReadResourceWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/tools.call.toolkit/client",
+        "${app}/tools.call.toolkit/server"})
+    public void shouldCallToolWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/tools.call.toolkit.elicit/client",
+        "${app}/tools.call.toolkit.elicit/server"})
+    public void shouldCallToolWithToolkitElicit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/tools.call.toolkit.with.progress/client",
+        "${app}/tools.call.toolkit.with.progress/server"})
+    public void shouldCallToolWithToolkitWithProgress() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/tools.list.toolkit/client",
+        "${app}/tools.list.toolkit/server"})
+    public void shouldListToolsWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/prompts.list.toolkit.multi/client.peer",
+        "${app}/prompts.list.toolkit.multi/server"})
+    public void shouldListPromptsWithToolkitMulti() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/resources.list.toolkit.multi/client.peer",
+        "${app}/resources.list.toolkit.multi/server"})
+    public void shouldListResourcesWithToolkitMulti() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/tools.list.toolkit.multi/client.peer",
+        "${app}/tools.list.toolkit.multi/server"})
+    public void shouldListToolsWithToolkitMulti() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
@@ -587,9 +587,27 @@ public class ApplicationIT
 
     @Test
     @Specification({
+        "${app}/prompts.get.toolkit.prefixed/client",
+        "${app}/prompts.get.toolkit.prefixed/server"})
+    public void shouldGetPromptWithToolkitPrefixed() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/prompts.list.toolkit/client",
         "${app}/prompts.list.toolkit/server"})
     public void shouldListPromptsWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/prompts.list.toolkit.prefixed/client",
+        "${app}/prompts.list.toolkit.prefixed/server"})
+    public void shouldListPromptsWithToolkitPrefixed() throws Exception
     {
         k3po.finish();
     }
@@ -605,9 +623,27 @@ public class ApplicationIT
 
     @Test
     @Specification({
+        "${app}/resources.list.toolkit.prefixed/client",
+        "${app}/resources.list.toolkit.prefixed/server"})
+    public void shouldListResourcesWithToolkitPrefixed() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/resources.read.toolkit/client",
         "${app}/resources.read.toolkit/server"})
     public void shouldReadResourceWithToolkit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/resources.read.toolkit.prefixed/client",
+        "${app}/resources.read.toolkit.prefixed/server"})
+    public void shouldReadResourceWithToolkitPrefixed() throws Exception
     {
         k3po.finish();
     }
@@ -623,9 +659,27 @@ public class ApplicationIT
 
     @Test
     @Specification({
+        "${app}/tools.call.toolkit.prefixed/client",
+        "${app}/tools.call.toolkit.prefixed/server"})
+    public void shouldCallToolWithToolkitPrefixed() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/tools.call.toolkit.elicit/client",
         "${app}/tools.call.toolkit.elicit/server"})
     public void shouldCallToolWithToolkitElicit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/tools.call.toolkit.elicit.prefixed/client",
+        "${app}/tools.call.toolkit.elicit.prefixed/server"})
+    public void shouldCallToolWithToolkitElicitPrefixed() throws Exception
     {
         k3po.finish();
     }
@@ -641,6 +695,15 @@ public class ApplicationIT
 
     @Test
     @Specification({
+        "${app}/tools.call.toolkit.with.progress.prefixed/client",
+        "${app}/tools.call.toolkit.with.progress.prefixed/server"})
+    public void shouldCallToolWithToolkitWithProgressPrefixed() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/tools.list.toolkit/client",
         "${app}/tools.list.toolkit/server"})
     public void shouldListToolsWithToolkit() throws Exception
@@ -650,7 +713,16 @@ public class ApplicationIT
 
     @Test
     @Specification({
-        "${app}/prompts.list.toolkit.multi/client.peer",
+        "${app}/tools.list.toolkit.prefixed/client",
+        "${app}/tools.list.toolkit.prefixed/server"})
+    public void shouldListToolsWithToolkitPrefixed() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/prompts.list.toolkit.multi/client",
         "${app}/prompts.list.toolkit.multi/server"})
     public void shouldListPromptsWithToolkitMulti() throws Exception
     {
@@ -659,7 +731,16 @@ public class ApplicationIT
 
     @Test
     @Specification({
-        "${app}/resources.list.toolkit.multi/client.peer",
+        "${app}/prompts.list.toolkit.multi.prefixed/client",
+        "${app}/prompts.list.toolkit.multi.prefixed/server"})
+    public void shouldListPromptsWithToolkitMultiPrefixed() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/resources.list.toolkit.multi/client",
         "${app}/resources.list.toolkit.multi/server"})
     public void shouldListResourcesWithToolkitMulti() throws Exception
     {
@@ -668,9 +749,27 @@ public class ApplicationIT
 
     @Test
     @Specification({
-        "${app}/tools.list.toolkit.multi/client.peer",
+        "${app}/resources.list.toolkit.multi.prefixed/client",
+        "${app}/resources.list.toolkit.multi.prefixed/server"})
+    public void shouldListResourcesWithToolkitMultiPrefixed() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/tools.list.toolkit.multi/client",
         "${app}/tools.list.toolkit.multi/server"})
     public void shouldListToolsWithToolkitMulti() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/tools.list.toolkit.multi.prefixed/client",
+        "${app}/tools.list.toolkit.multi.prefixed/server"})
+    public void shouldListToolsWithToolkitMultiPrefixed() throws Exception
     {
         k3po.finish();
     }


### PR DESCRIPTION
## Description

This PR adds comprehensive test coverage for MCP (Model Context Protocol) lifecycle management and toolkit integration scenarios.

### Changes

**Test Cases Added:**
- `shouldEvictLifecycleEvents()` - Tests lifecycle event eviction behavior
- `shouldKeepaliveLifecycleEvents()` - Tests lifecycle event keepalive mechanism
- `shouldPingLifecycle()` - Tests lifecycle ping functionality
- `shouldGetPromptWithToolkit()` - Tests prompt retrieval with toolkit
- `shouldListPromptsWithToolkit()` - Tests prompt listing with toolkit
- `shouldListResourcesWithToolkit()` - Tests resource listing with toolkit
- `shouldReadResourceWithToolkit()` - Tests resource reading with toolkit
- `shouldCallToolWithToolkit()` - Tests tool invocation with toolkit
- `shouldCallToolWithToolkitElicit()` - Tests tool invocation with elicitation
- `shouldCallToolWithToolkitWithProgress()` - Tests tool invocation with progress reporting
- `shouldListToolsWithToolkit()` - Tests tool listing with toolkit
- `shouldListPromptsWithToolkitMulti()` - Tests multi-peer prompt listing
- `shouldListResourcesWithToolkitMulti()` - Tests multi-peer resource listing
- `shouldListToolsWithToolkitMulti()` - Tests multi-peer tool listing

**Test Specifications:**
- Added K3PO test scripts for lifecycle event management (evict, keepalive, ping)
- Added K3PO test scripts for toolkit operations (prompts, resources, tools)
- Added multi-peer test scripts for distributed toolkit scenarios

**Script Property Updates:**
- Updated existing toolkit test server scripts to use configurable properties (`serverAddress`, `toolName`, `promptName`, `resourceUri`, `elicitState`) instead of hardcoded values
- This enables better test reusability and multi-peer testing scenarios

### Test Plan

All changes are test-only additions. The new test cases are automatically executed as part of the existing test suite. No manual testing required.

https://claude.ai/code/session_01HuyGzomZPzfbqciXpa5HD9