### PR TITLE
feat(binding-mcp): single session-id contract, negotiated protocol-version, partial-success hydration

### DIFF
--- a/runtime/binding-echo/src/test/java/io/aklivity/zilla/runtime/binding/echo/internal/bench/EchoWorker.java
+++ b/runtime/binding-echo/src/test/java/io/aklivity/zilla/runtime/binding/echo/internal/bench/EchoWorker.java
@@ -86,6 +86,14 @@ public class EchoWorker implements EngineContext
     }
 
     @Override
+    public boolean isLocalIndex(
+        long bindingId,
+        int hash)
+    {
+        return true;
+    }
+
+    @Override
     public long supplyReplyId(
         long initialId)
     {

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfiguration.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfiguration.java
@@ -49,6 +49,7 @@ public class McpConfiguration extends Configuration
     public static final PropertyDef<Duration> MCP_INACTIVITY_TIMEOUT;
     public static final IntPropertyDef MCP_SESSION_ID_ATTEMPTS;
     public static final IntPropertyDef MCP_KEEPALIVE_TOLERANCE;
+    public static final IntPropertyDef MCP_HYDRATE_ATTEMPTS_MAX;
     public static final PropertyDef<Duration> MCP_SSE_KEEPALIVE_INTERVAL;
     public static final BooleanPropertyDef MCP_ALT_SVC_ENABLED;
     public static final PropertyDef<Duration> MCP_ALT_SVC_MAX_AGE;
@@ -76,6 +77,7 @@ public class McpConfiguration extends Configuration
         MCP_SESSION_ID_ATTEMPTS = config.property("session.id.attempts",
             McpConfiguration::defaultSessionIdAttempts);
         MCP_KEEPALIVE_TOLERANCE = config.property("keepalive.tolerance", 2);
+        MCP_HYDRATE_ATTEMPTS_MAX = config.property("hydrate.attempts.max", 5);
         MCP_SSE_KEEPALIVE_INTERVAL = config.property(Duration.class, "sse.keepalive.interval",
             (c, v) -> Duration.parse(v), "PT15S");
         MCP_ALT_SVC_ENABLED = config.property("alt.svc.enabled", McpConfiguration::defaultAltSvcEnabled);
@@ -144,6 +146,11 @@ public class McpConfiguration extends Configuration
     public int sessionIdAttempts()
     {
         return MCP_SESSION_ID_ATTEMPTS.getAsInt(this);
+    }
+
+    public int hydrateAttemptsMax()
+    {
+        return MCP_HYDRATE_ATTEMPTS_MAX.getAsInt(this);
     }
 
     public Duration sseKeepaliveInterval()

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.LongUnaryOperator;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -83,6 +84,7 @@ import io.aklivity.zilla.runtime.engine.concurrent.Signaler;
 import io.aklivity.zilla.runtime.engine.config.BindingConfig;
 import io.aklivity.zilla.runtime.engine.guard.GuardHandler;
 import io.aklivity.zilla.runtime.engine.guard.GuardHandler.LongCompletionCallback;
+import io.aklivity.zilla.runtime.engine.util.function.LongIntPredicate;
 
 public final class McpClientFactory implements McpStreamFactory
 {
@@ -92,6 +94,7 @@ public final class McpClientFactory implements McpStreamFactory
         SERVER_RESOURCES.value();
 
     private static final String JSON_KEY_CAPABILITIES = "capabilities";
+    private static final String JSON_KEY_PROTOCOL_VERSION = "protocolVersion";
     private static final String JSON_KEY_TOOLS = "tools";
     private static final String JSON_KEY_PROMPTS = "prompts";
     private static final String JSON_KEY_RESOURCES = "resources";
@@ -129,7 +132,7 @@ public final class McpClientFactory implements McpStreamFactory
     private static final String CONTENT_TYPE_JSON = "application/json";
     private static final String CONTENT_TYPE_JSON_AND_EVENT_STREAM = "application/json, text/event-stream";
     private static final String CONTENT_TYPE_EVENT_STREAM = "text/event-stream";
-    private static final String MCP_PROTOCOL_VERSION = "2025-11-25";
+    private static final String MCP_PROTOCOL_VERSION = "2025-06-18";
     private static final String HTTP_METHOD_GET = "GET";
     private static final String HTTP_METHOD_POST = "POST";
 
@@ -193,6 +196,9 @@ public final class McpClientFactory implements McpStreamFactory
     private final BindingHandler streamFactory;
     private final LongUnaryOperator supplyInitialId;
     private final LongUnaryOperator supplyReplyId;
+    private final Supplier<String> supplySessionId;
+    private final LongIntPredicate isLocalIndex;
+    private final int sessionIdAttempts;
     private final int httpTypeId;
     private final int mcpTypeId;
     private final int decodeMax;
@@ -207,6 +213,7 @@ public final class McpClientFactory implements McpStreamFactory
         "/jsonrpc",
         "/id",
         "/method",
+        "/protocolVersion",
         "/params/progressToken",
         "/params/progress",
         "/params/total",
@@ -247,6 +254,9 @@ public final class McpClientFactory implements McpStreamFactory
         this.streamFactory = context.streamFactory();
         this.supplyInitialId = context::supplyInitialId;
         this.supplyReplyId = context::supplyReplyId;
+        this.supplySessionId = config.sessionIdSupplier();
+        this.isLocalIndex = context::isLocalIndex;
+        this.sessionIdAttempts = config.sessionIdAttempts();
         this.bindings = new Long2ObjectHashMap<>();
         this.httpTypeId = context.supplyTypeId(HTTP_TYPE_NAME);
         this.mcpTypeId = context.supplyTypeId(MCP_TYPE_NAME);
@@ -288,6 +298,26 @@ public final class McpClientFactory implements McpStreamFactory
     {
         final McpStream session = sessions.get(sessionId);
         return session instanceof McpLifecycleStream ? (McpLifecycleStream) session : null;
+    }
+
+    // mint a per-route session id (Xc) aligned to this worker, so that subsequent request streams
+    // hash-routed by Xc.hashCode() land back here where its session state lives
+    private String newSessionId(
+        long routedId)
+    {
+        String sessionId = null;
+
+        for (int i = 0; i < sessionIdAttempts; i++)
+        {
+            final String candidate = supplySessionId.get();
+            if (isLocalIndex.test(routedId, candidate.hashCode()))
+            {
+                sessionId = candidate;
+                break;
+            }
+        }
+
+        return sessionId;
     }
 
     @FunctionalInterface
@@ -1429,9 +1459,15 @@ public final class McpClientFactory implements McpStreamFactory
 
                 if (mcpBeginEx.kind() == KIND_LIFECYCLE)
                 {
-                    newStream = new McpLifecycleStream(
-                        binding, sender, originId, routedId, initialId, route.id, affinity,
-                        mcpBeginEx.lifecycle().sessionId().asString(), route.with)::onAppMessage;
+                    final String requestSessionId = mcpBeginEx.lifecycle().sessionId().asString();
+                    assert requestSessionId == null;
+                    final String sessionId = newSessionId(routedId);
+                    if (sessionId != null)
+                    {
+                        newStream = new McpLifecycleStream(
+                            binding, sender, originId, routedId, initialId, route.id, affinity,
+                            sessionId, route.with)::onAppMessage;
+                    }
                 }
                 else
                 {
@@ -1632,9 +1668,14 @@ public final class McpClientFactory implements McpStreamFactory
         {
         }
 
-        String resumeSessionId()
+        String transportSessionId()
         {
             return sessionId;
+        }
+
+        String protocolVersion()
+        {
+            return MCP_PROTOCOL_VERSION;
         }
 
         boolean isEventsUnsupported()
@@ -2043,7 +2084,8 @@ public final class McpClientFactory implements McpStreamFactory
     {
         private final Int2ObjectHashMap<McpRequestStream> requests = new Int2ObjectHashMap<>();
 
-        String responseSessionId;
+        String remoteSessionId;
+        String negotiatedVersion;
         private int nextRequestId = 2;
         private long keepaliveId = Signaler.NO_CANCEL_ID;
         private long lastActiveAt;
@@ -2052,9 +2094,15 @@ public final class McpClientFactory implements McpStreamFactory
         boolean eventsUnsupported;
 
         @Override
-        String resumeSessionId()
+        String transportSessionId()
         {
-            return responseSessionId != null ? responseSessionId : sessionId;
+            return remoteSessionId != null ? remoteSessionId : sessionId;
+        }
+
+        @Override
+        String protocolVersion()
+        {
+            return negotiatedVersion != null ? negotiatedVersion : MCP_PROTOCOL_VERSION;
         }
 
         @Override
@@ -2267,11 +2315,11 @@ public final class McpClientFactory implements McpStreamFactory
         void onNetBegin(
             BeginFW begin)
         {
-            if (responseSessionId == null)
+            if (remoteSessionId == null)
             {
                 final OctetsFW ext = begin.extension();
                 final HttpBeginExFW httpBeginEx = httpBeginExRO.tryWrap(ext.buffer(), ext.offset(), ext.limit());
-                responseSessionId = httpBeginEx == null ? sessionId : Optional.ofNullable(httpBeginEx.headers()
+                remoteSessionId = httpBeginEx == null ? sessionId : Optional.ofNullable(httpBeginEx.headers()
                     .matchFirst(h -> HTTP_HEADER_SESSION.equals(h.name().asString())))
                     .map(HttpHeaderFW::value)
                     .map(String16FW::asString)
@@ -2298,7 +2346,7 @@ public final class McpClientFactory implements McpStreamFactory
             }
             else
             {
-                final String sid = responseSessionId;
+                final String sid = sessionId;
                 final int caps = serverCapabilities;
                 doAppBegin(traceId, authorization, mcpBeginExRW
                     .wrap(codecBuffer, 0, codecBuffer.capacity())
@@ -2476,9 +2524,15 @@ public final class McpClientFactory implements McpStreamFactory
         }
 
         @Override
-        String resumeSessionId()
+        String transportSessionId()
         {
-            return session.resumeSessionId();
+            return session.transportSessionId();
+        }
+
+        @Override
+        String protocolVersion()
+        {
+            return session.protocolVersion();
         }
 
         @Override
@@ -3901,7 +3955,7 @@ public final class McpClientFactory implements McpStreamFactory
                 .headersItem(h -> h.name(HTTP_HEADER_METHOD).value(HTTP_METHOD_POST))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                 .headersItem(h -> h.name(HTTP_HEADER_ACCEPT).value(CONTENT_TYPE_JSON_AND_EVENT_STREAM))
-                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(MCP_PROTOCOL_VERSION))
+                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(mcp.protocolVersion()))
                 .build();
 
             int codecLength = 0;
@@ -3971,7 +4025,15 @@ public final class McpClientFactory implements McpStreamFactory
                         break;
                     case KEY_NAME:
                         final String key = parser.getString();
-                        if (depth == 1 && JSON_KEY_CAPABILITIES.equals(key))
+                        if (depth == 1 && JSON_KEY_PROTOCOL_VERSION.equals(key))
+                        {
+                            if (parser.hasNext() && parser.next() == JsonParser.Event.VALUE_STRING &&
+                                mcp instanceof McpLifecycleStream lifecycle)
+                            {
+                                lifecycle.negotiatedVersion = parser.getString();
+                            }
+                        }
+                        else if (depth == 1 && JSON_KEY_CAPABILITIES.equals(key))
                         {
                             inCapabilities = true;
                         }
@@ -4023,7 +4085,7 @@ public final class McpClientFactory implements McpStreamFactory
             long traceId,
             long authorization)
         {
-            final String sid = ((McpLifecycleStream) mcp).responseSessionId;
+            final String sid = mcp.transportSessionId();
             final HttpBeginExFW.Builder builder = httpBeginExRW
                 .wrap(extBuffer, 0, extBuffer.capacity())
                 .typeId(httpTypeId);
@@ -4036,7 +4098,7 @@ public final class McpClientFactory implements McpStreamFactory
                 .headersItem(h -> h.name(HTTP_HEADER_METHOD).value(HTTP_METHOD_POST))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                 .headersItem(h -> h.name(HTTP_HEADER_ACCEPT).value(CONTENT_TYPE_JSON_AND_EVENT_STREAM))
-                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(MCP_PROTOCOL_VERSION))
+                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(mcp.protocolVersion()))
                 .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid))
                 .build();
 
@@ -4060,7 +4122,7 @@ public final class McpClientFactory implements McpStreamFactory
             long traceId,
             long authorization)
         {
-            final String sid = ((McpLifecycleStream) mcp).responseSessionId;
+            final String sid = mcp.transportSessionId();
             final HttpBeginExFW.Builder builder = httpBeginExRW
                 .wrap(extBuffer, 0, extBuffer.capacity())
                 .typeId(httpTypeId);
@@ -4073,7 +4135,7 @@ public final class McpClientFactory implements McpStreamFactory
                 .headersItem(h -> h.name(HTTP_HEADER_METHOD).value(HTTP_METHOD_POST))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                 .headersItem(h -> h.name(HTTP_HEADER_ACCEPT).value(CONTENT_TYPE_JSON_AND_EVENT_STREAM))
-                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(MCP_PROTOCOL_VERSION))
+                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(mcp.protocolVersion()))
                 .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid))
                 .build();
 
