### PR TITLE
fix(binding-mcp): parse initialize without JPMS-blocked reflection

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/codec/McpInitializeParams.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/codec/McpInitializeParams.java
@@ -14,20 +14,10 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.codec;
 
-import jakarta.json.JsonValue;
+import jakarta.json.JsonObject;
 
 public class McpInitializeParams
 {
     public String protocolVersion;
-    public Capabilities capabilities;
-
-    public static class Capabilities
-    {
-        public Elicitation elicitation;
-    }
-
-    public static class Elicitation
-    {
-        public JsonValue url;
-    }
+    public JsonObject capabilities;
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -32,6 +32,7 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import jakarta.json.JsonValue;
 import jakarta.json.bind.JsonbBuilder;
 import jakarta.json.stream.JsonParser;
 import jakarta.json.stream.JsonParserFactory;
@@ -1867,12 +1868,14 @@ public final class McpServerFactory implements McpStreamFactory
             decodedProtocolVersion = params.protocolVersion;
 
             int capabilities = 0;
-            final McpInitializeParams.Elicitation elicitation =
-                params.capabilities != null ? params.capabilities.elicitation : null;
+            final JsonValue elicitation = params.capabilities != null
+                ? params.capabilities.get("elicitation")
+                : null;
             if (elicitation != null)
             {
                 capabilities |= CLIENT_ELICITATION.value() | CLIENT_ELICITATION_FORM.value();
-                if (elicitation.url != null)
+                if (elicitation.getValueType() == JsonValue.ValueType.OBJECT &&
+                    elicitation.asJsonObject().containsKey("url"))
                 {
                     capabilities |= CLIENT_ELICITATION_URL.value();
                 }

--- a/runtime/binding-mcp/src/main/moditect/module-info.java
+++ b/runtime/binding-mcp/src/main/moditect/module-info.java
@@ -19,6 +19,8 @@ module io.aklivity.zilla.runtime.binding.mcp
 
     exports io.aklivity.zilla.runtime.binding.mcp.config;
 
+    opens io.aklivity.zilla.runtime.binding.mcp.internal.codec;
+
     provides io.aklivity.zilla.runtime.engine.binding.BindingFactorySpi
         with io.aklivity.zilla.runtime.binding.mcp.internal.McpBindingFactorySpi;
 


### PR DESCRIPTION
## Problem

On the packaged **module-path** runtime image (the Docker image), every MCP `initialize` crashes the engine worker:

```
jakarta.json.bind.JsonbException: Error accessing field 'capabilities' declared in ... McpInitializeParams
Caused by: java.lang.IllegalAccessException: access to public member failed:
  ...McpInitializeParams.capabilities / ...McpInitializeParams$Capabilities/getField, from public Lookup
```

`McpServerFactory.onDecodeInitialize` deserializes `McpInitializeParams` with `JsonbBuilder.create().fromJson(...)`. yasson uses `MethodHandles` to build read handles; in a named module it cannot reflect into the encapsulated `internal.codec` package, so reading the `capabilities` field — whose type is the nested `Capabilities`/`Elicitation` classes added in #1820 — fails. Fields of accessible types (`String`, `JsonValue`) were unaffected, which is why this regressed only when the nested codec types were introduced.

It does not reproduce in the integration tests because they run on the **classpath** (unnamed module — every package open); it manifests only on the **module path**.

## Fix

- Read `capabilities` as a `jakarta.json.JsonObject` (an accessible jakarta.json type) and inspect `elicitation` and its `url` member via the JSON API, instead of reflecting into nested `internal.codec` POJOs.
- Add `opens io.aklivity.zilla.runtime.binding.mcp.internal.codec;` to the module descriptor as defense for any other JSON-B deserialization of codec POJOs (keeps compile-time encapsulation; permits runtime reflection only).

## Testing

- `./mvnw verify -pl runtime/binding-mcp` — 193 ITs green, checkstyle + coverage met.
- Existing `lifecycle.initialize.elicitation.url` / `.form` ITs cover client-capability detection.
- Verified against the module-path Docker image: `initialize` previously crash-looped on every request; now returns `200` with the negotiated protocol version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)