### PR TITLE
Add streaming JSON schema validation via ValidatingParser

### DIFF
--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSchema.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSchema.java
@@ -81,4 +81,31 @@ public interface JsonSchema
     boolean validate(
         JsonParser parser,
         Consumer<JsonSchemaDiagnostic> reporter);
+
+    /**
+     * Wraps {@code parser} in a validating {@link JsonParser} that validates the delegated event
+     * stream against this schema in a single pass as the caller pulls events. This replaces the
+     * justify {@code JsonValidationService.createJsonProvider(schema, throwing).createParser(...)}
+     * approach: the schema is compiled once and the returned parser carries no per-call setup
+     * beyond a fresh evaluator.
+     * <p>
+     * When {@code throwing} is {@code true}, a {@link JsonValidationException} is raised from
+     * {@link JsonParser#next()} as soon as the instance is determined not to conform. When
+     * {@code throwing} is {@code false}, the stream is validated silently and the failure is
+     * observable only via the {@link Consumer} overload.
+     */
+    JsonParser newParser(
+        boolean throwing,
+        JsonParser parser);
+
+    /**
+     * Variant of {@link #newParser(boolean, JsonParser)} that additionally reports each failing
+     * keyword + instance JSON-Pointer + message to {@code reporter} as it is detected, at parity
+     * with {@link #validate(JsonParser, Consumer)}. When {@code throwing} is {@code true} the
+     * reported diagnostics are also carried by the {@link JsonValidationException}.
+     */
+    JsonParser newParser(
+        boolean throwing,
+        JsonParser parser,
+        Consumer<JsonSchemaDiagnostic> reporter);
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonValidationException.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonValidationException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.json.JsonException;
+
+/**
+ * Thrown by a validating {@link jakarta.json.stream.JsonParser} produced via
+ * {@link JsonSchema#newParser(boolean, jakarta.json.stream.JsonParser)} when the instance
+ * event stream fails to conform to the schema and the parser was created in throwing mode.
+ * The {@link #diagnostics()} carry the failing keywords and instance JSON-Pointers gathered
+ * during the single pass that detected the failure.
+ */
+public class JsonValidationException extends JsonException
+{
+    private static final long serialVersionUID = 1L;
+
+    private final transient List<JsonSchemaDiagnostic> diagnostics;
+
+    public JsonValidationException(
+        List<JsonSchemaDiagnostic> diagnostics)
+    {
+        super(message(diagnostics));
+        this.diagnostics = List.copyOf(diagnostics);
+    }
+
+    public List<JsonSchemaDiagnostic> diagnostics()
+    {
+        return diagnostics;
+    }
+
+    private static String message(
+        List<JsonSchemaDiagnostic> diagnostics)
+    {
+        return diagnostics.isEmpty()
+            ? "JSON instance does not conform to schema"
+            : diagnostics.stream().map(JsonSchemaDiagnostic::toString).collect(Collectors.joining("; "));
+    }
+}

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
@@ -49,6 +49,7 @@ import io.aklivity.zilla.runtime.common.json.JsonRefResolver;
 import io.aklivity.zilla.runtime.common.json.JsonSchema;
 import io.aklivity.zilla.runtime.common.json.JsonSchema.Draft;
 import io.aklivity.zilla.runtime.common.json.JsonSchemaDiagnostic;
