### PR TITLE
fix(engine): release worker buffers in coordinated close to avoid JVM crash on binding fault

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
@@ -332,7 +332,9 @@ public final class Engine implements Collector, AutoCloseable
 
         if (config.drainOnClose())
         {
-            workers.forEach(EngineWorker::drain);
+            workers.stream()
+                   .filter(worker -> !worker.runner().isClosed())
+                   .forEach(EngineWorker::drain);
         }
 
         final List<Throwable> errors = new ArrayList<>();

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -881,6 +881,12 @@ public class EngineWorker implements EngineContext, Agent
         }
         finally
         {
+            targetsByIndex.forEach((k, v) -> quietClose(v));
+            quietClose(streamsLayout);
+            quietClose(bufferPoolLayout);
+            debitorsByIndex.forEach((k, v) -> quietClose(v));
+            quietClose(creditor);
+            quietClose(eventWriter);
             thread = null;
         }
     }
@@ -1058,14 +1064,6 @@ public class EngineWorker implements EngineContext, Agent
         }
 
         targetsByIndex.forEach((k, v) -> v.detach());
-        targetsByIndex.forEach((k, v) -> quietClose(v));
-
-        quietClose(streamsLayout);
-        quietClose(bufferPoolLayout);
-
-        debitorsByIndex.forEach((k, v) -> quietClose(v));
-        quietClose(creditor);
-        quietClose(eventWriter);
 
         if (acquiredBuffers != 0 || acquiredCreditors != 0 || acquiredDebitors != 0L)
         {


### PR DESCRIPTION
## Problem

A hot-path binding exception (e.g. a null-exchange NPE in a client stream factory) is caught by `EngineWorker.doWork` and rethrown wrapped in `AgentTerminationException`, terminating the worker agent. Agrona's `AgentRunner` then runs the agent's `onClose` **on the agent thread**, which released the worker's memory-mapped buffers **in advance**. The engine-coordinated `Engine.close()` then calls `drain()`, reading that worker's already-unmapped streams ring buffer via `Unsafe.getLongVolatile` → **SIGSEGV / JVM abort** (confirmed via `hs_err_pid` fatal-error log).

The intended policy is preserved: an uncaught binding exception should *stop the engine* — but it must not also crash the JVM.

## Fix

- **`EngineWorker`** — `onClose` no longer releases any memory-mapped resources. All releases (`targets`, `streamsLayout`, `bufferPoolLayout`, `debitors`, `creditor`, `eventWriter`) are deferred to `doClose`'s `finally`, which runs on the engine thread **after** `runner.close()` has stopped the agent. A self-terminated worker therefore no longer unmaps buffers the engine — or peer workers (shared `creditor`/`debitor` budget buffers) — still reference.
- **`Engine.close`** — skips draining a worker whose agent already terminated (`!worker.runner().isClosed()`); such a worker will never consume again, so draining it would otherwise spin until the 30s timeout.

## Validation

- Repro (NPE injected in a binding `newStream`): pre-fix → JVM abort (exit 134, `hs_err_pid`); post-fix → no crash, no `hs_err`, ~1.0s (no drain hang). The worker stops and the engine closes cleanly.
- `./mvnw verify -pl runtime/engine` (unit + `EngineIT` + jacoco + checkstyle): green on the `develop` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)