### PR TITLE
fix(binding-http): client connection reuse per origin/authority + per-connection exchange/queue scope

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -2148,12 +2148,8 @@ public final class HttpClientFactory implements HttpStreamFactory
             String scheme,
             String authority)
         {
-            HttpClient client = clients.stream().filter(
-                c -> c.canServe(scheme, authority) &&
-                (!HttpState.replyOpened(c.state) ||
-                c.encoder == HttpEncoder.HTTP_2 ||
-                c.exchange == null && c.encoder == HttpEncoder.HTTP_1_1 ||
-                c.encoder == HttpEncoder.H2C))
+            HttpClient client = clients.stream()
+                .filter(c -> c.canServe(scheme, authority) && c.available(versions))
                 .findFirst()
                 .orElse(null);
 
@@ -2163,6 +2159,14 @@ public final class HttpClientFactory implements HttpStreamFactory
                 client.scheme = scheme;
                 client.authority = authority;
                 onCreated(client);
+            }
+
+            if (client == null)
+            {
+                client = clients.stream()
+                    .filter(c -> c.canServe(scheme, authority) && c.reusable())
+                    .findFirst()
+                    .orElse(null);
             }
 
             return client;
@@ -4398,6 +4402,23 @@ public final class HttpClientFactory implements HttpStreamFactory
             return Objects.equals(this.scheme, scheme) &&
                 (Objects.equals(this.authority, authority) ||
                  encoder == HttpEncoder.HTTP_2 && serviceableNames.contains(authority));
+        }
+
+        private boolean available(
+            SortedSet<HttpVersion> versions)
+        {
+            return encoder == HttpEncoder.HTTP_2 ||
+                encoder == HttpEncoder.H2C ||
+                !HttpState.replyOpened(state) && versions.contains(HTTP_2) ||
+                exchange == null && httpQueueSlotLimit == 0;
+        }
+
+        private boolean reusable()
+        {
+            return !HttpState.replyOpened(state) ||
+                encoder == HttpEncoder.HTTP_2 ||
+                exchange == null && encoder == HttpEncoder.HTTP_1_1 ||
+                encoder == HttpEncoder.H2C;
         }
 
         private void flushNext()

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -37,12 +37,14 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.EnumMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
@@ -177,6 +179,7 @@ public final class HttpClientFactory implements HttpStreamFactory
     private static final String SCHEME = ":scheme";
     private static final String CACHE_CONTROL = "cache-control";
     private static final String8FW HEADER_AUTHORITY = new String8FW(":authority");
+    private static final String8FW HEADER_SCHEME = new String8FW(":scheme");
     private static final String8FW HEADER_USER_AGENT = new String8FW("user-agent");
     private static final String8FW HEADER_CONNECTION = new String8FW("connection");
     private static final String8FW HEADER_CONTENT_LENGTH = new String8FW("content-length");
@@ -2063,8 +2066,12 @@ public final class HttpClientFactory implements HttpStreamFactory
                     ? beginEx.headers().matchFirst(h -> HEADER_AUTHORITY.equals(h.name()))
                     : null;
             final String authority = authorityHeader != null ? authorityHeader.value().asString() : null;
+            final HttpHeaderFW schemeHeader = beginEx != null
+                    ? beginEx.headers().matchFirst(h -> HEADER_SCHEME.equals(h.name()))
+                    : null;
+            final String scheme = schemeHeader != null ? schemeHeader.value().asString() : null;
 
-            HttpClient client = supplyClient(authority);
+            HttpClient client = supplyClient(scheme, authority);
             final int queuedRequestLength = HttpQueueEntryFW.FIELD_OFFSET_VALUE_LENGTH + begin.extension().sizeof();
 
             if (client == null || queuedRequestLength > maximumRequestQueueSize)
