### PR TITLE
feat(binding-mcp): proxy hydration/forwarding fixes + per-upstream bootstrap credential

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
@@ -42,6 +42,7 @@ public final class McpBindingConfig
     public final long id;
     public final McpOptionsConfig options;
     public final GuardHandler guard;
+    public final String credentials;
     public final McpProxyCache cache;
     public final Map<String, McpProxySession> sessions;
     public final Map<String, McpRouteConfig> routeByPrefix;
@@ -85,6 +86,12 @@ public final class McpBindingConfig
             .map(a -> a.name)
             .map(binding.resolveId::applyAsLong)
             .map(context::supplyGuard)
+            .orElse(null);
+
+        this.credentials = Optional.ofNullable(options)
+            .map(o -> o.authorization)
+            .map(a -> a.credentials)
+            .filter(c -> !c.isEmpty())
             .orElse(null);
 
         this.cache = Optional.ofNullable(options)

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpOptionsConfigAdapter.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpOptionsConfigAdapter.java
@@ -24,6 +24,7 @@ import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonString;
 import jakarta.json.bind.adapter.JsonbAdapter;
 
+import io.aklivity.zilla.runtime.binding.mcp.config.McpAuthorizationConfigBuilder;
 import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheConfig;
 import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheConfigBuilder;
 import io.aklivity.zilla.runtime.binding.mcp.config.McpElicitationConfig;
@@ -44,6 +45,8 @@ public final class McpOptionsConfigAdapter implements OptionsConfigAdapterSpi, J
     private static final String ELICITATION_CALLBACK_NAME = "callback";
 
     private static final String AUTHORIZATION_NAME = "authorization";
+    private static final String AUTHORIZATION_NAME_NAME = "name";
+    private static final String AUTHORIZATION_CREDENTIALS_NAME = "credentials";
 
     private static final String CACHE_NAME = "cache";
     private static final String CACHE_STORE_NAME = "store";
@@ -98,7 +101,14 @@ public final class McpOptionsConfigAdapter implements OptionsConfigAdapterSpi, J
         if (mcpOptions.authorization != null)
         {
             JsonObjectBuilder authorization = Json.createObjectBuilder();
-            authorization.add("name", mcpOptions.authorization.name);
+            if (mcpOptions.authorization.name != null)
+            {
+                authorization.add(AUTHORIZATION_NAME_NAME, mcpOptions.authorization.name);
+            }
+            if (mcpOptions.authorization.credentials != null)
+            {
+                authorization.add(AUTHORIZATION_CREDENTIALS_NAME, mcpOptions.authorization.credentials);
+            }
             object.add(AUTHORIZATION_NAME, authorization);
         }
 
@@ -165,9 +175,17 @@ public final class McpOptionsConfigAdapter implements OptionsConfigAdapterSpi, J
         if (object.containsKey(AUTHORIZATION_NAME))
         {
             JsonObject authorization = object.getJsonObject(AUTHORIZATION_NAME);
-            builder.authorization()
-                .name(authorization.getString("name"))
-                .build();
+            McpAuthorizationConfigBuilder<McpOptionsConfigBuilder<McpOptionsConfig>> authorizationBuilder =
+                builder.authorization();
+            if (authorization.containsKey(AUTHORIZATION_NAME_NAME))
+            {
+                authorizationBuilder.name(authorization.getString(AUTHORIZATION_NAME_NAME));
+            }
+            if (authorization.containsKey(AUTHORIZATION_CREDENTIALS_NAME))
+            {
+                authorizationBuilder.credentials(authorization.getString(AUTHORIZATION_CREDENTIALS_NAME));
+            }
+            authorizationBuilder.build();
         }
 
         if (object.containsKey(CACHE_NAME))

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -110,6 +110,7 @@ public final class McpClientFactory implements McpStreamFactory
     private static final String JSON_RPC_VERSION = "2.0";
     private static final String HTTP_HEADER_METHOD = ":method";
     private static final String HTTP_HEADER_CONTENT_TYPE = "content-type";
+    private static final String HTTP_HEADER_CONTENT_LENGTH = "content-length";
     private static final String HTTP_HEADER_ACCEPT = "accept";
     private static final String HTTP_HEADER_STATUS = ":status";
     private static final String HTTP_HEADER_SESSION = "mcp-session-id";
@@ -3943,6 +3944,16 @@ public final class McpClientFactory implements McpStreamFactory
             long traceId,
             long authorization)
         {
+            int codecLength = 0;
+            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_INITIALIZE_PREFIX);
+            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, MCP_PROTOCOL_VERSION);
+            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_INITIALIZE_CLIENT_INFO);
+            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, clientName);
+            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_INITIALIZE_VERSION_PREFIX);
+            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, clientVersion);
+            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_INITIALIZE_SUFFIX);
+
+            final int contentLength = codecLength;
             final HttpBeginExFW.Builder builder = httpBeginExRW
                 .wrap(extBuffer, 0, extBuffer.capacity())
                 .typeId(httpTypeId);
@@ -3956,16 +3967,8 @@ public final class McpClientFactory implements McpStreamFactory
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                 .headersItem(h -> h.name(HTTP_HEADER_ACCEPT).value(CONTENT_TYPE_JSON_AND_EVENT_STREAM))
                 .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(mcp.protocolVersion()))
+                .headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(contentLength)))
                 .build();
-
-            int codecLength = 0;
-            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_INITIALIZE_PREFIX);
-            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, MCP_PROTOCOL_VERSION);
-            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_INITIALIZE_CLIENT_INFO);
-            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, clientName);
-            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_INITIALIZE_VERSION_PREFIX);
-            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, clientVersion);
-            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_INITIALIZE_SUFFIX);
 
             doNetBegin(traceId, authorization, httpBeginEx);
             doNetData(traceId, authorization, codecBuffer, 0, codecLength);
@@ -4086,6 +4089,9 @@ public final class McpClientFactory implements McpStreamFactory
             long authorization)
         {
             final String sid = mcp.transportSessionId();
+
+            final int codecLength = codecBuffer.putStringWithoutLengthAscii(0, JSON_RPC_NOTIFY_INITIALIZED);
+
             final HttpBeginExFW.Builder builder = httpBeginExRW
                 .wrap(extBuffer, 0, extBuffer.capacity())
                 .typeId(httpTypeId);
@@ -4100,9 +4106,8 @@ public final class McpClientFactory implements McpStreamFactory
                 .headersItem(h -> h.name(HTTP_HEADER_ACCEPT).value(CONTENT_TYPE_JSON_AND_EVENT_STREAM))
                 .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(mcp.protocolVersion()))
                 .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid))
+                .headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(codecLength)))
                 .build();
-
-            final int codecLength = codecBuffer.putStringWithoutLengthAscii(0, JSON_RPC_NOTIFY_INITIALIZED);
 
             doNetBegin(traceId, authorization, httpBeginEx);
             doNetData(traceId, authorization, codecBuffer, 0, codecLength);
@@ -4123,6 +4128,13 @@ public final class McpClientFactory implements McpStreamFactory
             long authorization)
         {
             final String sid = mcp.transportSessionId();
+
+            int codecLength = 0;
+            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_REQUEST_ID_PREFIX);
+            codecLength += codecBuffer.putIntAscii(codecLength, ((McpLifecycleStream) mcp).nextRequestId++);
+            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_PING_METHOD);
+
+            final int contentLength = codecLength;
             final HttpBeginExFW.Builder builder = httpBeginExRW
                 .wrap(extBuffer, 0, extBuffer.capacity())
                 .typeId(httpTypeId);
@@ -4137,12 +4149,8 @@ public final class McpClientFactory implements McpStreamFactory
                 .headersItem(h -> h.name(HTTP_HEADER_ACCEPT).value(CONTENT_TYPE_JSON_AND_EVENT_STREAM))
                 .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(mcp.protocolVersion()))
                 .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid))
+                .headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(contentLength)))
                 .build();
-
-            int codecLength = 0;
-            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_REQUEST_ID_PREFIX);
-            codecLength += codecBuffer.putIntAscii(codecLength, ((McpLifecycleStream) mcp).nextRequestId++);
-            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_PING_METHOD);
 
             doNetBegin(traceId, authorization, httpBeginEx);
             doNetData(traceId, authorization, codecBuffer, 0, codecLength);
@@ -4531,12 +4539,14 @@ public final class McpClientFactory implements McpStreamFactory
             final String sid = mcp.transportSessionId();
             extBuilder.headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid));
 
-            final HttpBeginExFW httpBeginEx = extBuilder.build();
-
             int codecLength = 0;
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_REQUEST_ID_PREFIX);
             codecLength += codecBuffer.putIntAscii(codecLength, request.requestId);
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_TOOLS_LIST_METHOD);
+
+            final int contentLength = codecLength;
+            extBuilder.headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(contentLength)));
+            final HttpBeginExFW httpBeginEx = extBuilder.build();
 
             doNetBegin(traceId, authorization, httpBeginEx);
             doNetData(traceId, authorization, codecBuffer, 0, codecLength);
@@ -4630,12 +4640,14 @@ public final class McpClientFactory implements McpStreamFactory
             final String sid = mcp.transportSessionId();
             extBuilder.headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid));
 