@@ -4105,7 +4167,7 @@ public final class McpClientFactory implements McpStreamFactory
             long traceId,
             long authorization)
         {
-            final String sid = mcp.resumeSessionId();
+            final String sid = mcp.transportSessionId();
             final HttpBeginExFW.Builder builder = httpBeginExRW
                 .wrap(extBuffer, 0, extBuffer.capacity())
                 .typeId(httpTypeId);
@@ -4117,7 +4179,7 @@ public final class McpClientFactory implements McpStreamFactory
             builder
                 .headersItem(h -> h.name(HTTP_HEADER_METHOD).value(HTTP_METHOD_GET))
                 .headersItem(h -> h.name(HTTP_HEADER_ACCEPT).value(CONTENT_TYPE_EVENT_STREAM))
-                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(MCP_PROTOCOL_VERSION))
+                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(mcp.protocolVersion()))
                 .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid));
             if (lastEventId != null && !lastEventId.isEmpty())
             {
@@ -4464,9 +4526,9 @@ public final class McpClientFactory implements McpStreamFactory
                 .headersItem(h -> h.name(HTTP_HEADER_METHOD).value(HTTP_METHOD_POST))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                 .headersItem(h -> h.name(HTTP_HEADER_ACCEPT).value(CONTENT_TYPE_JSON_AND_EVENT_STREAM))
-                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(MCP_PROTOCOL_VERSION));
+                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(mcp.protocolVersion()));
 
-            final String sid = mcp.sessionId;
+            final String sid = mcp.transportSessionId();
             extBuilder.headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid));
 
             final HttpBeginExFW httpBeginEx = extBuilder.build();
@@ -4506,9 +4568,9 @@ public final class McpClientFactory implements McpStreamFactory
                 .headersItem(h -> h.name(HTTP_HEADER_METHOD).value(HTTP_METHOD_POST))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                 .headersItem(h -> h.name(HTTP_HEADER_ACCEPT).value(CONTENT_TYPE_JSON_AND_EVENT_STREAM))
-                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(MCP_PROTOCOL_VERSION));
+                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(mcp.protocolVersion()));
 
-            final String sid = mcp.sessionId;
+            final String sid = mcp.transportSessionId();
             extBuilder.headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid));
 
             if (mcp.credentials != null)
@@ -4563,9 +4625,9 @@ public final class McpClientFactory implements McpStreamFactory
                 .headersItem(h -> h.name(HTTP_HEADER_METHOD).value(HTTP_METHOD_POST))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                 .headersItem(h -> h.name(HTTP_HEADER_ACCEPT).value(CONTENT_TYPE_JSON_AND_EVENT_STREAM))
-                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(MCP_PROTOCOL_VERSION));
+                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(mcp.protocolVersion()));
 
-            final String sid = mcp.sessionId;
+            final String sid = mcp.transportSessionId();
             extBuilder.headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid));
 
             final HttpBeginExFW httpBeginEx = extBuilder.build();
@@ -4606,9 +4668,9 @@ public final class McpClientFactory implements McpStreamFactory
                 .headersItem(h -> h.name(HTTP_HEADER_METHOD).value(HTTP_METHOD_POST))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                 .headersItem(h -> h.name(HTTP_HEADER_ACCEPT).value(CONTENT_TYPE_JSON_AND_EVENT_STREAM))
-                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(MCP_PROTOCOL_VERSION));
+                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(mcp.protocolVersion()));
 
-            final String sid = mcp.sessionId;
+            final String sid = mcp.transportSessionId();
             extBuilder.headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid));
 
             final HttpBeginExFW httpBeginEx = extBuilder.build();
@@ -4659,9 +4721,9 @@ public final class McpClientFactory implements McpStreamFactory
                 .headersItem(h -> h.name(HTTP_HEADER_METHOD).value(HTTP_METHOD_POST))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                 .headersItem(h -> h.name(HTTP_HEADER_ACCEPT).value(CONTENT_TYPE_JSON_AND_EVENT_STREAM))
-                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(MCP_PROTOCOL_VERSION));
+                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(mcp.protocolVersion()));
 
-            final String sid = mcp.sessionId;
+            final String sid = mcp.transportSessionId();
             extBuilder.headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid));
 
             final HttpBeginExFW httpBeginEx = extBuilder.build();
@@ -4702,9 +4764,9 @@ public final class McpClientFactory implements McpStreamFactory
                 .headersItem(h -> h.name(HTTP_HEADER_METHOD).value(HTTP_METHOD_POST))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                 .headersItem(h -> h.name(HTTP_HEADER_ACCEPT).value(CONTENT_TYPE_JSON_AND_EVENT_STREAM))
-                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(MCP_PROTOCOL_VERSION));
+                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(mcp.protocolVersion()));
 
-            final String sid = mcp.sessionId;
+            final String sid = mcp.transportSessionId();
             extBuilder.headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid));
 
             final HttpBeginExFW httpBeginEx = extBuilder.build();
@@ -4752,7 +4814,7 @@ public final class McpClientFactory implements McpStreamFactory
             long traceId,
             long authorization)
         {
-            final String sid = mcp.sessionId;
+            final String sid = mcp.transportSessionId();
             final HttpBeginExFW.Builder builder = httpBeginExRW
                 .wrap(extBuffer, 0, extBuffer.capacity())
                 .typeId(httpTypeId);
@@ -4763,7 +4825,7 @@ public final class McpClientFactory implements McpStreamFactory
             }
             final HttpBeginExFW httpBeginEx = builder
                 .headersItem(h -> h.name(HTTP_HEADER_METHOD).value("DELETE"))
-                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(MCP_PROTOCOL_VERSION))
+                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(mcp.protocolVersion()))
                 .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid))
                 .build();
 
@@ -4852,6 +4914,7 @@ public final class McpClientFactory implements McpStreamFactory
         private final long replyId;
         private final long affinity;
         private final String sessionId;
+        private final String protocolVersion;
         private final int requestId;
         private final McpWithConfig with;
 
@@ -4873,7 +4936,8 @@ public final class McpClientFactory implements McpStreamFactory
         {
             this.initialId = supplyInitialId.applyAsLong(mcp.resolvedId);
             this.replyId = supplyReplyId.applyAsLong(initialId);
-            this.sessionId = mcp.sessionId;
+            this.sessionId = mcp.transportSessionId();
+            this.protocolVersion = mcp.protocolVersion();
             this.requestId = mcp.requestId;
             this.originId = mcp.routedId;
             this.routedId = mcp.resolvedId;
@@ -4901,7 +4965,7 @@ public final class McpClientFactory implements McpStreamFactory
                 .headersItem(h -> h.name(HTTP_HEADER_METHOD).value(HTTP_METHOD_POST))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                 .headersItem(h -> h.name(HTTP_HEADER_ACCEPT).value(CONTENT_TYPE_JSON_AND_EVENT_STREAM))
-                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(MCP_PROTOCOL_VERSION))
+                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(protocolVersion))
                 .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid))
                 .build();
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyItemFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyItemFactory.java
@@ -26,6 +26,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpBindingConfig;
 import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpRouteConfig;
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyLifecycleFactory.McpLifecycleClient;
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyLifecycleFactory.McpLifecycleServer;
+import io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyLifecycleFactory.McpRouteRequest;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.Flyweight;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.OctetsFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.AbortFW;
@@ -40,6 +41,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.WindowFW;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.util.function.LongIntToLongFunction;
 
 abstract class McpProxyItemFactory implements BindingHandler
 {
@@ -69,7 +71,7 @@ abstract class McpProxyItemFactory implements BindingHandler
     private final MutableDirectBuffer writeBuffer;
     private final MutableDirectBuffer codecBuffer;
     private final BindingHandler streamFactory;
-    private final LongUnaryOperator supplyInitialId;
+    private final LongIntToLongFunction supplyInitialIdHash;
     private final LongUnaryOperator supplyReplyId;
     private final int mcpTypeId;
     private final LongFunction<McpBindingConfig> supplyBinding;
@@ -84,7 +86,7 @@ abstract class McpProxyItemFactory implements BindingHandler
         this.writeBuffer = context.writeBuffer();
         this.codecBuffer = new UnsafeBuffer(new byte[context.writeBuffer().capacity()]);
         this.streamFactory = context.streamFactory();
-        this.supplyInitialId = context::supplyInitialId;
+        this.supplyInitialIdHash = context::supplyInitialId;
         this.supplyReplyId = context::supplyReplyId;
         this.mcpTypeId = context.supplyTypeId(MCP_TYPE_NAME);
         this.supplyBinding = supplyBinding;
@@ -263,7 +265,7 @@ abstract class McpProxyItemFactory implements BindingHandler
 
             state = McpState.openingInitial(state);
 
-            client.doClientBegin(traceId, lifecycle.sessionId, identifier);
+            client.doClientBegin(traceId);
 
             flushServerWindow(traceId, 0L, 0, 0L, 0);
         }
@@ -492,15 +494,15 @@ abstract class McpProxyItemFactory implements BindingHandler
         }
     }
 
