### PR TITLE
fix(binding-mcp): keep proxied tool-call result when upstream sends a resumable flush

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -4714,32 +4714,32 @@ public final class McpServerFactory implements McpStreamFactory
 
             assert replyAck <= replySeq;
 
+            final McpFlushExFW flushEx = extension.get(mcpFlushExRO::tryWrap);
+
             if (replySeq > replyAck + decodeMax)
             {
                 cleanupApp(traceId, authorization);
             }
             else if (!server.sseUpgrade)
             {
-                cleanupApp(traceId, authorization);
-            }
-            else if (extension.sizeof() > 0)
-            {
-                final McpFlushExFW flushEx =
-                    mcpFlushExRO.tryWrap(extension.buffer(), extension.offset(), extension.limit());
-                if (flushEx != null)
+                if (flushEx == null || flushEx.kind() != McpFlushExFW.KIND_RESUMABLE)
                 {
-                    if (flushEx.kind() == McpFlushExFW.KIND_ELICIT_COMPLETE)
-                    {
-                        onAppFlushElicitComplete(traceId, authorization, flushEx.elicitComplete());
-                    }
-                    else if (sse != null)
-                    {
-                        encodeRequestEventViaEventStream(traceId, authorization, flushEx);
-                    }
-                    else
-                    {
-                        server.doEncodeRequestEvent(traceId, authorization, requestId, flushEx);
-                    }
+                    cleanupApp(traceId, authorization);
+                }
+            }
+            else if (flushEx != null)
+            {
+                if (flushEx.kind() == McpFlushExFW.KIND_ELICIT_COMPLETE)
+                {
+                    onAppFlushElicitComplete(traceId, authorization, flushEx.elicitComplete());
+                }
+                else if (sse != null)
+                {
+                    encodeRequestEventViaEventStream(traceId, authorization, flushEx);
+                }
+                else
+                {
+                    server.doEncodeRequestEvent(traceId, authorization, requestId, flushEx);
                 }
             }
         }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
@@ -307,6 +307,16 @@ public class McpServerIT
     @Test
     @Configuration("server.timeout.yaml")
     @Specification({
+        "${net}/tools.call/client",
+        "${app}/tools.call.resumable/server"})
+    public void shouldCallToolWithUpstreamResumableFlush() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
         "${net}/tools.call.elicit.completed/client",
         "${app}/tools.call.elicit.completed/server"})
     public void shouldCallToolElicitCompleted() throws Exception

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.resumable/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.resumable/client.rpt
@@ -1,0 +1,80 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsCall()
+                               .sessionId("session-1")
+                               .name("get_weather")
+                               .contentLength(59)
+                               .build()
+                           .build()}
+
+connected
+
+write '{'
+        '"name":"get_weather",'
+        '"arguments":'
+        '{'
+          '"location": "New York"'
+        '}'
+      '}'
+
+read advised zilla:flush ${mcp:matchFlushEx()
+                               .typeId(zilla:id("mcp"))
+                               .resumable()
+                                   .id("0")
+                                   .build()
+                               .build()}
+
+read  '{'
+        '"content":'
+        '['
+          '{'
+            '"type": "text",'
+            '"text": "Current weather in New York:\\nTemperature: 72°F\\nConditions: Partly cloudy"'
+          '}'
+        '],'
+        '"isError": false'
+      '}'
+read closed
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.resumable/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.resumable/server.rpt
@@ -1,0 +1,84 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsCall()
+                              .sessionId("session-1")
+                              .name("get_weather")
+                              .contentLength(59)
+                              .build()
+                          .build()}
+
+connected
+
+read  '{'
+        '"name":"get_weather",'
+        '"arguments":'
+        '{'
+          '"location": "New York"'
+        '}'
+      '}'
+
+write flush
+
+write advise zilla:flush ${mcp:flushEx()
+                               .typeId(zilla:id("mcp"))
+                               .resumable()
+                                   .id("0")
+                                   .build()
+                               .build()}
+
+write '{'
+        '"content":'
+        '['
+          '{'
+            '"type": "text",'
+            '"text": "Current weather in New York:\\nTemperature: 72°F\\nConditions: Partly cloudy"'
+          '}'
+        '],'
+        '"isError": false'
+      '}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
@@ -200,6 +200,15 @@ public class ApplicationIT
 
     @Test
     @Specification({
+        "${app}/tools.call.resumable/client",
+        "${app}/tools.call.resumable/server"})
+    public void shouldCallToolWithUpstreamResumableFlush() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/tools.call/client",
         "${app}/tools.call/server"})
     public void shouldCallTool() throws Exception


### PR DESCRIPTION
## Problem

A real MCP SDK upstream (StreamableHTTP transport — e.g. `@modelcontextprotocol/server-everything`) emits a **leading empty-`data:` SSE event** on every response. Zilla's mcp client decodes it as a resumption marker (`onDecodeResumable`) and relays it north as a **resumable flush**.

For a unary `tools/call`, the north response is plain `application/json` (not SSE-upgraded), so `McpServer.McpRequestStream.onAppFlush` hit the `!server.sseUpgrade` branch and called `cleanupApp` — tearing down the reply stream **before** the result DATA arrived. The result was dropped and the client saw the connection close mid-response (`transfer closed with outstanding read data remaining` / `terminated`).

Net effect: real SDK clients (MCP Inspector, SDK-based clients) could initialize and `tools/list` against the proxy, but every proxied `tools/call` failed.

## Fix

In `onAppFlush`, resolve `flushEx = extension.get(mcpFlushExRO::tryWrap)` and, on a non-SSE response, ignore a `KIND_RESUMABLE` flush instead of calling `cleanupApp`. The resumption marker is irrelevant to a buffered JSON response, so the pending result now flows through.

## Testing

- New `tools.call.resumable` scenario: a resumable flush is delivered before the result on a non-SSE response.
  - `McpServerIT.shouldCallToolWithUpstreamResumableFlush` (against the engine) — **fails** on the old code (result dropped), passes with the fix.
  - `ApplicationIT.shouldCallToolWithUpstreamResumableFlush` (peer script consistency).
- `./mvnw verify -pl runtime/binding-mcp` — 196 ITs green, checkstyle + coverage met.
- End-to-end verified against the develop-SNAPSHOT image: a real MCP SDK client's `everything__echo` tool call now returns through the proxy.

Builds on #1821 and #1822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)