-            final HttpBeginExFW httpBeginEx = extBuilder.build();
-
             int codecLength = 0;
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_REQUEST_ID_PREFIX);
             codecLength += codecBuffer.putIntAscii(codecLength, request.requestId);
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_PROMPTS_LIST_METHOD);
+
+            final int contentLength = codecLength;
+            extBuilder.headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(contentLength)));
+            final HttpBeginExFW httpBeginEx = extBuilder.build();
 
             doNetBegin(traceId, authorization, httpBeginEx);
             doNetData(traceId, authorization, codecBuffer, 0, codecLength);
@@ -4726,12 +4738,14 @@ public final class McpClientFactory implements McpStreamFactory
             final String sid = mcp.transportSessionId();
             extBuilder.headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid));
 
-            final HttpBeginExFW httpBeginEx = extBuilder.build();
-
             int codecLength = 0;
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_REQUEST_ID_PREFIX);
             codecLength += codecBuffer.putIntAscii(codecLength, request.requestId);
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_RESOURCES_LIST_METHOD);
+
+            final int contentLength = codecLength;
+            extBuilder.headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(contentLength)));
+            final HttpBeginExFW httpBeginEx = extBuilder.build();
 
             doNetBegin(traceId, authorization, httpBeginEx);
             doNetData(traceId, authorization, codecBuffer, 0, codecLength);

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -1485,6 +1485,13 @@ public final class McpClientFactory implements McpStreamFactory
                             affinity, authorization);
                         if (request != null)
                         {
+                            request.contentLength = switch (mcpBeginEx.kind())
+                            {
+                            case KIND_TOOLS_CALL -> mcpBeginEx.toolsCall().contentLength();
+                            case KIND_PROMPTS_GET -> mcpBeginEx.promptsGet().contentLength();
+                            case KIND_RESOURCES_READ -> mcpBeginEx.resourcesRead().contentLength();
+                            default -> -1;
+                            };
                             newStream = request::onAppMessage;
                         }
                     }
@@ -2503,6 +2510,7 @@ public final class McpClientFactory implements McpStreamFactory
     {
         final McpLifecycleStream session;
         final int requestId;
+        int contentLength = -1;
         private HttpEventStream sse;
 
         JsonParser paramsParser;
@@ -4499,6 +4507,7 @@ public final class McpClientFactory implements McpStreamFactory
     private abstract class HttpRequestStream extends HttpStream
     {
         protected final McpRequestStream request;
+        protected int paramsForwarded;
 
         HttpRequestStream(
             McpStream mcp)
@@ -4506,6 +4515,36 @@ public final class McpClientFactory implements McpStreamFactory
             super(mcp);
             this.request = (McpRequestStream) mcp;
             this.decoder = decodeJsonRpc;
+        }
+
+        @Override
+        void doEncodeRequestData(
+            long traceId,
+            long authorization,
+            DirectBuffer buffer,
+            int offset,
+            int limit)
+        {
+            paramsForwarded += limit - offset;
+            doNetData(traceId, authorization, buffer, offset, limit);
+        }
+
+        int streamedContentLength(
+            int prefixLength)
+        {
+            return prefixLength + request.contentLength + JSON_RPC_PARAMS_CLOSE.length();
+        }
+
+        void doEncodeStreamedRequestEnd(
+            long traceId,
+            long authorization)
+        {
+            int codecLength = codecBuffer.putStringWithoutLengthAscii(0, JSON_RPC_PARAMS_CLOSE);
+            final int padding = request.contentLength - paramsForwarded;
+            codecBuffer.setMemory(codecLength, padding, (byte) ' ');
+            codecLength += padding;
+            doNetData(traceId, authorization, codecBuffer, 0, codecLength);
+            doNetEnd(traceId, authorization);
         }
     }
 
@@ -4588,12 +4627,15 @@ public final class McpClientFactory implements McpStreamFactory
                 extBuilder.headersItem(h -> h.name(HTTP_HEADER_AUTHORIZATION).value(BEARER_PREFIX + mcp.credentials));
             }
 
-            final HttpBeginExFW httpBeginEx = extBuilder.build();
-
+            paramsForwarded = 0;
             int codecLength = 0;
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_REQUEST_ID_PREFIX);
             codecLength += codecBuffer.putIntAscii(codecLength, request.requestId);
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_TOOLS_CALL_METHOD);
+
+            final int contentLength = streamedContentLength(codecLength);
+            extBuilder.headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(contentLength)));
+            final HttpBeginExFW httpBeginEx = extBuilder.build();
 
             doNetBegin(traceId, authorization, httpBeginEx);
             doNetData(traceId, authorization, codecBuffer, 0, codecLength);
@@ -4604,9 +4646,7 @@ public final class McpClientFactory implements McpStreamFactory
             long traceId,
             long authorization)
         {
-            final int codecLength = codecBuffer.putStringWithoutLengthAscii(0, JSON_RPC_PARAMS_CLOSE);
-            doNetData(traceId, authorization, codecBuffer, 0, codecLength);
-            doNetEnd(traceId, authorization);
+            doEncodeStreamedRequestEnd(traceId, authorization);
         }
     }
 
@@ -4685,12 +4725,15 @@ public final class McpClientFactory implements McpStreamFactory
             final String sid = mcp.transportSessionId();
             extBuilder.headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid));
 
-            final HttpBeginExFW httpBeginEx = extBuilder.build();
-
+            paramsForwarded = 0;
             int codecLength = 0;
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_REQUEST_ID_PREFIX);
             codecLength += codecBuffer.putIntAscii(codecLength, request.requestId);
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_PROMPTS_GET_METHOD);
+
+            final int contentLength = streamedContentLength(codecLength);
+            extBuilder.headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(contentLength)));
+            final HttpBeginExFW httpBeginEx = extBuilder.build();
 
             doNetBegin(traceId, authorization, httpBeginEx);
             doNetData(traceId, authorization, codecBuffer, 0, codecLength);
@@ -4701,9 +4744,7 @@ public final class McpClientFactory implements McpStreamFactory
             long traceId,
             long authorization)
         {
-            final int codecLength = codecBuffer.putStringWithoutLengthAscii(0, JSON_RPC_PARAMS_CLOSE);
-            doNetData(traceId, authorization, codecBuffer, 0, codecLength);
-            doNetEnd(traceId, authorization);
+            doEncodeStreamedRequestEnd(traceId, authorization);
         }
 
     }
@@ -4783,12 +4824,15 @@ public final class McpClientFactory implements McpStreamFactory
             final String sid = mcp.transportSessionId();
             extBuilder.headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid));
 
-            final HttpBeginExFW httpBeginEx = extBuilder.build();
-
+            paramsForwarded = 0;
             int codecLength = 0;
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_REQUEST_ID_PREFIX);
             codecLength += codecBuffer.putIntAscii(codecLength, request.requestId);
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_RESOURCES_READ_METHOD);
+
+            final int contentLength = streamedContentLength(codecLength);
+            extBuilder.headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(contentLength)));
+            final HttpBeginExFW httpBeginEx = extBuilder.build();
 
             doNetBegin(traceId, authorization, httpBeginEx);
             doNetData(traceId, authorization, codecBuffer, 0, codecLength);
@@ -4799,9 +4843,7 @@ public final class McpClientFactory implements McpStreamFactory
             long traceId,
             long authorization)
         {
-            final int codecLength = codecBuffer.putStringWithoutLengthAscii(0, JSON_RPC_PARAMS_CLOSE);
-            doNetData(traceId, authorization, codecBuffer, 0, codecLength);
-            doNetEnd(traceId, authorization);
+            doEncodeStreamedRequestEnd(traceId, authorization);
         }
 
     }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -1731,11 +1731,27 @@ public final class McpClientFactory implements McpStreamFactory
             doAppWindow(traceId, authorization, 0L, 0);
         }
 
+        abstract McpBindingConfig binding();
+
         boolean proceedWithRequest(
             long traceId,
             long authorization,
             McpBeginExFW mcpBeginEx)
         {
+            final McpBindingConfig binding = binding();
+            final GuardHandler guard = binding.guard;
+            if (guard != null)
+            {
+                final long sessionId = guard.reauthorize(traceId, binding.id, initialId, null);
+                if ((sessionId & GuardHandler.MASK_AUTHORIZED) != 0L)
+                {
+                    credentials = guard.credentials(sessionId);
+                }
+            }
+            if (credentials == null)
+            {
+                credentials = binding.credentials;
+            }
             return true;
         }
 
@@ -2100,6 +2116,12 @@ public final class McpClientFactory implements McpStreamFactory
         private int failedKeepalives;
         private HttpEventStream sse;
         boolean eventsUnsupported;
+
+        @Override
+        McpBindingConfig binding()
+        {
+            return binding;
+        }
 
         @Override
         String transportSessionId()
@@ -2533,6 +2555,12 @@ public final class McpClientFactory implements McpStreamFactory
         }
 
         @Override
+        McpBindingConfig binding()
+        {
+            return session.binding;
+        }
+
+        @Override
         String transportSessionId()
         {
             return session.transportSessionId();
@@ -2899,6 +2927,7 @@ public final class McpClientFactory implements McpStreamFactory
             final GuardHandler guard = session.binding.guard;
             if (guard == null)
             {
+                credentials = session.binding.credentials;
                 return true;
             }
 
@@ -2910,7 +2939,7 @@ public final class McpClientFactory implements McpStreamFactory
                 return true;
             }
 