-    private final class McpClient
+    private final class McpClient implements McpRouteRequest
     {
         private final McpServer server;
         private final long originId;
         private final long routedId;
         private final McpLifecycleClient lifecycle;
 
-        private final long initialId;
-        private final long replyId;
+        private long initialId;
+        private long replyId;
 
         private MessageConsumer sender;
         private int state;
@@ -523,26 +525,44 @@ abstract class McpProxyItemFactory implements BindingHandler
             this.originId = server.lifecycle.originId;
             this.routedId = routedId;
             this.lifecycle = server.lifecycle.supplyClient(routedId);
-            this.initialId = supplyInitialId.applyAsLong(routedId);
-            this.replyId = supplyReplyId.applyAsLong(initialId);
         }
 
         private void doClientBegin(
-            long traceId,
-            String sessionId,
-            String identifier)
+            long traceId)
         {
             lifecycle.doClientBegin(traceId);
+            lifecycle.register(traceId, this);
+        }
 
-            final McpBeginExFW beginEx = mcpBeginExRW
-                .wrap(codecBuffer, 0, codecBuffer.capacity())
-                .typeId(mcpTypeId)
-                .inject(b -> injectInitialBeginEx(b, sessionId, identifier))
-                .build();
+        @Override
+        public void onLifecycleSettled(
+            long traceId)
+        {
+            if (McpState.initialClosed(state) || McpState.replyClosed(state))
+            {
+                return;
+            }
 
-            sender = newStream(this::onClientMessage, originId, routedId, initialId,
-                initialSeq, initialAck, initialMax, traceId, server.authorization, server.affinity, beginEx);
-            state = McpState.openingInitial(state);
+            final String sid = lifecycle.sessionId;
+            if (sid != null)
+            {
+                initialId = supplyInitialIdHash.apply(routedId, sid.hashCode());
+                replyId = supplyReplyId.applyAsLong(initialId);
+
+                final McpBeginExFW beginEx = mcpBeginExRW
+                    .wrap(codecBuffer, 0, codecBuffer.capacity())
+                    .typeId(mcpTypeId)
+                    .inject(b -> injectInitialBeginEx(b, sid, server.identifier))
+                    .build();
+
+                sender = newStream(this::onClientMessage, originId, routedId, initialId,
+                    initialSeq, initialAck, initialMax, traceId, server.authorization, server.affinity, beginEx);
+                state = McpState.openingInitial(state);
+            }
+            else
+            {
+                server.doServerReset(traceId);
+            }
         }
 
         private void doClientData(
@@ -580,8 +600,11 @@ abstract class McpProxyItemFactory implements BindingHandler
         {
             if (!McpState.initialClosed(state))
             {
-                doEnd(sender, originId, routedId, initialId,
-                    initialSeq, initialAck, initialMax, traceId, server.authorization);
+                if (McpState.initialOpening(state))
+                {
+                    doEnd(sender, originId, routedId, initialId,
+                        initialSeq, initialAck, initialMax, traceId, server.authorization);
+                }
                 state = McpState.closedInitial(state);
             }
         }
@@ -591,8 +614,11 @@ abstract class McpProxyItemFactory implements BindingHandler
         {
             if (!McpState.initialClosed(state))
             {
-                doAbort(sender, originId, routedId, initialId,
-                    initialSeq, initialAck, initialMax, traceId, server.authorization);
+                if (McpState.initialOpening(state))
+                {
+                    doAbort(sender, originId, routedId, initialId,
+                        initialSeq, initialAck, initialMax, traceId, server.authorization);
+                }
                 state = McpState.closedInitial(state);
             }
         }
@@ -602,9 +628,12 @@ abstract class McpProxyItemFactory implements BindingHandler
             long budgetId,
             int padding)
         {
-            state = McpState.openedReply(state);
-            doWindow(sender, originId, routedId, replyId,
-                replySeq, replyAck, replyMax, traceId, server.authorization, budgetId, padding);
+            if (McpState.initialOpening(state))
+            {
+                state = McpState.openedReply(state);
+                doWindow(sender, originId, routedId, replyId,
+                    replySeq, replyAck, replyMax, traceId, server.authorization, budgetId, padding);
+            }
         }
 
         private void flushClientWindow(
@@ -630,8 +659,11 @@ abstract class McpProxyItemFactory implements BindingHandler
         {
             if (!McpState.replyClosed(state))
             {
-                doReset(sender, originId, routedId, replyId,
-                    replySeq, replyAck, replyMax, traceId, server.authorization, emptyRO);
+                if (McpState.initialOpening(state))
+                {
+                    doReset(sender, originId, routedId, replyId,
+                        replySeq, replyAck, replyMax, traceId, server.authorization, emptyRO);
+                }
                 state = McpState.closedReply(state);
             }
         }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
@@ -19,9 +19,11 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeg
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.LongFunction;
 import java.util.function.LongUnaryOperator;
+import java.util.function.Supplier;
 
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -61,6 +63,7 @@ import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
 import io.aklivity.zilla.runtime.engine.concurrent.Signaler;
+import io.aklivity.zilla.runtime.engine.util.function.LongIntPredicate;
 
 final class McpProxyLifecycleFactory implements BindingHandler
 {
@@ -107,6 +110,9 @@ final class McpProxyLifecycleFactory implements BindingHandler
     private final LongUnaryOperator supplyReplyId;
     private final int mcpTypeId;
     private final LongFunction<McpBindingConfig> supplyBinding;
+    private final Supplier<String> supplySessionId;
+    private final LongIntPredicate isLocalIndex;
+    private final int sessionIdAttempts;
 
     McpProxyLifecycleFactory(
         McpConfiguration config,
@@ -123,6 +129,16 @@ final class McpProxyLifecycleFactory implements BindingHandler
         this.supplyReplyId = context::supplyReplyId;
         this.mcpTypeId = context.supplyTypeId(MCP_TYPE_NAME);
         this.supplyBinding = supplyBinding;
+        this.supplySessionId = config.sessionIdSupplier();
+        this.isLocalIndex = context::isLocalIndex;
+        this.sessionIdAttempts = config.sessionIdAttempts();
+    }
+
+    @FunctionalInterface
+    interface McpRouteRequest
+    {
+        void onLifecycleSettled(
+            long traceId);
     }
 
     @Override
@@ -148,9 +164,12 @@ final class McpProxyLifecycleFactory implements BindingHandler
 
         if (binding != null && beginEx != null && beginEx.kind() == KIND_LIFECYCLE)
         {
-            final String sessionId = beginEx.lifecycle().sessionId().asString();
+            final String requestSessionId = beginEx.lifecycle().sessionId().asString();
+            assert requestSessionId == null;
+
             final McpRouteConfig route = binding.resolve(beginEx, authorization);
-            if (route != null)
+            final String sessionId = route != null ? newSessionId(routedId) : null;
+            if (sessionId != null)
             {
                 final int clientCapabilities = beginEx.lifecycle().capabilities();
                 final McpLifecycleServer lifecycle = new McpLifecycleServer(
@@ -162,6 +181,24 @@ final class McpProxyLifecycleFactory implements BindingHandler
         }
 
         return newStream;
+    }
+
+    private String newSessionId(
+        long bindingId)
+    {
+        String sessionId = null;
+
+        for (int i = 0; i < sessionIdAttempts; i++)
+        {
+            final String candidate = supplySessionId.get();
+            if (isLocalIndex.test(bindingId, candidate.hashCode()))
+            {
+                sessionId = candidate;
+                break;
+            }
+        }
+
+        return sessionId;
     }
 
     final class McpLifecycleServer implements McpProxySession
@@ -702,6 +739,7 @@ final class McpProxyLifecycleFactory implements BindingHandler
         private int state;
         String sessionId;
         private String resumeId;
+        private final List<McpRouteRequest> requests = new ArrayList<>();
 
         private long initialSeq;
         private long initialAck;
@@ -729,18 +767,43 @@ final class McpProxyLifecycleFactory implements BindingHandler
         {
             if (!McpState.initialOpening(state))
             {
-                final String sid = server.sessionId;
                 final int clientCapabilities = server.clientCapabilities;
                 final McpBeginExFW beginEx = mcpBeginExRW
                     .wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(mcpTypeId)
-                    .lifecycle(l -> l.sessionId(sid).capabilities(clientCapabilities))
+                    .lifecycle(l -> l.capabilities(clientCapabilities))
                     .build();
 
-                sessionId = sid;
                 sender = newStream(this::onClientMessage, originId, routedId, initialId,
                     initialSeq, initialAck, initialMax, traceId, server.authorization, server.affinity, beginEx);
                 state = McpState.openingInitial(state);
+            }
+        }
+
+        void register(
+            long traceId,
+            McpRouteRequest request)
+        {
+            if (McpState.replyOpened(state) && sessionId != null ||
+                McpState.initialClosed(state) ||
+                McpState.replyClosed(state))
+            {
+                request.onLifecycleSettled(traceId);
+            }
+            else
+            {
+                requests.add(request);
+            }
+        }
+
+        private void settleRequests(
+            long traceId)
+        {
+            if (!requests.isEmpty())
+            {
+                final List<McpRouteRequest> copy = new ArrayList<>(requests);
+                requests.clear();
+                copy.forEach(request -> request.onLifecycleSettled(traceId));
             }
         }
 
@@ -906,6 +969,8 @@ final class McpProxyLifecycleFactory implements BindingHandler
 
             server.onClientLifecycleOpened(traceId);
 
+            settleRequests(traceId);
+
             if (resumeId != null || server.resumePending)
             {
                 doClientResume(traceId, authorization);
@@ -928,6 +993,7 @@ final class McpProxyLifecycleFactory implements BindingHandler
             assert replyAck <= replySeq;
 
             state = McpState.closedReply(state);
+            settleRequests(traceId);
             doClientEnd(traceId);
             server.clients.remove(routedId, this);
             server.doServerEnd(traceId);
@@ -949,6 +1015,7 @@ final class McpProxyLifecycleFactory implements BindingHandler
             assert replyAck <= replySeq;
 
             state = McpState.closedReply(state);
+            settleRequests(traceId);
             doClientAbort(traceId);
             server.clients.remove(routedId, this);
             server.doServerAbort(traceId);
@@ -991,6 +1058,7 @@ final class McpProxyLifecycleFactory implements BindingHandler
             assert initialAck <= initialSeq;
 
             state = McpState.closedInitial(state);
+            settleRequests(traceId);
             doClientReset(traceId);
             server.clients.remove(routedId, this);
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyListFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyListFactory.java
@@ -37,6 +37,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpBindingConfig;
 import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpRoutePrefix;
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyLifecycleFactory.McpLifecycleClient;
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyLifecycleFactory.McpLifecycleServer;
+import io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyLifecycleFactory.McpRouteRequest;
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.cache.McpProxyCache;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.Flyweight;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.OctetsFW;
@@ -54,6 +55,7 @@ import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
 import io.aklivity.zilla.runtime.engine.buffer.BufferPool;
+import io.aklivity.zilla.runtime.engine.util.function.LongIntToLongFunction;
 
 abstract class McpProxyListFactory implements BindingHandler
 {
@@ -86,7 +88,7 @@ abstract class McpProxyListFactory implements BindingHandler
     private final BindingHandler streamFactory;
     private final BufferPool bufferPool;
     private final int decodeMax;
-    private final LongUnaryOperator supplyInitialId;
+    private final LongIntToLongFunction supplyInitialIdHash;
     private final LongUnaryOperator supplyReplyId;
     private final LongSupplier supplyTraceId;
     private final int mcpTypeId;
@@ -117,7 +119,7 @@ abstract class McpProxyListFactory implements BindingHandler
         this.streamFactory = context.streamFactory();
         this.bufferPool = context.bufferPool();
         this.decodeMax = bufferPool.slotCapacity();
-        this.supplyInitialId = context::supplyInitialId;
+        this.supplyInitialIdHash = context::supplyInitialId;
         this.supplyReplyId = context::supplyReplyId;
         this.supplyTraceId = context::supplyTraceId;
         this.mcpTypeId = context.supplyTypeId(MCP_TYPE_NAME);
@@ -202,15 +204,15 @@ abstract class McpProxyListFactory implements BindingHandler
     protected abstract String sessionId(
         McpBeginExFW beginEx);
 
-    private final class McpListClient
+    private final class McpListClient implements McpRouteRequest
     {
         private final McpListServer server;
         private final long originId;
         private final long routedId;
         private final String8FW prefix;
         private final McpLifecycleClient lifecycle;
-        private final long initialId;
-        private final long replyId;
+        private long initialId;
+        private long replyId;
 
         private MessageConsumer sender;
         private int state;
@@ -247,25 +249,44 @@ abstract class McpProxyListFactory implements BindingHandler
             this.routedId = routedId;
             this.prefix = prefix;
             this.lifecycle = server.lifecycle.supplyClient(routedId);
-            this.initialId = supplyInitialId.applyAsLong(routedId);
-            this.replyId = supplyReplyId.applyAsLong(initialId);
         }
 
         private void doClientBegin(
             long traceId)
         {
             lifecycle.doClientBegin(traceId);
+            lifecycle.register(traceId, this);
+        }
+
+        @Override
+        public void onLifecycleSettled(
+            long traceId)
+        {
+            if (McpState.initialClosed(state) || McpState.replyClosed(state))
+            {
+                return;
+            }
 
             final String sid = lifecycle.sessionId;
-            final McpBeginExFW beginEx = mcpBeginExRW
-                .wrap(codecBuffer, 0, codecBuffer.capacity())
-                .typeId(mcpTypeId)
-                .inject(b -> injectInitialBeginEx(b, sid))
-                .build();
+            if (sid != null)
+            {
+                initialId = supplyInitialIdHash.apply(routedId, sid.hashCode());
+                replyId = supplyReplyId.applyAsLong(initialId);
 
-            sender = newStream(this::onClientMessage, originId, routedId, initialId,
-                initialSeq, initialAck, initialMax, traceId, server.authorization, server.affinity, beginEx);
-            state = McpState.openingInitial(state);
+                final McpBeginExFW beginEx = mcpBeginExRW
+                    .wrap(codecBuffer, 0, codecBuffer.capacity())
+                    .typeId(mcpTypeId)
+                    .inject(b -> injectInitialBeginEx(b, sid))
+                    .build();
+
+                sender = newStream(this::onClientMessage, originId, routedId, initialId,
+                    initialSeq, initialAck, initialMax, traceId, server.authorization, server.affinity, beginEx);
+                state = McpState.openingInitial(state);
+            }
+            else
+            {
+                server.onClientError(traceId);
+            }
         }
 
         private void doClientEnd(
@@ -274,8 +295,11 @@ abstract class McpProxyListFactory implements BindingHandler
             if (!McpState.initialClosed(state) &&
                 McpState.replyClosed(state))
             {
-                doEnd(sender, originId, routedId, initialId,
-                    initialSeq, initialAck, initialMax, traceId, server.authorization);
+                if (McpState.initialOpening(state))
+                {
+                    doEnd(sender, originId, routedId, initialId,
+                        initialSeq, initialAck, initialMax, traceId, server.authorization);
+                }
                 state = McpState.closedInitial(state);
             }
         }
@@ -285,8 +309,11 @@ abstract class McpProxyListFactory implements BindingHandler
         {
             if (!McpState.initialClosed(state))
             {
-                doAbort(sender, originId, routedId, initialId,
-                    initialSeq, initialAck, initialMax, traceId, server.authorization);
+                if (McpState.initialOpening(state))
+                {
+                    doAbort(sender, originId, routedId, initialId,
+                        initialSeq, initialAck, initialMax, traceId, server.authorization);
+                }
                 state = McpState.closedInitial(state);
             }
         }
@@ -296,8 +323,11 @@ abstract class McpProxyListFactory implements BindingHandler
         {
             if (!McpState.replyClosed(state))
             {
-                doReset(sender, originId, routedId, replyId,
-                    replySeq, replyAck, replyMax, traceId, server.authorization, emptyRO);
+                if (McpState.initialOpening(state))
+                {
+                    doReset(sender, originId, routedId, replyId,
+                        replySeq, replyAck, replyMax, traceId, server.authorization, emptyRO);
+                }
                 state = McpState.closedReply(state);
             }
         }
@@ -307,9 +337,12 @@ abstract class McpProxyListFactory implements BindingHandler
             long budgetId,
             int padding)
         {
-            state = McpState.openedReply(state);
-            doWindow(sender, originId, routedId, replyId,
-                replySeq, replyAck, replyMax, traceId, server.authorization, budgetId, padding);
+            if (McpState.initialOpening(state))
+            {
+                state = McpState.openedReply(state);
+                doWindow(sender, originId, routedId, replyId,
+                    replySeq, replyAck, replyMax, traceId, server.authorization, budgetId, padding);
+            }
         }
 
         private void flushClientWindow(
@@ -1677,8 +1710,18 @@ abstract class McpProxyListFactory implements BindingHandler
 
             if (cachedBuf == null)
             {
-                doServerAbort(traceId);
-                return;
+                if (!cache.degraded())
+                {
+                    doServerAbort(traceId);
+                    return;
+                }
+
+                final DirectBuffer prelude = listReplyOpenPrelude();
+                final byte[] empty = new byte[prelude.capacity() + listReplyCloseRO.capacity()];
+                prelude.getBytes(0, empty, 0, prelude.capacity());
+                listReplyCloseRO.getBytes(0, empty, prelude.capacity(), listReplyCloseRO.capacity());
+                cachedBuf = new UnsafeBuffer(empty);
+                cachedLen = empty.length;
             }
 
             while (emitOffset < cachedLen)

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -82,6 +82,7 @@ import io.aklivity.zilla.runtime.engine.buffer.BufferPool;
 import io.aklivity.zilla.runtime.engine.concurrent.Signaler;
 import io.aklivity.zilla.runtime.engine.config.BindingConfig;
 import io.aklivity.zilla.runtime.engine.util.function.LongIntPredicate;
+import io.aklivity.zilla.runtime.engine.util.function.LongIntToLongFunction;
 
 public final class McpServerFactory implements McpStreamFactory
 {
@@ -138,7 +139,7 @@ public final class McpServerFactory implements McpStreamFactory
     private static final String JSON_RPC_ERROR_MESSAGE = ",\"message\":\"";
     private static final String JSON_RPC_ERROR_SUFFIX = "\"}}";
     private static final String INITIALIZE_RESPONSE_PROTOCOL_PREFIX =
-        "{\"protocolVersion\":\"2025-11-25\",\"capabilities\":";
+        "{\"protocolVersion\":\"2025-06-18\",\"capabilities\":";
     private static final String INITIALIZE_RESPONSE_SERVER_INFO_PREFIX = ",\"serverInfo\":{\"name\":\"";
     private static final String INITIALIZE_RESPONSE_VERSION_PREFIX = "\",\"version\":\"";
     private static final String INITIALIZE_RESPONSE_SUFFIX = "\"}}";
@@ -207,6 +208,7 @@ public final class McpServerFactory implements McpStreamFactory
     private final MutableDirectBuffer codecBuffer;
     private final BindingHandler streamFactory;
     private final LongUnaryOperator supplyInitialId;
+    private final LongIntToLongFunction supplyInitialIdHash;
     private final LongUnaryOperator supplyReplyId;
     private final LongIntPredicate isLocalIndex;
     private final int httpTypeId;
@@ -269,6 +271,7 @@ public final class McpServerFactory implements McpStreamFactory
         this.codecBuffer = new UnsafeBuffer(new byte[context.writeBuffer().capacity()]);
         this.streamFactory = context.streamFactory();
         this.supplyInitialId = context::supplyInitialId;
+        this.supplyInitialIdHash = context::supplyInitialId;
         this.supplyReplyId = context::supplyReplyId;
         this.isLocalIndex = context::isLocalIndex;
         this.bindings = new Long2ObjectHashMap<>();
@@ -1816,7 +1819,6 @@ public final class McpServerFactory implements McpStreamFactory
                     .wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(mcpTypeId)
                     .lifecycle(i -> i
-                        .sessionId(session.sessionId)
                         .capabilities(CLIENT_CAPABILITIES))
                     .build();
                 session.doAppBegin(traceId, authorization, beginEx);
@@ -1911,7 +1913,7 @@ public final class McpServerFactory implements McpStreamFactory
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId)
                 .toolsList(t -> t
-                    .sessionId(session.sessionId))
+                    .sessionId(session.unifiedId))
                 .build();
 
             assert stream == null;
@@ -1928,7 +1930,7 @@ public final class McpServerFactory implements McpStreamFactory
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId)
                 .toolsCall(t -> t
-                    .sessionId(session.sessionId)
+                    .sessionId(session.unifiedId)
                     .name(name))
                 .build();
 
@@ -1945,7 +1947,7 @@ public final class McpServerFactory implements McpStreamFactory
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId)
                 .promptsList(p -> p
-                    .sessionId(session.sessionId))
+                    .sessionId(session.unifiedId))
                 .build();
 
             assert stream == null;
@@ -1962,7 +1964,7 @@ public final class McpServerFactory implements McpStreamFactory
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId)
                 .promptsGet(p -> p
-                    .sessionId(session.sessionId)
+                    .sessionId(session.unifiedId)
                     .name(name))
                 .build();
 
