### PR TITLE
[codex] Improve binding-mcp coverage gate

### DIFF
--- a/runtime/binding-mcp/pom.xml
+++ b/runtime/binding-mcp/pom.xml
@@ -24,8 +24,8 @@
   </licenses>
 
   <properties>
-    <jacoco.coverage.ratio>0.00</jacoco.coverage.ratio>
-    <jacoco.missed.count>500</jacoco.missed.count>
+    <jacoco.coverage.ratio>0.87</jacoco.coverage.ratio>
+    <jacoco.missed.count>0</jacoco.missed.count>
   </properties>
 
   <dependencies>

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/config/McpConfigTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/config/McpConfigTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.config;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.Test;
+
+public class McpConfigTest
+{
+    @Test
+    public void shouldBuildElicitationWithDefaultCallback()
+    {
+        McpElicitationConfig elicitation = McpElicitationConfig.builder()
+            .build();
+
+        assertThat(elicitation.callback, equalTo(McpElicitationConfig.DEFAULT_CALLBACK_PATH));
+    }
+
+    @Test
+    public void shouldBuildElicitationWithCallback()
+    {
+        McpElicitationConfig elicitation = McpElicitationConfig.builder()
+            .callback("oauth/callback")
+            .build();
+
+        assertThat(elicitation.callback, equalTo("oauth/callback"));
+    }
+
+    @Test
+    public void shouldMapElicitation()
+    {
+        String callback = McpElicitationConfig.<String>builder(e -> e.callback)
+            .callback("auth/complete")
+            .build();
+
+        assertThat(callback, equalTo("auth/complete"));
+    }
+
+    @Test
+    public void shouldCreatePrompt()
+    {
+        McpPromptConfig prompt = new McpPromptConfig("prompt", "description");
+
+        assertThat(prompt.name, equalTo("prompt"));
+        assertThat(prompt.description, equalTo("description"));
+    }
+}

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/codec/McpCapabilitiesTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/codec/McpCapabilitiesTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.codec;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.util.Map;
+import java.util.Optional;
+
+import jakarta.json.Json;
+
+import org.junit.Test;
+
+public class McpCapabilitiesTest
+{
+    @Test
+    public void shouldCreateClientCapabilities()
+    {
+        McpClientCapabilities capabilities = new McpClientCapabilities();
+        capabilities.experimental = Json.createObjectBuilder()
+            .add("feature", true)
+            .build();
+
+        capabilities.roots = capabilities.new Roots();
+        capabilities.roots.listChanged = true;
+
+        capabilities.sampling = capabilities.new Sampling();
+        capabilities.sampling.context = new McpClientCapabilities.Sampling.Context();
+        capabilities.sampling.tools = new McpClientCapabilities.Sampling.Tools();
+
+        capabilities.elicitation = capabilities.new Elicitation();
+        capabilities.elicitation.form = new McpClientCapabilities.Elicitation.Form();
+        capabilities.elicitation.url = new McpClientCapabilities.Elicitation.Url();
+
+        capabilities.tasks = capabilities.new Tasks();
+        capabilities.tasks.list = new McpClientCapabilities.Tasks.List();
+        capabilities.tasks.cancel = new McpClientCapabilities.Tasks.Cancel();
+        capabilities.tasks.requests = capabilities.tasks.new Requests();
+        capabilities.tasks.requests.sampling = capabilities.tasks.requests.new Sampling();
+        capabilities.tasks.requests.sampling.createMessage =
+            new McpClientCapabilities.Tasks.Requests.Sampling.CreateMessage();
+        capabilities.tasks.requests.elicitation = capabilities.tasks.requests.new Elicitation();
+        capabilities.tasks.requests.elicitation.create =
+            new McpClientCapabilities.Tasks.Requests.Elicitation.Create();
+
+        assertThat(capabilities.experimental.getBoolean("feature"), is(true));
+        assertThat(capabilities.roots.listChanged, is(true));
+        assertThat(capabilities.sampling.context, notNullValue());
+        assertThat(capabilities.sampling.tools, notNullValue());
+        assertThat(capabilities.elicitation.form, notNullValue());
+        assertThat(capabilities.elicitation.url, notNullValue());
+        assertThat(capabilities.tasks.list, notNullValue());
+        assertThat(capabilities.tasks.cancel, notNullValue());
+        assertThat(capabilities.tasks.requests.sampling.createMessage, notNullValue());
+        assertThat(capabilities.tasks.requests.elicitation.create, notNullValue());
+    }
+
+    @Test
+    public void shouldCreateInitializeRequestParams()
+    {
+        McpImplementationInfo implementation = new McpImplementationInfo();
+        implementation.name = "zilla";
+        implementation.version = "1.0";
+
+        McpInitializeRequestParams params = new McpInitializeRequestParams();
+        params.protocolVersion = "2025-03-26";
+        params.capabilities = new McpClientCapabilities();
+        params.clientInfo = implementation;
+
+        assertThat(params.protocolVersion, equalTo("2025-03-26"));
+        assertThat(params.capabilities, notNullValue());
+        assertThat(params.clientInfo.name, equalTo("zilla"));
+        assertThat(params.clientInfo.version, equalTo("1.0"));
+    }
+
+    @Test
+    public void shouldCreateServerCapabilities()
+    {
+        McpServerCapabilities.Logging logging = new McpServerCapabilities.Logging();
+        McpServerCapabilities.Completions completions = new McpServerCapabilities.Completions();
+        McpServerCapabilities.Prompts prompts = new McpServerCapabilities.Prompts(true);
+        McpServerCapabilities.Resources resources = new McpServerCapabilities.Resources(true, true);
+        McpServerCapabilities.Tools tools = new McpServerCapabilities.Tools(true);
+
+        McpServerCapabilities capabilities = new McpServerCapabilities(
+            Optional.of(Map.of("feature", "enabled")),
+            Optional.of(logging),
+            Optional.of(completions),
+            Optional.of(prompts),
+            Optional.of(resources),
+            Optional.of(tools));
+
+        assertThat(capabilities.experimental().orElseThrow().get("feature"), equalTo("enabled"));
+        assertThat(capabilities.logging().orElseThrow(), equalTo(logging));
+        assertThat(capabilities.completions().orElseThrow(), equalTo(completions));
+        assertThat(capabilities.prompts().orElseThrow().listChanged(), is(true));
+        assertThat(capabilities.resources().orElseThrow().subscribe(), is(true));
+        assertThat(capabilities.resources().orElseThrow().listChanged(), is(true));
+        assertThat(capabilities.tools().orElseThrow().listChanged(), is(true));
+    }
+
+    @Test
+    public void shouldCreateServerTaskCapabilities()
+    {
+        McpServerCapabilities.Tasks.List list = new McpServerCapabilities.Tasks.List();
+        McpServerCapabilities.Tasks.Cancel cancel = new McpServerCapabilities.Tasks.Cancel();
+        McpServerCapabilities.Tasks.Requests.Tools.Call call =
+            new McpServerCapabilities.Tasks.Requests.Tools.Call();
+        McpServerCapabilities.Tasks.Requests.Tools tools =
+            new McpServerCapabilities.Tasks.Requests.Tools(Optional.of(call));
+        McpServerCapabilities.Tasks.Requests requests =
+            new McpServerCapabilities.Tasks.Requests(Optional.of(tools));
+        McpServerCapabilities.Tasks tasks =
+            new McpServerCapabilities.Tasks(Optional.of(list), Optional.of(cancel), Optional.of(requests));
+
+        assertThat(tasks.list().orElseThrow(), equalTo(list));
+        assertThat(tasks.cancel().orElseThrow(), equalTo(cancel));
+        assertThat(tasks.requests().orElseThrow().tools().orElseThrow().call().orElseThrow(), equalTo(call));
+    }
+}

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
@@ -40,6 +40,8 @@ import io.aklivity.zilla.runtime.engine.test.annotation.Configure;
 
 public class McpServerIT
 {
+    private static final String ENGINE_WORKERS_NAME = "zilla.engine.workers";
+
     private final K3poRule k3po = new K3poRule()
         .addScriptRoot("net", "io/aklivity/zilla/specs/binding/mcp/streams/network")
         .addScriptRoot("app", "io/aklivity/zilla/specs/binding/mcp/streams/application");
@@ -806,6 +808,16 @@ public class McpServerIT
     @Specification({
         "${net}/reject.auth.callback.unknown.elicitation/client"})
     public void shouldRejectAuthCallbackUnknownElicitation() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
+        "${net}/lifecycle.redirect.session/client"})
+    @Configure(name = ENGINE_WORKERS_NAME, value = "2")
+    public void shouldRedirectLifecycleForRemoteSession() throws Exception
     {
         k3po.finish();
     }

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.redirect.session/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.redirect.session/client.rpt
@@ -1,0 +1,31 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "GET")
+                            .header(":scheme", "http")
+                            .header(":authority", "localhost:8080")
+                            .header(":path", "/mcp")
+                            .header("accept", "text/event-stream")
+                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-session-id", "session-2")
+                            .build()}
+
+write advised zilla:redirect 0x00000000243a3abbL

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.redirect.session/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.redirect.session/server.rpt
@@ -1,0 +1,31 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "GET")
+                           .header(":path", "/mcp")
+                           .header("accept", "text/event-stream")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-session-id", "session-2")
+                           .build()}
+
+read advise zilla:redirect 0x00000000243a3abbL

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
@@ -488,6 +488,15 @@ public class NetworkIT
 
     @Test
     @Specification({
+        "${net}/lifecycle.redirect.session/client",
+        "${net}/lifecycle.redirect.session/server"})
+    public void shouldRedirectLifecycleForRemoteSession() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${net}/reject.method.not.allowed/client",
         "${net}/reject.method.not.allowed/server"})
     public void shouldRejectMethodNotAllowed() throws Exception


### PR DESCRIPTION
## What changed

- Added focused binding-mcp unit coverage for MCP config and capability DTO classes.
- Added a runtime MCP server redirect integration scenario for a session routed to another worker.
- Added the matching `lifecycle.redirect.session/server.rpt` peer script and `NetworkIT` method so the new network script pair is validated in `binding-mcp.spec`.
- Tightened `runtime/binding-mcp` JaCoCo gates from the placeholder values to `0.87` instruction coverage and `0` missed classes.

## Why

`binding-mcp` still had placeholder coverage gates (`0.00` / `500`) even though the full suite covered most of the module. The remaining missed class was the redirect handler, so this PR covers that path through the normal K3po binding test pattern instead of reflection-only testing.

## Validation

- `./mvnw -B -pl specs/binding-mcp.spec clean verify`
- `./mvnw -B -pl runtime/binding-mcp -am clean verify`
- `./mvnw -B -pl runtime/binding-mcp jacoco:report`
- Final full-suite JaCoCo result: instruction coverage `0.874222`, class coverage `125/125`, missed classes `0`.