### PR TITLE
feat(engine): add renew operation to StoreHandler

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/store/StoreHandler.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/store/StoreHandler.java
@@ -158,6 +158,40 @@ public interface StoreHandler
         Consumer<String> completion);
 
     /**
+     * Extends the TTL of a lock previously acquired via {@link #lock}, provided the supplied token
+     * matches the current holder.
+     * <p>
+     * Used by callers that hold a lock longer than its initial TTL — for example, a singleton
+     * worker that owns a coordination lease for the lifetime of its binding. The caller schedules
+     * renewals at an interval shorter than the lease TTL; if any renewal fails the caller has
+     * lost ownership and must surrender any externally-visible state predicated on holding the
+     * lock.
+     * </p>
+     * <p>
+     * On a successful ownership-checked renewal, the completion receives the supplied token and
+     * the lock's expiry is reset to {@code now + ttl}. On failure — the token does not match the
+     * current holder, or the lock has already expired and possibly been reacquired by another
+     * holder — the completion receives {@code null}. As with {@link #unlock}, the implementation
+     * does not surface information about another holder to a caller that did not prove ownership.
+     * </p>
+     * <p>
+     * The completion fires <em>strictly later</em> than the call returns, on the caller's I/O
+     * thread, following the same async contract as the other {@code StoreHandler} operations.
+     * </p>
+     *
+     * @param key         the key whose lock is being renewed
+     * @param token       the ownership token returned by a prior {@link #lock} call
+     * @param ttl         the new lease duration counted from now, or {@code null} for no expiry
+     * @param completion  a callback that receives the supplied {@code token} on a successful
+     *                    ownership-checked renewal, or {@code null} otherwise
+     */
+    void renew(
+        String key,
+        String token,
+        Duration ttl,
+        Consumer<String> completion);
+
+    /**
      * Registers a listener invoked when the value associated with the given key changes.
      * <p>
      * Registration returns synchronously. The listener fires <em>strictly later</em> than the

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
@@ -23,6 +23,7 @@ import static java.util.Collections.emptyList;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -118,6 +119,7 @@ final class TestBindingFactory implements BindingHandler
     private VaultAssertion vaultAssertion;
     private StoreHandler store;
     private List<StoreAssertion> storeAssertions;
+    private final Map<String, String> heldLockTokens = new HashMap<>();
     private long authorization;
 
     TestBindingFactory(
@@ -730,17 +732,48 @@ final class TestBindingFactory implements BindingHandler
                                 doInitialReset(traceId);
                             }
                         }
+                        if (token != null)
+                        {
+                            heldLockTokens.put(k, token);
+                        }
                         callbackFired.value = true;
                     });
                     break;
                 case "unlock":
-                    store.unlock(a.key, a.value, v ->
+                    store.unlock(a.key, resolveToken(a), v ->
                     {
                         if (Thread.currentThread() != dispatchThread ||
                             callbackFired.value ||
                             a.hasExpect && !Objects.equals(v, a.expect))
                         {
                             doInitialReset(traceId);
+                        }
+                        if (v != null)
+                        {
+                            heldLockTokens.remove(a.key);
+                        }
+                        callbackFired.value = true;
+                    });
+                    break;
+                case "renew":
+                    store.renew(a.key, resolveToken(a), a.ttl, v ->
+                    {
+                        if (Thread.currentThread() != dispatchThread ||
+                            callbackFired.value)
+                        {
+                            doInitialReset(traceId);
+                        }
+                        // expect="" or "null" → v must be null (renew failed);
+                        // expect=non-empty → v must be non-null (renew succeeded)
+                        if (a.hasExpect)
+                        {
+                            boolean expectRenewed = a.expect != null && !a.expect.isEmpty() &&
+                                !"null".equals(a.expect);
+                            boolean renewed = v != null;
+                            if (expectRenewed != renewed)
+                            {
+                                doInitialReset(traceId);
+                            }
                         }
                         callbackFired.value = true;
                     });
@@ -767,6 +800,13 @@ final class TestBindingFactory implements BindingHandler
                     doInitialReset(traceId);
                 }
             }
+        }
+
+        private String resolveToken(
+            StoreAssertion a)
+        {
+            // explicit token via value, otherwise use the most recent token captured by a prior lock
+            return a.value != null && !a.value.isEmpty() ? a.value : heldLockTokens.get(a.key);
         }
 
         private void onInitialData(

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/store/TestLockEntry.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/store/TestLockEntry.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.test.internal.store;
+
+record TestLockEntry(
+    String token,
+    long expiresAt)
+{
+}

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/store/TestStore.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/store/TestStore.java
@@ -16,6 +16,7 @@
 package io.aklivity.zilla.runtime.engine.test.internal.store;
 
 import java.net.URL;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -28,11 +29,15 @@ public final class TestStore implements Store
     public static final String NAME = "test";
 
     private final ConcurrentMap<Long, ConcurrentMap<String, String>> storage;
+    private final ConcurrentMap<Long, ConcurrentMap<String, List<TestWatcher>>> storageListeners;
+    private final ConcurrentMap<Long, ConcurrentMap<String, TestLockEntry>> storageLocks;
 
     public TestStore(
         Configuration config)
     {
         this.storage = new ConcurrentHashMap<>();
+        this.storageListeners = new ConcurrentHashMap<>();
+        this.storageLocks = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -51,12 +56,24 @@ public final class TestStore implements Store
     public TestStoreContext supply(
         EngineContext context)
     {
-        return new TestStoreContext(context, this::acquireEntries);
+        return new TestStoreContext(context, this::acquireEntries, this::acquireListeners, this::acquireLocks);
     }
 
     private ConcurrentMap<String, String> acquireEntries(
         long storeId)
     {
         return storage.computeIfAbsent(storeId, id -> new ConcurrentHashMap<>());
+    }
+
+    private ConcurrentMap<String, List<TestWatcher>> acquireListeners(
+        long storeId)
+    {
+        return storageListeners.computeIfAbsent(storeId, id -> new ConcurrentHashMap<>());
+    }
+
+    private ConcurrentMap<String, TestLockEntry> acquireLocks(
+        long storeId)
+    {
+        return storageLocks.computeIfAbsent(storeId, id -> new ConcurrentHashMap<>());
     }
 }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/store/TestStoreContext.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/store/TestStoreContext.java
@@ -15,6 +15,7 @@
  */
 package io.aklivity.zilla.runtime.engine.test.internal.store;
 