@@ -2138,10 +2145,11 @@ public final class HttpClientFactory implements HttpStreamFactory
         }
 
         private HttpClient supplyClient(
+            String scheme,
             String authority)
         {
             HttpClient client = clients.stream().filter(
-                c -> Objects.equals(c.authority, authority) &&
+                c -> c.canServe(scheme, authority) &&
                 (!HttpState.replyOpened(c.state) ||
                 c.encoder == HttpEncoder.HTTP_2 ||
                 c.exchange == null && c.encoder == HttpEncoder.HTTP_1_1 ||
@@ -2152,6 +2160,7 @@ public final class HttpClientFactory implements HttpStreamFactory
             if (client == null && clients.size() < maximumConnectionsPerRoute)
             {
                 client = new HttpClient(this);
+                client.scheme = scheme;
                 client.authority = authority;
                 onCreated(client);
             }
@@ -2243,7 +2252,9 @@ public final class HttpClientFactory implements HttpStreamFactory
         private int initialSharedBudget;
         private long requestSharedBudgetIndex = NO_CREDITOR_INDEX;
         private String protocolUpgrade = null;
+        private String scheme;
         private String authority;
+        private final Set<String> serviceableNames = new HashSet<>();
 
         private int httpQueueSlot = NO_SLOT;
         private int httpQueueSlotOffset;
@@ -4380,6 +4391,15 @@ public final class HttpClientFactory implements HttpStreamFactory
             return maxClientStreamId;
         }
 
+        private boolean canServe(
+            String scheme,
+            String authority)
+        {
+            return Objects.equals(this.scheme, scheme) &&
+                (Objects.equals(this.authority, authority) ||
+                 encoder == HttpEncoder.HTTP_2 && serviceableNames.contains(authority));
+        }
+
         private void flushNext()
         {
             dequeue:
@@ -4399,7 +4419,7 @@ public final class HttpClientFactory implements HttpStreamFactory
                     client = encoder == HttpEncoder.HTTP_2 ||
                             encoder == HttpEncoder.HTTP_1_1 && httpExchange.client.exchange == null ||
                             encoder == HttpEncoder.H2C ?
-                            httpExchange.client : pool.supplyClient(httpExchange.client.authority);
+                            httpExchange.client : pool.supplyClient(httpExchange.client.scheme, httpExchange.client.authority);
 
                     if (client != null)
                     {

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -2918,30 +2918,38 @@ public final class HttpClientFactory implements HttpStreamFactory
             long authorization,
             HttpBeginExFW beginEx)
         {
-            exchange.resolveResponse(beginEx);
-            boolean valid = exchange.validateResponseHeaders(beginEx);
-            if (valid)
+            if (exchange == null)
             {
-                exchange.doResponseBegin(traceId, authorization, beginEx);
-
-                final HttpHeaderFW connection = beginEx.headers().matchFirst(h -> HEADER_CONNECTION.equals(h.name()));
-                if (connection != null && connectionClose.reset(connection.value().asString()).matches())
-                {
-                    exchange.state = HttpState.closingReply(exchange.state);
-                }
-
-                final HttpHeaderFW status = beginEx.headers().matchFirst(h -> HEADER_STATUS.equals(h.name()));
-                if (status != null &&
-                    encoder == HttpEncoder.HTTP_1_1 &&
-                    STATUS_101.equals(status.value()))
-                {
-                    pool.onUpgradedOrClosed(this);
-                }
+                decoder = decodeHttp11Ignore;
+                cleanupNetwork(traceId, authorization);
             }
             else
             {
-                exchange.onResponseInvalid(traceId, authorization);
-                decoder = decodeHttp11Ignore;
+                exchange.resolveResponse(beginEx);
+                boolean valid = exchange.validateResponseHeaders(beginEx);
+                if (valid)
+                {
+                    exchange.doResponseBegin(traceId, authorization, beginEx);
+
+                    final HttpHeaderFW connection = beginEx.headers().matchFirst(h -> HEADER_CONNECTION.equals(h.name()));
+                    if (connection != null && connectionClose.reset(connection.value().asString()).matches())
+                    {
+                        exchange.state = HttpState.closingReply(exchange.state);
+                    }
+
+                    final HttpHeaderFW status = beginEx.headers().matchFirst(h -> HEADER_STATUS.equals(h.name()));
+                    if (status != null &&
+                        encoder == HttpEncoder.HTTP_1_1 &&
+                        STATUS_101.equals(status.value()))
+                    {
+                        pool.onUpgradedOrClosed(this);
+                    }
+                }
+                else
+                {
+                    exchange.onResponseInvalid(traceId, authorization);
+                    decoder = decodeHttp11Ignore;
+                }
             }
         }
 

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -1746,7 +1746,7 @@ public final class HttpClientFactory implements HttpStreamFactory
         {
             if (client.applicationHeadersProcessed.size() < config.maxConcurrentApplicationHeaders())
             {
-                final HttpExchange exchange = client.pool.exchanges.get(streamId);
+                final HttpExchange exchange = client.exchanges.get(streamId);
                 if (HttpState.replyOpening(exchange.state))
                 {
                     client.onDecodeHttp2Trailers(traceId, authorization, http2Headers);
@@ -2035,12 +2035,8 @@ public final class HttpClientFactory implements HttpStreamFactory
     {
         private final long bindingId;
         private final long resolvedId;
-        private final Int2ObjectHashMap<HttpExchange> exchanges;
         private final List<HttpClient> clients;
 
-        private int httpQueueSlot = NO_SLOT;
-        private int httpQueueSlotOffset;
-        private int httpQueueSlotLimit;
         private SortedSet<HttpVersion> versions;
 
         private HttpClientPool(
@@ -2050,7 +2046,6 @@ public final class HttpClientFactory implements HttpStreamFactory
             this.bindingId = bindingId;
             this.resolvedId = resolvedId;
             this.clients = new LinkedList<>();
-            this.exchanges = new Int2ObjectHashMap<>();
         }
 
         public MessageConsumer newStream(
@@ -2076,7 +2071,7 @@ public final class HttpClientFactory implements HttpStreamFactory
             {
                 newStream = rejectWithStatusCode(sender, begin, HEADERS_431_REQUEST_TOO_LARGE);
             }
-            else if (queuedRequestLength <= availableSlotSize())
+            else if (queuedRequestLength <= client.availableSlotSize())
             {
                 final HttpPromise promise = client.promises.stream().filter(p -> p.matches(beginEx.headers()))
                         .findFirst().orElse(null);
@@ -2088,7 +2083,7 @@ public final class HttpClientFactory implements HttpStreamFactory
 
                 if (promise != null)
                 {
-                    final HttpExchange exchange = exchanges.get(promise.promiseId);
+                    final HttpExchange exchange = client.exchanges.get(promise.promiseId);
                     newStream = exchange::onApplication;
                     client.promises.remove(promise);
                 }
@@ -2097,7 +2092,7 @@ public final class HttpClientFactory implements HttpStreamFactory
                     final int nextStreamId = client.nextStreamId();
                     final HttpExchange exchange = client.newExchange(sender, originId, routedId, initialId, authorization,
                             overrides, nextStreamId);
-                    exchanges.put(nextStreamId, exchange);
+                    client.exchanges.put(nextStreamId, exchange);
                     newStream = exchange::onApplication;
                 }
             }
@@ -2142,66 +2137,6 @@ public final class HttpClientFactory implements HttpStreamFactory
             return newStream;
         }
 
-        private void flushNext()
-        {
-            dequeue:
-            while (httpQueueSlotOffset != httpQueueSlotLimit)
-            {
-                final MutableDirectBuffer httpQueueBuffer = bufferPool.buffer(httpQueueSlot);
-                final HttpQueueEntryFW queueEntry = queueEntryRO.wrap(httpQueueBuffer, httpQueueSlotOffset, httpQueueSlotLimit);
-                final int streamId = queueEntry.streamId();
-                final long traceId = queueEntry.traceId();
-                final long authorization = queueEntry.authorization();
-                final HttpExchange httpExchange = exchanges.get(streamId);
-                HttpClient client = null;
-
-                if (httpExchange != null)
-                {
-                    final HttpEncoder encoder = httpExchange.client.encoder;
-                    client = encoder == HttpEncoder.HTTP_2 ||
-                            encoder == HttpEncoder.HTTP_1_1 && httpExchange.client.exchange == null ||
-                            encoder == HttpEncoder.H2C ?
-                            httpExchange.client : supplyClient(httpExchange.client.authority);
-
-                    if (client != null)
-                    {
-                        httpExchange.doRequestBegin(traceId, authorization, queueEntry.value());
-                    }
-                    else
-                    {
-                        httpExchange.doResponseAbort(traceId, authorization, EMPTY_OCTETS);
-                    }
-                }
-                httpQueueSlotOffset += queueEntry.sizeof();
-
-                if (client != null && client.encoder == HttpEncoder.H2C)
-                {
-                    break dequeue;
-                }
-            }
-
-            cleanupQueueSlotIfNecessary();
-        }
-
-        private void cleanupQueueSlotIfNecessary()
-        {
-            if (httpQueueSlot != NO_SLOT && httpQueueSlotOffset == httpQueueSlotLimit)
-            {
-                bufferPool.release(httpQueueSlot);
-                httpQueueSlot = NO_SLOT;
-                httpQueueSlotOffset = 0;
-                httpQueueSlotLimit = 0;
-            }
-        }
-
-        private void acquireQueueSlotIfNecessary()
-        {
-            if (httpQueueSlot == NO_SLOT)
-            {
-                httpQueueSlot = bufferPool.acquire(resolvedId);
-            }
-        }
-
         private HttpClient supplyClient(
             String authority)
         {
@@ -2236,11 +2171,6 @@ public final class HttpClientFactory implements HttpStreamFactory
         {
             clients.remove(client);
             assert clients.size() <= maximumConnectionsPerRoute;
-        }
-
-        private int availableSlotSize()
-        {
-            return bufferPool.slotCapacity() - httpQueueSlotLimit;
         }
     }
 
@@ -2305,6 +2235,7 @@ public final class HttpClientFactory implements HttpStreamFactory
         private final LongHashSet applicationHeadersProcessed;
 
         private final List<HttpPromise> promises;
+        private final Int2ObjectHashMap<HttpExchange> exchanges;
         private HttpExchange exchange;
         private LongLongConsumer cleanupHandler;
         private int requestSharedBudget;
@@ -2313,6 +2244,10 @@ public final class HttpClientFactory implements HttpStreamFactory
         private long requestSharedBudgetIndex = NO_CREDITOR_INDEX;
         private String protocolUpgrade = null;
         private String authority;
+
+        private int httpQueueSlot = NO_SLOT;
+        private int httpQueueSlotOffset;
+        private int httpQueueSlotLimit;
 
         private HttpClient(
             HttpClientPool pool)
@@ -2328,6 +2263,7 @@ public final class HttpClientFactory implements HttpStreamFactory
             this.remoteSettings = new Http2Settings();
             this.applicationHeadersProcessed = new LongHashSet();
             this.promises = new ArrayList<>(maximumPushPromiseListSize);
+            this.exchanges = new Int2ObjectHashMap<>();
             this.decodeContext = new HpackContext(localSettings.headerTableSize, false);
             this.encodeContext = new HpackContext(remoteSettings.headerTableSize, true);
             this.encodeHeadersBuffer = new ExpandableArrayBuffer();
@@ -2372,7 +2308,7 @@ public final class HttpClientFactory implements HttpStreamFactory
             if (promises.size() == maximumPushPromiseListSize)
             {
                 final HttpPromise oldPromise = promises.remove(0);
-                final HttpExchange httpExchange = pool.exchanges.remove(oldPromise.promiseId);
+                final HttpExchange httpExchange = exchanges.remove(oldPromise.promiseId);
                 doEncodeHttp2RstStream(traceId, httpExchange.streamId, Http2ErrorCode.CANCEL);
 
             }
@@ -2437,7 +2373,7 @@ public final class HttpClientFactory implements HttpStreamFactory
 
                 remoteSharedBudget = encodeMax;
 
-                for (HttpExchange exchange: pool.exchanges.values())
+                for (HttpExchange exchange: exchanges.values())
                 {
                     exchange.remoteBudget += encodeMax;
                     exchange.flushRequestWindow(traceId, 0);
@@ -2454,7 +2390,7 @@ public final class HttpClientFactory implements HttpStreamFactory
                      pool.versions.contains(HTTP_2))
             {
                 this.encoder = HttpEncoder.H2C;
-                for (HttpExchange exchange: pool.exchanges.values())
+                for (HttpExchange exchange: exchanges.values())
                 {
                     exchange.remoteBudget += encodeMax;
                 }
@@ -2462,7 +2398,7 @@ public final class HttpClientFactory implements HttpStreamFactory
 
             doNetworkWindow(traceId, 0L, 0, 0);
 
-            pool.flushNext();
+            flushNext();
         }
 
         private void onNetworkData(
@@ -2528,7 +2464,7 @@ public final class HttpClientFactory implements HttpStreamFactory
             }
             else
             {
-                pool.exchanges.forEach((id, exchange) ->
+                exchanges.forEach((id, exchange) ->
                 {
                     if (!HttpState.replyOpening(exchange.state) || decodeSlot == NO_SLOT)
                     {
@@ -2555,7 +2491,7 @@ public final class HttpClientFactory implements HttpStreamFactory
 
             cleanupDecodeSlotIfNecessary();
 
-            pool.exchanges.forEach((id, exchange) -> exchange.cleanup(traceId, authorization));
+            exchanges.forEach((id, exchange) -> exchange.cleanup(traceId, authorization));
 
             if (!HttpState.initialClosing(state))
             {
@@ -2575,7 +2511,7 @@ public final class HttpClientFactory implements HttpStreamFactory
             cleanupBudgetCreditorIfNecessary();
             cleanupEncodeSlotIfNecessary();
 
-            pool.exchanges.forEach((id, exchange) -> exchange.cleanup(traceId, authorization));
+            exchanges.forEach((id, exchange) -> exchange.cleanup(traceId, authorization));
 
             if (!HttpState.replyClosing(state))
             {
@@ -2894,7 +2830,7 @@ public final class HttpClientFactory implements HttpStreamFactory
                 {
                     state = HttpState.closeReply(state);
 
-                    pool.exchanges.forEach((id, exchange) -> exchange.cleanup(traceId, authorization));
+                    exchanges.forEach((id, exchange) -> exchange.cleanup(traceId, authorization));
 
                     doNetworkEnd(traceId, authorization);
                 }
@@ -3345,7 +3281,7 @@ public final class HttpClientFactory implements HttpStreamFactory
             Http2RstStreamFW http2RstStream)
         {
             final int streamId = http2RstStream.streamId();
-            final HttpExchange exchange = pool.exchanges.get(streamId);
+            final HttpExchange exchange = exchanges.get(streamId);
 
             if (exchange != null)
             {
@@ -3361,7 +3297,7 @@ public final class HttpClientFactory implements HttpStreamFactory
             final int streamId = http2Priority.streamId();
             final int parentStream = http2Priority.parentStream();
 
-            final HttpExchange exchange = pool.exchanges.get(streamId);
+            final HttpExchange exchange = exchanges.get(streamId);
             if (exchange != null)
             {
                 if (parentStream == streamId)
@@ -3381,7 +3317,7 @@ public final class HttpClientFactory implements HttpStreamFactory
         {
             int progress = 0;
 
-            final HttpExchange exchange = pool.exchanges.get(streamId);
+            final HttpExchange exchange = exchanges.get(streamId);
 
             if (exchange == null)
             {
@@ -3476,7 +3412,7 @@ public final class HttpClientFactory implements HttpStreamFactory
 
             if (endHeaders)
             {
-                final HttpExchange exchange = pool.exchanges.get(streamId);
+                final HttpExchange exchange = exchanges.get(streamId);
                 if (exchange != null && HttpState.replyOpening(exchange.state))
                 {
                     onDecodeHttp2Trailers(traceId, authorization, streamId, headersBuffer, 0, headersSlotOffset);
@@ -3522,7 +3458,7 @@ public final class HttpClientFactory implements HttpStreamFactory
             else
             {
                 final Map<String, String> headers = headersDecoder.headers;
-                final HttpExchange exchange = pool.exchanges.get(streamId);
+                final HttpExchange exchange = exchanges.get(streamId);
                 exchange.responseContentLength = headersDecoder.contentLength;
 
                 final HttpBeginExFW beginEx = beginExRW.wrap(extBuffer, 0, extBuffer.capacity())
@@ -3586,7 +3522,7 @@ public final class HttpClientFactory implements HttpStreamFactory
             }
             else
             {
-                final HttpExchange exchange = pool.exchanges.get(streamId);
+                final HttpExchange exchange = exchanges.get(streamId);
 
                 final long promiseId = supplyPromiseId.applyAsLong(exchange.requestId);
                 final MessageConsumer sender = supplySender.apply(promiseId);
@@ -3594,7 +3530,7 @@ public final class HttpClientFactory implements HttpStreamFactory
                 final HttpExchange promisedExchange =
                        new HttpExchange(this, sender, exchange.originId, exchange.routedId, promiseId, exchange.sessionId,
                                EMPTY_OVERRIDES, promisedStreamId);
-                pool.exchanges.put(promisedStreamId, promisedExchange);
+                exchanges.put(promisedStreamId, promisedExchange);
 
 
                 addNewPromise(traceId, promisedStreamId, headers);
@@ -3621,7 +3557,7 @@ public final class HttpClientFactory implements HttpStreamFactory
             int offset,
             int limit)
         {
-            final HttpExchange exchange = pool.exchanges.get(streamId);
+            final HttpExchange exchange = exchanges.get(streamId);
             if (exchange != null)
             {
                 final HpackHeaderBlockFW headerBlock = headerBlockRO.wrap(buffer, offset, limit);
@@ -3842,7 +3778,7 @@ public final class HttpClientFactory implements HttpStreamFactory
                     final long remoteInitialCredit = remoteSettings.initialWindowSize - remoteInitialBudget;
                     if (remoteInitialCredit != 0)
                     {
-                        for (HttpExchange stream: pool.exchanges.values())
+                        for (HttpExchange stream: exchanges.values())
                         {
                             final long newRemoteBudget = stream.remoteBudget + remoteInitialCredit;
                             if (newRemoteBudget > MAX_REMOTE_BUDGET)
@@ -3878,7 +3814,7 @@ public final class HttpClientFactory implements HttpStreamFactory
             // initial budget can become negative
             if (localInitialCredit != 0)
             {
-                for (HttpExchange stream: pool.exchanges.values())
+                for (HttpExchange stream: exchanges.values())
                 {
                     stream.localBudget += localInitialCredit;
                     stream.flushResponseWindowUpdate(traceId, authorization);
@@ -3937,7 +3873,7 @@ public final class HttpClientFactory implements HttpStreamFactory
             }
             else
             {
-                final HttpExchange exchange = pool.exchanges.get(streamId);
+                final HttpExchange exchange = exchanges.get(streamId);
                 if (exchange != null)
                 {
                     exchange.onRequestWindowUpdate(traceId, authorization, credit);
@@ -3972,7 +3908,7 @@ public final class HttpClientFactory implements HttpStreamFactory
         {
             final int lastStreamId = http2Goaway.lastStreamId();
 
-            pool.exchanges.entrySet()
+            exchanges.entrySet()
                     .stream()
                     .filter(e -> e.getKey() > lastStreamId)
                     .map(Map.Entry::getValue)
@@ -4344,7 +4280,7 @@ public final class HttpClientFactory implements HttpStreamFactory
                     {
                         cleanupEncodeSlotIfNecessary();
 
-                        if (pool.exchanges.isEmpty() && decoder == decodeHttp2IgnoreAll)
+                        if (exchanges.isEmpty() && decoder == decodeHttp2IgnoreAll)
                         {
                             doNetworkEnd(traceId, authorization);
                         }
@@ -4444,6 +4380,71 @@ public final class HttpClientFactory implements HttpStreamFactory
             return maxClientStreamId;
         }
 
+        private void flushNext()
+        {
+            dequeue:
+            while (httpQueueSlotOffset != httpQueueSlotLimit)
+            {
+                final MutableDirectBuffer httpQueueBuffer = bufferPool.buffer(httpQueueSlot);
+                final HttpQueueEntryFW queueEntry = queueEntryRO.wrap(httpQueueBuffer, httpQueueSlotOffset, httpQueueSlotLimit);
+                final int streamId = queueEntry.streamId();
+                final long traceId = queueEntry.traceId();
+                final long authorization = queueEntry.authorization();
+                final HttpExchange httpExchange = exchanges.get(streamId);
+                HttpClient client = null;
+
+                if (httpExchange != null)
+                {
+                    final HttpEncoder encoder = httpExchange.client.encoder;
+                    client = encoder == HttpEncoder.HTTP_2 ||
+                            encoder == HttpEncoder.HTTP_1_1 && httpExchange.client.exchange == null ||
+                            encoder == HttpEncoder.H2C ?
+                            httpExchange.client : pool.supplyClient(httpExchange.client.authority);
+
+                    if (client != null)
+                    {
+                        httpExchange.doRequestBegin(traceId, authorization, queueEntry.value());
+                    }
+                    else
+                    {
+                        httpExchange.doResponseAbort(traceId, authorization, EMPTY_OCTETS);
+                    }
+                }
+                httpQueueSlotOffset += queueEntry.sizeof();
+
+                if (client != null && client.encoder == HttpEncoder.H2C)
+                {
+                    break dequeue;
+                }
+            }
+
+            cleanupQueueSlotIfNecessary();
+        }
+
+        private void cleanupQueueSlotIfNecessary()
+        {
+            if (httpQueueSlot != NO_SLOT && httpQueueSlotOffset == httpQueueSlotLimit)
+            {
+                bufferPool.release(httpQueueSlot);
+                httpQueueSlot = NO_SLOT;
+                httpQueueSlotOffset = 0;
+                httpQueueSlotLimit = 0;
+            }
+        }
+
+        private void acquireQueueSlotIfNecessary()
+        {
+            if (httpQueueSlot == NO_SLOT)
+            {
+                httpQueueSlot = bufferPool.acquire(routedId);
+            }
+        }
+
+        private int availableSlotSize()
+        {
+            return bufferPool.slotCapacity() - httpQueueSlotLimit;
+        }
+
         private void cleanup(
             long traceId,
             long authorization,
@@ -4459,7 +4460,7 @@ public final class HttpClientFactory implements HttpStreamFactory
             long authorization)
         {
             int remaining = config.concurrentStreamsCleanup();
-            for (Iterator<HttpExchange> iterator = pool.exchanges.values().iterator();
+            for (Iterator<HttpExchange> iterator = exchanges.values().iterator();
                     iterator.hasNext() && remaining > 0; remaining--)
             {
                 final HttpExchange stream = iterator.next();
@@ -4468,6 +4469,8 @@ public final class HttpClientFactory implements HttpStreamFactory
                     stream.cleanup(traceId, authorization);
                 }
             }
+
+            cleanupQueueSlotIfNecessary();
 
             cleanupHandler.accept(traceId, authorization);
         }
@@ -4693,9 +4696,9 @@ public final class HttpClientFactory implements HttpStreamFactory
                 }
                 else
                 {
-                    client.pool.acquireQueueSlotIfNecessary();
-                    final MutableDirectBuffer httpQueueBuffer = bufferPool.buffer(client.pool.httpQueueSlot);
-                    final int headerSlotLimit = client.pool.httpQueueSlotLimit;
+                    client.acquireQueueSlotIfNecessary();
+                    final MutableDirectBuffer httpQueueBuffer = bufferPool.buffer(client.httpQueueSlot);
+                    final int headerSlotLimit = client.httpQueueSlotLimit;
                     final HttpQueueEntryFW queueEntry = queueEntryRW
                             .wrap(httpQueueBuffer, headerSlotLimit, httpQueueBuffer.capacity())
                             .streamId(streamId)
@@ -4704,7 +4707,7 @@ public final class HttpClientFactory implements HttpStreamFactory
                             .value(beginEx.buffer(), beginEx.offset(), beginEx.sizeof())
                             .build();
 
-                    client.pool.httpQueueSlotLimit += queueEntry.sizeof();
+                    client.httpQueueSlotLimit += queueEntry.sizeof();
                 }
             }
 
@@ -5054,11 +5057,11 @@ public final class HttpClientFactory implements HttpStreamFactory
 
         private void onExchangeClosed()
         {
-            final HttpExchange exchange = this.client.pool.exchanges.remove(streamId);
+            final HttpExchange exchange = this.client.exchanges.remove(streamId);
             if (exchange != null)
             {
                 client.exchange = null;
-                client.pool.flushNext();
+                client.flushNext();
             }
         }
 

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -42,6 +42,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.SortedSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
@@ -2063,8 +2064,12 @@ public final class HttpClientFactory implements HttpStreamFactory
             MessageConsumer newStream;
 
             final HttpBeginExFW beginEx = begin.extension().get(beginExRO::tryWrap);
+            final HttpHeaderFW authorityHeader = beginEx != null
+                    ? beginEx.headers().matchFirst(h -> HEADER_AUTHORITY.equals(h.name()))
+                    : null;
+            final String authority = authorityHeader != null ? authorityHeader.value().asString() : null;
 
-            HttpClient client = supplyClient();
+            HttpClient client = supplyClient(authority);
             final int queuedRequestLength = HttpQueueEntryFW.FIELD_OFFSET_VALUE_LENGTH + begin.extension().sizeof();
 
             if (client == null || queuedRequestLength > maximumRequestQueueSize)
@@ -2156,7 +2161,7 @@ public final class HttpClientFactory implements HttpStreamFactory
                     client = encoder == HttpEncoder.HTTP_2 ||
                             encoder == HttpEncoder.HTTP_1_1 && httpExchange.client.exchange == null ||
                             encoder == HttpEncoder.H2C ?
-                            httpExchange.client : supplyClient();
+                            httpExchange.client : supplyClient(httpExchange.client.authority);
 
                     if (client != null)
                     {
@@ -2197,19 +2202,22 @@ public final class HttpClientFactory implements HttpStreamFactory
             }
         }
 
-        private HttpClient supplyClient()
+        private HttpClient supplyClient(
+            String authority)
         {
             HttpClient client = clients.stream().filter(
-                c -> !HttpState.replyOpened(c.state) ||
+                c -> Objects.equals(c.authority, authority) &&
+                (!HttpState.replyOpened(c.state) ||
                 c.encoder == HttpEncoder.HTTP_2 ||
                 c.exchange == null && c.encoder == HttpEncoder.HTTP_1_1 ||
-                c.encoder == HttpEncoder.H2C)
+                c.encoder == HttpEncoder.H2C))
                 .findFirst()
                 .orElse(null);
 
             if (client == null && clients.size() < maximumConnectionsPerRoute)
             {
                 client = new HttpClient(this);
+                client.authority = authority;
                 onCreated(client);
             }
 
@@ -2304,6 +2312,7 @@ public final class HttpClientFactory implements HttpStreamFactory
         private int initialSharedBudget;
         private long requestSharedBudgetIndex = NO_CREDITOR_INDEX;
         private String protocolUpgrade = null;
+        private String authority;
 
         private HttpClient(
             HttpClientPool pool)

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/ConnectionManagementIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/ConnectionManagementIT.java
@@ -104,6 +104,16 @@ public class ConnectionManagementIT
     }
 
     @Test
+    @Configuration("client.authority.yaml")
+    @Specification({
+        "${app}/requests.different.authorities/client",
+        "${net}/requests.different.authorities/server" })
+    public void shouldNotReuseConnectionAcrossAuthorities() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Configuration("client.yaml")
     @Specification({
         "${app}/multiple.requests.pipelined/client",

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/ConnectionManagementIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/ConnectionManagementIT.java
@@ -126,6 +126,16 @@ public class ConnectionManagementIT
     @Test
     @Configuration("client.yaml")
     @Specification({
+        "${app}/concurrent.requests.same.authority/client",
+        "${net}/concurrent.requests.same.authority/server" })
+    public void shouldDistributeConcurrentRequestsToSameAuthorityAcrossConnections() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
         "${app}/multiple.requests.pipelined/client",
         "${net}/multiple.requests.pipelined/server" })
     @Ignore("Issuing pipelined requests is not yet implemented")

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/ConnectionManagementIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/ConnectionManagementIT.java
@@ -114,6 +114,16 @@ public class ConnectionManagementIT
     }
 
     @Test
+    @Configuration("client.authority.yaml")
+    @Specification({
+        "${app}/concurrent.requests.different.authorities/client",
+        "${net}/concurrent.requests.different.authorities/server" })
+    public void shouldHandleConcurrentRequestsToDifferentAuthorities() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Configuration("client.yaml")
     @Specification({
         "${app}/multiple.requests.pipelined/client",

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/client/ConnectionManagementIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/client/ConnectionManagementIT.java
@@ -66,6 +66,17 @@ public class ConnectionManagementIT
     }
 
     @Test
+    @Configuration("client.authorities.yaml")
+    @Specification({
+        "${app}/concurrent.requests.different.authorities/client",
+        "${net}/concurrent.requests.different.authorities/server" })
+    @Configure(name = HTTP_STREAM_INITIAL_WINDOW_NAME, value = "65535")
+    public void shouldHandleConcurrentRequestsToDifferentAuthorities() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Configuration("client.override.yaml")
     @Specification({
         "${app}/http.get.exchange.with.header.override/client",

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/client.authority.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/client.authority.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: http
+    kind: client
+    options:
+      versions:
+        - http/1.1
+    routes:
+      - exit: net0
+        when:
+          - headers:
+              :authority: authority-a:8080
+          - headers:
+              :authority: authority-b:8080

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/client.authorities.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/client.authorities.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: http
+    kind: client
+    options:
+      versions:
+        - h2
+    routes:
+      - exit: net0
+        when:
+          - headers:
+              :authority: authority-a:8080
+          - headers:
+              :authority: authority-b:8080

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/concurrent.requests.different.authorities/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/concurrent.requests.different.authorities/client.rpt
@@ -1,0 +1,63 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":scheme", "http")
+                              .header(":method", "GET")
+                              .header(":path", "/request1")
+                              .header(":authority", "authority-a:8080")
+                              .build()}
+connected
+
+write close
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":status", "200")
+                             .header("content-length", "9")
+                             .build()}
+
+read "response1"
+read closed
+
+connect "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":scheme", "http")
+                              .header(":method", "GET")
+                              .header(":path", "/request2")
+                              .header(":authority", "authority-b:8080")
+                              .build()}
+connected
+
+write close
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":status", "200")
+                             .header("content-length", "9")
+                             .build()}
+
+read "response2"
+read closed

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/concurrent.requests.same.authority/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/concurrent.requests.same.authority/client.rpt
@@ -1,0 +1,63 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":scheme", "http")
+                              .header(":method", "GET")
+                              .header(":path", "/")
+                              .header(":authority", "localhost:8080")
+                              .build()}
+connected
+
+write close
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":status", "200")
+                             .header("content-length", "8")
+                             .build()}
+
+read "response"
+read closed
+
+connect "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":scheme", "http")
+                              .header(":method", "GET")
+                              .header(":path", "/")
+                              .header(":authority", "localhost:8080")
+                              .build()}
+connected
+
+write close
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":status", "200")
+                             .header("content-length", "8")
+                             .build()}
+
+read "response"
+read closed

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/requests.different.authorities/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/requests.different.authorities/client.rpt
@@ -1,0 +1,65 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":scheme", "http")
+                              .header(":method", "GET")
+                              .header(":path", "/request1")
+                              .header(":authority", "authority-a:8080")
+                              .build()}
+connected
+
+write close
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":status", "200")
+                             .header("content-length", "9")
+                             .build()}
+
+read "response1"
+read closed
+read notify RESPONSE_ONE_RECEIVED
+
+connect await RESPONSE_ONE_RECEIVED
+        "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":scheme", "http")
+                              .header(":method", "GET")
+                              .header(":path", "/request2")
+                              .header(":authority", "authority-b:8080")
+                              .build()}
+connected
+
+write close
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":status", "200")
+                             .header("content-length", "9")
+                             .build()}
+
+read "response2"
+read closed

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/concurrent.requests.different.authorities/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/concurrent.requests.different.authorities/client.rpt
@@ -1,0 +1,59 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":method", "GET")
+                              .header(":scheme", "http")
+                              .header(":path", "/")
+                              .header(":authority", "authority-a:8080")
+                              .build()}
+connected
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":status", "200")
+                             .header("content-length", "9")
+                             .build()}
+
+read "response1"
+read closed
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":method", "GET")
+                              .header(":scheme", "http")
+                              .header(":path", "/")
+                              .header(":authority", "authority-b:8080")
+                              .build()}
+connected
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":status", "200")
+                             .header("content-length", "9")
+                             .build()}
+
+read "response2"
+read closed

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/concurrent.requests.different.authorities/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/concurrent.requests.different.authorities/server.rpt
@@ -1,0 +1,51 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property serverInitialWindow 8192
+
+accept "zilla://streams/net0"
+  option zilla:window ${serverInitialWindow}
+  option zilla:transmission "duplex"
+
+accepted
+connected
+
+read "GET /request1 HTTP/1.1" "\r\n"
+read "Host: authority-a:8080" "\r\n"
+read "\r\n"
+
+read notify REQUEST_A_RECEIVED
+write await REQUEST_B_RECEIVED
+
+write "HTTP/1.1 200 OK\r\n"
+write "Content-Length: 9" "\r\n"
+write "\r\n"
+write "response1"
+
+accepted
+connected
+
+read "GET /request2 HTTP/1.1" "\r\n"
+read "Host: authority-b:8080" "\r\n"
+read "\r\n"
+
+read notify REQUEST_B_RECEIVED
+write await REQUEST_A_RECEIVED
+
+write "HTTP/1.1 200 OK\r\n"
+write "Content-Length: 9" "\r\n"
+write "\r\n"
+write "response2"

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/concurrent.requests.same.authority/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/concurrent.requests.same.authority/server.rpt
@@ -1,0 +1,51 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property serverInitialWindow 8192
+
+accept "zilla://streams/net0"
+  option zilla:window ${serverInitialWindow}
+  option zilla:transmission "duplex"
+
+accepted
+connected
+
+read "GET / HTTP/1.1" "\r\n"
+read "Host: localhost:8080" "\r\n"
+read "\r\n"
+
+read notify REQUEST_1_RECEIVED
+write await REQUEST_2_RECEIVED
+
+write "HTTP/1.1 200 OK\r\n"
+write "Content-Length: 8" "\r\n"
+write "\r\n"
+write "response"
+
+accepted
+connected
+
+read "GET / HTTP/1.1" "\r\n"
+read "Host: localhost:8080" "\r\n"
+read "\r\n"
+
+read notify REQUEST_2_RECEIVED
+write await REQUEST_1_RECEIVED
+
+write "HTTP/1.1 200 OK\r\n"
+write "Content-Length: 8" "\r\n"
+write "\r\n"
+write "response"

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/requests.different.authorities/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/requests.different.authorities/server.rpt
@@ -1,0 +1,47 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property serverInitialWindow 8192
+
+accept "zilla://streams/net0"
+  option zilla:window ${serverInitialWindow}
+  option zilla:transmission "duplex"
+
+accepted
+connected
+
+read "GET /request1 HTTP/1.1" "\r\n"
+read "Host: authority-a:8080" "\r\n"
+read "\r\n"
+
+read notify REQUEST_ONE_RECEIVED
+
+write "HTTP/1.1 200 OK\r\n"
+write "Content-Length: 9" "\r\n"
+write "\r\n"
+write "response1"
+
+accepted
+connected
+
+read "GET /request2 HTTP/1.1" "\r\n"
+read "Host: authority-b:8080" "\r\n"
+read "\r\n"
+
+write "HTTP/1.1 200 OK\r\n"
+write "Content-Length: 9" "\r\n"
+write "\r\n"
+write "response2"

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/concurrent.requests.different.authorities/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/concurrent.requests.different.authorities/server.rpt
@@ -1,0 +1,145 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:window 8192
+       option zilla:transmission "duplex"
+
+# connection 1 - authority-a
+accepted
+connected
+
+write [0x00 0x00 0x12]                   # length = 18
+      [0x04]                             # HTTP2 SETTINGS frame
+      [0x00]                             # flags = 0x00
+      [0x00 0x00 0x00 0x00]              # stream_id = 0
+      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x04) = 0
+      [0x00 0x06 0x00 0x00 0x20 0x00]    # SETTINGS_MAX_HEADER_LIST_SIZE(0x06) = 8192
+write flush
+
+read "PRI * HTTP/2.0\r\n"
+     "\r\n"
+     "SM\r\n"
+     "\r\n"
+
+read  [0x00 0x00 0x0c]                   # length = 12
+      [0x04]                             # HTTP2 SETTINGS frame
+      [0x00]                             # flags = 0x00
+      [0x00 0x00 0x00 0x00]              # stream_id = 0
+      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0xff 0xff]    # SETTINGS_INITIAL_WINDOW_SIZE(0x04) = 65535
+
+write [0x00 0x00 0x00]                  # length = 0
+      [0x04]                            # HTTP2 SETTINGS frame
+      [0x01]                            # ACK
+      [0x00 0x00 0x00 0x00]             # stream_id = 0
+write flush
+
+read [0x00 0x00 0x15]                   # length = 21
+     [0x01]                             # HEADERS frame
+     [0x05]                             # END_HEADERS | END_STREAM
+     [0x00 0x00 0x00 0x01]              # stream_id = 1
+     [0x82]                             # :method: GET
+     [0x86]                             # :scheme: http
+     [0x84]                             # :path: /
+     [0x01] [0x10] "authority-a:8080"   # :authority: authority-a:8080
+
+read [0x00 0x00 0x00]                   # length = 0
+     [0x04]                             # HTTP2 SETTINGS frame
+     [0x01]                             # ACK
+     [0x00 0x00 0x00 0x00]              # stream_id = 0
+
+read notify REQUEST_A_RECEIVED
+write await REQUEST_B_RECEIVED
+
+write [0x00 0x00 0x05]                  # length = 5
+      [0x01]                            # HTTP2 HEADERS frame
+      [0x04]                            # END_HEADERS
+      [0x00 0x00 0x00 0x01]             # stream_id=1
+      [0x88]                            # :status: 200
+      [0x0f 0x0d] [0x01] "9"            # content-length: 9
+write flush
+
+write [0x00 0x00 0x09]                  # length = 9
+      [0x00]                            # HTTP2 DATA frame
+      [0x01]                            # END_STREAM
+      [0x00 0x00 0x00 0x01]             # stream_id=1
+      "response1"
+write flush
+
+# connection 2 - authority-b
+accepted
+connected
+
+write [0x00 0x00 0x12]                   # length = 18
+      [0x04]                             # HTTP2 SETTINGS frame
+      [0x00]                             # flags = 0x00
+      [0x00 0x00 0x00 0x00]              # stream_id = 0
+      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x04) = 0
+      [0x00 0x06 0x00 0x00 0x20 0x00]    # SETTINGS_MAX_HEADER_LIST_SIZE(0x06) = 8192
+write flush
+
+read "PRI * HTTP/2.0\r\n"
+     "\r\n"
+     "SM\r\n"
+     "\r\n"
+
+read  [0x00 0x00 0x0c]                   # length = 12
+      [0x04]                             # HTTP2 SETTINGS frame
+      [0x00]                             # flags = 0x00
+      [0x00 0x00 0x00 0x00]              # stream_id = 0
+      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0xff 0xff]    # SETTINGS_INITIAL_WINDOW_SIZE(0x04) = 65535
+
+write [0x00 0x00 0x00]                  # length = 0
+      [0x04]                            # HTTP2 SETTINGS frame
+      [0x01]                            # ACK
+      [0x00 0x00 0x00 0x00]             # stream_id = 0
+write flush
+
+read [0x00 0x00 0x15]                   # length = 21
+     [0x01]                             # HEADERS frame
+     [0x05]                             # END_HEADERS | END_STREAM
+     [0x00 0x00 0x00 0x01]              # stream_id = 1
+     [0x82]                             # :method: GET
+     [0x86]                             # :scheme: http
+     [0x84]                             # :path: /
+     [0x01] [0x10] "authority-b:8080"   # :authority: authority-b:8080
+
+read [0x00 0x00 0x00]                   # length = 0
+     [0x04]                             # HTTP2 SETTINGS frame
+     [0x01]                             # ACK
+     [0x00 0x00 0x00 0x00]              # stream_id = 0
+
+read notify REQUEST_B_RECEIVED
+write await REQUEST_A_RECEIVED
+
+write [0x00 0x00 0x05]                  # length = 5
+      [0x01]                            # HTTP2 HEADERS frame
+      [0x04]                            # END_HEADERS
+      [0x00 0x00 0x00 0x01]             # stream_id=1
+      [0x88]                            # :status: 200
+      [0x0f 0x0d] [0x01] "9"            # content-length: 9
+write flush
+
+write [0x00 0x00 0x09]                  # length = 9
+      [0x00]                            # HTTP2 DATA frame
+      [0x01]                            # END_STREAM
+      [0x00 0x00 0x00 0x01]             # stream_id=1
+      "response2"
+write flush