@@ -1979,7 +1981,7 @@ public final class McpServerFactory implements McpStreamFactory
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId)
                 .resourcesList(r -> r
-                    .sessionId(session.sessionId))
+                    .sessionId(session.unifiedId))
                 .build();
 
             assert stream == null;
@@ -1996,7 +1998,7 @@ public final class McpServerFactory implements McpStreamFactory
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId)
                 .resourcesRead(r -> r
-                    .sessionId(session.sessionId)
+                    .sessionId(session.unifiedId)
                     .uri(uri))
                 .build();
 
@@ -2948,6 +2950,7 @@ public final class McpServerFactory implements McpStreamFactory
     private final class McpLifecycleStream
     {
         private final String sessionId;
+        private String unifiedId;
         private final Object2ObjectHashMap<String, McpRequestStream> requests;
         private final Object2ObjectHashMap<String, McpRequestStream> elicitations;
 
@@ -3166,7 +3169,9 @@ public final class McpServerFactory implements McpStreamFactory
             if (beginEx != null && beginEx.kind() == KIND_LIFECYCLE)
             {
                 serverCapabilities = beginEx.lifecycle().capabilities();
+                unifiedId = beginEx.lifecycle().sessionId().asString();
             }
+            assert unifiedId != null;
 
             server.doEncodeInitialize(traceId, authorization);
 
@@ -4045,7 +4050,8 @@ public final class McpServerFactory implements McpStreamFactory
             this.server = server;
             this.originId = server.routedId;
             this.routedId = server.resolvedId;
-            this.initialId = supplyInitialId.applyAsLong(server.resolvedId);
+            assert session.unifiedId != null;
+            this.initialId = supplyInitialIdHash.apply(server.resolvedId, session.unifiedId.hashCode());
             this.replyId = supplyReplyId.applyAsLong(initialId);
         }
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -19,7 +19,6 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabiliti
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabilities.CLIENT_SAMPLING;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_LIFECYCLE;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
-import static io.aklivity.zilla.runtime.engine.internal.stream.StreamId.streamIndex;
 
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -82,7 +81,7 @@ import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
 import io.aklivity.zilla.runtime.engine.buffer.BufferPool;
 import io.aklivity.zilla.runtime.engine.concurrent.Signaler;
 import io.aklivity.zilla.runtime.engine.config.BindingConfig;