-            if (sessionId == GuardHandler.NEEDS_PREAUTHORIZE)
+            if (sessionId == GuardHandler.NEEDS_PREAUTHORIZE && session.binding.credentials == null)
             {
                 final String preauthorizeUrl = guard.preauthorize(traceId, session.binding.id, initialId, null);
                 if (preauthorizeUrl == null)
@@ -2937,6 +2966,12 @@ public final class McpClientFactory implements McpStreamFactory
                     traceId, ELICIT_TIMEOUT_SIGNAL_ID, 0);
 
                 return false;
+            }
+
+            if (session.binding.credentials != null)
+            {
+                credentials = session.binding.credentials;
+                return true;
             }
 
             doAppReset(traceId, authorization);
@@ -3289,6 +3324,15 @@ public final class McpClientFactory implements McpStreamFactory
             this.replyId = supplyReplyId.applyAsLong(initialId);
             this.affinity = mcp.affinity;
             this.replyMax = decodeMax;
+        }
+
+        final void injectAuthorization(
+            HttpBeginExFW.Builder builder)
+        {
+            if (mcp.credentials != null)
+            {
+                builder.headersItem(h -> h.name(HTTP_HEADER_AUTHORIZATION).value(BEARER_PREFIX + mcp.credentials));
+            }
         }
 
         abstract void onDecodeParseError(
@@ -3970,13 +4014,14 @@ public final class McpClientFactory implements McpStreamFactory
                 mcp.with.headers.forEach((name, value) ->
                     builder.headersItem(h -> h.name(name).value(value)));
             }
-            final HttpBeginExFW httpBeginEx = builder
+            builder
                 .headersItem(h -> h.name(HTTP_HEADER_METHOD).value(HTTP_METHOD_POST))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                 .headersItem(h -> h.name(HTTP_HEADER_ACCEPT).value(CONTENT_TYPE_JSON_AND_EVENT_STREAM))
                 .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(mcp.protocolVersion()))
-                .headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(contentLength)))
-                .build();
+                .headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(contentLength)));
+            injectAuthorization(builder);
+            final HttpBeginExFW httpBeginEx = builder.build();
 
             doNetBegin(traceId, authorization, httpBeginEx);
             doNetData(traceId, authorization, codecBuffer, 0, codecLength);
@@ -4108,14 +4153,15 @@ public final class McpClientFactory implements McpStreamFactory
                 mcp.with.headers.forEach((name, value) ->
                     builder.headersItem(h -> h.name(name).value(value)));
             }
-            final HttpBeginExFW httpBeginEx = builder
+            builder
                 .headersItem(h -> h.name(HTTP_HEADER_METHOD).value(HTTP_METHOD_POST))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                 .headersItem(h -> h.name(HTTP_HEADER_ACCEPT).value(CONTENT_TYPE_JSON_AND_EVENT_STREAM))
                 .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(mcp.protocolVersion()))
                 .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid))
-                .headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(codecLength)))
-                .build();
+                .headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(codecLength)));
+            injectAuthorization(builder);
+            final HttpBeginExFW httpBeginEx = builder.build();
 
             doNetBegin(traceId, authorization, httpBeginEx);
             doNetData(traceId, authorization, codecBuffer, 0, codecLength);
@@ -4151,14 +4197,15 @@ public final class McpClientFactory implements McpStreamFactory
                 mcp.with.headers.forEach((name, value) ->
                     builder.headersItem(h -> h.name(name).value(value)));
             }
-            final HttpBeginExFW httpBeginEx = builder
+            builder
                 .headersItem(h -> h.name(HTTP_HEADER_METHOD).value(HTTP_METHOD_POST))
                 .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                 .headersItem(h -> h.name(HTTP_HEADER_ACCEPT).value(CONTENT_TYPE_JSON_AND_EVENT_STREAM))
                 .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(mcp.protocolVersion()))
                 .headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid))
-                .headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(contentLength)))
-                .build();
+                .headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(contentLength)));
+            injectAuthorization(builder);
+            final HttpBeginExFW httpBeginEx = builder.build();
 
             doNetBegin(traceId, authorization, httpBeginEx);
             doNetData(traceId, authorization, codecBuffer, 0, codecLength);
@@ -4201,6 +4248,7 @@ public final class McpClientFactory implements McpStreamFactory
             {
                 builder.headersItem(h -> h.name(HTTP_HEADER_LAST_EVENT_ID).value(lastEventId));
             }
+            injectAuthorization(builder);
             final HttpBeginExFW httpBeginEx = builder.build();
 
             state = McpState.openingInitial(state);
@@ -4583,6 +4631,8 @@ public final class McpClientFactory implements McpStreamFactory
             codecLength += codecBuffer.putIntAscii(codecLength, request.requestId);
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_TOOLS_LIST_METHOD);
 
+            injectAuthorization(extBuilder);
+
             final int contentLength = codecLength;
             extBuilder.headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(contentLength)));
             final HttpBeginExFW httpBeginEx = extBuilder.build();
@@ -4622,10 +4672,7 @@ public final class McpClientFactory implements McpStreamFactory
             final String sid = mcp.transportSessionId();
             extBuilder.headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid));
 
-            if (mcp.credentials != null)
-            {
-                extBuilder.headersItem(h -> h.name(HTTP_HEADER_AUTHORIZATION).value(BEARER_PREFIX + mcp.credentials));
-            }
+            injectAuthorization(extBuilder);
 
             paramsForwarded = 0;
             int codecLength = 0;
@@ -4685,6 +4732,8 @@ public final class McpClientFactory implements McpStreamFactory
             codecLength += codecBuffer.putIntAscii(codecLength, request.requestId);
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_PROMPTS_LIST_METHOD);
 
+            injectAuthorization(extBuilder);
+
             final int contentLength = codecLength;
             extBuilder.headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(contentLength)));
             final HttpBeginExFW httpBeginEx = extBuilder.build();
@@ -4730,6 +4779,8 @@ public final class McpClientFactory implements McpStreamFactory
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_REQUEST_ID_PREFIX);
             codecLength += codecBuffer.putIntAscii(codecLength, request.requestId);
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_PROMPTS_GET_METHOD);
+
+            injectAuthorization(extBuilder);
 
             final int contentLength = streamedContentLength(codecLength);
             extBuilder.headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(contentLength)));
@@ -4784,6 +4835,8 @@ public final class McpClientFactory implements McpStreamFactory
             codecLength += codecBuffer.putIntAscii(codecLength, request.requestId);
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_RESOURCES_LIST_METHOD);
 
+            injectAuthorization(extBuilder);
+
             final int contentLength = codecLength;
             extBuilder.headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(contentLength)));
             final HttpBeginExFW httpBeginEx = extBuilder.build();
@@ -4829,6 +4882,8 @@ public final class McpClientFactory implements McpStreamFactory
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_REQUEST_ID_PREFIX);
             codecLength += codecBuffer.putIntAscii(codecLength, request.requestId);
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_RESOURCES_READ_METHOD);
+
+            injectAuthorization(extBuilder);
 
             final int contentLength = streamedContentLength(codecLength);
             extBuilder.headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(contentLength)));

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyItemFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyItemFactory.java
@@ -124,6 +124,7 @@ abstract class McpProxyItemFactory implements BindingHandler
                 {
                     final String identifier = route.strip(beginEx);
                     final int contentLength = contentLength(beginEx);
+                    final String prefix = route.prefix(beginEx);
 
                     newStream = new McpServer(
                         lifecycle,
@@ -135,7 +136,8 @@ abstract class McpProxyItemFactory implements BindingHandler
                         affinity,
                         authorization,
                         identifier,
-                        contentLength)::onServerMessage;
+                        contentLength,
+                        prefix)::onServerMessage;
                 }
             }
         }
@@ -172,6 +174,8 @@ abstract class McpProxyItemFactory implements BindingHandler
         private final long authorization;
         private final String identifier;
         private final int contentLength;
+        private final String prefix;
+        private boolean prefixStripped;
         private final McpClient client;
 
         private int state;
@@ -196,7 +200,8 @@ abstract class McpProxyItemFactory implements BindingHandler
             long affinity,
             long authorization,
             String identifier,
-            int contentLength)
+            int contentLength,
+            String prefix)
         {
             this.lifecycle = lifecycle;
             this.sender = sender;
@@ -208,6 +213,7 @@ abstract class McpProxyItemFactory implements BindingHandler
             this.authorization = authorization;
             this.identifier = identifier;
             this.contentLength = contentLength;
+            this.prefix = prefix;
             this.client = new McpClient(this, resolvedId);
         }
 
@@ -298,8 +304,58 @@ abstract class McpProxyItemFactory implements BindingHandler
 
             assert initialAck <= initialSeq;
 