+import java.util.List;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.LongFunction;
 
@@ -28,13 +29,19 @@ public final class TestStoreContext implements StoreContext
 {
     private final Signaler signaler;
     private final LongFunction<ConcurrentMap<String, String>> supplyEntries;
+    private final LongFunction<ConcurrentMap<String, List<TestWatcher>>> supplyListeners;
+    private final LongFunction<ConcurrentMap<String, TestLockEntry>> supplyLocks;
 
     public TestStoreContext(
         EngineContext context,
-        LongFunction<ConcurrentMap<String, String>> supplyEntries)
+        LongFunction<ConcurrentMap<String, String>> supplyEntries,
+        LongFunction<ConcurrentMap<String, List<TestWatcher>>> supplyListeners,
+        LongFunction<ConcurrentMap<String, TestLockEntry>> supplyLocks)
     {
         this.signaler = context.signaler();
         this.supplyEntries = supplyEntries;
+        this.supplyListeners = supplyListeners;
+        this.supplyLocks = supplyLocks;
     }
 
     @Override
@@ -46,7 +53,9 @@ public final class TestStoreContext implements StoreContext
         {
             options.entries.forEach(entries::putIfAbsent);
         }
-        return new TestStoreHandler(store, signaler, entries);
+        final ConcurrentMap<String, List<TestWatcher>> listeners = supplyListeners.apply(store.id);
+        final ConcurrentMap<String, TestLockEntry> locks = supplyLocks.apply(store.id);
+        return new TestStoreHandler(store, signaler, entries, listeners, locks);
     }
 
     @Override

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/store/TestStoreHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/store/TestStoreHandler.java
@@ -156,6 +156,33 @@ public final class TestStoreHandler implements StoreHandler
     }
 
     @Override
