### PR TITLE
Separate engine initialization from startup

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
@@ -105,6 +105,7 @@ public final class Engine implements Collector, AutoCloseable
     private final RouterConfig routerConfig;
 
     private final EventWriter eventWriter;
+    private final AtomicBoolean initialized;
     private final AtomicBoolean closed;
 
     private FileSystem fileSystem = null;
@@ -271,6 +272,7 @@ public final class Engine implements Collector, AutoCloseable
         this.readonly = readonly;
         this.manager = manager;
         this.diagnostics = diagnostics;
+        this.initialized = new AtomicBoolean(false);
         this.closed = new AtomicBoolean(false);
     }
 
@@ -290,14 +292,23 @@ public final class Engine implements Collector, AutoCloseable
         manager.process(config);
     }
 
+    public void init()
+    {
+        if (initialized.compareAndSet(false, true))
+        {
+            for (EngineWorker worker : workers)
+            {
+                worker.doStart();
+            }
+
+            boss.doStart();
+        }
+    }
+
     public void start() throws Exception
     {
-        for (EngineWorker worker : workers)
-        {
-            worker.doStart();
-        }
-
-        boss.doStart();
+        // start workers and boss if init() has not already been called; idempotent
+        init();
 
         // ignore the config file in read-only mode; no config will be read so no namespaces, bindings, etc. will be attached
         if (!readonly)

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineTest.java
@@ -75,6 +75,53 @@ public class EngineTest
     }
 
     @Test