-            client.doClientData(traceId, budgetId, flags, reserved,
-                payload.buffer(), payload.offset(), payload.sizeof());
+            final int prefixLen = prefix.length();
+            int prefixAt = -1;
+            if (prefixLen > 0 && !prefixStripped)
+            {
+                prefixStripped = true;
+                prefixAt = indexOfQuotedPrefix(payload.buffer(), payload.offset(), payload.limit());
+            }
+
+            if (prefixAt >= 0)
+            {
+                final DirectBuffer buf = payload.buffer();
+                final int offset = payload.offset();
+                final int limit = payload.limit();
+                final int head = prefixAt - offset;
+                final int tailFrom = prefixAt + prefixLen;
+                final int tailLen = limit - tailFrom;
+                codecBuffer.putBytes(0, buf, offset, head);
+                codecBuffer.putBytes(head, buf, tailFrom, tailLen);
+                client.doClientData(traceId, budgetId, flags, reserved - prefixLen, codecBuffer, 0, head + tailLen);
+            }
+            else
+            {
+                client.doClientData(traceId, budgetId, flags, reserved,
+                    payload.buffer(), payload.offset(), payload.sizeof());
+            }
+        }
+
+        private int indexOfQuotedPrefix(
+            DirectBuffer buf,
+            int offset,
+            int limit)
+        {
+            final int prefixLen = prefix.length();
+            int result = -1;
+
+            for (int at = offset; result < 0 && at + prefixLen < limit; at++)
+            {
+                if (buf.getByte(at) == (byte) '"')
+                {
+                    boolean match = true;
+                    for (int index = 0; match && index < prefixLen; index++)
+                    {
+                        match = buf.getByte(at + 1 + index) == (byte) prefix.charAt(index);
+                    }
+                    if (match)
+                    {
+                        result = at + 1;
+                    }
+                }
+            }
+
+            return result;
         }
 
         private void onServerEnd(
@@ -561,7 +617,7 @@ abstract class McpProxyItemFactory implements BindingHandler
                 final McpBeginExFW beginEx = mcpBeginExRW
                     .wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(mcpTypeId)
-                    .inject(b -> injectInitialBeginEx(b, sid, server.identifier, server.contentLength))
+                    .inject(b -> injectInitialBeginEx(b, sid, server.identifier, server.contentLength - server.prefix.length()))
                     .build();
 
                 sender = newStream(this::onClientMessage, originId, routedId, initialId,

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyItemFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyItemFactory.java
@@ -123,6 +123,7 @@ abstract class McpProxyItemFactory implements BindingHandler
                 if (route != null)
                 {
                     final String identifier = route.strip(beginEx);
+                    final int contentLength = contentLength(beginEx);
 
                     newStream = new McpServer(
                         lifecycle,
@@ -133,7 +134,8 @@ abstract class McpProxyItemFactory implements BindingHandler
                         route.id,
                         affinity,
                         authorization,
-                        identifier)::onServerMessage;
+                        identifier,
+                        contentLength)::onServerMessage;
                 }
             }
         }
@@ -144,7 +146,8 @@ abstract class McpProxyItemFactory implements BindingHandler
     protected abstract void injectInitialBeginEx(
         McpBeginExFW.Builder builder,
         String sessionId,
-        String identifier);
+        String identifier,
+        int contentLength);
 
     protected abstract void injectReplyBeginEx(
         McpBeginExFW.Builder builder,
@@ -152,6 +155,9 @@ abstract class McpProxyItemFactory implements BindingHandler
         McpBeginExFW upstream);
 
     protected abstract String sessionId(
+        McpBeginExFW beginEx);
+
+    protected abstract int contentLength(
         McpBeginExFW beginEx);
 
     private final class McpServer
@@ -165,6 +171,7 @@ abstract class McpProxyItemFactory implements BindingHandler
         private final long affinity;
         private final long authorization;
         private final String identifier;
+        private final int contentLength;
         private final McpClient client;
 
         private int state;
@@ -188,7 +195,8 @@ abstract class McpProxyItemFactory implements BindingHandler
             long resolvedId,
             long affinity,
             long authorization,
-            String identifier)
+            String identifier,
+            int contentLength)
         {
             this.lifecycle = lifecycle;
             this.sender = sender;
@@ -199,6 +207,7 @@ abstract class McpProxyItemFactory implements BindingHandler
             this.affinity = affinity;
             this.authorization = authorization;
             this.identifier = identifier;
+            this.contentLength = contentLength;
             this.client = new McpClient(this, resolvedId);
         }
 
@@ -552,7 +561,7 @@ abstract class McpProxyItemFactory implements BindingHandler
                 final McpBeginExFW beginEx = mcpBeginExRW
                     .wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(mcpTypeId)
-                    .inject(b -> injectInitialBeginEx(b, sid, server.identifier))
+                    .inject(b -> injectInitialBeginEx(b, sid, server.identifier, server.contentLength))
                     .build();
 
                 sender = newStream(this::onClientMessage, originId, routedId, initialId,

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
@@ -268,6 +268,11 @@ final class McpProxyLifecycleFactory implements BindingHandler
             return eventIds != null && originId != routedId;
         }
 
+        private boolean hydrating()
+        {
+            return originId == routedId;
+        }
+
         private void onDecodeEventId(
             long routedId,
             String eventId)
@@ -1018,7 +1023,10 @@ final class McpProxyLifecycleFactory implements BindingHandler
             settleRequests(traceId);
             doClientAbort(traceId);
             server.clients.remove(routedId, this);
-            server.doServerAbort(traceId);
+            if (!(server.hydrating() && sessionId == null))
+            {
+                server.doServerAbort(traceId);
+            }
         }
 
         private void onClientWindow(
@@ -1062,13 +1070,17 @@ final class McpProxyLifecycleFactory implements BindingHandler
             doClientReset(traceId);
             server.clients.remove(routedId, this);
 
-            if (extension.sizeof() > 0 && !McpState.replyOpened(server.state))
+            final boolean bearer = extension.sizeof() > 0;
+            if (!(server.hydrating() && sessionId == null))
             {
-                server.onClientBearerReset(traceId, extension, this);
-            }
-            else
-            {
-                server.doServerReset(traceId, extension);
+                if (bearer && !McpState.replyOpened(server.state))
+                {
+                    server.onClientBearerReset(traceId, extension, this);
+                }
+                else
+                {
+                    server.doServerReset(traceId, extension);
+                }
             }
         }
     }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyListFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyListFactory.java
@@ -285,7 +285,7 @@ abstract class McpProxyListFactory implements BindingHandler
             }
             else
             {
-                server.onClientError(traceId);
+                server.onClientSkip(traceId);
             }
         }
 
@@ -1308,6 +1308,13 @@ abstract class McpProxyListFactory implements BindingHandler
         {
             remaining.clear();
             doServerAbort(traceId);
+        }
+
+        private void onClientSkip(
+            long traceId)
+        {
+            client = null;
+            onNextClient(traceId);
         }
 
         private void onNextClient(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyPromptsGetFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyPromptsGetFactory.java
@@ -35,9 +35,10 @@ final class McpProxyPromptsGetFactory extends McpProxyItemFactory
     protected void injectInitialBeginEx(
         McpBeginExFW.Builder builder,
         String sessionId,
-        String identifier)
+        String identifier,
+        int contentLength)
     {
-        builder.promptsGet(p -> p.sessionId(sessionId).name(identifier));
+        builder.promptsGet(p -> p.sessionId(sessionId).name(identifier).contentLength(contentLength));
     }
 
     @Override
@@ -54,5 +55,12 @@ final class McpProxyPromptsGetFactory extends McpProxyItemFactory
         McpBeginExFW beginEx)
     {
         return beginEx.promptsGet().sessionId().asString();
+    }
+
+    @Override
+    protected int contentLength(
+        McpBeginExFW beginEx)
+    {
+        return beginEx.promptsGet().contentLength();
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyResourcesReadFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyResourcesReadFactory.java
@@ -35,9 +35,10 @@ final class McpProxyResourcesReadFactory extends McpProxyItemFactory
     protected void injectInitialBeginEx(
         McpBeginExFW.Builder builder,
         String sessionId,
-        String identifier)
+        String identifier,
+        int contentLength)
     {
-        builder.resourcesRead(r -> r.sessionId(sessionId).uri(identifier));
+        builder.resourcesRead(r -> r.sessionId(sessionId).uri(identifier).contentLength(contentLength));
     }
 
     @Override
@@ -54,5 +55,12 @@ final class McpProxyResourcesReadFactory extends McpProxyItemFactory
         McpBeginExFW beginEx)
     {
         return beginEx.resourcesRead().sessionId().asString();
+    }
+
+    @Override
+    protected int contentLength(
+        McpBeginExFW beginEx)
+    {
+        return beginEx.resourcesRead().contentLength();
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyToolsCallFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyToolsCallFactory.java
@@ -35,9 +35,10 @@ final class McpProxyToolsCallFactory extends McpProxyItemFactory
     protected void injectInitialBeginEx(
         McpBeginExFW.Builder builder,
         String sessionId,
-        String identifier)
+        String identifier,
+        int contentLength)
     {
-        builder.toolsCall(t -> t.sessionId(sessionId).name(identifier));
+        builder.toolsCall(t -> t.sessionId(sessionId).name(identifier).contentLength(contentLength));
     }
 
     @Override