+    public void renew(
+        String key,
+        String token,
+        Duration ttl,
+        Consumer<String> completion)
+    {
+        final long now = System.currentTimeMillis();
+        final TestLockEntry current = locks.get(key);
+        String result = null;
+        if (current != null && current.expiresAt() > now && current.token().equals(token))
+        {
+            final long expiresAt = ttl == null ? Long.MAX_VALUE : now + ttl.toMillis();
+            final TestLockEntry renewed = new TestLockEntry(token, expiresAt);
+            if (locks.replace(key, current, renewed))
+            {
+                result = token;
+            }
+        }
+        else if (current != null && current.expiresAt() <= now)
+        {
+            locks.remove(key, current);
+        }
+        final String outcome = result;
+        defer(() -> completion.accept(outcome));
+    }
+
+    @Override
     public Closeable watch(
         String key,
         BiConsumer<String, String> listener)

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/store/TestStoreHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/store/TestStoreHandler.java
@@ -20,7 +20,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
@@ -33,19 +32,21 @@ import io.aklivity.zilla.runtime.engine.store.StoreHandler;
 public final class TestStoreHandler implements StoreHandler
 {
     private final ConcurrentMap<String, String> entries;
-    private final ConcurrentMap<String, List<BiConsumer<String, String>>> listeners;
+    private final ConcurrentMap<String, List<TestWatcher>> listeners;
     private final ConcurrentMap<String, TestLockEntry> locks;
     private final Signaler signaler;
 
     public TestStoreHandler(
         StoreConfig store,
         Signaler signaler,
-        ConcurrentMap<String, String> entries)
+        ConcurrentMap<String, String> entries,
+        ConcurrentMap<String, List<TestWatcher>> listeners,
+        ConcurrentMap<String, TestLockEntry> locks)
     {
         this.entries = Objects.requireNonNull(entries);
         this.signaler = Objects.requireNonNull(signaler);
-        this.listeners = new ConcurrentHashMap<>();
-        this.locks = new ConcurrentHashMap<>();
+        this.listeners = Objects.requireNonNull(listeners);
+        this.locks = Objects.requireNonNull(locks);
     }
 
     @Override
@@ -121,7 +122,7 @@ public final class TestStoreHandler implements StoreHandler
         final String token = UUID.randomUUID().toString();
         final TestLockEntry candidate = new TestLockEntry(token, expiresAt);
         TestLockEntry existing = locks.putIfAbsent(key, candidate);
-        if (existing != null && existing.expiresAt <= now)
+        if (existing != null && existing.expiresAt() <= now)
         {
             existing = locks.replace(key, existing, candidate) ? null : locks.get(key);
         }
@@ -138,14 +139,14 @@ public final class TestStoreHandler implements StoreHandler
         final long now = System.currentTimeMillis();
         final TestLockEntry current = locks.get(key);
         final String result;
-        if (current != null && current.expiresAt > now && current.token.equals(token))
+        if (current != null && current.expiresAt() > now && current.token().equals(token))
         {
             locks.remove(key, current);
             result = token;
         }
         else
         {
-            if (current != null && current.expiresAt <= now)
+            if (current != null && current.expiresAt() <= now)
             {
                 locks.remove(key, current);
             }
@@ -159,14 +160,15 @@ public final class TestStoreHandler implements StoreHandler
         String key,
         BiConsumer<String, String> listener)
     {
-        final List<BiConsumer<String, String>> list = listeners.computeIfAbsent(key, k -> new CopyOnWriteArrayList<>());
-        list.add(listener);
+        final TestWatcher watcher = new TestWatcher(listener, signaler);
+        final List<TestWatcher> list = listeners.computeIfAbsent(key, k -> new CopyOnWriteArrayList<>());
+        list.add(watcher);
         return () ->
         {
-            final List<BiConsumer<String, String>> current = listeners.get(key);
+            final List<TestWatcher> current = listeners.get(key);
             if (current != null)
             {
-                current.remove(listener);
+                current.remove(watcher);
             }
         };
     }
@@ -175,13 +177,13 @@ public final class TestStoreHandler implements StoreHandler
         String key,
         String value)
     {
-        final List<BiConsumer<String, String>> list = listeners.get(key);
+        final List<TestWatcher> list = listeners.get(key);
         if (list != null && !list.isEmpty())
         {
             final long now = System.currentTimeMillis();
-            for (BiConsumer<String, String> listener : list)
+            for (TestWatcher w : list)
             {
-                signaler.signalAt(now, 0, ignored -> listener.accept(key, value));
+                w.signaler().signalAt(now, 0, ignored -> w.listener().accept(key, value));
             }
         }
     }
@@ -191,11 +193,5 @@ public final class TestStoreHandler implements StoreHandler
     {
         // contract: callback fires strictly later than the call, on the caller's I/O thread
         signaler.signalAt(System.currentTimeMillis(), 0, ignored -> task.run());
-    }
-
-    private record TestLockEntry(
-        String token,
-        long expiresAt)
-    {
     }
 }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/store/TestWatcher.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/store/TestWatcher.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.test.internal.store;
+
+import java.util.function.BiConsumer;
+
+import io.aklivity.zilla.runtime.engine.concurrent.Signaler;
+
+record TestWatcher(
+    BiConsumer<String, String> listener,
+    Signaler signaler)
+{
+}

--- a/runtime/store-memory/src/main/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStoreHandler.java
+++ b/runtime/store-memory/src/main/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStoreHandler.java
@@ -166,6 +166,34 @@ final class MemoryStoreHandler implements StoreHandler
     }
 
     @Override
