### PR TITLE
fix(docker-image): include metrics-mcp module in the runtime image

### DIFF
--- a/cloud/docker-image/src/main/docker/zpm.json.template
+++ b/cloud/docker-image/src/main/docker/zpm.json.template
@@ -62,6 +62,7 @@
     "io.aklivity.zilla:metrics-stream",
     "io.aklivity.zilla:metrics-http",
     "io.aklivity.zilla:metrics-grpc",
+    "io.aklivity.zilla:metrics-mcp",
     "io.aklivity.zilla:model-avro",
     "io.aklivity.zilla:model-core",
     "io.aklivity.zilla:model-json",


### PR DESCRIPTION
## Problem

PR #1837 added MCP metrics (`mcp.*` counters + histograms) and wired `metrics-mcp` as a `cloud/docker-image` **maven** dependency, but did **not** add it to the **zpm image manifest** (`zpm.json.template`). The Dockerfile builds the runtime via `zpmw install` from that manifest, so the packaged image's jlink module set never included `io.aklivity.zilla.runtime.metrics.mcp`.

Effect: in a deployed Zilla, any `telemetry.metrics` entry like `mcp.tools.call` fails schema validation —

```
ConfigException: [/telemetry/metrics/...] The value must be one of
["grpc.request.size", ..., "http.duration", ..., "stream.closes.sent"].
```

— because the mcp metrics group (and its schema patch) isn't on the engine classpath. So MCP metrics couldn't actually be used despite #1837.

## Fix

Add `io.aklivity.zilla:metrics-mcp` to `zpm.json.template` (alongside `metrics-stream`/`http`/`grpc`). The Dockerfile regenerates `zpm.json` from the template, so this is the single source of truth.

## Verification

Rebuilt `develop-SNAPSHOT`:
- `java --list-modules` now includes `io.aklivity.zilla.runtime.metrics.mcp`
- a config with `telemetry.metrics: [mcp.*]` on an mcp server binding validates and emits, e.g. `mcp_tools_call_total{method="tools.call",outcome="ok",tool="..."}` via the prometheus exporter.

Follow-up to #1837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)