@@ -54,5 +55,12 @@ final class McpProxyToolsCallFactory extends McpProxyItemFactory
         McpBeginExFW beginEx)
     {
         return beginEx.toolsCall().sessionId().asString();
+    }
+
+    @Override
+    protected int contentLength(
+        McpBeginExFW beginEx)
+    {
+        return beginEx.toolsCall().contentLength();
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -103,6 +103,7 @@ public final class McpServerFactory implements McpStreamFactory
     private static final String HTTP_HEADER_STATUS = ":status";
     private static final String HTTP_HEADER_WWW_AUTHENTICATE = "www-authenticate";
     private static final String HTTP_HEADER_CONTENT_TYPE = "content-type";
+    private static final String HTTP_HEADER_CONTENT_LENGTH = "content-length";
     private static final String HTTP_HEADER_ALT_SVC = "alt-svc";
     private static final String HTTP_HEADER_ACCEPT = "accept";
     private static final String HTTP_HEADER_LAST_EVENT_ID = "last-event-id";
@@ -401,6 +402,11 @@ public final class McpServerFactory implements McpStreamFactory
                 else
                 {
                     final String redirectURI = binding.resolveRedirectURI(httpBeginEx);
+                    final int contentLength = Optional.ofNullable(httpBeginEx.headers()
+                            .matchFirst(h -> HTTP_HEADER_CONTENT_LENGTH.equals(h.name().asString())))
+                        .map(h -> h.value().asString())
+                        .map(Integer::parseInt)
+                        .orElse(-1);
                     newStream = new McpServer(
                         sender,
                         originId,
@@ -409,7 +415,8 @@ public final class McpServerFactory implements McpStreamFactory
                         resolvedId,
                         session,
                         redirectURI,
-                        altSvc)::onNetMessage;
+                        altSvc,
+                        contentLength)::onNetMessage;
                 }
                 break;
             case "GET":
@@ -1006,6 +1013,13 @@ public final class McpServerFactory implements McpStreamFactory
             }
 
             final String value = parser.getString();
+            if (server.contentLength < 0)
+            {
+                server.onDecodeInvalidRequest(traceId, authorization);
+                server.decoder = decodeIgnore;
+                break decode;
+            }
+
             switch (server.decodedMethod)
             {
             case "tools/call":
@@ -1284,6 +1298,7 @@ public final class McpServerFactory implements McpStreamFactory
 
         private final String redirectURI;
         private final String altSvc;
+        private final int contentLength;
 
         private McpServer(
             MessageConsumer sender,
@@ -1293,7 +1308,8 @@ public final class McpServerFactory implements McpStreamFactory
             long resolvedId,
             McpLifecycleStream session,
             String redirectURI,
-            String altSvc)
+            String altSvc,
+            int contentLength)
         {
             this.net = sender;
             this.originId = originId;
@@ -1306,6 +1322,7 @@ public final class McpServerFactory implements McpStreamFactory
             this.initialMax = decodeMax;
             this.redirectURI = redirectURI;
             this.altSvc = altSvc;
+            this.contentLength = contentLength;
         }
 
         private void onNetMessage(
@@ -1926,12 +1943,14 @@ public final class McpServerFactory implements McpStreamFactory
             long traceId,
             long authorization)
         {
+            final int paramsLength = contentLength - decodedParamsProgress - 1;
             McpBeginExFW beginEx = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId)
                 .toolsCall(t -> t
                     .sessionId(session.unifiedId)
-                    .name(name))
+                    .name(name)
+                    .contentLength(paramsLength))
                 .build();
 
             assert stream == null;
@@ -1960,12 +1979,14 @@ public final class McpServerFactory implements McpStreamFactory
             long traceId,
             long authorization)
         {
+            final int paramsLength = contentLength - decodedParamsProgress - 1;
             McpBeginExFW beginEx = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId)
                 .promptsGet(p -> p
                     .sessionId(session.unifiedId)
-                    .name(name))
+                    .name(name)
+                    .contentLength(paramsLength))
                 .build();
 
             assert stream == null;
@@ -1994,12 +2015,14 @@ public final class McpServerFactory implements McpStreamFactory
             long traceId,
             long authorization)
         {
+            final int paramsLength = contentLength - decodedParamsProgress - 1;
             McpBeginExFW beginEx = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId)
                 .resourcesRead(r -> r
                     .sessionId(session.unifiedId)
-                    .uri(uri))
+                    .uri(uri)
+                    .contentLength(paramsLength))
                 .build();
 
             assert stream == null;

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -19,6 +19,7 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabiliti
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabilities.CLIENT_SAMPLING;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_LIFECYCLE;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
+import static java.lang.Integer.toUnsignedLong;
 
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -5328,6 +5329,12 @@ public final class McpServerFactory implements McpStreamFactory
         return isLocalIndex.test(routedId, sessionId.hashCode());
     }
 
+    static long redirectHash(
+        String sessionId)
+    {
+        return toUnsignedLong(sessionId.hashCode());
+    }
+
     private String extractSessionIdFromState(
         String path)
     {
@@ -5414,7 +5421,7 @@ public final class McpServerFactory implements McpStreamFactory
         {
             final long authorization = begin.authorization();
             doRedirect(sender, originId, routedId, streamId, sequence, acknowledge, traceId, authorization,
-                sessionId.hashCode(), extension);
+                redirectHash(sessionId), extension);
         }
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -4404,6 +4404,8 @@ public final class McpServerFactory implements McpStreamFactory
                         .inject(server::injectAltSvc)
                         .build());
             }
+
+            flushAppWindow(traceId, authorization, 0L, 0, 0, encodeMax);
         }
 
         private void onAppData(

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientIT.java
@@ -67,6 +67,16 @@ public class McpClientIT
     }
 
     @Test
+    @Configuration("client.credentials.yaml")
+    @Specification({
+        "${app}/lifecycle.initialize/client",
+        "${net}/lifecycle.initialize.credentials/server"})
+    public void shouldInitializeLifecycleWithBootstrapCredential() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Configuration("client.yaml")
     @Specification({
         "${app}/lifecycle.initialize/client",

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheIT.java
@@ -101,6 +101,17 @@ public class McpProxyCacheIT
     }
 
     @Test
+    @Configuration("proxy.cache.toolkit.multi.yaml")
+    @Specification({
+        "${app}/cache.hydrate.toolkit.multi.skip.unauthorized/server",
+        "${app}/cache.hydrate.toolkit.multi.skip.unauthorized/client" })
+    @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
+    public void shouldHydrateToolkitMultiSkippingUnauthorizedRoute() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Configuration("proxy.cache.seeded.yaml")
     @Specification({
         "${app}/cache.serve.initialize/client" })

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactoryTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactoryTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
+
+import static io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpServerFactory.redirectHash;
+import static java.lang.Integer.toUnsignedLong;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class McpServerFactoryTest
+{
+    @Test
+    public void shouldWidenSessionHashUnsigned() throws Exception
+    {
+        boolean coveredNegativeHash = false;
+        for (int i = 0; i < 5000; i++)
+        {
+            final String sessionId = "session-" + i;
+            coveredNegativeHash |= sessionId.hashCode() < 0;
+
+            assertEquals(sessionId, toUnsignedLong(sessionId.hashCode()), redirectHash(sessionId));
+        }
+        assertTrue("expected a session id with a negative hashCode in the sample", coveredNegativeHash);
+    }
+
+    @Test
+    public void shouldNotSignExtendNegativeHash() throws Exception
+    {
+        final String sessionId = "76da87be-f7f8-4f0f-a2a5-edc2816abaa3";
+        assertTrue(sessionId.hashCode() < 0);
+
+        assertTrue(redirectHash(sessionId) != (long) sessionId.hashCode());
+        assertEquals(toUnsignedLong(sessionId.hashCode()), redirectHash(sessionId));
+    }
+}

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
@@ -177,6 +177,16 @@ public class McpServerIT
     @Test
     @Configuration("server.yaml")
     @Specification({
+        "${net}/reject.tools.call.without.content.length/client",
+        "${app}/reject.tools.call.without.content.length/server"})
+    public void shouldRejectToolsCallWithoutContentLength() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
         "${net}/tools.call.10k/client",
         "${app}/tools.call.10k/server"})
     public void shouldCallToolWith10kParams() throws Exception

--- a/specs/binding-mcp.spec/src/main/java/io/aklivity/zilla/specs/binding/mcp/internal/McpFunctions.java
+++ b/specs/binding-mcp.spec/src/main/java/io/aklivity/zilla/specs/binding/mcp/internal/McpFunctions.java
@@ -174,6 +174,7 @@ public final class McpFunctions
         {
             private String sessionId;
             private String name;
+            private int contentLength = -1;
 
             public McpToolsCallBeginExBuilder sessionId(
                 String sessionId)
@@ -189,9 +190,16 @@ public final class McpFunctions
                 return this;
             }
 
+            public McpToolsCallBeginExBuilder contentLength(
+                int contentLength)
+            {
+                this.contentLength = contentLength;
+                return this;
+            }
+
             public McpBeginExBuilder build()
             {
-                beginExRW.toolsCall(b -> b.sessionId(sessionId).name(name));
+                beginExRW.toolsCall(b -> b.sessionId(sessionId).name(name).contentLength(contentLength));
                 return McpBeginExBuilder.this;
             }
         }
@@ -218,6 +226,7 @@ public final class McpFunctions
         {
             private String sessionId;
             private String name;
+            private int contentLength = -1;
 
             public McpPromptsGetBeginExBuilder sessionId(
                 String sessionId)
@@ -233,9 +242,16 @@ public final class McpFunctions
                 return this;
             }
 