-import io.aklivity.zilla.runtime.engine.util.function.LongLongFunction;
+import io.aklivity.zilla.runtime.engine.util.function.LongIntPredicate;
 
 public final class McpServerFactory implements McpStreamFactory
 {
@@ -208,8 +207,8 @@ public final class McpServerFactory implements McpStreamFactory
     private final MutableDirectBuffer codecBuffer;
     private final BindingHandler streamFactory;
     private final LongUnaryOperator supplyInitialId;
-    private final LongLongFunction<Long> supplyInitialIdByHash;
     private final LongUnaryOperator supplyReplyId;
+    private final LongIntPredicate isLocalIndex;
     private final int httpTypeId;
     private final int mcpTypeId;
     private final BufferPool decodePool;
@@ -250,7 +249,6 @@ public final class McpServerFactory implements McpStreamFactory
     private final McpConfiguration config;
     private final Long2ObjectHashMap<McpBindingConfig> bindings;
     private final Map<String, McpServerFactory.McpLifecycleStream> sessions;
-    private final int localIndex;
 
     public McpServerFactory(
         McpConfiguration config,
@@ -271,8 +269,8 @@ public final class McpServerFactory implements McpStreamFactory
         this.codecBuffer = new UnsafeBuffer(new byte[context.writeBuffer().capacity()]);
         this.streamFactory = context.streamFactory();
         this.supplyInitialId = context::supplyInitialId;
-        this.supplyInitialIdByHash = (bindingId, hash) -> context.supplyInitialId(bindingId, (int) hash);
         this.supplyReplyId = context::supplyReplyId;
+        this.isLocalIndex = context::isLocalIndex;
         this.bindings = new Long2ObjectHashMap<>();
         this.httpTypeId = context.supplyTypeId(HTTP_TYPE_NAME);
         this.mcpTypeId = context.supplyTypeId(MCP_TYPE_NAME);
@@ -282,7 +280,6 @@ public final class McpServerFactory implements McpStreamFactory
         this.encodeMax = encodePool.slotCapacity();
         this.sessionIdAttempts = config.sessionIdAttempts();
         this.sessions = new Object2ObjectHashMap<>();
-        this.localIndex = context.index();
         this.parserFactory = StreamingJson.createParserFactory(Map.of(
             StreamingJson.PATH_INCLUDES, SERVER_JSON_PATH_INCLUDES,
             StreamingJson.TOKEN_MAX_BYTES, decodeMax));
@@ -376,7 +373,7 @@ public final class McpServerFactory implements McpStreamFactory
                 .orElse(null);
             final String altSvc = buildAltSvc(authority);
 
-            if (sessionId != null && !isSessionIdAligned(resolvedId, sessionId))
+            if (sessionId != null && !isSessionIdAligned(routedId, sessionId))
             {
                 newStream = new McpRedirectHandler(
                     sender,
@@ -1802,7 +1799,7 @@ public final class McpServerFactory implements McpStreamFactory
             long traceId,
             long authorization)
         {
-            final String sessionId = newSessionId(resolvedId);
+            final String sessionId = newSessionId(routedId);
             if (sessionId == null)
             {
                 doNetReset(traceId, authorization);
@@ -5276,14 +5273,14 @@ public final class McpServerFactory implements McpStreamFactory
     }
 
     private String newSessionId(
-        long resolvedId)
+        long routedId)
     {
         String sessionId = null;
 
         for (int i = 0; i < sessionIdAttempts; i++)
         {
             final String candidate = supplySessionId.get();
-            if (isSessionIdAligned(resolvedId, candidate))
+            if (isSessionIdAligned(routedId, candidate))
             {
                 sessionId = candidate;
                 break;
@@ -5294,12 +5291,10 @@ public final class McpServerFactory implements McpStreamFactory
     }
 
     private boolean isSessionIdAligned(
-        long resolvedId,
+        long routedId,
         String sessionId)
     {
-        final long initialId = supplyInitialIdByHash.apply(resolvedId, sessionId.hashCode());
-        final int alignedIndex = streamIndex(initialId);
-        return alignedIndex == localIndex;
+        return isLocalIndex.test(routedId, sessionId.hashCode());
     }
 
     private String extractSessionIdFromState(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCache.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCache.java
@@ -56,6 +56,7 @@ public final class McpProxyCache
     public final Duration leaseTtl;
     public final Duration renewTtl;
     public final Duration leaseRetry;
+    public final int hydrateAttemptsMax;
     public final Duration cacheTtl;
 
     public String sessionId;
@@ -97,6 +98,7 @@ public final class McpProxyCache
         this.leaseTtl = config.leaseTtl();
         this.renewTtl = this.leaseTtl.dividedBy(3);
         this.leaseRetry = config.leaseRetry();
+        this.hydrateAttemptsMax = config.hydrateAttemptsMax();
         this.cacheTtl = cache.ttl;
         this.awaiters = new ArrayList<>();
         this.caches = new Int2ObjectHashMap<>();
@@ -198,11 +200,22 @@ public final class McpProxyCache
         populated = false;
     }
 
+    public void markDegraded(
+        int kind)
+    {
+        final McpListCache cache = caches.get(kind);
+        if (cache != null && !cache.populated)
+        {
+            cache.degraded = true;
+            checkReady();
+        }
+    }
+
     private void checkReady()
     {
         for (McpListCache cache : caches.values())
         {
-            if (!cache.populated)
+            if (!cache.settled())
             {
                 return;
             }
@@ -229,6 +242,17 @@ public final class McpProxyCache
         private String lockToken;
 
         boolean populated;
+        boolean degraded;
+
+        boolean settled()
+        {
+            return populated || degraded;
+        }
+
+        public boolean degraded()
+        {
+            return degraded;
+        }
 
         private McpListCache(
             int kind,
@@ -313,6 +337,10 @@ public final class McpProxyCache
                 changed = false;
             }
             populated = value != null;
+            if (populated)
+            {
+                degraded = false;
+            }
             checkReady();
             onSettled.accept(kind, changed);
         }
@@ -321,6 +349,7 @@ public final class McpProxyCache
             String key)
         {
             populated = true;
+            degraded = false;
             checkReady();
         }
     }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCacheHydrater.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCacheHydrater.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.LongSupplier;
 import java.util.function.LongUnaryOperator;
-import java.util.function.Supplier;
 
 import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
@@ -61,7 +60,6 @@ final class McpProxyCacheHydrater
     private final LongUnaryOperator supplyReplyId;
     private final LongSupplier supplyTraceId;
     private final int mcpTypeId;
-    private final Supplier<String> supplySessionId;
 
     private final BeginFW beginRO = new BeginFW();
     private final EndFW endRO = new EndFW();
@@ -70,6 +68,7 @@ final class McpProxyCacheHydrater
     private final FlushFW flushRO = new FlushFW();
     private final ResetFW resetRO = new ResetFW();
     private final WindowFW windowRO = new WindowFW();
+    private final McpBeginExFW mcpBeginExRO = new McpBeginExFW();
     private final McpFlushExFW mcpFlushExRO = new McpFlushExFW();
     private final BeginFW.Builder beginRW = new BeginFW.Builder();
     private final EndFW.Builder endRW = new EndFW.Builder();
@@ -92,7 +91,6 @@ final class McpProxyCacheHydrater
         this.supplyReplyId = context::supplyReplyId;
         this.supplyTraceId = context::supplyTraceId;
         this.mcpTypeId = context.supplyTypeId("mcp");
-        this.supplySessionId = config.sessionIdSupplier();
 
         this.hydraters = new Int2ObjectHashMap<>();
         hydraters.put(KIND_TOOLS_LIST, new McpToolsListHydrater());
@@ -183,7 +181,6 @@ final class McpProxyCacheHydrater
             if (acquired)
             {
                 final long traceId = supplyTraceId.getAsLong();
-                cache.sessionId = supplySessionId.get();
                 cache.authorization = cache.guard != null
                     ? cache.guard.reauthorize(traceId, cache.bindingId, 0L, cache.credentials)
                     : 0L;
@@ -333,6 +330,16 @@ final class McpProxyCacheHydrater
         {
             final long traceId = begin.traceId();
             state = McpState.openingReply(state);
+
+            final OctetsFW extension = begin.extension();
+            final McpBeginExFW beginEx = extension.sizeof() > 0
+                ? mcpBeginExRO.tryWrap(extension.buffer(), extension.offset(), extension.limit())
+                : null;
+            if (beginEx != null && beginEx.kind() == McpBeginExFW.KIND_LIFECYCLE)
+            {
+                handler.cache.sessionId = beginEx.lifecycle().sessionId().asString();
+            }
+
             doLifecycleWindow(traceId);
             handler.onLifecycleOpened(traceId);
         }
@@ -394,7 +401,7 @@ final class McpProxyCacheHydrater
             final McpBeginExFW beginEx = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId)
-                .lifecycle(l -> l.sessionId(handler.cache.sessionId))
+                .lifecycle(l -> l.capabilities(0))
                 .build();
 
             receiver = newStream(this::onLifecycleMessage, originId, routedId, initialId,

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCacheManager.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCacheManager.java
@@ -38,6 +38,7 @@ public final class McpProxyCacheManager implements McpProxyCacheListener
     private final Signaler signaler;
     private final long[] hydrateBackoffMs;
     private final long[] hydrateRetryIds;
+    private final int[] hydrateAttempts;
     private final Closeable[] watchHandles;
 
     private McpProxyCacheHandler handler;
@@ -57,6 +58,7 @@ public final class McpProxyCacheManager implements McpProxyCacheListener
         this.signaler = signaler;
         this.hydrateBackoffMs = new long[KIND_SLOTS];
         this.hydrateRetryIds = new long[KIND_SLOTS];
+        this.hydrateAttempts = new int[KIND_SLOTS];
         this.watchHandles = new Closeable[KIND_SLOTS];
         Arrays.fill(this.hydrateRetryIds, NO_CANCEL_ID);
         this.refreshId = NO_CANCEL_ID;
@@ -123,6 +125,7 @@ public final class McpProxyCacheManager implements McpProxyCacheListener
             return;
         }
         Arrays.fill(hydrateBackoffMs, 0L);
+        Arrays.fill(hydrateAttempts, 0);
         sessionBackoffMs = 0L;
         scheduleLifecycleRenew();
         for (int kind : cache.caches().keySet())
@@ -149,6 +152,8 @@ public final class McpProxyCacheManager implements McpProxyCacheListener
         {
             return;
         }
+        hydrateBackoffMs[kind] = 0L;
+        hydrateAttempts[kind] = 0;
         cancelRefresh();
         handler.hydrate(kind);
     }
@@ -253,6 +258,11 @@ public final class McpProxyCacheManager implements McpProxyCacheListener
         int kind)
     {
         cancelHydrateRetry(kind);
+        if (++hydrateAttempts[kind] >= cache.hydrateAttemptsMax)
+        {
+            cache.markDegraded(kind);
+            return;
+        }
         long delay = hydrateBackoffMs[kind];
         delay = delay == 0L ? cache.leaseRetry.toMillis() : Math.min(delay * 2L, cache.leaseTtl.toMillis());
         hydrateBackoffMs[kind] = delay;

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfigurationTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfigurationTest.java
@@ -19,6 +19,7 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration.MC
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration.MCP_CLIENT_NAME;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration.MCP_CLIENT_VERSION;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration.MCP_ELICITATION_ID;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration.MCP_HYDRATE_ATTEMPTS_MAX;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration.MCP_HYDRATE_FILTER;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration.MCP_INACTIVITY_TIMEOUT;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration.MCP_KEEPALIVE_TOLERANCE;
@@ -48,6 +49,7 @@ public class McpConfigurationTest
     public static final String MCP_INACTIVITY_TIMEOUT_NAME = "zilla.binding.mcp.inactivity.timeout";
     public static final String MCP_SESSION_ID_ATTEMPTS_NAME = "zilla.binding.mcp.session.id.attempts";
     public static final String MCP_KEEPALIVE_TOLERANCE_NAME = "zilla.binding.mcp.keepalive.tolerance";
+    public static final String MCP_HYDRATE_ATTEMPTS_MAX_NAME = "zilla.binding.mcp.hydrate.attempts.max";
     public static final String MCP_SSE_KEEPALIVE_INTERVAL_NAME = "zilla.binding.mcp.sse.keepalive.interval";
     public static final String MCP_ALT_SVC_ENABLED_NAME = "zilla.binding.mcp.alt.svc.enabled";
     public static final String MCP_ALT_SVC_MAX_AGE_NAME = "zilla.binding.mcp.alt.svc.max.age";
@@ -69,6 +71,7 @@ public class McpConfigurationTest
         assertEquals(MCP_INACTIVITY_TIMEOUT.name(), MCP_INACTIVITY_TIMEOUT_NAME);
         assertEquals(MCP_SESSION_ID_ATTEMPTS.name(), MCP_SESSION_ID_ATTEMPTS_NAME);
         assertEquals(MCP_KEEPALIVE_TOLERANCE.name(), MCP_KEEPALIVE_TOLERANCE_NAME);
+        assertEquals(MCP_HYDRATE_ATTEMPTS_MAX.name(), MCP_HYDRATE_ATTEMPTS_MAX_NAME);
         assertEquals(MCP_SSE_KEEPALIVE_INTERVAL.name(), MCP_SSE_KEEPALIVE_INTERVAL_NAME);
         assertEquals(MCP_ALT_SVC_ENABLED.name(), MCP_ALT_SVC_ENABLED_NAME);
         assertEquals(MCP_ALT_SVC_MAX_AGE.name(), MCP_ALT_SVC_MAX_AGE_NAME);

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientIT.java
@@ -19,6 +19,7 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfigurationTes
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfigurationTest.MCP_CLIENT_NAME_NAME;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfigurationTest.MCP_CLIENT_VERSION_NAME;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfigurationTest.MCP_INACTIVITY_TIMEOUT_NAME;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfigurationTest.MCP_SESSION_ID_NAME;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
@@ -48,6 +49,7 @@ public class McpClientIT
         .configurationRoot("io/aklivity/zilla/specs/binding/mcp/config")
         .configure(MCP_CLIENT_NAME_NAME, "test")
         .configure(MCP_CLIENT_VERSION_NAME, "1.0")
+        .configure(MCP_SESSION_ID_NAME, "%s::sessionId".formatted(McpClientIT.class.getName()))
         .external("net0")
         .clean();
 
@@ -60,6 +62,16 @@ public class McpClientIT
         "${app}/lifecycle.initialize/client",
         "${net}/lifecycle.initialize/server"})
     public void shouldInitializeLifecycle() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${app}/lifecycle.initialize/client",
+        "${net}/lifecycle.initialize.version/server"})
+    public void shouldInitializeLifecycleWithNegotiatedVersion() throws Exception
     {
         k3po.finish();
     }