+    public void renew(
+        String key,
+        String token,
+        Duration ttl,
+        Consumer<String> completion)
+    {
+        final long now = System.currentTimeMillis();
+        final LockEntry current = locks.get(key);
+        String result = null;
+        if (current != null && current.expiresAt() > now && current.token().equals(token))
+        {
+            final long expiresAt = expiresAt(ttl);
+            final LockEntry renewed = new LockEntry(token, expiresAt);
+            if (locks.replace(key, current, renewed))
+            {
+                result = token;
+            }
+        }
+        else if (current != null && current.expiresAt() <= now)
+        {
+            // expired holder still cluttering the map — clean up opportunistically
+            locks.remove(key, current);
+        }
+        final String outcome = result;
+        defer(() -> completion.accept(outcome));
+    }
+
+    @Override
     public Closeable watch(
         String key,
         BiConsumer<String, String> listener)

--- a/runtime/store-memory/src/test/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStoreHandlerIT.java
+++ b/runtime/store-memory/src/test/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStoreHandlerIT.java
@@ -77,6 +77,16 @@ public class MemoryStoreHandlerIT
     }
 
     @Test
+    @Configuration("store.renew.yaml")
+    @Specification({
+        "${net}/handshake/client",
+        "${app}/handshake/server"})
+    public void shouldRenewOwnedLock() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Configuration("store.watch.yaml")
     @Specification({
         "${net}/handshake/client",

--- a/specs/store-memory.spec/src/main/scripts/io/aklivity/zilla/specs/store/memory/config/store.renew.yaml
+++ b/specs/store-memory.spec/src/main/scripts/io/aklivity/zilla/specs/store/memory/config/store.renew.yaml
@@ -1,0 +1,43 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+stores:
+    memory0:
+        type: memory
+bindings:
+    net0:
+        type: test
+        kind: server
+        options:
+            store: memory0
+            assertions:
+                store:
+                    memory0:
+                        - op: lock
+                          key: lock.renewable
+                          ttl: PT1M
+                          expect: acquired
+                        - op: renew
+                          key: lock.renewable
+                          ttl: PT1M
+                          expect: renewed
+                        - op: renew
+                          key: lock.absent
+                          value: any-token
+                          expect: null
+        routes:
+            - exit: app0


### PR DESCRIPTION
## Summary

- Adds `StoreHandler.renew(key, token, ttl, completion)` to the engine SPI for callers that hold a coordination lock longer than its initial TTL — they schedule renewals at an interval shorter than the lease TTL, and a failed renewal signals that ownership has been lost so the caller can surrender state and let a new owner take over.
- Brings the in-tree TestStoreHandler up to the same contract surface as the lock/unlock/watch SPI introduced in #1790, so spec-level ITs can be written against `type: test` without depending on `store-memory` for correctness. TestStoreContext now supplies per-store watcher and lock maps shared across workers (mirroring the existing `supplyEntries` pattern); the new `TestWatcher` record carries the registering worker's signaler so cross-worker notify dispatches listener invocations onto the right thread.
- `store-memory` and `TestStoreHandler` both implement `renew` with an atomic `ConcurrentMap.replace` against the previously-observed lock entry — token match under unexpired TTL returns the original token; mismatch or expiry returns null. Expired entries are evicted opportunistically, matching the unlock cleanup behaviour.

## Commits

- `02630399` `test(engine): share watchers and locks per store across workers in TestStoreHandler` — the cross-worker test infrastructure that the renew SPI tests depend on.
- `aba18122` `feat(engine): add renew operation to StoreHandler` — the SPI method plus store-memory and TestStoreHandler implementations, TestBindingFactory renew assertion, and the `store.renew.yaml` spec config.

## Consumer

This SPI is consumed by `binding-mcp`'s cache lifecycle-lock-hold change (on a separate branch, depends on this PR). That change schedules `renew` at `leaseTtl / 3` for the worker that owns a binding's upstream lifecycle stream, so a single cache owner stays uninterrupted during normal operation and a holding node's crash triggers TTL-bounded takeover by another worker.

## Test plan

- [x] `./mvnw clean verify -pl runtime/store-memory -am` — `MemoryStoreHandlerIT` 5/5 (including new `shouldRenew`).
- [x] `./mvnw clean install -DskipTests -DskipITs -pl runtime/engine -am` — engine compiles after both commits.
- [ ] CI verifies the full reactor.

https://claude.ai/code/session_01Gx5yC2CuFd54Fyoy7kL3qg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gx5yC2CuFd54Fyoy7kL3qg)_