+            public McpPromptsGetBeginExBuilder contentLength(
+                int contentLength)
+            {
+                this.contentLength = contentLength;
+                return this;
+            }
+
             public McpBeginExBuilder build()
             {
-                beginExRW.promptsGet(b -> b.sessionId(sessionId).name(name));
+                beginExRW.promptsGet(b -> b.sessionId(sessionId).name(name).contentLength(contentLength));
                 return McpBeginExBuilder.this;
             }
         }
@@ -262,6 +278,7 @@ public final class McpFunctions
         {
             private String sessionId;
             private String uri;
+            private int contentLength = -1;
 
             public McpResourcesReadBeginExBuilder sessionId(
                 String sessionId)
@@ -277,9 +294,16 @@ public final class McpFunctions
                 return this;
             }
 
+            public McpResourcesReadBeginExBuilder contentLength(
+                int contentLength)
+            {
+                this.contentLength = contentLength;
+                return this;
+            }
+
             public McpBeginExBuilder build()
             {
-                beginExRW.resourcesRead(b -> b.sessionId(sessionId).uri(uri));
+                beginExRW.resourcesRead(b -> b.sessionId(sessionId).uri(uri).contentLength(contentLength));
                 return McpBeginExBuilder.this;
             }
         }
@@ -480,6 +504,7 @@ public final class McpFunctions
         {
             private String16FW sessionId;
             private String16FW name;
+            private Integer contentLength;
 
             public McpToolsCallBeginExMatcherBuilder sessionId(
                 String sessionId)
@@ -495,6 +520,13 @@ public final class McpFunctions
                 return this;
             }
 
+            public McpToolsCallBeginExMatcherBuilder contentLength(
+                int contentLength)
+            {
+                this.contentLength = contentLength;
+                return this;
+            }
+
             public McpBeginExMatcherBuilder build()
             {
                 return McpBeginExMatcherBuilder.this;
@@ -504,7 +536,7 @@ public final class McpFunctions
                 McpBeginExFW beginEx)
             {
                 final McpToolsCallBeginExFW toolsCall = beginEx.toolsCall();
-                return matchSessionId(toolsCall) && matchName(toolsCall);
+                return matchSessionId(toolsCall) && matchName(toolsCall) && matchContentLength(toolsCall);
             }
 
             private boolean matchSessionId(
@@ -517,6 +549,12 @@ public final class McpFunctions
                 McpToolsCallBeginExFW toolsCall)
             {
                 return name == null || name.equals(toolsCall.name());
+            }
+
+            private boolean matchContentLength(
+                McpToolsCallBeginExFW toolsCall)
+            {
+                return contentLength == null || contentLength == toolsCall.contentLength();
             }
         }
 
@@ -553,6 +591,7 @@ public final class McpFunctions
         {
             private String16FW sessionId;
             private String16FW name;
+            private Integer contentLength;
 
             public McpPromptsGetBeginExMatcherBuilder sessionId(
                 String sessionId)
@@ -568,6 +607,13 @@ public final class McpFunctions
                 return this;
             }
 
+            public McpPromptsGetBeginExMatcherBuilder contentLength(
+                int contentLength)
+            {
+                this.contentLength = contentLength;
+                return this;
+            }
+
             public McpBeginExMatcherBuilder build()
             {
                 return McpBeginExMatcherBuilder.this;
@@ -577,7 +623,7 @@ public final class McpFunctions
                 McpBeginExFW beginEx)
             {
                 final McpPromptsGetBeginExFW promptsGet = beginEx.promptsGet();
-                return matchSessionId(promptsGet) && matchName(promptsGet);
+                return matchSessionId(promptsGet) && matchName(promptsGet) && matchContentLength(promptsGet);
             }
 
             private boolean matchSessionId(
@@ -590,6 +636,12 @@ public final class McpFunctions
                 McpPromptsGetBeginExFW promptsGet)
             {
                 return name == null || name.equals(promptsGet.name());
+            }
+
+            private boolean matchContentLength(
+                McpPromptsGetBeginExFW promptsGet)
+            {
+                return contentLength == null || contentLength == promptsGet.contentLength();
             }
         }
 
@@ -626,6 +678,7 @@ public final class McpFunctions
         {
             private String16FW sessionId;
             private String16FW uri;
+            private Integer contentLength;
 
             public McpResourcesReadBeginExMatcherBuilder sessionId(
                 String sessionId)
@@ -641,6 +694,13 @@ public final class McpFunctions
                 return this;
             }
 
+            public McpResourcesReadBeginExMatcherBuilder contentLength(
+                int contentLength)
+            {
+                this.contentLength = contentLength;
+                return this;
+            }
+
             public McpBeginExMatcherBuilder build()
             {
                 return McpBeginExMatcherBuilder.this;
@@ -650,7 +710,7 @@ public final class McpFunctions
                 McpBeginExFW beginEx)
             {
                 final McpResourcesReadBeginExFW resourcesRead = beginEx.resourcesRead();
-                return matchSessionId(resourcesRead) && matchUri(resourcesRead);
+                return matchSessionId(resourcesRead) && matchUri(resourcesRead) && matchContentLength(resourcesRead);
             }
 
             private boolean matchSessionId(
@@ -663,6 +723,12 @@ public final class McpFunctions
                 McpResourcesReadBeginExFW resourcesRead)
             {
                 return uri == null || uri.equals(resourcesRead.uri());
+            }
+
+            private boolean matchContentLength(
+                McpResourcesReadBeginExFW resourcesRead)
+            {
+                return contentLength == null || contentLength == resourcesRead.contentLength();
             }
         }
     }

--- a/specs/binding-mcp.spec/src/main/resources/META-INF/zilla/mcp.idl
+++ b/specs/binding-mcp.spec/src/main/resources/META-INF/zilla/mcp.idl
@@ -136,6 +136,7 @@ scope mcp
         {
             string16 sessionId;
             string16 name;
+            int32 contentLength = -1;
         }
 
         struct McpPromptsListBeginEx
@@ -147,6 +148,7 @@ scope mcp
         {
             string16 sessionId;
             string16 name;
+            int32 contentLength = -1;
         }
 
         struct McpResourcesListBeginEx
@@ -158,6 +160,7 @@ scope mcp
         {
             string16 sessionId;
             string16 uri;
+            int32 contentLength = -1;
         }
 
         struct McpAbortEx extends core::stream::Extension

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/client.credentials.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/client.credentials.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: client
+    options:
+      authorization:
+        credentials: "test-token"
+    routes:
+      - exit: net0
+        with:
+          headers:
+            :scheme: http
+            :authority: localhost
+            :path: /mcp

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.toolkit.multi.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.toolkit.multi.yaml
@@ -1,0 +1,36 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+stores:
+  memory0:
+    type: test
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+    routes:
+      - exit: app1
+        when:
+          - toolkit: bluesky
+            capability: [tools]
+      - exit: app2
+        when:
+          - toolkit: quartz
+            capability: [tools]

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/mcp.schema.patch.json
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/mcp.schema.patch.json
@@ -132,9 +132,13 @@
                                     {
                                         "title": "Guard Name",
                                         "type": "string"
+                                    },
+                                    "credentials":
+                                    {
+                                        "title": "Credentials",
+                                        "type": "string"
                                     }
                                 },
-                                "required": [ "name" ],
                                 "additionalProperties": false
                             }
                         },

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit.multi.skip.unauthorized/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit.multi.skip.unauthorized/client.rpt
@@ -1,0 +1,58 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("agent-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("agent-1")
+                               .build()
+                           .build()}
+
+connected
+
+read  '{"tools":'
+        '['
+          '{"name":"quartz__get_current_time"}'
+        ']'
+      '}'
+read closed
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit.multi.skip.unauthorized/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit.multi.skip.unauthorized/server.rpt
@@ -1,0 +1,81 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/app1"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:reset.ext ${mcp:resetEx()
+                           .typeId(zilla:id("mcp"))
+                           .bearer()
+                               .realm("github")
+                               .scopes("repo")
+                               .error("INVALID_TOKEN")
+                               .build()
+                           .build()}
+
+read abort
+
+accept "zilla://streams/app2"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-2")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("session-2")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"tools":[{"name":"get_current_time"}]}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed.after.tools.call/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed.after.tools.call/client.rpt
@@ -51,6 +51,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("agent-1")
                                .name("get_weather")
+                               .contentLength(58)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed.after.tools.call/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed.after.tools.call/server.rpt
@@ -100,6 +100,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("agent-1")
                               .name("get_weather")
+                              .contentLength(58)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.reject.bearer/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.reject.bearer/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("agent-1")
                                .name("get_weather")
+                               .contentLength(59)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.reject.bearer/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.reject.bearer/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("agent-1")
                               .name("get_weather")
+                              .contentLength(59)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.requests/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.requests/client.rpt
@@ -51,6 +51,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .promptsGet()
                                .sessionId("session-1")
                                .name("weather_prompt")
+                               .contentLength(25)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.requests/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.requests/server.rpt
@@ -48,6 +48,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .promptsGet()
                               .sessionId("session-1")
                               .name("weather_prompt")
+                              .contentLength(25)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.100k.with.progress/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .promptsGet()
                                .sessionId("session-1")
                                .name("weather_prompt")
+                               .contentLength(60)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.100k.with.progress/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .promptsGet()
                               .sessionId("session-1")
                               .name("weather_prompt")
