### PR TITLE
Rename watch test barriers for clarity

### DIFF
--- a/runtime/filesystem-http/src/test/java/io/aklivity/zilla/runtime/filesystem/http/HttpFileSystemIT.java
+++ b/runtime/filesystem-http/src/test/java/io/aklivity/zilla/runtime/filesystem/http/HttpFileSystemIT.java
@@ -260,13 +260,13 @@ public class HttpFileSystemIT
                 // WHEN
                 k3po.start();
 
-                k3po.notifyBarrier("REGISTERED");
+                k3po.notifyBarrier("REGISTERED_INITIAL");
                 path.register(watcher);
 
                 WatchKey key1 = watcher.take();
                 List<WatchEvent<?>> events1 = key1.pollEvents();
 
-                k3po.notifyBarrier("MODIFIED");
+                k3po.notifyBarrier("RECEIVED_UPDATE");
 
                 WatchKey key2 = watcher.take();
                 List<WatchEvent<?>> events2 = key2.pollEvents();

--- a/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/watch/client.rpt
+++ b/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/watch/client.rpt
@@ -24,8 +24,10 @@ read http:status "200" "OK"
 read http:header "Etag" "AAAAAAA"
 read "Hello World!"
 read closed
+read notify CREATED
 
-connect "http://localhost:8080/hello.txt"
+connect await CREATED
+    "http://localhost:8080/hello.txt"
 connected
 
 write http:method "GET"

--- a/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/watch/client.rpt
+++ b/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/watch/client.rpt
@@ -19,14 +19,14 @@ connected
 write http:method "GET"
 write close
 
-read notify REGISTERED
+read notify REGISTERED_INITIAL
 read http:status "200" "OK"
 read http:header "Etag" "AAAAAAA"
 read "Hello World!"
 read closed
-read notify CREATED
+read notify RECEIVED_INITIAL
 
-connect await CREATED
+connect await RECEIVED_INITIAL
     "http://localhost:8080/hello.txt"
 connected
 
@@ -35,7 +35,7 @@ write http:header "If-None-Match" "AAAAAAA"
 write http:header "Prefer" "wait=86400"
 write close
 
-read notify MODIFIED
+read notify RECEIVED_UPDATE
 read http:status "200" "OK"
 read http:header "Etag" "BBBBBBB"
 read "Hello Universe!"

--- a/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/watch/server.rpt
+++ b/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/watch/server.rpt
@@ -20,7 +20,7 @@ connected
 read http:method "GET"
 read closed
 
-write await REGISTERED
+write await REGISTERED_INITIAL
 write http:status "200" "OK"
 write http:content-length
 write http:header "Etag" "AAAAAAA"
@@ -35,7 +35,7 @@ read http:header "If-None-Match" "AAAAAAA"
 read http:header "Prefer" "wait=86400"
 read closed
 
-write await MODIFIED
+write await RECEIVED_UPDATE
 write http:status "200" "OK"
 write http:content-length
 write http:header "Etag" "BBBBBBB"


### PR DESCRIPTION
## Description

Rename test synchronization barriers in the filesystem-http watch functionality to use more descriptive names that better reflect their purpose in the test flow.

### Changes

- Renamed `REGISTERED` barrier to `REGISTERED_INITIAL` to clarify it marks the initial file watch registration
- Renamed `MODIFIED` barrier to `RECEIVED_UPDATE` to better describe receiving an update notification
- Added `RECEIVED_INITIAL` barrier in client script to synchronize after receiving the initial response
- Updated client script to await `RECEIVED_INITIAL` before establishing the second connection

These changes improve test readability and make the synchronization points more explicit about what state they represent in the watch lifecycle.

### Files Modified

- `specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/watch/client.rpt`
- `specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/watch/server.rpt`
- `runtime/filesystem-http/src/test/java/io/aklivity/zilla/runtime/filesystem/http/HttpFileSystemIT.java`

### Test Plan

Existing integration tests (`HttpFileSystemIT.shouldWatch()`) cover this change and verify the watch functionality works correctly with the renamed barriers.

https://claude.ai/code/session_017U8EaLj7WiLEbNS8QU1hgF