+    public void shouldInitThenStart()
+    {
+        EngineConfiguration config = new EngineConfiguration(properties);
+        List<Throwable> errors = new LinkedList<>();
+        try (Engine engine = Engine.builder()
+                .config(config)
+                .errorHandler(errors::add)
+                .build())
+        {
+            engine.init();
+            engine.start();
+        }
+        catch (Throwable ex)
+        {
+            errors.add(ex);
+        }
+        finally
+        {
+            assertThat(errors, empty());
+        }
+    }
+
+    @Test
+    public void shouldInitIdempotent()
+    {
+        EngineConfiguration config = new EngineConfiguration(properties);
+        List<Throwable> errors = new LinkedList<>();
+        try (Engine engine = Engine.builder()
+                .config(config)
+                .errorHandler(errors::add)
+                .build())
+        {
+            engine.init();
+            engine.init();
+            engine.start();
+        }
+        catch (Throwable ex)
+        {
+            errors.add(ex);
+        }
+        finally
+        {
+            assertThat(errors, empty());
+        }
+    }
+
+    @Test
     public void shouldConfigure()
     {
         String resource = String.format("%s-%s.json", getClass().getSimpleName(), "configure");

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/EngineRule.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/EngineRule.java
@@ -101,7 +101,6 @@ public final class EngineRule implements TestRule
         this.properties = new Properties();
         this.exceptions = m -> false;
         this.interruptible = true;
-        this.beforeStart = null;
 
         configure(ENGINE_DRAIN_ON_CLOSE, true);
         configure(ENGINE_SYNTHETIC_ABORT, true);

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/EngineRule.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/EngineRule.java
@@ -93,6 +93,7 @@ public final class EngineRule implements TestRule
     private Predicate<String> exceptions;
     private boolean interruptible;
     private boolean clean;
+    private Runnable beforeStart;
 
     public EngineRule()
     {
@@ -100,6 +101,7 @@ public final class EngineRule implements TestRule
         this.properties = new Properties();
         this.exceptions = m -> false;
         this.interruptible = true;
+        this.beforeStart = () -> {};
 
         configure(ENGINE_DRAIN_ON_CLOSE, true);
         configure(ENGINE_SYNTHETIC_ABORT, true);
@@ -177,6 +179,13 @@ public final class EngineRule implements TestRule
     public EngineRule clean()
     {
         this.clean = true;
+        return this;
+    }
+
+    public EngineRule beforeStart(
+        Runnable beforeStart)
+    {
+        this.beforeStart = requireNonNull(beforeStart);
         return this;
     }
 
@@ -391,9 +400,33 @@ public final class EngineRule implements TestRule
                                 .errorHandler(errorHandler)
                                 .build();
 
+                // start workers and boss eagerly; bindings are attached by start() below
+                engine.init();
+
+                // attach bindings on a separate thread so an optional beforeStart hook can block
+                // (e.g. waiting for an external runtime to be ready) without stalling the test body
+                final Thread starter = new Thread(() ->
+                {
+                    try
+                    {
+                        beforeStart.run();
+                        engine.start();
+                    }
+                    catch (Throwable t)
+                    {
+                        errors.add(t);
+
+                        if (interruptible)
+                        {
+                            baseThread.interrupt();
+                        }
+                    }
+                });
+                starter.setName("engine-rule-before-start");
+
                 try
                 {
-                    engine.start();
+                    starter.start();
 
                     base.evaluate();
                 }
@@ -405,6 +438,7 @@ public final class EngineRule implements TestRule
                 {
                     try
                     {
+                        starter.join();
                         engine.close();
                     }
                     catch (Throwable t)

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/EngineRule.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/EngineRule.java
@@ -101,7 +101,7 @@ public final class EngineRule implements TestRule
         this.properties = new Properties();
         this.exceptions = m -> false;
         this.interruptible = true;
-        this.beforeStart = () -> {};
+        this.beforeStart = null;
 
         configure(ENGINE_DRAIN_ON_CLOSE, true);
         configure(ENGINE_SYNTHETIC_ABORT, true);
@@ -400,33 +400,49 @@ public final class EngineRule implements TestRule
                                 .errorHandler(errorHandler)
                                 .build();
 
-                // start workers and boss eagerly; bindings are attached by start() below
-                engine.init();
-
-                // attach bindings on a separate thread so an optional beforeStart hook can block
-                // (e.g. waiting for an external runtime to be ready) without stalling the test body
-                final Thread starter = new Thread(() ->
+                // when no beforeStart hook is set, preserve existing behavior exactly: start (and implicitly
+                // init) the engine synchronously on the test thread before the test body runs.
+                // when a hook is set, init the engine eagerly and run the hook followed by start() on a
+                // separate thread so the hook can block (e.g. waiting for an external runtime to be ready)
+                // without stalling the test body, while bindings attach once the hook returns.
+                final Thread starter;
+                if (beforeStart == null)
                 {
-                    try
+                    starter = null;
+                }
+                else
+                {
+                    engine.init();
+                    starter = new Thread(() ->
                     {
-                        beforeStart.run();
-                        engine.start();
-                    }
-                    catch (Throwable t)
-                    {
-                        errors.add(t);
-
-                        if (interruptible)
+                        try
                         {
-                            baseThread.interrupt();
+                            beforeStart.run();
+                            engine.start();
                         }
-                    }
-                });
-                starter.setName("engine-rule-before-start");
+                        catch (Throwable t)
+                        {
+                            errors.add(t);
+
+                            if (interruptible)
+                            {
+                                baseThread.interrupt();
+                            }
+                        }
+                    });
+                    starter.setName("engine-rule-before-start");
+                }
 
                 try
                 {
-                    starter.start();
+                    if (starter != null)
+                    {
+                        starter.start();
+                    }
+                    else
+                    {
+                        engine.start();
+                    }
 
                     base.evaluate();
                 }
@@ -438,7 +454,10 @@ public final class EngineRule implements TestRule
                 {
                     try
                     {
-                        starter.join();
+                        if (starter != null)
+                        {
+                            starter.join();
+                        }
                         engine.close();
                     }
                     catch (Throwable t)


### PR DESCRIPTION
## Description

This change separates engine initialization from startup by introducing an explicit `init()` method and refactoring the startup sequence. The key improvements are:

1. **New `init()` method**: Starts workers and boss threads eagerly, with idempotent behavior (safe to call multiple times)
2. **Deferred binding attachment**: The `start()` method now attaches bindings after initialization, allowing for optional pre-startup hooks
3. **EngineRule enhancement**: Added `beforeStart()` hook to allow tests to execute custom logic (e.g., waiting for external services) on a separate thread before engine startup, without blocking the test body

### Changes

**Engine.java**
- Added `initialized` AtomicBoolean field to track initialization state
- New `init()` method that idempotently starts workers and boss
- Modified `start()` to call `init()` first, ensuring backward compatibility

**EngineRule.java**
- Added `beforeStart` field and `beforeStart(Runnable)` configuration method
- Refactored `evaluate()` to spawn a separate "engine-rule-before-start" thread that:
  - Calls the optional `beforeStart` hook
  - Calls `engine.start()` to attach bindings
  - Handles errors and interrupts the test thread if needed
- Added `starter.join()` in finally block to ensure proper cleanup

**EngineTest.java**
- Added `shouldInitThenStart()` test: verifies init() followed by start() works correctly
- Added `shouldInitIdempotent()` test: verifies calling init() multiple times is safe

### Motivation

This separation enables test scenarios where initialization (worker/boss startup) must happen before a blocking operation (e.g., waiting for an external runtime), while keeping the test body non-blocking. The idempotent init() design maintains backward compatibility with existing code that calls start() directly.

### Test Plan

Added unit tests covering the new init() behavior and idempotency. Existing tests continue to pass as start() remains backward compatible.

https://claude.ai/code/session_01XcNeWBUJAA87NSf9R4KdVT