@@ -559,5 +571,10 @@ public class McpClientIT
     public void shouldGetPromptWith100kMessageWithProgress() throws Exception
     {
         k3po.finish();
+    }
+
+    public static String sessionId()
+    {
+        return "session-1";
     }
 }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheIT.java
@@ -14,14 +14,18 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
 
+import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfigurationTest.MCP_HYDRATE_ATTEMPTS_MAX_NAME;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfigurationTest.MCP_HYDRATE_FILTER_NAME;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfigurationTest.MCP_SESSION_ID_NAME;
 import static io.aklivity.zilla.runtime.engine.test.EngineRule.ENGINE_BUFFER_SLOT_CAPACITY_NAME;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
+import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -132,6 +136,19 @@ public class McpProxyCacheIT
         "${app}/cache.serve.tools.list/client" })
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
     public void shouldServeToolsList() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.cache.yaml")
+    @Specification({
+        "${app}/cache.serve.tools.list.degraded/server",
+        "${app}/cache.serve.tools.list.degraded/client" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
+    @Configure(name = MCP_HYDRATE_ATTEMPTS_MAX_NAME, value = "1")
+    public void shouldServeToolsListWhenDegraded() throws Exception
     {
         k3po.finish();
     }
@@ -329,9 +346,18 @@ public class McpProxyCacheIT
         k3po.finish();
     }
 
+    private static final List<String> SESSION_IDS = List.of("hydrate-1", "agent-1");
+    private static Iterator<String> sessionIds = SESSION_IDS.iterator();
+
     public static String sessionId()
     {
-        return "hydrate-1";
+        return sessionIds.next();
+    }
+
+    @After
+    public void resetSessionIds()
+    {
+        sessionIds = SESSION_IDS.iterator();
     }
 
     private static final String[] CONTENDED_SESSION_IDS = { "hydrate-A", "hydrate-B" };

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -14,6 +14,7 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
 
+import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfigurationTest.MCP_SESSION_ID_NAME;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
@@ -40,6 +41,7 @@ public class McpProxyIT
         .directory("target/zilla-itests")
         .countersBufferCapacity(8192)
         .configurationRoot("io/aklivity/zilla/specs/binding/mcp/config")
+        .configure(MCP_SESSION_ID_NAME, "%s::sessionId".formatted(McpProxyIT.class.getName()))
         .external("app1")
         .external("app2")
         .clean();
@@ -522,5 +524,10 @@ public class McpProxyIT
     public void shouldCallToolElicitTimeoutProxied() throws Exception
     {
         k3po.finish();
+    }
+
+    public static String sessionId()
+    {
+        return "session-1";
     }
 }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleIT.java
@@ -14,6 +14,7 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
 
+import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfigurationTest.MCP_SESSION_ID_NAME;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
@@ -40,6 +41,7 @@ public class McpProxyLifecycleIT
         .directory("target/zilla-itests")
         .countersBufferCapacity(8192)
         .configurationRoot("io/aklivity/zilla/specs/binding/mcp/config")
+        .configure(MCP_SESSION_ID_NAME, "%s::sessionId".formatted(McpProxyLifecycleIT.class.getName()))
         .external("app1")
         .clean();
 
@@ -121,5 +123,10 @@ public class McpProxyLifecycleIT
     public void shouldRejectLifecycleInitializeWithBearerChallenge() throws Exception
     {
         k3po.finish();
+    }
+
+    public static String sessionId()
+    {
+        return "agent-1";
     }
 }

--- a/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/bench/TlsWorker.java
+++ b/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/bench/TlsWorker.java
@@ -157,6 +157,14 @@ public class TlsWorker implements EngineContext
     }
 
     @Override
+    public boolean isLocalIndex(
+        long bindingId,
+        int hash)
+    {
+        return true;
+    }
+
+    @Override
     public long supplyReplyId(
         long initialId)
     {

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineContext.java
@@ -125,6 +125,22 @@ public interface EngineContext
         int hash);
 
     /**
+     * Returns {@code true} if hash-based affinity for the given binding and {@code hash}
+     * selects this thread, {@code false} otherwise. Equivalent to checking whether
+     * {@link #supplyInitialId(long, int)} with the same arguments would pin a stream to
+     * this thread, but without allocating a stream id. The selection is deterministic:
+     * {@code Math.floorMod(hash, mask.cardinality())} over the binding's affinity mask.
+     *
+     * @param bindingId  the binding id whose affinity mask to consult
+     * @param hash       opaque integer hash; same hash yields the same result for a
+     *                   given binding affinity mask
+     * @return {@code true} if hash maps to this thread; otherwise {@code false}
+     */
+    boolean isLocalIndex(
+        long bindingId,
+        int hash);
+
+    /**
      * Returns the reply (outbound) stream id paired with the given initial stream id.
      *
      * @param initialId  the initial stream id

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -544,6 +544,14 @@ public class EngineWorker implements EngineContext, Agent
     }
 
     @Override
+    public boolean isLocalIndex(
+        long bindingId,
+        int hash)
+    {
+        return localIndex == resolveRemoteIndex(bindingId, hash);
+    }
+
+    @Override
     public long supplyReplyId(
         long initialId)
     {

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/util/function/LongIntPredicate.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/util/function/LongIntPredicate.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.util.function;
+
+/**
+ * A predicate that accepts one {@code long} and one {@code int} argument,
+ * avoiding the boxing overhead of {@link java.util.function.BiPredicate BiPredicate&lt;Long, Integer&gt;}.
+ */
+@FunctionalInterface
+public interface LongIntPredicate
+{
+    /**
+     * Evaluates this predicate on the given arguments.
+     *
+     * @param value1  the {@code long} argument
+     * @param value2  the {@code int} argument
+     * @return {@code true} if the input arguments match the predicate, otherwise {@code false}
+     */
+    boolean test(long value1, int value2);
+}

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/util/function/LongIntToLongFunction.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/util/function/LongIntToLongFunction.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.util.function;
+
+/**
+ * A function that accepts one {@code long} and one {@code int} argument and produces a
+ * {@code long} result, avoiding the boxing overhead of
+ * {@link java.util.function.BiFunction BiFunction&lt;Long, Integer, Long&gt;}.
+ */
+@FunctionalInterface
+public interface LongIntToLongFunction
+{
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param value1  the {@code long} argument
+     * @param value2  the {@code int} argument
+     * @return the function result
+     */
+    long apply(long value1, int value2);
+}

