### PR TITLE
fix(binding-http): reset streaming response on remote client disconnect

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpServerFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpServerFactory.java
@@ -1900,7 +1900,7 @@ public final class HttpServerFactory implements HttpStreamFactory
 
                 if (exchange != null)
                 {
-                    exchange.onNetworkEnd(traceId);
+                    exchange.onNetworkEnd(traceId, authorization);
                 }
                 else
                 {
@@ -2982,11 +2982,18 @@ public final class HttpServerFactory implements HttpStreamFactory
             }
 
             private void onNetworkEnd(
-                long traceId)
+                long traceId,
+                long authorization)
             {
                 if (requestState != HttpExchangeState.CLOSED)
                 {
                     doRequestAbort(traceId, EMPTY_OCTETS);
+                }
+
+                if (responseState == HttpExchangeState.OPEN)
+                {
+                    doResponseReset(traceId);
+                    doNetworkAbort(traceId, authorization);
                 }
             }
 

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/ConnectionManagementIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/ConnectionManagementIT.java
@@ -60,6 +60,16 @@ public class ConnectionManagementIT
     }
 
     @Test
+    @Configuration("server.yaml")
+    @Specification({
+        "${net}/client.close.during.response/client",
+        "${app}/client.close.during.response/server" })
+    public void shouldResetResponseWhenClientClosesDuringResponse() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Configuration("server.override.yaml")
     @Specification({
         "${net}/request.with.header.override/client",

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/ConnectionManagementIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/ConnectionManagementIT.java
@@ -269,6 +269,17 @@ public class ConnectionManagementIT
     @Test
     @Configuration("server.yaml")
     @Specification({
+        "${net}/client.close.during.response/client",
+        "${app}/client.close.during.response/server"
+    })
+    public void shouldResetResponseWhenClientClosesDuringResponse() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
         "${net}/server.sent.read.abort.on.open.request/client",
         "${app}/server.sent.read.abort.on.open.request/server"
     })

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/client.close.during.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/client.close.during.response/server.rpt
@@ -1,0 +1,43 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/app0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+accepted
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":scheme", "http")
+                             .header(":method", "GET")
+                             .header(":path", "/")
+                             .header(":authority", "localhost:8080")
+                             .build()}
+
+connected
+
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":status", "200")
+                              .header("content-length", "13")
+                              .build()}
+write flush
+
+write notify RESPONSE_STARTED
+
+write aborted

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.close.during.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.close.during.response/server.rpt
@@ -1,0 +1,43 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "duplex"
+accepted
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":method", "GET")
+                             .header(":scheme", "http")
+                             .header(":path", "/")
+                             .header(":authority", "localhost:8080")
+                             .build()}
+
+connected
+
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":status", "200")
+                              .header("content-length", "13")
+                              .build()}
+write flush
+
+write notify RESPONSE_STARTED
+
+write aborted

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/client.close.during.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/client.close.during.response/client.rpt
@@ -1,0 +1,30 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+connected
+
+write "GET / HTTP/1.1" "\r\n"
+write "Host: localhost:8080" "\r\n"
+write "\r\n"
+
+read "HTTP/1.1 200 OK\r\n"
+
+read await RESPONSE_STARTED
+
+write close

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.close.during.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.close.during.response/client.rpt
@@ -1,0 +1,69 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "duplex"
+connected
+
+# client connection preface
+write "PRI * HTTP/2.0\r\n"
+      "\r\n"
+      "SM\r\n"
+      "\r\n"
+write flush
+
+# server connection preface - SETTINGS frame
+read [0x00 0x00 0x12]                   # length = 18
+     [0x04]                             # HTTP2 SETTINGS frame
+     [0x00]                             # flags = 0x00
+     [0x00 0x00 0x00 0x00]              # stream_id = 0
+     [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x04) = 0
+     [0x00 0x06 0x00 0x00 0x20 0x00]    # SETTINGS_MAX_HEADER_LIST_SIZE(0x06) = 8192
+
+write [0x00 0x00 0x0c]                   # length = 12
+      [0x04]                             # HTTP2 SETTINGS frame
+      [0x00]                             # flags = 0x00
+      [0x00 0x00 0x00 0x00]              # stream_id = 0
+      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0xff 0xff]    # SETTINGS_INITIAL_WINDOW_SIZE(0x04) = 65535
+write flush
+
+read [0x00 0x00 0x00]                   # length = 0
+     [0x04]                             # HTTP2 SETTINGS frame
+     [0x01]                             # ACK
+     [0x00 0x00 0x00 0x00]              # stream_id = 0
+
+write [0x00 0x00 0x13]                                      # length = 19
+      [0x01]                                                # HEADERS frame
+      [0x05]                                                # END_STREAM | END_HEADERS
+      [0x00 0x00 0x00 0x01]                                 # stream_id = 1
+      [0x82]                                                # :method: GET
+      [0x86]                                                # :scheme: http
+      [0x84]                                                # :path: /
+      [0x01] [0x0e] "localhost:8080"                        # :authority: localhost:8080
+write flush
+
+write [0x00 0x00 0x00]                  # length = 0
+      [0x04]                            # HTTP2 SETTINGS frame
+      [0x01]                            # ACK
+      [0x00 0x00 0x00 0x00]             # stream_id = 0
+write flush
+
+read await RESPONSE_STARTED
+
+write close


### PR DESCRIPTION
## Problem

For an HTTP/1.1 server exchange whose request is already complete but whose response is still **streaming** (e.g. Server-Sent Events), a graceful client disconnect arrives as a network `END`. `HttpExchange.onNetworkEnd` only aborted the request and left the open response untouched, so the application's response stream was never reset and was only reaped later by the inactivity timeout. This is inconsistent with HTTP/2, which resets the reply on `END` via cleanup.

## Change

- When the response is `OPEN` on network `END`, reset it and abort the network reply, mirroring the existing `onDecodeBodyInvalid` path. The `responseState == OPEN` guard preserves the valid HTTP half-close case (client closes its request side then reads the full response), which still completes via the existing `replyCloseOnFlush` path.
- Add server IT `rfc7230 .../client.close.during.response`: a streaming response is reset (write aborted) when the client closes the connection mid-response.
- Add the matching `rfc7540` (HTTP/2) scenario to lock in parity — HTTP/2 already handles this via `Http2Server` cleanup on network `END`; the test pins the behavior.

## Verification

`./mvnw clean verify -pl runtime/binding-http` is green. The new `shouldResetResponseWhenClientClosesDuringResponse` runs in both the rfc7230 and rfc7540 server `ConnectionManagementIT`s; all four `ConnectionManagementIT` classes pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)