+                              .contentLength(60)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.10k.with.progress/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .promptsGet()
                                .sessionId("session-1")
                                .name("weather_prompt")
+                               .contentLength(60)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.10k.with.progress/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .promptsGet()
                               .sessionId("session-1")
                               .name("weather_prompt")
+                              .contentLength(60)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.aborted/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .promptsGet()
                                .sessionId("session-1")
                                .name("weather_prompt")
+                               .contentLength(25)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.aborted/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .promptsGet()
                               .sessionId("session-1")
                               .name("weather_prompt")
+                              .contentLength(25)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit.prefixed/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .promptsGet()
                                .sessionId("session-1")
                                .name("bluesky__weather_prompt")
+                               .contentLength(34)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit.prefixed/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .promptsGet()
                               .sessionId("session-1")
                               .name("bluesky__weather_prompt")
+                              .contentLength(34)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/client.rpt
@@ -44,14 +44,14 @@ write zilla:begin.ext ${mcp:beginEx()
                            .promptsGet()
                                .sessionId("session-1")
                                .name("weather_prompt")
-                               .contentLength(34)
+                               .contentLength(25)
                                .build()
                            .build()}
 
 connected
 
 write '{'
-        '"name":"bluesky__weather_prompt"'
+        '"name":"weather_prompt"'
       '}'
 
 read  '{"messages":'

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .promptsGet()
                                .sessionId("session-1")
                                .name("weather_prompt")
+                               .contentLength(34)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/server.rpt
@@ -44,14 +44,14 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .promptsGet()
                               .sessionId("session-1")
                               .name("weather_prompt")
-                              .contentLength(34)
+                              .contentLength(25)
                               .build()
                           .build()}
 
 connected
 
 read  '{'
-        '"name":"bluesky__weather_prompt"'
+        '"name":"weather_prompt"'
       '}'
 
 write flush

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .promptsGet()
                               .sessionId("session-1")
                               .name("weather_prompt")
+                              .contentLength(34)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .promptsGet()
                                .sessionId("session-1")
                                .name("weather_prompt")
+                               .contentLength(25)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .promptsGet()
                               .sessionId("session-1")
                               .name("weather_prompt")
+                              .contentLength(25)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.tools.call.without.content.length/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.tools.call.without.content.length/server.rpt
@@ -13,46 +13,24 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+accept "zilla://streams/app0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
 
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .lifecycle()
-                               .build()
-                           .build()}
-
-connected
+accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("session-1")
                               .build()
                           .build()}
 
-read notify LIFECYCLE_INITIALIZED
-
-connect await LIFECYCLE_INITIALIZED
-        "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+connected
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourcesRead()
+                           .lifecycle()
                                .sessionId("session-1")
-                               .uri("file:///data/readme.txt")
-                               .contentLength(33)
                                .build()
                            .build()}
-
-connected
-
-write '{"uri":"file:///data/readme.txt"}'
-
-read  '{"contents":[{"uri":"file:///data/readme.txt","mimeType":"text/plain","text":"Hello World"}]}'
-read closed
-
-write close
+write flush

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k.with.progress/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .resourcesRead()
                                .sessionId("session-1")
                                .uri("file:///data/image.png")
+                               .contentLength(67)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k.with.progress/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .resourcesRead()
                               .sessionId("session-1")
                               .uri("file:///data/image.png")
+                              .contentLength(67)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .resourcesRead()
                                .sessionId("session-1")
                                .uri("file:///data/image.png")
+                               .contentLength(32)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .resourcesRead()
                               .sessionId("session-1")
                               .uri("file:///data/image.png")
+                              .contentLength(32)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k.with.progress/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .resourcesRead()
                                .sessionId("session-1")
                                .uri("file:///data/image.png")
+                               .contentLength(67)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k.with.progress/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .resourcesRead()
                               .sessionId("session-1")
                               .uri("file:///data/image.png")
+                              .contentLength(67)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .resourcesRead()
                                .sessionId("session-1")
                                .uri("file:///data/image.png")
+                               .contentLength(32)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .resourcesRead()
                               .sessionId("session-1")
                               .uri("file:///data/image.png")
+                              .contentLength(32)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.aborted/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .resourcesRead()
                                .sessionId("session-1")
                                .uri("file:///data/readme.txt")
+                               .contentLength(33)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.aborted/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .resourcesRead()
                               .sessionId("session-1")
                               .uri("file:///data/readme.txt")
+                              .contentLength(33)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit.prefixed/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .resourcesRead()
                                .sessionId("session-1")
                                .uri("bluesky+file:///data/readme.txt")
+                               .contentLength(41)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit.prefixed/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .resourcesRead()
                               .sessionId("session-1")
                               .uri("bluesky+file:///data/readme.txt")
+                              .contentLength(41)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .resourcesRead()
                                .sessionId("session-1")
                                .uri("file:///data/readme.txt")
+                               .contentLength(41)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/client.rpt
@@ -44,14 +44,14 @@ write zilla:begin.ext ${mcp:beginEx()
                            .resourcesRead()
                                .sessionId("session-1")
                                .uri("file:///data/readme.txt")
-                               .contentLength(41)
+                               .contentLength(33)
                                .build()
                            .build()}
 
 connected
 
 write '{'
-        '"uri":"bluesky+file:///data/readme.txt"'
+        '"uri":"file:///data/readme.txt"'
       '}'
 
 read  '{"contents":'

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .resourcesRead()
                               .sessionId("session-1")
                               .uri("file:///data/readme.txt")
+                              .contentLength(41)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/server.rpt
@@ -44,14 +44,14 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .resourcesRead()
                               .sessionId("session-1")
                               .uri("file:///data/readme.txt")
-                              .contentLength(41)
+                              .contentLength(33)
                               .build()
                           .build()}
 
 connected
 
 read  '{'
-        '"uri":"bluesky+file:///data/readme.txt"'
+        '"uri":"file:///data/readme.txt"'
       '}'
 
 write flush

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .resourcesRead()
                               .sessionId("session-1")
                               .uri("file:///data/readme.txt")
+                              .contentLength(33)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k.with.progress/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(133440)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k.with.progress/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(133440)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(133405)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(133405)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k.with.progress/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(13440)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k.with.progress/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(13440)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(13405)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(13405)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.aborted/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(59)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.aborted/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(59)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.guarded/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.guarded/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(59)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.guarded/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.guarded/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(59)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.proxied/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.proxied/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(59)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.proxied/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.proxied/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(59)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(59)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(59)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.guarded/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.guarded/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(59)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.guarded/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.guarded/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(59)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.proxied/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.proxied/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(59)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.proxied/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.proxied/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(59)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(59)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(59)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.guarded/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.guarded/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(59)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.guarded/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.guarded/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(59)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.proxied/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.proxied/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(59)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.proxied/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.proxied/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(59)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(59)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(59)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.reject.bearer/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.reject.bearer/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(59)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.reject.bearer/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.reject.bearer/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(59)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit.prefixed/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("bluesky__get_weather")
+                               .contentLength(68)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit.prefixed/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("bluesky__get_weather")
+                              .contentLength(68)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(68)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(68)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.prefixed/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("bluesky__get_weather")
+                               .contentLength(68)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.prefixed/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("bluesky__get_weather")
+                              .contentLength(68)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress.prefixed/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("bluesky__get_weather")
+                               .contentLength(103)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress.prefixed/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("bluesky__get_weather")
+                              .contentLength(103)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/client.rpt
@@ -44,14 +44,14 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
-                               .contentLength(103)
+                               .contentLength(94)
                                .build()
                            .build()}
 
 connected
 
 write '{'
-        '"name":"bluesky__get_weather",'
+        '"name":"get_weather",'
         '"arguments":'
         '{'
           '"location": "New York"'

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(103)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(103)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/server.rpt
@@ -44,14 +44,14 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
-                              .contentLength(103)
+                              .contentLength(94)
                               .build()
                           .build()}
 
 connected
 
 read  '{'
-        '"name":"bluesky__get_weather",'
+        '"name":"get_weather",'
         '"arguments":'
         '{'
           '"location": "New York"'

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/client.rpt
@@ -44,14 +44,14 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
-                               .contentLength(68)
+                               .contentLength(59)
                                .build()
                            .build()}
 
 connected
 
 write '{'
-        '"name":"bluesky__get_weather",'
+        '"name":"get_weather",'
         '"arguments":'
         '{'
           '"location": "New York"'

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(68)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(68)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/server.rpt
@@ -44,14 +44,14 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
-                              .contentLength(68)
+                              .contentLength(59)
                               .build()
                           .build()}
 
 connected
 
 read  '{'