+import io.aklivity.zilla.runtime.common.json.JsonValidationException;
 
 /**
  * An immutable, compiled JSON Schema that validates an instance by consuming a streaming
@@ -214,6 +215,23 @@ public final class JsonSchemaImpl implements JsonSchema
             verdict = eval.feed(parser.next(), parser);
         }
         return verdict == Verdict.VALID;
+    }
+
+    @Override
+    public JsonParser newParser(
+        boolean throwing,
+        JsonParser parser)
+    {
+        return newParser(throwing, parser, null);
+    }
+
+    @Override
+    public JsonParser newParser(
+        boolean throwing,
+        JsonParser parser,
+        Consumer<JsonSchemaDiagnostic> reporter)
+    {
+        return new ValidatingParser(throwing, parser, reporter);
     }
 
     private JsonSchemaImpl(
@@ -1469,6 +1487,103 @@ public final class JsonSchemaImpl implements JsonSchema
             String segment)
         {
             return segment.replace("~", "~0").replace("/", "~1");
+        }
+    }
+
+    private final class ValidatingParser implements JsonParser
+    {
+        private final JsonParser delegate;
+        private final boolean throwing;
+        private final Consumer<JsonSchemaDiagnostic> reporter;
+        private final List<JsonSchemaDiagnostic> diagnostics;
+        private final Eval eval;
+
+        private Verdict verdict;
+
+        private ValidatingParser(
+            boolean throwing,
+            JsonParser delegate,
+            Consumer<JsonSchemaDiagnostic> reporter)
+        {
+            this.delegate = delegate;
+            this.throwing = throwing;
+            this.reporter = reporter;
+            this.diagnostics = throwing || reporter != null ? new ArrayList<>() : null;
+            this.eval = diagnostics != null ? eval(new Trace(this::report)) : eval();
+            this.verdict = Verdict.PENDING;
+        }
+
+        @Override
+        public Event next()
+        {
+            Event event = delegate.next();
+            if (verdict == Verdict.PENDING)
+            {
+                verdict = eval.feed(event, this);
+                if (verdict == Verdict.INVALID && throwing)
+                {
+                    throw new JsonValidationException(diagnostics);
+                }
+            }
+            return event;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return delegate.hasNext();
+        }
+
+        @Override
+        public String getString()
+        {
+            return delegate.getString();
+        }
+
+        @Override
+        public boolean isIntegralNumber()
+        {
+            return delegate.isIntegralNumber();
+        }
+
+        @Override
+        public int getInt()
+        {
+            return delegate.getInt();
+        }
+
+        @Override
+        public long getLong()
+        {
+            return delegate.getLong();
+        }
+
+        @Override
+        public BigDecimal getBigDecimal()
+        {
+            return delegate.getBigDecimal();
+        }
+
+        @Override
+        public JsonLocation getLocation()
+        {
+            return delegate.getLocation();
+        }
+
+        @Override
+        public void close()
+        {
+            delegate.close();
+        }
+
+        private void report(
+            JsonSchemaDiagnostic diagnostic)
+        {
+            diagnostics.add(diagnostic);
+            if (reporter != null)
+            {
+                reporter.accept(diagnostic);
+            }
         }
     }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
@@ -1639,14 +1639,18 @@ public final class JsonSchemaImpl implements JsonSchema
             this.dynScope = context != null ? parentScope.push(context.base.toString()) : parentScope;
             this.annotate = context != null && is2019Plus(context.draft());
             this.valueTokens = constantCanon != null || enumCanons != null ? new ArrayList<>() : null;
+            // allOf branches must all match, so a failing branch is a genuine failure and reports
+            // through the shared trace; the remaining combinators select among candidate branches
+            // where a non-matching branch is expected, so they evaluate under Trace.NONE and only
+            // the combine() summary diagnostic surfaces when the combinator as a whole fails.
             this.allOfEvals = evalsOf(allOf, trace);
-            this.anyOfEvals = evalsOf(anyOf, trace);
-            this.oneOfEvals = evalsOf(oneOf, trace);
-            this.notEval = notSchema != null ? notSchema.eval(trace, dynScope) : null;
-            this.ifEval = ifSchema != null ? ifSchema.eval(trace, dynScope) : null;
-            this.thenEval = thenSchema != null ? thenSchema.eval(trace, dynScope) : null;
-            this.elseEval = elseSchema != null ? elseSchema.eval(trace, dynScope) : null;
-            this.dependentSchemaEvals = evalsOfMap(dependentSchemas, trace);
+            this.anyOfEvals = evalsOf(anyOf, Trace.NONE);
+            this.oneOfEvals = evalsOf(oneOf, Trace.NONE);
+            this.notEval = notSchema != null ? notSchema.eval(Trace.NONE, dynScope) : null;
+            this.ifEval = ifSchema != null ? ifSchema.eval(Trace.NONE, dynScope) : null;
+            this.thenEval = thenSchema != null ? thenSchema.eval(Trace.NONE, dynScope) : null;
+            this.elseEval = elseSchema != null ? elseSchema.eval(Trace.NONE, dynScope) : null;
+            this.dependentSchemaEvals = evalsOfMap(dependentSchemas, Trace.NONE);
             this.trackKeys = required != null || dependentRequired != null || dependentSchemaEvals != null;
         }
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaDiagnosticsTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaDiagnosticsTest.java
@@ -107,6 +107,76 @@ class JsonSchemaDiagnosticsTest
     }
 
     @Test
+    void shouldNotReportFailingAnyOfBranchWhenAnotherMatches()
+    {
+        List<JsonSchemaDiagnostic> diagnostics = new ArrayList<>();
+        boolean valid = JsonSchema.of("{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]}")
+            .validate(parserFor("5 "), diagnostics::add);
+        assertTrue(valid);
+        assertTrue(diagnostics.isEmpty(), "expected no diagnostics, got " + diagnostics);
+    }
+
+    @Test
+    void shouldNotReportFailingOneOfBranchesWhenExactlyOneMatches()
+    {
+        List<JsonSchemaDiagnostic> diagnostics = new ArrayList<>();
+        boolean valid = JsonSchema.of("{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]}")
+            .validate(parserFor("5 "), diagnostics::add);
+        assertTrue(valid);
+        assertTrue(diagnostics.isEmpty(), "expected no diagnostics, got " + diagnostics);
+    }
+
+    @Test
+    void shouldNotReportFailingNotSubschemaWhenInstanceDiffers()
+    {
+        List<JsonSchemaDiagnostic> diagnostics = new ArrayList<>();
+        boolean valid = JsonSchema.of("{\"not\":{\"type\":\"string\"}}")
+            .validate(parserFor("5 "), diagnostics::add);
+        assertTrue(valid);
+        assertTrue(diagnostics.isEmpty(), "expected no diagnostics, got " + diagnostics);
+    }
+
+    @Test
+    void shouldNotReportFailingIfConditionWhenElseBranchMatches()
+    {
+        List<JsonSchemaDiagnostic> diagnostics = new ArrayList<>();
+        String schema = "{\"if\":{\"type\":\"string\"},\"then\":{\"minLength\":3}," +
+            "\"else\":{\"type\":\"integer\"}}";
+        boolean valid = JsonSchema.of(schema)
+            .validate(parserFor("5 "), diagnostics::add);
+        assertTrue(valid);
+        assertTrue(diagnostics.isEmpty(), "expected no diagnostics, got " + diagnostics);
+    }
+
+    @Test
+    void shouldReportSelectedThenBranchFailureWithoutElseLeak()
+    {
+        List<JsonSchemaDiagnostic> diagnostics = new ArrayList<>();
+        String schema = "{\"if\":{\"type\":\"string\"},\"then\":{\"minLength\":5}," +
+            "\"else\":{\"type\":\"integer\"}}";
+        boolean valid = JsonSchema.of(schema)
+            .validate(parserFor("\"ab\" "), diagnostics::add);
+        assertFalse(valid);
+        assertTrue(diagnostics.stream().anyMatch(d -> "then".equals(d.keyword())),
+            "expected then diagnostic, got " + diagnostics);
+        assertTrue(diagnostics.stream().noneMatch(d -> "type".equals(d.keyword())),
+            "expected no leaked else type diagnostic, got " + diagnostics);
+    }
+
+    @Test
+    void shouldNotReportDependentSchemaWhenTriggerAbsent()
+    {
+        List<JsonSchemaDiagnostic> diagnostics = new ArrayList<>();
+        String schema = "{\"dependentSchemas\":{\"credit_card\":" +
+            "{\"properties\":{\"billing_address\":{\"type\":\"string\"}}," +
+            "\"required\":[\"billing_address\"]}}}";
+        boolean valid = JsonSchema.of(schema)
+            .validate(parserFor("{\"name\":\"x\"} "), diagnostics::add);
+        assertTrue(valid);
+        assertTrue(diagnostics.isEmpty(), "expected no diagnostics, got " + diagnostics);
+    }
+
+    @Test
     void shouldFormatToStringAsLineColPointerMessage()
     {
         List<JsonSchemaDiagnostic> diagnostics = new ArrayList<>();

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaValidatingParserTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaValidatingParserTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.json.stream.JsonParser;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+class JsonSchemaValidatingParserTest
+{
+    @Test
+    void shouldParseValidInstanceWithoutThrowing()
+    {
+        JsonSchema schema = JsonSchema.of("{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"}}}");
+        JsonParser parser = schema.newParser(true, parserFor("{\"name\":\"hi\"} "));
+        drain(parser);
+    }
+
+    @Test
+    void shouldThrowOnInvalidInstanceWhenThrowing()
+    {
+        JsonSchema schema = JsonSchema.of("{\"type\":\"string\"}");
+        JsonParser parser = schema.newParser(true, parserFor("5 "));
+        JsonValidationException ex = assertThrows(JsonValidationException.class, () -> drain(parser));
+        assertFalse(ex.diagnostics().isEmpty());
+        assertEquals("type", ex.diagnostics().get(0).keyword());
+    }
+
+    @Test
+    void shouldThrowOnInvalidNestedInstanceWhenThrowing()
+    {
+        String text = "{\"type\":\"object\",\"properties\":{\"a\":{\"type\":\"object\"," +
+            "\"properties\":{\"b\":{\"type\":\"integer\"}}}}}";
+        JsonSchema schema = JsonSchema.of(text);
+        JsonParser parser = schema.newParser(true, parserFor("{\"a\":{\"b\":\"oops\"}} "));
+        JsonValidationException ex = assertThrows(JsonValidationException.class, () -> drain(parser));
+        boolean hasNested = ex.diagnostics().stream()
+            .anyMatch(d -> "type".equals(d.keyword()) && "/a/b".equals(d.pointer()));
+        assertTrue(hasNested, "expected diagnostic at /a/b, got " + ex.diagnostics());
+    }
+
+    @Test
+    void shouldReportDiagnosticsWithoutThrowingWhenNotThrowing()
+    {
+        List<JsonSchemaDiagnostic> diagnostics = new ArrayList<>();
+        JsonSchema schema = JsonSchema.of("{\"type\":\"string\"}");
+        JsonParser parser = schema.newParser(false, parserFor("5 "), diagnostics::add);
+        drain(parser);
+        assertEquals(1, diagnostics.size());
+        assertEquals("type", diagnostics.get(0).keyword());
+    }
+
+    @Test
+    void shouldReportAndThrowWhenThrowingWithReporter()
+    {
+        List<JsonSchemaDiagnostic> diagnostics = new ArrayList<>();
+        JsonSchema schema = JsonSchema.of("{\"type\":\"string\"}");
+        JsonParser parser = schema.newParser(true, parserFor("5 "), diagnostics::add);
+        JsonValidationException ex = assertThrows(JsonValidationException.class, () -> drain(parser));
+        assertEquals(diagnostics, ex.diagnostics());
+        assertFalse(diagnostics.isEmpty());
+    }
+
+    @Test
+    void shouldNotReportWhenValidAndNotThrowing()
+    {
+        List<JsonSchemaDiagnostic> diagnostics = new ArrayList<>();
+        JsonSchema schema = JsonSchema.of("{\"type\":\"string\"}");
+        JsonParser parser = schema.newParser(false, parserFor("\"hi\" "), diagnostics::add);
+        drain(parser);
+        assertTrue(diagnostics.isEmpty());
+    }
+
+    @Test
+    void shouldNotThrowOnInvalidWhenNotThrowingWithoutReporter()
+    {
+        JsonSchema schema = JsonSchema.of("{\"type\":\"string\"}");
+        JsonParser parser = schema.newParser(false, parserFor("5 "));
+        drain(parser);
+    }
+
+    @Test
+    void shouldDelegateParserReadsDuringValidation()
+    {
+        JsonSchema schema = JsonSchema.of("{\"type\":\"object\",\"properties\":{\"count\":{\"type\":\"integer\"}}}");
+        JsonParser parser = schema.newParser(true, parserFor("{\"count\":42} "));
+        List<String> keys = new ArrayList<>();
+        int value = 0;
+        while (parser.hasNext())
+        {
+            JsonParser.Event event = parser.next();
+            if (event == JsonParser.Event.KEY_NAME)
+            {
+                keys.add(parser.getString());
+            }
+            else if (event == JsonParser.Event.VALUE_NUMBER)
+            {
+                value = parser.getInt();
+            }
+        }
+        assertEquals(List.of("count"), keys);
+        assertEquals(42, value);
+    }
+
+    private static void drain(
+        JsonParser parser)
+    {
+        while (parser.hasNext())
+        {
+            parser.next();
+        }
+    }
+
+    private static JsonParser parserFor(
+        String text)
+    {
+        byte[] bytes = text.getBytes(UTF_8);
+        DirectBufferInputStreamEx in = new DirectBufferInputStreamEx();
+        in.wrap(new UnsafeBuffer(bytes), 0, bytes.length);
+        return StreamingJson.createParser(in);
+    }
+}


### PR DESCRIPTION
## Description

Adds support for single-pass JSON schema validation via a new `ValidatingParser` that wraps a delegate `JsonParser` and validates the event stream against a compiled schema as events are consumed.

### Changes

- **New `JsonValidationException`**: Thrown by validating parsers in throwing mode when validation fails, carrying diagnostic details (failing keywords, JSON-Pointers, messages).

- **New `JsonSchema.newParser()` methods**: Two overloads that wrap a `JsonParser` in a validating parser:
  - `newParser(boolean throwing, JsonParser parser)` — validates silently or throws on failure
  - `newParser(boolean throwing, JsonParser parser, Consumer<JsonSchemaDiagnostic> reporter)` — additionally reports diagnostics to a callback

- **`ValidatingParser` implementation**: An inner class in `JsonSchemaImpl` that delegates all parser operations to the wrapped parser while running validation in parallel. Validation occurs during `next()` calls and raises `JsonValidationException` immediately upon detecting a schema violation (when throwing mode is enabled).

- **Trace isolation for combinators**: Fixed diagnostic reporting to prevent false positives from non-matching branches in `anyOf`, `oneOf`, `not`, `if`/`then`/`else`, and `dependentSchemas`. These now evaluate under `Trace.NONE` so only the combinator's summary diagnostic surfaces on failure, not leaked branch failures.

- **Test coverage**: Added `JsonSchemaValidatingParserTest` with comprehensive tests for valid/invalid instances, nested validation, throwing vs. non-throwing modes, and diagnostic reporting. Added integration tests in `JsonSchemaDiagnosticsTest` verifying that non-matching combinator branches do not leak diagnostics.

### Motivation

Replaces the previous `JsonValidationService.createJsonProvider(schema, throwing).createParser(...)` pattern with a simpler, more efficient API where the schema is compiled once and reused across multiple parser instances without per-call setup overhead.

### Test Plan

All new functionality is covered by unit tests:
- `JsonSchemaValidatingParserTest` validates parser behavior, exception handling, and diagnostic reporting
- `JsonSchemaDiagnosticsTest` new tests verify combinator branch isolation
- Existing tests continue to pass

https://claude.ai/code/session_015FAXnV2jbaAoT8X2dmQAyD