### PR DESCRIPTION
## Description

General `binding-http` client connection-management fixes, **extracted from the
`examples/mcp.proxy` branch (#1793)** so they can land on `develop` independently. The
defect surfaced via the MCP proxy's shared `sys:http_client` fanning out to multiple
upstream authorities, but it is general to `binding-http`: any single `http` client binding
that routes to more than one `:authority` is affected.

Fixes #1811.

## Changes

- **Reuse client connections per origin / `:authority`** via a `canServe` coalescing seam on
  `HttpClient` (previously `supplyClient()` reused any idle connection by HTTP version + idle
  state only, never matching `:authority`, so a request could be sent over a connection to a
  different host).
- **Scope `exchanges` + the request queue per connection** (moved from `HttpClientPool` down
  into `HttpClient`). Stream ids are per-connection (1, 3, 5 …), so the pool-wide map/queue
  collided across concurrent authorities and stalled a request.
- **Pin HTTP/2 stream-id scope per connection.**
- **Distribute concurrent same-origin requests across connections** (tiered `supplyClient`:
  prefer-ready / new-under-limit / at-limit-fallback).
- **Guard a null exchange** when decoding HTTP/1.1 response headers in a teardown race.

## Testing

`./mvnw verify -pl runtime/binding-http` — `rfc7230`/`rfc7540` client + server
connection-management ITs green, including new regression scenarios:

- `requests.different.authorities` — sequential requests to two authorities through one
  client binding must open two connections (old: response2 never arrives).
- `concurrent.requests.different.authorities` — two concurrent cross-authority exchanges
  coexist (old: `TestTimedOut`; new: passes).
- `concurrent.requests.same.authority` — concurrent same-origin requests distributed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
