### PR TITLE
chore(docker-image): drop stale leadpony justify/joy assembly includes

### DIFF
--- a/cloud/docker-image/src/main/docker/assembly.xml
+++ b/cloud/docker-image/src/main/docker/assembly.xml
@@ -49,8 +49,6 @@
         <include>org/apache/maven/maven-parent/**</include>
         <include>jakarta/json/**</include>
         <include>jakarta/inject/**</include>
-        <include>org/leadpony/justify/**</include>
-        <include>org/leadpony/joy/**</include>
         <include>org/snakeyaml/snakeyaml-engine/**</include>
         <include>org/eclipse/yasson/**</include>
         <include>org/glassfish/**</include>


### PR DESCRIPTION
## Summary

`leadpony-justify` (and its `leadpony-joy` JSON-P implementation) were excised when the JSON Schema
validator replacement landed (#1858 / #1859). No module declares a dependency on them any longer — a
repo-wide search finds zero `pom.xml` references — so these two `<include>` globs in the Docker image
assembly match nothing and are dead config:

```xml
<include>org/leadpony/justify/**</include>
<include>org/leadpony/joy/**</include>
```

This removes them. Declarative XML only — no functional or test impact; CI validates packaging.

This is the last loose end for #1858 (validator merged + justify dependency removed); the issue is
closeable once this merges.

Refs #1858

https://claude.ai/code/session_01FLArrJUqABDFLt53KrUNtN

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLArrJUqABDFLt53KrUNtN)_