-        '"name":"bluesky__get_weather",'
+        '"name":"get_weather",'
         '"arguments":'
         '{'
           '"location": "New York"'

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.resume/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.resume/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(94)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.resume/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.resume/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(94)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspend/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspend/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(94)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspend/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspend/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(94)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspended/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspended/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(94)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspended/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspended/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(94)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(94)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(94)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call/client.rpt
@@ -44,6 +44,7 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("get_weather")
+                               .contentLength(59)
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call/server.rpt
@@ -44,6 +44,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("get_weather")
+                              .contentLength(59)
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.credentials/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.credentials/server.rpt
@@ -1,0 +1,74 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-06-18")
+                           .header("authorization", "Bearer test-token")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "200")
+                            .header("content-type", "application/json")
+                            .header("mcp-session-id", "session-1")
+                            .build()}
+write flush
+
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write flush
+
+write close
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-06-18")
+                           .header("mcp-session-id", "session-1")
+                           .header("authorization", "Bearer test-token")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "202")
+                            .build()}
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.requests/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.requests/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "82")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.requests/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.requests/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "82")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.100k.with.progress/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "117")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.100k.with.progress/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "117")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.10k.with.progress/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "117")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.10k.with.progress/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "117")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.aborted/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "82")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.aborted/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "82")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "82")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "82")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.tools.call.without.content.length/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.tools.call.without.content.length/client.rpt
@@ -84,63 +84,16 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
-                            .header("content-length", "115")
                             .build()}
 
 connected
 
-write '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_weather","arguments":{"location": "New York"}}}'
-
+write '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_weather","arguments":{"location":"New York"}}}'
 write close
 
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
-                           .header(":status", "200")
-                           .header("content-type", "text/event-stream")
+                           .header(":status", "400")
                            .build()}
-
-read 'id: 2:1\n'
-read 'data: {'
-       '"jsonrpc":"2.0",'
-       '"method":"elicitation/create",'
-       '"params":'
-       '{'
-         '"mode":"url",'
-         '"elicitationId":"elicit-1",'
-         '"url":"https://server.example.com/authorize?state=session-1.elicit-1.7f3a9b1c&redirect_uri='
-         ${http:encodeQuery("https://localhost:8080/mcp/auth/callback")}
-         '"'
-       '}'
-     '}\n'
-read '\n'
-
-read 'id: 2:1\n'
-read 'data: {'
-       '"jsonrpc":"2.0",'
-       '"method":"elicitation/complete",'
-       '"params":'
-       '{'
-         '"elicitationId":"elicit-1",'
-         '"status":"completed"'
-       '}'
-     '}\n'
-read '\n'
-
-read 'data: {'
-       '"jsonrpc":"2.0",'
-       '"id":2,'
-       '"result":'
-       '{'
-         '"content":'
-         '['
-           '{'
-             '"type": "text",'
-             '"text": "Current weather in New York:\\nTemperature: 72°F\\nConditions: Partly cloudy"'
-           '}'
-         '],'
-         '"isError": false'
-       '}'
-     '}\n'
-read '\n'
 
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.tools.call.without.content.length/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.tools.call.without.content.length/server.rpt
@@ -81,24 +81,17 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
-                           .header("content-length", "13461")
                            .build()}
 
 connected
 
-read '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_weather","arguments":{"image":"'
-read ${core:randomBase64(10000)}
-read '","location":"New York"}}}'
+read '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_weather","arguments":{"location":"New York"}}}'
 read closed
 
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
-                            .header(":status", "200")
-                            .header("content-type", "application/json")
+                            .header(":status", "400")
                             .build()}
-write flush
-
-write '{"jsonrpc":"2.0","id":2,"result":{"content":[{"type": "text","text": "ok"}],"isError": false}}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k.with.progress/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "127")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k.with.progress/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "127")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "92")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "92")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k.with.progress/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "127")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k.with.progress/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "127")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "92")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "92")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.aborted/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "93")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.aborted/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "93")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "93")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "93")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k.with.progress/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "133496")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k.with.progress/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "133496")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "133461")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "133461")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k.with.progress/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "13496")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k.with.progress/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "13496")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "13461")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.aborted/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "115")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.aborted/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "115")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed.proxied/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed.proxied/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "115")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "115")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "115")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined.proxied/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined.proxied/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "115")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined.proxied/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined.proxied/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "115")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "115")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "115")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.timeout/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.timeout/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "115")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.timeout/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.timeout/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "115")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.reject.bearer/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.reject.bearer/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "115")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.reject.bearer/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.reject.bearer/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "115")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.resume/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.resume/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "150")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.resume/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.resume/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "150")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspend/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspend/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "150")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspend/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspend/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "150")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspended/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspended/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "150")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspended/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspended/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "150")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "150")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "150")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call/client.rpt
@@ -84,6 +84,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-06-18")
                             .header("mcp-session-id", "session-1")
+                            .header("content-length", "115")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call/server.rpt
@@ -81,6 +81,7 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-06-18")
                            .header("mcp-session-id", "session-1")
+                           .header("content-length", "115")
                            .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/internal/McpFunctionsTest.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/internal/McpFunctionsTest.java
@@ -117,6 +117,7 @@ public class McpFunctionsTest
             .toolsCall()
                 .sessionId("session-1")
                 .name("my-tool")
+                .contentLength(59)
                 .build()
             .build();
 
@@ -131,6 +132,7 @@ public class McpFunctionsTest
             .toolsCall()
                 .sessionId("session-1")
                 .name("my-tool")
+                .contentLength(59)
                 .build()
             .build();
 
@@ -141,7 +143,8 @@ public class McpFunctionsTest
             .typeId(0)
             .toolsCall(b -> b
                 .sessionId("session-1")
-                .name("my-tool"))
+                .name("my-tool")
+                .contentLength(59))
             .build();
 
         assertNotNull(matcher.match(byteBuf));
@@ -190,6 +193,7 @@ public class McpFunctionsTest
             .promptsGet()
                 .sessionId("session-1")
                 .name("my-prompt")
+                .contentLength(25)
                 .build()
             .build();
 
@@ -204,6 +208,7 @@ public class McpFunctionsTest
             .promptsGet()
                 .sessionId("session-1")
                 .name("my-prompt")
+                .contentLength(25)
                 .build()
             .build();
 
@@ -214,7 +219,8 @@ public class McpFunctionsTest
             .typeId(0)
             .promptsGet(b -> b
                 .sessionId("session-1")
-                .name("my-prompt"))
+                .name("my-prompt")
+                .contentLength(25))
             .build();
 
         assertNotNull(matcher.match(byteBuf));
@@ -263,6 +269,7 @@ public class McpFunctionsTest
             .resourcesRead()
                 .sessionId("session-1")
                 .uri("file:///data/resource.txt")
+                .contentLength(33)
                 .build()
             .build();
 
@@ -277,6 +284,7 @@ public class McpFunctionsTest
             .resourcesRead()
                 .sessionId("session-1")
                 .uri("file:///data/resource.txt")
+                .contentLength(33)
                 .build()
             .build();
 
@@ -287,7 +295,8 @@ public class McpFunctionsTest
             .typeId(0)
             .resourcesRead(b -> b
                 .sessionId("session-1")
-                .uri("file:///data/resource.txt"))
+                .uri("file:///data/resource.txt")
+                .contentLength(33))
             .build();
 
         assertNotNull(matcher.match(byteBuf));

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
@@ -146,6 +146,15 @@ public class NetworkIT
 
     @Test
     @Specification({
+        "${net}/reject.tools.call.without.content.length/client",
+        "${net}/reject.tools.call.without.content.length/server"})
+    public void shouldRejectToolsCallWithoutContentLength() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${net}/tools.call.10k/client",
         "${net}/tools.call.10k/server"})
     public void shouldCallToolWith10kParams() throws Exception


### PR DESCRIPTION
## Description

The remaining MCP proxy hydration/forwarding fixes plus the **per-upstream bootstrap
credential** — the third and final binding-mcp extraction from the `examples/mcp.proxy`
branch (#1793), after cache refresh (#1814) and the single session-id contract (#1816).

Fixes #1817.

## Changes

- **`fix`: frame client HTTP request bodies with `Content-Length`.**
- **`feat`: frame streamed request bodies with `Content-Length`** — the server stamps a
  guesstimate `contentLength` on `McpBeginEx`; the client declares a south `Content-Length`
  and whitespace-pads (no buffering / chunked) for streamed `tools/call` / `prompts/get` /
  `resources/read`.
- **`fix`: grant the proxy reply window** when the request reply begins (north `tools/list`
  reply-window race).
- **`fix`: strip the toolkit prefix** from the forwarded tool name in the proxy request body.
- **`fix`: degrade gracefully when a south route fails cache hydration** — skip a
  never-established route (`sessionId == null`) and isolate its per-route lifecycle failure
  from the shared hydrater, so healthy routes still aggregate.
- **`feat`: per-upstream bootstrap credential** on the mcp client binding
  (`options.authorization.credentials`) — used when there's no inbound client token.
- **`fix`: widen the redirect hash unsigned** — `RedirectFW` carried `sessionId.hashCode()`
  sign-extended; binding-http folds it via `Long.hashCode`, so a negative hash routed the
  cross-worker redirect to the wrong worker → re-redirect → HTTP 500 for ~half of sessions
  under multiple workers. Widen with `Integer.toUnsignedLong` so the fold round-trips.

## Notes

General binding-mcp behavior, independent of the example. The example-config edits that
accompanied two of these commits (`degrade gracefully`, `bootstrap credential`) are
**excluded** and remain on the example branch. After this, only `examples/mcp.proxy` remains
on #1793.

## Testing

`./mvnw verify -pl specs/binding-mcp.spec,runtime/binding-mcp` — binding-mcp ITs
(server/client/proxy/lifecycle/cache) + spec ITs green, against develop's engine
(post #1816).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