--- a/specs/binding-mcp.spec/src/main/resources/META-INF/zilla/mcp.idl
+++ b/specs/binding-mcp.spec/src/main/resources/META-INF/zilla/mcp.idl
@@ -123,7 +123,7 @@ scope mcp
 
         struct McpLifecycleBeginEx
         {
-            string16 sessionId;
+            string16 sessionId = null;
             uint16 capabilities = 0;
         }
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.100k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.100k/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("hydrate-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.100k/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("hydrate-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.10k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.10k/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("hydrate-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.10k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.10k/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("hydrate-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.credentials/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.credentials/client.rpt
@@ -23,7 +23,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("hydrate-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.credentials/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.credentials/server.rpt
@@ -26,7 +26,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("hydrate-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.error/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.error/client.rpt
@@ -21,7 +21,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("hydrate-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.error/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.error/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("hydrate-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.lifecycle.reconnect/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.lifecycle.reconnect/client.rpt
@@ -21,7 +21,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("hydrate-1")
                                .build()
                            .build()}
 
@@ -113,7 +112,6 @@ connect await LIFECYCLE_ABORTED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("hydrate-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.lifecycle.reconnect/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.lifecycle.reconnect/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("hydrate-1")
                               .build()
                           .build()}
 
@@ -109,7 +108,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("hydrate-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit/client.rpt
@@ -21,7 +21,6 @@ connect "zilla://streams/app1"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("hydrate-1")
                                .build()
                            .build()}
 
@@ -107,7 +106,6 @@ connect await APP1_RESOURCES
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("hydrate-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit/server.rpt
@@ -22,7 +22,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("hydrate-1")
                               .build()
                           .build()}
 
@@ -105,7 +104,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("hydrate-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("hydrate-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("hydrate-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed.after.tools.call/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed.after.tools.call/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("agent-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed.after.tools.call/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed.after.tools.call/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("hydrate-1")
                               .build()
                           .build()}
 
@@ -73,7 +72,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("agent-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed.during.refresh/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed.during.refresh/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("agent-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed.during.refresh/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed.during.refresh/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("hydrate-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("agent-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("hydrate-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.prompts/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.prompts/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("hydrate-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.prompts/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.prompts/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("hydrate-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.resources/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.resources/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("hydrate-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.resources/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.resources/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("hydrate-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.contended/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.contended/client.rpt
@@ -21,7 +21,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("hydrate-A")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.contended/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.contended/server.rpt
@@ -25,7 +25,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("hydrate-A")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.error.retry/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.error.retry/client.rpt
@@ -21,7 +21,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("hydrate-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.error.retry/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.error.retry/server.rpt
@@ -25,7 +25,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("hydrate-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.error/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.error/client.rpt
@@ -21,7 +21,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("hydrate-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.error/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.error/server.rpt
@@ -25,7 +25,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("hydrate-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.notify/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.notify/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("agent-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("hydrate-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("hydrate-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.initialize/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.initialize/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("agent-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.initialize/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.initialize/server.rpt
@@ -25,7 +25,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("agent-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.prompts.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.prompts.list/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("agent-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.prompts.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.prompts.list/server.rpt
@@ -25,7 +25,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("agent-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.resources.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.resources.list/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("agent-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.resources.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.resources.list/server.rpt
@@ -25,7 +25,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("agent-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.100k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.100k/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("agent-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.100k/server.rpt
@@ -25,7 +25,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("agent-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.10k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.10k/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("agent-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.10k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.10k/server.rpt
@@ -25,7 +25,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("agent-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.degraded/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.degraded/client.rpt
@@ -1,0 +1,54 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("agent-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("agent-1")
+                               .build()
+                           .build()}
+
+connected
+
+read '{"tools":[]}'
+read closed
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.degraded/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.degraded/server.rpt
@@ -1,0 +1,51 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("hydrate-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("hydrate-1")
+                              .build()
+                          .build()}
+
+connected
+
+write abort

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.during.hydrate/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.during.hydrate/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("agent-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.during.hydrate/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.during.hydrate/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("hydrate-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("agent-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list/server.rpt
@@ -25,7 +25,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("agent-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.reject.bearer/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.reject.bearer/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("agent-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.reject.bearer/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.reject.bearer/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("agent-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.read.abort/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.read.abort/client.rpt
@@ -21,7 +21,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("agent-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.read.abort/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.read.abort/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("agent-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.write.abort/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.write.abort/client.rpt
@@ -21,7 +21,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("agent-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.write.abort/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.write.abort/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("agent-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.write.close/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.write.close/client.rpt
@@ -21,7 +21,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("agent-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.write.close/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.write.close/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("agent-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.evict/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.evict/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.evict/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.evict/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.keepalive/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.keepalive/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.keepalive/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.keepalive/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.open/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.open/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.open/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.open/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.aggregate.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.aggregate.prefixed/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.aggregate/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.aggregate/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app1"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 
@@ -55,7 +54,6 @@ connect "zilla://streams/app2"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.aggregate/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.aggregate/server.rpt
@@ -22,7 +22,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 
@@ -60,7 +59,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.duplicate/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.duplicate/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.duplicate/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.duplicate/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.partial.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.partial.prefixed/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.partial.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.partial.prefixed/server.rpt
@@ -22,7 +22,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 
@@ -63,7 +62,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.partial/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.partial/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app1"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.partial/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.partial/server.rpt
@@ -22,7 +22,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.reject.bearer/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.reject.bearer/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.reject.bearer/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.reject.bearer/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.unsupported/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.unsupported/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.unsupported/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.unsupported/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.aborted/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.aborted/server.rpt
@@ -22,7 +22,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.alt.svc/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.alt.svc/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.alt.svc/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.alt.svc/server.rpt
@@ -22,7 +22,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.reject.bearer.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.reject.bearer.toolkit.multi/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.reject.bearer.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.reject.bearer.toolkit.multi/server.rpt
@@ -22,7 +22,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 
@@ -47,7 +46,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.reject.bearer/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.reject.bearer/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.reject.bearer/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.reject.bearer/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.prompts.list.changed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.prompts.list.changed/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.prompts.list.changed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.prompts.list.changed/server.rpt
@@ -22,7 +22,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.resources.list.changed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.resources.list.changed/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.resources.list.changed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.resources.list.changed/server.rpt
@@ -22,7 +22,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.tools.list.changed.toolkit.multi.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.tools.list.changed.toolkit.multi.prefixed/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.tools.list.changed.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.tools.list.changed.toolkit.multi/server.rpt
@@ -22,7 +22,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 
@@ -89,7 +88,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.tools.list.changed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.tools.list.changed/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.tools.list.changed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.tools.list.changed/server.rpt
@@ -22,7 +22,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.ping/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.ping/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.ping/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.ping/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.read.abort/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.read.abort/client.rpt
@@ -21,7 +21,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("agent-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.read.abort/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.read.abort/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("agent-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.write.abort/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.write.abort/client.rpt
@@ -21,7 +21,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("agent-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.write.abort/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.write.abort/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("agent-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.write.close/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.write.close/client.rpt
@@ -21,7 +21,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("agent-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.write.close/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.write.close/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("agent-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.events/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.events/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.events/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.events/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.requests/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.requests/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.requests/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.requests/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.suspend.events/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.suspend.events/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.suspend.events/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.suspend.events/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.suspended.events/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.suspended.events/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.suspended.events/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.suspended.events/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout.events/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout.events/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout.events/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout.events/server.rpt
@@ -22,7 +22,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout.rejected/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout.rejected/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout.rejected/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout.rejected/server.rpt
@@ -22,7 +22,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout/server.rpt
@@ -22,7 +22,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.100k.with.progress/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.100k.with.progress/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.10k.with.progress/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.10k.with.progress/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.aborted/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.aborted/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit.prefixed/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit.prefixed/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.aborted/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.aborted/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi.prefixed/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi.prefixed/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app1"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 
@@ -68,7 +67,6 @@ connect await SERVER_1_DONE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/server.rpt
@@ -22,7 +22,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 
@@ -69,7 +68,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.prefixed/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.prefixed/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.method.before.id/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.method.before.id/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.method.before.id/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.method.before.id/server.rpt
@@ -22,7 +22,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.params.array/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.params.array/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.params.array/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.params.array/server.rpt
@@ -22,7 +22,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.params.before.method/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.params.before.method/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.params.before.method/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.params.before.method/server.rpt
@@ -22,7 +22,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.aborted/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.aborted/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi.prefixed/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi.prefixed/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app1"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 
@@ -68,7 +67,6 @@ connect await SERVER_1_DONE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/server.rpt
@@ -22,7 +22,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 
@@ -69,7 +68,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.prefixed/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.prefixed/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k.with.progress/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k.with.progress/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k.with.progress/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k.with.progress/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.aborted/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.aborted/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit.prefixed/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit.prefixed/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k.with.progress/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k.with.progress/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k.with.progress/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k.with.progress/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.aborted/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.aborted/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.guarded/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.guarded/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.guarded/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.guarded/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.proxied/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.proxied/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.proxied/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.proxied/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.guarded/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.guarded/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.guarded/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.guarded/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.proxied/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.proxied/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.proxied/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.proxied/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.guarded/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.guarded/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.guarded/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.guarded/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.proxied/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.proxied/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.proxied/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.proxied/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.reject.bearer/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.reject.bearer/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.reject.bearer/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.reject.bearer/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit.prefixed/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit.prefixed/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.prefixed/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.prefixed/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress.prefixed/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress.prefixed/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.resume/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.resume/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.resume/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.resume/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspend/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspend/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspend/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspend/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspended/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspended/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspended/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspended/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.aborted/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.aborted/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.canceled/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.canceled/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.canceled/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.canceled/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.prefixed/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.prefixed/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app1"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 
@@ -68,7 +67,6 @@ connect await SERVER_1_DONE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/server.rpt
@@ -22,7 +22,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 
@@ -69,7 +68,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.prefixed/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.prefixed/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list/client.rpt
@@ -20,7 +20,6 @@ connect "zilla://streams/app0"
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("session-1")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list/server.rpt
@@ -24,7 +24,6 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.evict/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.evict/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -81,7 +81,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
                             .header("accept", "text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -109,7 +109,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
                             .header("accept", "text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.evict/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.evict/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -78,7 +78,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":method", "GET")
                            .header(":path", "/mcp")
                            .header("accept", "text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -102,7 +102,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":method", "GET")
                            .header(":path", "/mcp")
                            .header("accept", "text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.keepalive/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.keepalive/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -81,7 +81,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
                             .header("accept", "text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.keepalive/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.keepalive/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -78,7 +78,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":method", "GET")
                            .header(":path", "/mcp")
                            .header("accept", "text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.open/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.open/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -81,7 +81,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
                             .header("accept", "text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.open/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.open/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -78,7 +78,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":method", "GET")
                            .header(":path", "/mcp")
                            .header("accept", "text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.resume.reject.bearer/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.resume.reject.bearer/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -81,7 +81,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
                             .header("accept", "text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .header("last-event-id", "event-99")
                             .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.resume.reject.bearer/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.resume.reject.bearer/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -78,7 +78,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":method", "GET")
                            .header(":path", "/mcp")
                            .header("accept", "text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .header("last-event-id", "event-99")
                            .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.resume/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.resume/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -81,7 +81,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
                             .header("accept", "text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .header("last-event-id", "event-99")
                             .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.resume/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.resume/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -78,7 +78,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":method", "GET")
                            .header(":path", "/mcp")
                            .header("accept", "text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .header("last-event-id", "event-99")
                            .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.session.missing/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.session.missing/client.rpt
@@ -24,7 +24,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
                             .header("accept", "text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 # TODO: enable once k3po supports `connect aborted` followed by `read zilla:reset.ext`

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.session.missing/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.session.missing/server.rpt
@@ -24,7 +24,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":method", "GET")
                            .header(":path", "/mcp")
                            .header("accept", "text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 # TODO: enable once k3po supports a `reject zilla:reset.ext ${...}` primitive

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.session.unknown/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.session.unknown/client.rpt
@@ -24,7 +24,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
                             .header("accept", "text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-unknown")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.session.unknown/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.session.unknown/server.rpt
@@ -24,7 +24,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":method", "GET")
                            .header(":path", "/mcp")
                            .header("accept", "text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-unknown")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.unsupported/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.unsupported/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -81,7 +81,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
                             .header("accept", "text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.unsupported/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.unsupported/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -78,7 +78,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":method", "GET")
                            .header(":path", "/mcp")
                            .header("accept", "text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.aborted/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read aborted

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.aborted/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write abort

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.alt.svc/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.alt.svc/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -41,7 +41,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("alt-svc", "http=\":8080\"; ma=86400")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -58,7 +58,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.alt.svc/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.alt.svc/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -42,7 +42,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -55,7 +55,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.reject.bearer/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.reject.bearer/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.reject.bearer/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.reject.bearer/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.version/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.version/client.rpt
@@ -1,0 +1,70 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "POST")
+                            .header(":scheme", "http")
+                            .header(":authority", "localhost:8080")
+                            .header(":path", "/mcp")
+                            .header("content-type", "application/json")
+                            .header("accept", "application/json, text/event-stream")
+                            .header("mcp-protocol-version", "2025-06-18")
+                            .build()}
+
+connected
+
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write close
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":status", "200")
+                           .header("content-type", "application/json")
+                           .header("mcp-session-id", "session-1")
+                           .headerMissing("alt-svc")
+                           .build()}
+
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read closed
+read notify LIFECYCLE_INITIALIZING
+
+connect await LIFECYCLE_INITIALIZING
+        "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "POST")
+                            .header(":scheme", "http")
+                            .header(":authority", "localhost:8080")
+                            .header(":path", "/mcp")
+                            .header("content-type", "application/json")
+                            .header("accept", "application/json, text/event-stream")
+                            .header("mcp-protocol-version", "2025-03-26")
+                            .header("mcp-session-id", "session-1")
+                            .build()}
+
+connected
+
+write '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+write close
+
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.version/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.version/server.rpt
@@ -1,0 +1,72 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-06-18")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "200")
+                            .header("content-type", "application/json")
+                            .header("mcp-session-id", "session-1")
+                            .build()}
+write flush
+
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write flush
+
+write close
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-03-26")
+                           .header("mcp-session-id", "session-1")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "202")
+                            .build()}
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -41,7 +41,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .headerMissing("alt-svc")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -58,7 +58,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.prompts.list.changed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.prompts.list.changed/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -81,7 +81,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
                             .header("accept", "text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.prompts.list.changed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.prompts.list.changed/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -78,7 +78,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":method", "GET")
                            .header(":path", "/mcp")
                            .header("accept", "text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.resources.list.changed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.resources.list.changed/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -81,7 +81,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
                             .header("accept", "text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.resources.list.changed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.resources.list.changed/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -78,7 +78,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":method", "GET")
                            .header(":path", "/mcp")
                            .header("accept", "text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.tools.list.changed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.tools.list.changed/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -81,7 +81,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
                             .header("accept", "text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.tools.list.changed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.tools.list.changed/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -78,7 +78,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":method", "GET")
                            .header(":path", "/mcp")
                            .header("accept", "text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.ping/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.ping/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.ping/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.ping/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.events/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.events/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -81,7 +81,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
                             .header("accept", "text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -108,7 +108,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":scheme", "http")
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.events/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.events/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -78,7 +78,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":method", "GET")
                            .header(":path", "/mcp")
                            .header("accept", "text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -101,7 +101,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "DELETE")
                            .header(":path", "/mcp")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.requests/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.requests/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -107,7 +107,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":scheme", "http")
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.requests/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.requests/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -98,7 +98,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "DELETE")
                            .header(":path", "/mcp")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -80,7 +80,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":scheme", "http")
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -77,7 +77,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "DELETE")
                            .header(":path", "/mcp")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.suspend.events/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.suspend.events/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -81,7 +81,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
                             .header("accept", "text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.suspend.events/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.suspend.events/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -78,7 +78,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":method", "GET")
                            .header(":path", "/mcp")
                            .header("accept", "text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.suspended.events/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.suspended.events/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -81,7 +81,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
                             .header("accept", "text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.suspended.events/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.suspended.events/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -78,7 +78,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":method", "GET")
                            .header(":path", "/mcp")
                            .header("accept", "text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout.events/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout.events/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -81,7 +81,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
                             .header("accept", "text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout.events/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout.events/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -78,7 +78,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":method", "GET")
                            .header(":path", "/mcp")
                            .header("accept", "text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout.rejected/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout.rejected/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -107,7 +107,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -130,7 +130,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":scheme", "http")
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout.rejected/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout.rejected/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -98,7 +98,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -115,7 +115,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "DELETE")
                            .header(":path", "/mcp")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.100k.with.progress/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.100k.with.progress/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.10k.with.progress/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.10k.with.progress/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.aborted/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.aborted/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.list.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.list.aborted/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.list.aborted/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.list/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.list/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.accept.unsupported/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.accept.unsupported/client.rpt
@@ -25,7 +25,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/xml")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 # TODO: enable once k3po supports `connect aborted` followed by `read zilla:reset.ext`

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.accept.unsupported/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.accept.unsupported/server.rpt
@@ -25,7 +25,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/xml")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 # TODO: enable once k3po supports a `reject zilla:reset.ext ${...}` primitive

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.method.not.allowed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.method.not.allowed/client.rpt
@@ -23,7 +23,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":scheme", "http")
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 # TODO: enable once k3po supports `connect aborted` followed by `read zilla:reset.ext`

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.method.not.allowed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.method.not.allowed/server.rpt
@@ -23,7 +23,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":method", "PUT")
                            .header(":path", "/mcp")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 # TODO: enable once k3po supports a `reject zilla:reset.ext ${...}` primitive

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.method.before.id/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.method.before.id/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.method.before.id/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.method.before.id/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.array/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.array/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.array/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.array/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.before.method/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.before.method/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.before.method/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.before.method/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.list.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.list.aborted/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.list.aborted/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.list/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.list/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k.with.progress/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k.with.progress/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k.with.progress/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k.with.progress/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.aborted/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.aborted/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k.with.progress/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k.with.progress/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k.with.progress/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k.with.progress/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.aborted/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.aborted/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed.proxied/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed.proxied/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed.proxied/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed.proxied/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined.proxied/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined.proxied/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined.proxied/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined.proxied/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.timeout/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.timeout/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.timeout/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.timeout/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.reject.bearer/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.reject.bearer/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.reject.bearer/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.reject.bearer/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.resume/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.resume/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -120,7 +120,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":authority", "localhost:8080")
                             .header(":path", "/mcp")
                             .header("accept", "text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .header("last-event-id", "2:1")
                             .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.resume/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.resume/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -114,7 +114,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":method", "GET")
                            .header(":path", "/mcp")
                            .header("accept", "text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .header("last-event-id", "2:1")
                            .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspend/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspend/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspend/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspend/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspended/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspended/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspended/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspended/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list.aborted/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list.aborted/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list.canceled/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list.canceled/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -113,7 +113,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list.canceled/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list.canceled/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -107,7 +107,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list/client.rpt
@@ -25,12 +25,12 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
@@ -40,7 +40,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("mcp-session-id", "session-1")
                            .build()}
 
-read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed
 read notify LIFECYCLE_INITIALIZING
 
@@ -57,7 +57,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 
@@ -82,7 +82,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header(":path", "/mcp")
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
-                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
                             .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list/server.rpt
@@ -25,12 +25,12 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
@@ -41,7 +41,7 @@ write zilla:begin.ext ${http:beginEx()
                             .build()}
 write flush
 
-write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close
@@ -54,7 +54,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 
@@ -79,7 +79,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header(":path", "/mcp")
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
-                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
                            .build()}
 

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
@@ -47,6 +47,15 @@ public class NetworkIT
 
     @Test
     @Specification({
+        "${net}/lifecycle.initialize.version/client",
+        "${net}/lifecycle.initialize.version/server"})
+    public void shouldInitializeLifecycleWithNegotiatedVersion() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${net}/lifecycle.initialize.reject.bearer/client",
         "${net}/lifecycle.initialize.reject.bearer/server"})
     public void shouldRejectLifecycleInitializeOnUpstreamBearerChallenge() throws Exception


### PR DESCRIPTION
## Description

The **single session-id contract** across the mcp server/proxy/client, with **negotiated
MCP-Protocol-Version** and **per-toolkit partial-success hydration**. Fixes the mcp.proxy
`400 "No valid session ID"` retry-storm (the cache hydrater originated a local session id
the remote never issued).

**Extracted from the `examples/mcp.proxy` branch (#1793)**; second of three sequential
binding-mcp extractions (cache refresh #1813 → **this** → proxy fixes + bootstrap credential).
Fixes #1815.

## Commits

1. **`feat(engine,binding-mcp): isLocalIndex worker affinity + worker-aligned local
   session-id generation`** — a prerequisite split from the example commit "prevent stall on
   local sessionId generation" (example edits excluded). Adds the engine SPI
   `EngineContext.isLocalIndex` + `LongIntPredicate` util (`EngineWorker` impl;
   `EchoWorker`/`TlsWorker` test EngineContext implementers updated per the engine SPI
   convention), and mints worker-aligned session ids in `McpServerFactory`.
2. **`feat(binding-mcp): single session-id contract, negotiated protocol-version,
   partial-success hydration`** — see below.

## What commit 2 does

**Single session-id contract (WS1):** lifecycle (`initialize`) requests carry no sessionId;
the reply carries the minted id; non-lifecycle requests carry it (one id per stream). The
**proxy** mints a worker-aligned unified id and is the sole minter/mapper, hash-routing each
south request by its id; the **server** maps `S↔U` and still returns `S` on the HTTP
`mcp-session-id` header; the **client** adopts the remote-minted `X` for the outbound HTTP
header; the **cache hydrater** sends no id and adopts the proxy-minted one. New engine util
`LongIntToLongFunction` for hash-routed `supplyInitialId`.

**Negotiated MCP-Protocol-Version (WS3):** default `2025-06-18`; capture
`result.protocolVersion` from the `initialize` response and send the negotiated version on
subsequent request headers.

**Per-toolkit partial success (WS2):** `hydrate.attempts.max` bounds per-kind retries; on
exhaustion the kind is marked degraded (`settled = populated || degraded`) and serves an
empty list envelope instead of aborting.

## Engine SPI note

Adds one method to `EngineContext` (`isLocalIndex`), with **all in-tree implementers
updated** (`EngineWorker`, plus the `EchoWorker`/`TlsWorker` test implementers).

## Testing

`./mvnw verify -pl specs/binding-mcp.spec,runtime/binding-mcp` — server/client/proxy/
proxy-lifecycle/proxy-cache ITs, `McpConfigurationTest`, and spec application/network/cache
ITs green, incl. new `lifecycle.initialize.version` (negotiation) and
`cache.serve.tools.list.degraded` (partial-success) scenarios. Engine + `EchoWorker`/
`TlsWorker` compile with the new SPI; CI runs the full engine suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
