### PR TITLE
[codex] Raise metrics-grpc coverage gate

### DIFF
--- a/runtime/metrics-grpc/pom.xml
+++ b/runtime/metrics-grpc/pom.xml
@@ -24,8 +24,8 @@
   </licenses>
 
   <properties>
-    <jacoco.coverage.ratio>0.00</jacoco.coverage.ratio>
-    <jacoco.missed.count>99</jacoco.missed.count>
+    <jacoco.coverage.ratio>0.98</jacoco.coverage.ratio>
+    <jacoco.missed.count>1</jacoco.missed.count>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Summary

Raise the `runtime/metrics-grpc` JaCoCo gate from the placeholder zero threshold to match the module's actual tested coverage.

The observed module coverage after generating the JaCoCo report is:

- instruction coverage: `0.984485`
- missed classes: `1`

This updates the POM gate to `0.98` instruction coverage and `1` missed class so regressions are caught without exceeding the current measured coverage.

## Validation

- `./mvnw -B -pl runtime/binding-mcp,runtime/metrics-grpc -am clean verify`
- `./mvnw -B -pl runtime/binding-mcp,runtime/metrics-grpc jacoco:report`