### PR TITLE
Add streaming JSON pipeline to common-json: bounded back-pressure, verbatim values, zero-allocation projection

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -79,7 +79,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.ResetFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.SignalFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.WindowFW;
 import io.aklivity.zilla.runtime.common.json.DirectBufferInputStreamEx;
-import io.aklivity.zilla.runtime.common.json.StreamingJson;
+import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
@@ -284,12 +284,12 @@ public final class McpClientFactory implements McpStreamFactory
         this.signaler = context.signaler();
         this.clientName = config.clientName();
         this.clientVersion = config.clientVersion();
-        this.responseParserFactory = StreamingJson.createParserFactory(Map.of(
-            StreamingJson.PATH_INCLUDES, CLIENT_JSON_PATH_INCLUDES,
-            StreamingJson.TOKEN_MAX_BYTES, decodeMax));
-        this.requestParserFactory = StreamingJson.createParserFactory(Map.of(
-            StreamingJson.PATH_INCLUDES, List.of(),
-            StreamingJson.TOKEN_MAX_BYTES, encodeMax));
+        this.responseParserFactory = JsonEx.createParserFactory(Map.of(
+            JsonEx.PATH_INCLUDES, CLIENT_JSON_PATH_INCLUDES,
+            JsonEx.TOKEN_MAX_BYTES, decodeMax));
+        this.requestParserFactory = JsonEx.createParserFactory(Map.of(
+            JsonEx.PATH_INCLUDES, List.of(),
+            JsonEx.TOKEN_MAX_BYTES, encodeMax));
 
         final Int2ObjectHashMap<McpSessionIdResolver> resolvers = new Int2ObjectHashMap<>();
         resolvers.put(KIND_TOOLS_LIST, ex -> ex.toolsList().sessionId().asString());

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyListFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyListFactory.java
@@ -52,7 +52,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.ResetFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.WindowFW;
 import io.aklivity.zilla.runtime.common.json.DirectBufferInputStreamEx;
-import io.aklivity.zilla.runtime.common.json.StreamingJson;
+import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
@@ -132,8 +132,8 @@ abstract class McpProxyListFactory implements BindingHandler
         this.mcpTypeId = context.supplyTypeId(MCP_TYPE_NAME);
         this.supplyBinding = supplyBinding;
         this.kind = kind;
-        this.listItemParserFactory = StreamingJson.createParserFactory(
-            Map.of(StreamingJson.PATH_INCLUDES, pathIncludes));
+        this.listItemParserFactory = JsonEx.createParserFactory(
+            Map.of(JsonEx.PATH_INCLUDES, pathIncludes));
     }
 
     @Override

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -76,7 +76,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.ResetFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.SignalFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.WindowFW;
 import io.aklivity.zilla.runtime.common.json.DirectBufferInputStreamEx;
-import io.aklivity.zilla.runtime.common.json.StreamingJson;
+import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
@@ -291,9 +291,9 @@ public final class McpServerFactory implements McpStreamFactory
         this.encodeMax = encodePool.slotCapacity();
         this.sessionIdAttempts = config.sessionIdAttempts();
         this.sessions = new Object2ObjectHashMap<>();
-        this.parserFactory = StreamingJson.createParserFactory(Map.of(
-            StreamingJson.PATH_INCLUDES, SERVER_JSON_PATH_INCLUDES,
-            StreamingJson.TOKEN_MAX_BYTES, decodeMax));
+        this.parserFactory = JsonEx.createParserFactory(Map.of(
+            JsonEx.PATH_INCLUDES, SERVER_JSON_PATH_INCLUDES,
+            JsonEx.TOKEN_MAX_BYTES, decodeMax));
     }
 
     @Override

--- a/runtime/common-json/README.md
+++ b/runtime/common-json/README.md
@@ -62,8 +62,9 @@ if (pipeline.feed(in, off, len) == JsonPipeline.Status.COMPLETED)   // ADVANCED 
   parser and throws on the first violation.
 - **`JsonSink.of(generator)`** renders the event stream as normalized, compact JSON.
   **`JsonSink.of(generator, Delivery.SEGMENTABLE)`** opts a kept value in to verbatim delivery: it
-  arrives as `START_SEGMENT`/`CONTINUE_SEGMENT`/`END_SEGMENT` raw byte slices spliced unchanged,
-  preserving the original bytes (and any insignificant whitespace) rather than re-rendering.
+  arrives as `SEGMENT` raw byte slices (one per fragment, `deferredBytes()` true on all but the last)
+  spliced unchanged, preserving the original bytes (and any insignificant whitespace) rather than
+  re-rendering.
 
 ### Four-state status
 

--- a/runtime/common-json/README.md
+++ b/runtime/common-json/README.md
@@ -9,15 +9,15 @@ keeps parse, transform, and serialize on a single pass with no intermediate DOM.
 
 ## Pull parser
 
-`StreamingJson.createParser()` returns a resumable pull cursor fed one frame at a time via
+`JsonEx.createParser()` returns a resumable pull cursor fed one frame at a time via
 `wrap(buffer, offset, length)`, then driven with the standard `hasNext()` / `next()`. It also
-implements `jakarta.json.stream.JsonParser`, so `StreamingJson.createParser(in)` works anywhere a
+implements `jakarta.json.stream.JsonParser`, so `JsonEx.createParser(in)` works anywhere a
 one-shot pull parser is expected. `PATH_INCLUDES` / `PATH_EXCLUDES` config bounds which paths are
 materialized (so deep values can be scanned and discarded without allocating), and `TOKEN_MAX_BYTES`
 fails fast on a single value that cannot make progress under reset semantics.
 
 ```java
-JsonParserEx parser = StreamingJson.createParser().wrap(buffer, offset, length);
+JsonParserEx parser = JsonEx.createParser().wrap(buffer, offset, length);
 while (parser.hasNext())
 {
     switch (parser.next())
@@ -31,13 +31,13 @@ while (parser.hasNext())
 
 ## Streaming pipeline
 
-`StreamingJson.stream(parser)` layers a composable push pipeline over the same cursor: it pumps the
+`JsonEx.stream(parser)` layers a composable push pipeline over the same cursor: it pumps the
 parser and feeds each event through an ordered chain of `JsonTransform` stages to a terminal `JsonSink`.
 
 ```java
-JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(out, 0, out.capacity());
-JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
-    .transform(StreamingJson.projector(List.of("/id", "/name")))
+JsonGeneratorEx generator = JsonEx.createGenerator().wrap(out, 0, out.capacity());
+JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+    .transform(JsonEx.projector(List.of("/id", "/name")))
     .into(JsonSink.of(generator));
 pipeline.reset();
 if (pipeline.feed(in, off, len) == JsonPipeline.Status.COMPLETED)   // ADVANCED / SUSPENDED / COMPLETED / REJECTED
@@ -46,14 +46,14 @@ if (pipeline.feed(in, off, len) == JsonPipeline.Status.COMPLETED)   // ADVANCED 
 }
 ```
 
-- **`StreamingJson.stream(parser)`** begins the pipeline; **`JsonStream`** appends stages (`transform`)
+- **`JsonEx.stream(parser)`** begins the pipeline; **`JsonStream`** appends stages (`transform`)
   and terminates (`into`), yielding the runnable **`JsonPipeline`** (`reset` / `feed` / `Status`).
 - **`JsonSource`** is the per-event read-only value view handed to a stage — the parser's accessors
   without the cursor advance, so a stage cannot disturb the pump.
 - **`JsonTransform`** is an intermediate stage (`feed(control, source, event, sink)`); **`JsonSink`**
   is the terminal (`feed(control, source, event)`). Third parties may implement either to consume or
   rewrite the projected event stream (e.g. field masking, encryption).
-- **`StreamingJson.projector(pointers)`** returns a `JsonTransform` that prunes a document to a set of
+- **`JsonEx.projector(pointers)`** returns a `JsonTransform` that prunes a document to a set of
   retained RFC 6901 pointers (`-` matches any array index), forwarding only kept events.
   `projector(schema)` derives the pointers from a `JsonSchema`.
 - **`JsonSchema.of(text).validator()`** returns a `JsonTransform` that forwards every event and adds
@@ -80,7 +80,7 @@ if (pipeline.feed(in, off, len) == JsonPipeline.Status.COMPLETED)   // ADVANCED 
 
 ### Bounded output and streaming
 
-`StreamingJson.createGenerator().wrap(out, 0, limit)` bounds the output. `limit` is a **hard bound**
+`JsonEx.createGenerator().wrap(out, 0, limit)` bounds the output. `limit` is a **hard bound**
 asserted at `wrap` to fit the buffer capacity: the usable region is exactly `[offset, limit)` and no
 write crosses it. A driver watches `generator.remaining()` and, when it nears the limit at an event
 boundary, the sink returns `SUSPENDED`.
@@ -92,8 +92,8 @@ re-wrap, so the value continues exactly where it paused; `reset()` clears that c
 value.
 
 ```java
-JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(out, 0, limit);
-JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+JsonGeneratorEx generator = JsonEx.createGenerator().wrap(out, 0, limit);
+JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
     .into(JsonSink.of(generator));
 pipeline.reset();
 
@@ -136,7 +136,7 @@ simple — no stage has to be suspend/resume aware unless it originates `SUSPEND
 
 ### Writing JSON directly
 
-`StreamingJson.createGenerator()` is a buffer-backed, compact writer that inserts structural separators
+`JsonEx.createGenerator()` is a buffer-backed, compact writer that inserts structural separators
 and quoting automatically from an internal context stack, emitting in source order with no
 insignificant whitespace. It implements `jakarta.json.stream.JsonGenerator` with covariant returns for
 fluent chaining, plus the streaming-to-buffer extensions: `writeNumber(literal)` emits a numeric
@@ -144,7 +144,7 @@ lexeme verbatim, `writeRaw` / `writeRawContinue` splice a pre-encoded value (in 
 and `writeSegment` writes a bounded, deferred-tracking fragment.
 
 ```java
-JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(out, 0, out.capacity());
+JsonGeneratorEx generator = JsonEx.createGenerator().wrap(out, 0, out.capacity());
 generator.writeStartObject()
     .write("id", id)
     .write("name", name)

--- a/runtime/common-json/README.md
+++ b/runtime/common-json/README.md
@@ -116,8 +116,15 @@ open structure — does not leak that structure into the next checkout.
 A value whose verbatim form exceeds `remaining()` is **fragmented mid-byte** rather than overrunning
 the bound. `generator.writeSegment(source, index, length, deferred)` appends the bytes that fit and
 records `deferred` — how many bytes of the value remain — and the sink returns `SUSPENDED`; on resume
-it continues from where it paused until `deferred` reaches zero. A value of any size streams this way
-through the segment path, never buffered in full.
+it continues from where it paused until `deferred` reaches zero. A value of any size streams this way,
+never buffered in full.
+
+This covers both a verbatim container subtree (`SEGMENTABLE` delivery) and a **scalar string value**.
+A string value larger than the bound is read as its raw token bytes — the parser exposes the token
+slice via `JsonSource.getSegment()`, contiguous because a readable scalar is only emitted once whole in
+one frame — and spliced across chunks; a string that fits is still re-encoded normalized (a re-encode is
+never longer than the raw token, so the fit check is safe). So a giant `{"data":"…"}` value streams in
+both `STRUCTURED` and `SEGMENTABLE` delivery.
 
 Resumption is a **per-stage cascade**, not an event replay: `JsonSink.resume(control, source)` and
 `JsonTransform.resume(control, source, sink)` continue any in-flight fragment before the next event is
@@ -149,9 +156,9 @@ int length = generator.length();
 
 The pipeline operates on a single buffered frame and is bounded by the value size and, for structured
 rendering, by nesting depth — no unbounded document is buffered. The hard `[offset, limit)` bound makes
-the constraint explicit: a value larger than the bound must arrive through the **segment path**, which
-fragments it across chunks; a one-shot structured scalar or an object key written in a single call must
-fit the bound. Malformed wire (a syntax error in the frame) is rejected as `REJECTED`.
+the constraint explicit: container subtrees and string values larger than the bound stream across chunks
+(see above), while a one-shot number/`true`/`false`/`null` or an object **key** written in a single call
+must fit the bound. Malformed input (a syntax error in the frame) is rejected as `REJECTED`.
 
 ## Run performance benchmarks
 

--- a/runtime/common-json/README.md
+++ b/runtime/common-json/README.md
@@ -119,13 +119,13 @@ records `deferred` — how many bytes of the value remain — and the sink retur
 it continues from where it paused until `deferred` reaches zero. A value of any size streams this way
 through the segment path, never buffered in full.
 
-Resumption is a **per-stage cascade**, not an event replay: `JsonSink.resume()` and
-`JsonTransform.resume(downstream)` continue any in-flight fragment before the next event is pulled.
-`JsonTransform.resume(downstream)` defaults to `downstream.resume()`, so a stage that only forwards
-events ignores it entirely; a stage that itself emits a value across chunks (substituting or expanding
-output) overrides `resume(downstream)` to continue its own emission, draining the downstream first.
-This keeps the transform contract simple — no stage has to be suspend/resume aware unless it originates
-`SUSPENDED`.
+Resumption is a **per-stage cascade**, not an event replay: `JsonSink.resume(control, source)` and
+`JsonTransform.resume(control, source, sink)` continue any in-flight fragment before the next event is
+pulled, with the same `control` and `source` context as `feed`. `JsonTransform.resume(control, source,
+sink)` defaults to `sink.resume(control, source)`, so a stage that only forwards events ignores it
+entirely; a stage that itself emits a value across chunks (substituting or expanding output) overrides
+it to continue its own emission, draining the downstream first. This keeps the transform contract
+simple — no stage has to be suspend/resume aware unless it originates `SUSPENDED`.
 
 ### Writing JSON directly
 

--- a/runtime/common-json/README.md
+++ b/runtime/common-json/README.md
@@ -40,7 +40,7 @@ JsonPipeline pipeline = StreamingJson.createParser().stream()
     .transform(StreamingJson.projector(List.of("/id", "/name")))
     .into(JsonSink.of(generator));
 pipeline.reset();
-if (pipeline.feed(in, off, len) == JsonPipeline.Status.COMPLETE)   // RESUMABLE / SUSPENDED / COMPLETE / REJECTED
+if (pipeline.feed(in, off, len) == JsonPipeline.Status.COMPLETED)   // ADVANCED / SUSPENDED / COMPLETED / REJECTED
 {
     int length = generator.length();    // projected JSON bytes in out
 }
@@ -69,11 +69,11 @@ if (pipeline.feed(in, off, len) == JsonPipeline.Status.COMPLETE)   // RESUMABLE 
 
 `feed` returns one of four states, separating **input** bounding from **output** bounding:
 
-- **`RESUMABLE`** — the parser exhausted this frame mid-value; feed the next frame to continue. The
+- **`ADVANCED`** — the parser exhausted this frame mid-value; feed the next frame to continue. The
   parser is not re-wrapped on a resumed feed, so a value spanning frames reassembles seamlessly.
 - **`SUSPENDED`** — the bounded output filled; drain it, re-target the generator, and feed the same
   frame again to continue (see below).
-- **`COMPLETE`** — the current top-level value finished and was accepted.
+- **`COMPLETED`** — the current top-level value finished and was accepted.
 - **`REJECTED`** — the value was rejected (malformed JSON, or a schema violation from a `validator`
   stage); the output must be abandoned. Malformed input surfaces as `REJECTED` rather than escaping
   `feed` as an exception.
@@ -104,11 +104,11 @@ while (status == JsonPipeline.Status.SUSPENDED)   // output full
     generator.wrap(out, 0, limit);                // re-target output, structural context preserved
     status = pipeline.feed(in, off, len);         // resume the in-flight value
 }
-// COMPLETE: emit the final generator.length() bytes
+// COMPLETED: emit the final generator.length() bytes
 ```
 
 `reset()` also clears the generator's structural context (via the pipeline's `reset()` cascade), so a
-generator returned to a pool mid-value — an abandoned `RESUMABLE` frame or a `REJECTED` value left with
+generator returned to a pool mid-value — an abandoned `ADVANCED` frame or a `REJECTED` value left with
 open structure — does not leak that structure into the next checkout.
 
 ### Fragmenting values larger than the bound

--- a/runtime/common-json/README.md
+++ b/runtime/common-json/README.md
@@ -1,5 +1,158 @@
 # common-json
 
+A provider-free, streaming JSON library for the hot path: a resumable pull parser and a buffer-backed
+generator over Agrona `DirectBuffer`s, composable into validating, projecting, transforming pipelines.
+It ships its own `jakarta.json` implementation and needs **no JSON provider** on the classpath.
+
+JSON Schema validation and the schema model live alongside the wire codec; the streaming pipeline
+keeps parse, transform, and serialize on a single pass with no intermediate DOM.
+
+## Pull parser
+
+`StreamingJson.createParser()` returns a resumable pull cursor fed one frame at a time via
+`wrap(buffer, offset, length)`, then driven with the standard `hasNext()` / `next()`. It also
+implements `jakarta.json.stream.JsonParser`, so `StreamingJson.createParser(in)` works anywhere a
+one-shot pull parser is expected. `PATH_INCLUDES` / `PATH_EXCLUDES` config bounds which paths are
+materialized (so deep values can be scanned and discarded without allocating), and `TOKEN_MAX_BYTES`
+fails fast on a single value that cannot make progress under reset semantics.
+
+```java
+JsonParserEx parser = StreamingJson.createParser().wrap(buffer, offset, length);
+while (parser.hasNext())
+{
+    switch (parser.next())
+    {
+    case KEY_NAME: CharSequence key = parser.getKey(); break;
+    case VALUE_STRING: String value = parser.getString(); break;
+    default: break;
+    }
+}
+```
+
+## Streaming pipeline
+
+`stream()` layers a composable push pipeline over the same cursor: it pumps the parser and feeds each
+event through an ordered chain of `JsonTransform` stages to a terminal `JsonSink`.
+
+```java
+JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(out, 0, out.capacity());
+JsonPipeline pipeline = StreamingJson.createParser().stream()
+    .transform(StreamingJson.projector(List.of("/id", "/name")))
+    .into(JsonSink.of(generator));
+pipeline.reset();
+if (pipeline.feed(in, off, len) == JsonPipeline.Status.COMPLETE)   // RESUMABLE / SUSPENDED / COMPLETE / REJECTED
+{
+    int length = generator.length();    // projected JSON bytes in out
+}
+```
+
+- **`stream()`** begins the pipeline; **`JsonStream`** appends stages (`transform`) and terminates
+  (`into`), yielding the runnable **`JsonPipeline`** (`reset` / `feed` / `Status`).
+- **`JsonSource`** is the per-event read-only value view handed to a stage — the parser's accessors
+  without the cursor advance, so a stage cannot disturb the pump.
+- **`JsonTransform`** is an intermediate stage (`feed(control, source, event, sink)`); **`JsonSink`**
+  is the terminal (`feed(control, source, event)`). Third parties may implement either to consume or
+  rewrite the projected event stream (e.g. field masking, encryption).
+- **`StreamingJson.projector(pointers)`** returns a `JsonTransform` that prunes a document to a set of
+  retained RFC 6901 pointers (`-` matches any array index), forwarding only kept events.
+  `projector(schema)` derives the pointers from a `JsonSchema`.
+- **`JsonSchema.of(text).validator()`** returns a `JsonTransform` that forwards every event and adds
+  schema validation, reporting at the value boundary so callers abort on `REJECTED`
+  (emit-then-abort). For a one-shot validating pull parse, `schema.newParser(validate, parser)` wraps a
+  parser and throws on the first violation.
+- **`JsonSink.of(generator)`** renders the event stream as normalized, compact JSON.
+  **`JsonSink.of(generator, Delivery.SEGMENTABLE)`** opts a kept value in to verbatim delivery: it
+  arrives as `START_SEGMENT`/`CONTINUE_SEGMENT`/`END_SEGMENT` raw byte slices spliced unchanged,
+  preserving the original bytes (and any insignificant whitespace) rather than re-rendering.
+
+### Four-state status
+
+`feed` returns one of four states, separating **input** bounding from **output** bounding:
+
+- **`RESUMABLE`** — the parser exhausted this frame mid-value; feed the next frame to continue. The
+  parser is not re-wrapped on a resumed feed, so a value spanning frames reassembles seamlessly.
+- **`SUSPENDED`** — the bounded output filled; drain it, re-target the generator, and feed the same
+  frame again to continue (see below).
+- **`COMPLETE`** — the current top-level value finished and was accepted.
+- **`REJECTED`** — the value was rejected (malformed JSON, or a schema violation from a `validator`
+  stage); the output must be abandoned. Malformed input surfaces as `REJECTED` rather than escaping
+  `feed` as an exception.
+
+### Bounded output and streaming
+
+`StreamingJson.createGenerator().wrap(out, 0, limit)` bounds the output. `limit` is a **hard bound**
+asserted at `wrap` to fit the buffer capacity: the usable region is exactly `[offset, limit)` and no
+write crosses it. A driver watches `generator.remaining()` and, when it nears the limit at an event
+boundary, the sink returns `SUSPENDED`.
+
+Unlike a format with merge semantics, the chunks are **consecutive byte ranges of one continuous
+serialization that the consumer concatenates** — there is no per-chunk framing to reopen. The
+generator preserves its structural context (open object/array depth and pending separators) across the
+re-wrap, so the value continues exactly where it paused; `reset()` clears that context to begin a fresh
+value.
+
+```java
+JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(out, 0, limit);
+JsonPipeline pipeline = StreamingJson.createParser().stream()
+    .into(JsonSink.of(generator));
+pipeline.reset();
+
+JsonPipeline.Status status = pipeline.feed(in, off, len);
+while (status == JsonPipeline.Status.SUSPENDED)   // output full
+{
+    emitDataFrame(out, 0, generator.length());    // drain — flow-controlled
+    generator.wrap(out, 0, limit);                // re-target output, structural context preserved
+    status = pipeline.feed(in, off, len);         // resume the in-flight value
+}
+// COMPLETE: emit the final generator.length() bytes
+```
+
+`reset()` also clears the generator's structural context (via the pipeline's `reset()` cascade), so a
+generator returned to a pool mid-value — an abandoned `RESUMABLE` frame or a `REJECTED` value left with
+open structure — does not leak that structure into the next checkout.
+
+### Fragmenting values larger than the bound
+
+A value whose verbatim form exceeds `remaining()` is **fragmented mid-byte** rather than overrunning
+the bound. `generator.writeSegment(source, index, length, deferred)` appends the bytes that fit and
+records `deferred` — how many bytes of the value remain — and the sink returns `SUSPENDED`; on resume
+it continues from where it paused until `deferred` reaches zero. A value of any size streams this way
+through the segment path, never buffered in full.
+
+Resumption is a **per-stage cascade**, not an event replay: `JsonSink.resume()` and
+`JsonTransform.resume(downstream)` continue any in-flight fragment before the next event is pulled.
+`JsonTransform.resume(downstream)` defaults to `downstream.resume()`, so a stage that only forwards
+events ignores it entirely; a stage that itself emits a value across chunks (substituting or expanding
+output) overrides `resume(downstream)` to continue its own emission, draining the downstream first.
+This keeps the transform contract simple — no stage has to be suspend/resume aware unless it originates
+`SUSPENDED`.
+
+### Writing JSON directly
+
+`StreamingJson.createGenerator()` is a buffer-backed, compact writer that inserts structural separators
+and quoting automatically from an internal context stack, emitting in source order with no
+insignificant whitespace. It implements `jakarta.json.stream.JsonGenerator` with covariant returns for
+fluent chaining, plus the streaming-to-buffer extensions: `writeNumber(literal)` emits a numeric
+lexeme verbatim, `writeRaw` / `writeRawContinue` splice a pre-encoded value (in one or more fragments),
+and `writeSegment` writes a bounded, deferred-tracking fragment.
+
+```java
+JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(out, 0, out.capacity());
+generator.writeStartObject()
+    .write("id", id)
+    .write("name", name)
+    .writeEnd();
+int length = generator.length();
+```
+
+### Bounded-buffer contract
+
+The pipeline operates on a single buffered frame and is bounded by the value size and, for structured
+rendering, by nesting depth — no unbounded document is buffered. The hard `[offset, limit)` bound makes
+the constraint explicit: a value larger than the bound must arrive through the **segment path**, which
+fragments it across chunks; a one-shot structured scalar or an object key written in a single call must
+fit the bound. Malformed wire (a syntax error in the frame) is rejected as `REJECTED`.
+
 ## Run performance benchmarks
 
 Build the benchmark jar from this directory:

--- a/runtime/common-json/README.md
+++ b/runtime/common-json/README.md
@@ -31,12 +31,12 @@ while (parser.hasNext())
 
 ## Streaming pipeline
 
-`stream()` layers a composable push pipeline over the same cursor: it pumps the parser and feeds each
-event through an ordered chain of `JsonTransform` stages to a terminal `JsonSink`.
+`StreamingJson.stream(parser)` layers a composable push pipeline over the same cursor: it pumps the
+parser and feeds each event through an ordered chain of `JsonTransform` stages to a terminal `JsonSink`.
 
 ```java
 JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(out, 0, out.capacity());
-JsonPipeline pipeline = StreamingJson.createParser().stream()
+JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
     .transform(StreamingJson.projector(List.of("/id", "/name")))
     .into(JsonSink.of(generator));
 pipeline.reset();
@@ -46,8 +46,8 @@ if (pipeline.feed(in, off, len) == JsonPipeline.Status.COMPLETED)   // ADVANCED 
 }
 ```
 
-- **`stream()`** begins the pipeline; **`JsonStream`** appends stages (`transform`) and terminates
-  (`into`), yielding the runnable **`JsonPipeline`** (`reset` / `feed` / `Status`).
+- **`StreamingJson.stream(parser)`** begins the pipeline; **`JsonStream`** appends stages (`transform`)
+  and terminates (`into`), yielding the runnable **`JsonPipeline`** (`reset` / `feed` / `Status`).
 - **`JsonSource`** is the per-event read-only value view handed to a stage — the parser's accessors
   without the cursor advance, so a stage cannot disturb the pump.
 - **`JsonTransform`** is an intermediate stage (`feed(control, source, event, sink)`); **`JsonSink`**
@@ -93,7 +93,7 @@ value.
 
 ```java
 JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(out, 0, limit);
-JsonPipeline pipeline = StreamingJson.createParser().stream()
+JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
     .into(JsonSink.of(generator));
 pipeline.reset();
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonEvent.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonEvent.java
@@ -19,9 +19,10 @@ import jakarta.json.stream.JsonParser.Event;
 /**
  * The event currency of a {@link JsonStream} pipeline. A superset of the structured events of
  * {@code jakarta.json.stream.JsonParser.Event} (which cannot be extended) plus document framing
- * ({@link #START_DOCUMENT} / {@link #END_DOCUMENT}) and segment framing ({@link #START_SEGMENT} /
- * {@link #CONTINUE_SEGMENT} / {@link #END_SEGMENT}). A segment run delivers one complete value as
- * raw bytes rather than as structured events; {@link #segmented()} distinguishes those events.
+ * ({@link #START_DOCUMENT} / {@link #END_DOCUMENT}) and a single {@link #SEGMENT} event. A segment run
+ * delivers one complete value as raw bytes rather than as structured events, one {@link #SEGMENT} per
+ * fragment; {@link JsonSource#deferredBytes()} is {@code true} on every fragment but the last.
+ * {@link #segmented()} distinguishes the segment event.
  */
 public enum JsonEvent
 {
@@ -37,13 +38,11 @@ public enum JsonEvent
     VALUE_TRUE,
     VALUE_FALSE,
     VALUE_NULL,
-    START_SEGMENT,
-    CONTINUE_SEGMENT,
-    END_SEGMENT;
+    SEGMENT;
 
     public boolean segmented()
     {
-        return this == START_SEGMENT || this == CONTINUE_SEGMENT || this == END_SEGMENT;
+        return this == SEGMENT;
     }
 
     public static JsonEvent of(

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonEx.java
@@ -36,7 +36,7 @@ import io.aklivity.zilla.runtime.common.json.internal.JsonStreamImpl;
  * parser also supports. It requires no {@code jakarta.json} provider on the classpath;
  * {@code common-json} ships the implementation.
  */
-public final class StreamingJson
+public final class JsonEx
 {
     /**
      * Config key whose value is a {@code List<String>} of JSON Pointer (RFC 6901) syntax
@@ -68,7 +68,7 @@ public final class StreamingJson
      */
     public static final String TOKEN_MAX_BYTES = "io.aklivity.zilla.runtime.common.json.token.max.bytes";
 
-    private StreamingJson()
+    private JsonEx()
     {
     }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEx.java
@@ -126,6 +126,15 @@ public interface JsonGeneratorEx extends JsonGenerator
     JsonGeneratorEx writeKey(
         String name);
 
+    /**
+     * Writes an object key from a {@code CharSequence} without first materializing a {@link String},
+     * letting a streaming caller forward a non-owning char view (e.g. a key still buffered upstream)
+     * straight to the wire. Semantics match {@link #writeKey(String)}; the chars are escaped and
+     * encoded as they are read.
+     */
+    JsonGeneratorEx writeKey(
+        CharSequence name);
+
     @Override
     JsonGeneratorEx writeEnd();
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEx.java
@@ -76,6 +76,14 @@ public interface JsonGeneratorEx extends JsonGenerator
         String literal);
 
     /**
+     * Emits a numeric literal from a {@code CharSequence} verbatim without first materializing a
+     * {@link String}, letting a streaming caller forward a non-owning char view of the lexeme.
+     * Semantics match {@link #writeNumber(String)}.
+     */
+    JsonGeneratorEx writeNumber(
+        CharSequence literal);
+
+    /**
      * Splices a pre-encoded JSON value from {@code source} verbatim as the next value, with no
      * re-encoding.
      */
@@ -141,6 +149,14 @@ public interface JsonGeneratorEx extends JsonGenerator
     @Override
     JsonGeneratorEx write(
         String value);
+
+    /**
+     * Writes a string value from a {@code CharSequence} without first materializing a {@link String},
+     * the value-side counterpart to {@link #writeKey(CharSequence)}. Semantics match
+     * {@link #write(String)}; the chars are escaped and encoded as they are read.
+     */
+    JsonGeneratorEx write(
+        CharSequence value);
 
     @Override
     JsonGeneratorEx write(

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEx.java
@@ -28,7 +28,7 @@ import org.agrona.MutableDirectBuffer;
  * {@code jakarta.json.stream} contract lacks. This is the {@code *Ex} pattern for going beyond
  * JSON-P: a sub-interface of the standard type adding the extra methods a streaming, buffer-
  * backed caller needs, implemented internally by {@code JsonGeneratorImpl} and obtained via
- * {@link StreamingJson#createGenerator()}.
+ * {@link JsonEx#createGenerator()}.
  * <p>
  * Every inherited {@link JsonGenerator} method is redeclared with a covariant {@code
  * JsonGeneratorEx} return so the standard write methods chain fluently alongside the extensions.

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEx.java
@@ -50,6 +50,14 @@ public interface JsonGeneratorEx extends JsonGenerator
         int limit);
 
     /**
+     * Clears the structural context (open object/array depth and pending separators) without
+     * re-targeting the buffer, readying the instance for a fresh top-level value. Reuse across pooled
+     * callers calls this — via the pipeline's {@code reset()} cascade — so an instance returned mid-value
+     * does not leak open structure into the next value.
+     */
+    void reset();
+
+    /**
      * Reports the number of bytes written since the last {@link #wrap}.
      */
     int length();

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEx.java
@@ -94,6 +94,20 @@ public interface JsonGeneratorEx extends JsonGenerator
         int index,
         int length);
 
+    /**
+     * Appends {@code length} content bytes of a value verbatim within the usable region {@code [offset,
+     * limit)}, with no re-encoding and no structural separator (the value's leading separator is emitted
+     * once, before its first segment). {@code deferred} reports how many bytes of this value remain to be
+     * written after these {@code length} bytes; a driver fragments a value larger than {@link #remaining()}
+     * by writing what fits, leaving {@code deferred > 0}, draining, then continuing on resume until
+     * {@code deferred} reaches zero.
+     */
+    JsonGeneratorEx writeSegment(
+        DirectBuffer source,
+        int index,
+        int length,
+        int deferred);
+
     @Override
     JsonGeneratorEx writeStartObject();
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEx.java
@@ -37,16 +37,37 @@ public interface JsonGeneratorEx extends JsonGenerator
 {
     /**
      * (Re)targets the generator at {@code buffer} starting at {@code offset}, resetting all
-     * context. Reuse a single instance per worker thread across values.
+     * structural context and binding the limit to the buffer's full capacity. Reuse a single
+     * instance per worker thread across values.
      */
     JsonGeneratorEx wrap(
         MutableDirectBuffer buffer,
         int offset);
 
     /**
-     * Reports the number of bytes written since the last {@link #wrap(MutableDirectBuffer, int)}.
+     * Re-targets the generator at {@code buffer} starting at {@code offset} with a hard byte
+     * {@code limit} (rather than the buffer's full capacity), the bound a chunking driver watches via
+     * {@link #remaining()} to decide when to drain and resume. Unlike {@link #wrap(MutableDirectBuffer,
+     * int)}, the structural context (open object/array depth and pending separators) is preserved, so a
+     * value paused by {@link JsonPipeline.Status#SUSPENDED} continues across the drain as one
+     * uninterrupted serialization. The two-argument {@link #wrap(MutableDirectBuffer, int)} is
+     * equivalent with {@code limit} set to the buffer capacity and the context reset.
+     */
+    JsonGeneratorEx wrap(
+        MutableDirectBuffer buffer,
+        int offset,
+        int limit);
+
+    /**
+     * Reports the number of bytes written since the last {@link #wrap}.
      */
     int length();
+
+    /**
+     * Bytes that may still be written before reaching the {@code limit} set at {@link #wrap}. A driver
+     * checks this at an event boundary to decide whether to suspend (drain) before the next write.
+     */
+    int remaining();
 
     /**
      * Emits a numeric literal verbatim, preserving the exact source lexeme (e.g. {@code -2.5e3})

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEx.java
@@ -36,22 +36,13 @@ import org.agrona.MutableDirectBuffer;
 public interface JsonGeneratorEx extends JsonGenerator
 {
     /**
-     * (Re)targets the generator at {@code buffer} starting at {@code offset}, resetting all
-     * structural context and binding the limit to the buffer's full capacity. Reuse a single
-     * instance per worker thread across values.
-     */
-    JsonGeneratorEx wrap(
-        MutableDirectBuffer buffer,
-        int offset);
-
-    /**
      * Re-targets the generator at {@code buffer} starting at {@code offset} with a hard byte
-     * {@code limit} (rather than the buffer's full capacity), the bound a chunking driver watches via
-     * {@link #remaining()} to decide when to drain and resume. Unlike {@link #wrap(MutableDirectBuffer,
-     * int)}, the structural context (open object/array depth and pending separators) is preserved, so a
-     * value paused by {@link JsonPipeline.Status#SUSPENDED} continues across the drain as one
-     * uninterrupted serialization. The two-argument {@link #wrap(MutableDirectBuffer, int)} is
-     * equivalent with {@code limit} set to the buffer capacity and the context reset.
+     * {@code limit}, the bound a chunking driver watches via {@link #remaining()} to decide when to
+     * drain and resume; {@code limit} must be supported by the buffer capacity. Structural context
+     * (open object/array depth and pending separators) is preserved, so a value paused by
+     * {@link JsonPipeline.Status#SUSPENDED} continues across the drain as one uninterrupted
+     * serialization. For an unbounded value pass the buffer's capacity as {@code limit}. Reuse a
+     * single instance per worker thread across values.
      */
     JsonGeneratorEx wrap(
         MutableDirectBuffer buffer,

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonParserEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonParserEx.java
@@ -30,12 +30,6 @@ import org.agrona.DirectBuffer;
 public interface JsonParserEx extends JsonParser
 {
     /**
-     * Begins a pipeline pumped by this parser; append stages with {@link JsonStream#transform} and
-     * terminate with {@link JsonStream#into}.
-     */
-    JsonStream stream();
-
-    /**
      * Borrows {@code buffer} as the input for the next pump, starting at {@code offset} for {@code length}
      * bytes. The buffer is read in place for the duration of the pump; resume state carried in the parser
      * bridges values that span frames.

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonParserEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonParserEx.java
@@ -23,7 +23,7 @@ import org.agrona.DirectBuffer;
  * {@code jakarta.json.stream} contract lacks. This is the {@code *Ex} pattern for going beyond JSON-P:
  * a sub-interface of the standard type that drives a {@link JsonStream} pipeline.
  * <p>
- * Obtain an instance from {@link StreamingJson#createParser()} (the implementation is internal). Reuse a
+ * Obtain an instance from {@link JsonEx#createParser()} (the implementation is internal). Reuse a
  * single instance per worker thread, calling {@link #wrap(DirectBuffer, int, int)} to borrow each frame's
  * buffer before pumping.
  */

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonPipeline.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonPipeline.java
@@ -20,14 +20,21 @@ import org.agrona.DirectBuffer;
  * A runnable, resumable {@code common-json} pipeline assembled from a {@link JsonStream} description
  * terminated with a {@link JsonSink}. Reuse a single instance per worker thread: call {@link #reset()}
  * once per top-level value, then {@link #feed(DirectBuffer, int, int)} per frame, resuming a value left
- * {@link Status#PENDING} by an earlier frame.
+ * {@link Status#RESUMABLE} by an earlier frame.
+ * <p>
+ * Output is bounded by the terminal generator's limit: when it fills at an event boundary,
+ * {@code feed} returns {@link Status#SUSPENDED} with a complete, drainable region in the output buffer;
+ * the caller drains it, re-targets the generator at a fresh region (preserving its structural context),
+ * and calls {@code feed} again with the same frame to resume the in-flight value from where it paused.
  */
 public interface JsonPipeline
 {
     enum Status
     {
         /** the current top-level value is still in progress; feed more bytes to continue */
-        PENDING,
+        RESUMABLE,
+        /** the bounded output filled: drain the buffer, re-target the generator, then {@link #feed} again to resume */
+        SUSPENDED,
         /** the current top-level value finished and was accepted */
         COMPLETE,
         /** the current top-level value was rejected; the output must be abandoned */

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonPipeline.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonPipeline.java
@@ -20,7 +20,7 @@ import org.agrona.DirectBuffer;
  * A runnable, resumable {@code common-json} pipeline assembled from a {@link JsonStream} description
  * terminated with a {@link JsonSink}. Reuse a single instance per worker thread: call {@link #reset()}
  * once per top-level value, then {@link #feed(DirectBuffer, int, int)} per frame, resuming a value left
- * {@link Status#RESUMABLE} by an earlier frame.
+ * {@link Status#ADVANCED} by an earlier frame.
  * <p>
  * Output is bounded by the terminal generator's limit: when it fills at an event boundary,
  * {@code feed} returns {@link Status#SUSPENDED} with a complete, drainable region in the output buffer;
@@ -31,12 +31,12 @@ public interface JsonPipeline
 {
     enum Status
     {
-        /** the current top-level value is still in progress; feed more bytes to continue */
-        RESUMABLE,
+        /** the pump advanced through all available input mid-value; feed the next frame to continue */
+        ADVANCED,
         /** the bounded output filled: drain the buffer, re-target the generator, then {@link #feed} again to resume */
         SUSPENDED,
         /** the current top-level value finished and was accepted */
-        COMPLETE,
+        COMPLETED,
         /** the current top-level value was rejected; the output must be abandoned */
         REJECTED
     }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonPipeline.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonPipeline.java
@@ -31,20 +31,43 @@ public interface JsonPipeline
 {
     enum Status
     {
-        /** the pump advanced through all available input mid-value; feed the next frame to continue */
+        /** an event was consumed; the pump advances to the next — an internal sink-to-pump signal */
         ADVANCED,
         /** the bounded output filled: drain the buffer, re-target the generator, then {@link #feed} again to resume */
         SUSPENDED,
+        /** the input window was consumed mid-value: {@link #feed} the next window (input back-pressure) */
+        STARVED,
         /** the current top-level value finished and was accepted */
         COMPLETED,
-        /** the current top-level value was rejected; the output must be abandoned */
+        /** the current top-level value was rejected (malformed or truncated); the output must be abandoned */
         REJECTED
     }
 
     void reset();
 
+    /**
+     * Feeds a whole value in one shot (equivalent to {@link #feed(DirectBuffer, int, int, boolean)} with
+     * {@code last == true}), for callers that reassemble the value before feeding it.
+     */
+    default Status feed(
+        DirectBuffer buffer,
+        int offset,
+        int length)
+    {
+        return feed(buffer, offset, length, true);
+    }
+
+    /**
+     * Feeds one input window; {@code last} marks the final window. Returns {@link Status#STARVED} when the
+     * window is consumed before the value completes (input back-pressure — feed the next window),
+     * {@link Status#SUSPENDED} when the bounded output fills (output back-pressure — drain and re-feed the
+     * same window), {@link Status#COMPLETED} on a clean value end, or {@link Status#REJECTED} on malformed
+     * or truncated input. {@code STARVED} is returned only when {@code last == false}; an incomplete value
+     * under {@code last == true} yields {@code REJECTED}.
+     */
     Status feed(
         DirectBuffer buffer,
         int offset,
-        int length);
+        int length,
+        boolean last);
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSchema.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSchema.java
@@ -116,7 +116,7 @@ public interface JsonSchema
      * lets a downstream projector see the complete, unpruned stream (required for whole-value
      * keywords like {@code required}, {@code additionalProperties}, and the combinators); the
      * stage's own {@link JsonPipeline.Status} reflects the schema verdict — {@link
-     * JsonPipeline.Status#COMPLETE} when the value validates, {@link
+     * JsonPipeline.Status#COMPLETED} when the value validates, {@link
      * JsonPipeline.Status#REJECTED} when it does not. Rejection is reported at the value boundary,
      * after the forwarded events have already been emitted, so callers abort the output stream on
      * {@code REJECTED} (emit-then-abort).

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSchema.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSchema.java
@@ -126,7 +126,7 @@ public interface JsonSchema
     /**
      * Returns the RFC 6901 JSON Pointers to retain when projecting an instance of this schema — the
      * union of paths declared across all branches of the schema. Suitable for {@link
-     * StreamingJson#projector(java.util.List)}.
+     * JsonEx#projector(java.util.List)}.
      */
     List<String> retainedPaths();
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSink.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSink.java
@@ -42,6 +42,18 @@ public interface JsonSink
         JsonSource source,
         JsonEvent event);
 
+    /**
+     * Continues any output left in flight by a prior {@link JsonPipeline.Status#SUSPENDED} — a value
+     * being written across chunks — before the next event is fed. Returns {@link
+     * JsonPipeline.Status#SUSPENDED} if the bounded output filled again, or {@link
+     * JsonPipeline.Status#RESUMABLE} when nothing remains pending. A stage with no in-flight output
+     * returns {@code RESUMABLE}; the default is sufficient for stages that only forward events.
+     */
+    default JsonPipeline.Status resume()
+    {
+        return JsonPipeline.Status.RESUMABLE;
+    }
+
     default void reset()
     {
     }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSink.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSink.java
@@ -44,12 +44,15 @@ public interface JsonSink
 
     /**
      * Continues any output left in flight by a prior {@link JsonPipeline.Status#SUSPENDED} — a value
-     * being written across chunks — before the next event is fed. Returns {@link
+     * being written across chunks — before the next event is fed, reading the in-flight value from
+     * {@code source} and steering the immediate upstream with {@code control}. Returns {@link
      * JsonPipeline.Status#SUSPENDED} if the bounded output filled again, or {@link
      * JsonPipeline.Status#RESUMABLE} when nothing remains pending. A stage with no in-flight output
      * returns {@code RESUMABLE}; the default is sufficient for stages that only forward events.
      */
-    default JsonPipeline.Status resume()
+    default JsonPipeline.Status resume(
+        JsonController control,
+        JsonSource source)
     {
         return JsonPipeline.Status.RESUMABLE;
     }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSink.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSink.java
@@ -47,14 +47,14 @@ public interface JsonSink
      * being written across chunks — before the next event is fed, reading the in-flight value from
      * {@code source} and steering the immediate upstream with {@code control}. Returns {@link
      * JsonPipeline.Status#SUSPENDED} if the bounded output filled again, or {@link
-     * JsonPipeline.Status#RESUMABLE} when nothing remains pending. A stage with no in-flight output
-     * returns {@code RESUMABLE}; the default is sufficient for stages that only forward events.
+     * JsonPipeline.Status#ADVANCED} when nothing remains pending. A stage with no in-flight output
+     * returns {@code ADVANCED}; the default is sufficient for stages that only forward events.
      */
     default JsonPipeline.Status resume(
         JsonController control,
         JsonSource source)
     {
-        return JsonPipeline.Status.RESUMABLE;
+        return JsonPipeline.Status.ADVANCED;
     }
 
     default void reset()

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSource.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSource.java
@@ -30,18 +30,6 @@ public interface JsonSource
 {
     String getString();
 
-    /**
-     * Valid only on a {@code VALUE_STRING} or {@code VALUE_NUMBER} event; non-owning, on-stack char
-     * view of the current scalar's chars, letting a stage that consumes them immediately (e.g.
-     * re-encoding to a sink) avoid the {@link #getString()} allocation. The default materializes via
-     * {@link #getString()}; a streaming source overrides it to return a view backed by its own buffer,
-     * valid only for the duration of the current call.
-     */
-    default CharSequence getStringView()
-    {
-        return getString();
-    }
-
     // valid only on a key event; non-owning, on-stack char view of the current key
     CharSequence getKey();
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSource.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSource.java
@@ -30,6 +30,18 @@ public interface JsonSource
 {
     String getString();
 
+    /**
+     * Valid only on a {@code VALUE_STRING} or {@code VALUE_NUMBER} event; non-owning, on-stack char
+     * view of the current scalar's chars, letting a stage that consumes them immediately (e.g.
+     * re-encoding to a sink) avoid the {@link #getString()} allocation. The default materializes via
+     * {@link #getString()}; a streaming source overrides it to return a view backed by its own buffer,
+     * valid only for the duration of the current call.
+     */
+    default CharSequence getStringView()
+    {
+        return getString();
+    }
+
     // valid only on a key event; non-owning, on-stack char view of the current key
     CharSequence getKey();
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSource.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSource.java
@@ -44,4 +44,12 @@ public interface JsonSource
      * current contiguous slice, valid on-stack only.
      */
     DirectBuffer getSegment();
+
+    /**
+     * Whether the current value has bytes still deferred to later events — {@code true} while more of
+     * this same value follows (the value is being streamed across input frames because it exceeds the
+     * input window), {@code false} when this event completes it. A JSON string is quote-delimited, so
+     * this is a "more is coming" signal, not a remaining byte count.
+     */
+    boolean deferredBytes();
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonStream.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonStream.java
@@ -15,7 +15,7 @@
 package io.aklivity.zilla.runtime.common.json;
 
 /**
- * A description of a {@code common-json} pipeline — a driver bound by {@link StreamingJson#stream(JsonParserEx)} plus
+ * A description of a {@code common-json} pipeline — a driver bound by {@link JsonEx#stream(JsonParserEx)} plus
  * an ordered list of {@link JsonTransform} stages. Append stages with {@link #transform(JsonTransform)}
  * (left-to-right, in data-flow order); terminate with {@link #into(JsonSink)} to obtain the runnable,
  * resumable {@link JsonPipeline}. A {@code JsonStream} carries no state and is not itself runnable.

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonStream.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonStream.java
@@ -15,7 +15,7 @@
 package io.aklivity.zilla.runtime.common.json;
 
 /**
- * A description of a {@code common-json} pipeline — a driver bound by {@link JsonParserEx#stream()} plus
+ * A description of a {@code common-json} pipeline — a driver bound by {@link StreamingJson#stream(JsonParserEx)} plus
  * an ordered list of {@link JsonTransform} stages. Append stages with {@link #transform(JsonTransform)}
  * (left-to-right, in data-flow order); terminate with {@link #into(JsonSink)} to obtain the runnable,
  * resumable {@link JsonPipeline}. A {@code JsonStream} carries no state and is not itself runnable.

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonTransform.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonTransform.java
@@ -33,16 +33,17 @@ public interface JsonTransform
         JsonSink sink);
 
     /**
-     * Continues output this stage left in flight by a prior {@link JsonPipeline.Status#SUSPENDED} —
-     * a value it was emitting to {@code sink} across chunks — before the next event is fed. Returns
-     * {@link JsonPipeline.Status#SUSPENDED} if the bounded output filled again, or {@link
-     * JsonPipeline.Status#RESUMABLE} when this stage has nothing more to emit. The {@code resume()}
-     * cascade drains the downstream first, so a stage that only forwards events keeps the default.
+     * Continues output left in flight by a prior {@link JsonPipeline.Status#SUSPENDED} before the next
+     * event is fed. The default forwards to {@code sink.resume()}, draining whatever is pending
+     * downstream — sufficient for a stage that only forwards events. A stage that itself emits a value
+     * across chunks (substituting or expanding output) overrides this to continue its own emission,
+     * draining the downstream first. Returns {@link JsonPipeline.Status#SUSPENDED} if the bounded output
+     * filled again, or {@link JsonPipeline.Status#RESUMABLE} when nothing remains pending.
      */
     default JsonPipeline.Status resume(
         JsonSink sink)
     {
-        return JsonPipeline.Status.RESUMABLE;
+        return sink.resume();
     }
 
     default void reset()

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonTransform.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonTransform.java
@@ -34,16 +34,19 @@ public interface JsonTransform
 
     /**
      * Continues output left in flight by a prior {@link JsonPipeline.Status#SUSPENDED} before the next
-     * event is fed. The default forwards to {@code sink.resume()}, draining whatever is pending
-     * downstream — sufficient for a stage that only forwards events. A stage that itself emits a value
-     * across chunks (substituting or expanding output) overrides this to continue its own emission,
-     * draining the downstream first. Returns {@link JsonPipeline.Status#SUSPENDED} if the bounded output
-     * filled again, or {@link JsonPipeline.Status#RESUMABLE} when nothing remains pending.
+     * event is fed, with the same {@code control} and {@code source} context as {@link #feed}. The
+     * default forwards to {@code sink.resume(control, source)}, draining whatever is pending downstream —
+     * sufficient for a stage that only forwards events. A stage that itself emits a value across chunks
+     * (substituting or expanding output) overrides this to continue its own emission, draining the
+     * downstream first. Returns {@link JsonPipeline.Status#SUSPENDED} if the bounded output filled again,
+     * or {@link JsonPipeline.Status#RESUMABLE} when nothing remains pending.
      */
     default JsonPipeline.Status resume(
+        JsonController control,
+        JsonSource source,
         JsonSink sink)
     {
-        return sink.resume();
+        return sink.resume(control, source);
     }
 
     default void reset()

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonTransform.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonTransform.java
@@ -39,7 +39,7 @@ public interface JsonTransform
      * sufficient for a stage that only forwards events. A stage that itself emits a value across chunks
      * (substituting or expanding output) overrides this to continue its own emission, draining the
      * downstream first. Returns {@link JsonPipeline.Status#SUSPENDED} if the bounded output filled again,
-     * or {@link JsonPipeline.Status#RESUMABLE} when nothing remains pending.
+     * or {@link JsonPipeline.Status#ADVANCED} when nothing remains pending.
      */
     default JsonPipeline.Status resume(
         JsonController control,

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonTransform.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonTransform.java
@@ -32,6 +32,19 @@ public interface JsonTransform
         JsonEvent event,
         JsonSink sink);
 
+    /**
+     * Continues output this stage left in flight by a prior {@link JsonPipeline.Status#SUSPENDED} —
+     * a value it was emitting to {@code sink} across chunks — before the next event is fed. Returns
+     * {@link JsonPipeline.Status#SUSPENDED} if the bounded output filled again, or {@link
+     * JsonPipeline.Status#RESUMABLE} when this stage has nothing more to emit. The {@code resume()}
+     * cascade drains the downstream first, so a stage that only forwards events keeps the default.
+     */
+    default JsonPipeline.Status resume(
+        JsonSink sink)
+    {
+        return JsonPipeline.Status.RESUMABLE;
+    }
+
     default void reset()
     {
     }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/StreamingJson.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/StreamingJson.java
@@ -25,6 +25,7 @@ import io.aklivity.zilla.runtime.common.json.internal.JsonGeneratorImpl;
 import io.aklivity.zilla.runtime.common.json.internal.JsonParserFactoryImpl;
 import io.aklivity.zilla.runtime.common.json.internal.JsonParserImpl;
 import io.aklivity.zilla.runtime.common.json.internal.JsonProjectorImpl;
+import io.aklivity.zilla.runtime.common.json.internal.JsonStreamImpl;
 
 /**
  * Entry point for {@code common-json}'s streaming JSON parsing over Agrona buffers.
@@ -119,6 +120,18 @@ public final class StreamingJson
     public static JsonGeneratorEx createGenerator()
     {
         return new JsonGeneratorImpl();
+    }
+
+    /**
+     * Begins a push pipeline pumped by {@code parser}: append stages with {@link JsonStream#transform}
+     * and terminate with {@link JsonStream#into}. The {@code parser} (from {@link #createParser()} or
+     * {@link #createParser(Map)}) supplies the events; stages see a non-advancing {@link JsonSource}
+     * view of each.
+     */
+    public static JsonStream stream(
+        JsonParserEx parser)
+    {
+        return new JsonStreamImpl((JsonParserImpl) parser);
     }
 
     /**

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -346,6 +346,7 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         int length)
     {
         preValue();
+        assert progress + length <= limit;
         buffer.putBytes(progress, source, index, length);
         progress += length;
         return this;
@@ -357,6 +358,7 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         int index,
         int length)
     {
+        assert progress + length <= limit;
         buffer.putBytes(progress, source, index, length);
         progress += length;
         return this;
@@ -502,6 +504,7 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     private void putByte(
         int value)
     {
+        assert progress < limit;
         buffer.putByte(progress, (byte) value);
         progress++;
     }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -51,6 +51,7 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     private int progress;
     private int limit;
     private int depth;
+    private int deferred;
     private boolean afterKey;
 
     @Override
@@ -77,6 +78,7 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     public void reset()
     {
         this.depth = 0;
+        this.deferred = 0;
         this.afterKey = false;
     }
 
@@ -361,6 +363,20 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         assert progress + length <= limit;
         buffer.putBytes(progress, source, index, length);
         progress += length;
+        return this;
+    }
+
+    @Override
+    public JsonGeneratorImpl writeSegment(
+        DirectBuffer source,
+        int index,
+        int length,
+        int deferred)
+    {
+        assert progress + length <= limit;
+        buffer.putBytes(progress, source, index, length);
+        progress += length;
+        this.deferred = deferred;
         return this;
     }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -48,6 +48,7 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
 
     private MutableDirectBuffer buffer;
     private int offset;
+    private int progress;
     private int limit;
     private int depth;
     private boolean afterKey;
@@ -59,16 +60,36 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     {
         this.buffer = buffer;
         this.offset = offset;
-        this.limit = offset;
+        this.progress = offset;
+        this.limit = buffer.capacity();
         this.depth = 0;
         this.afterKey = false;
         return this;
     }
 
     @Override
+    public JsonGeneratorImpl wrap(
+        MutableDirectBuffer buffer,
+        int offset,
+        int limit)
+    {
+        this.buffer = buffer;
+        this.offset = offset;
+        this.progress = offset;
+        this.limit = limit;
+        return this;
+    }
+
+    @Override
     public int length()
     {
-        return limit - offset;
+        return progress - offset;
+    }
+
+    @Override
+    public int remaining()
+    {
+        return limit - progress;
     }
 
     @Override
@@ -331,8 +352,8 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         int length)
     {
         preValue();
-        buffer.putBytes(limit, source, index, length);
-        limit += length;
+        buffer.putBytes(progress, source, index, length);
+        progress += length;
         return this;
     }
 
@@ -342,8 +363,8 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         int index,
         int length)
     {
-        buffer.putBytes(limit, source, index, length);
-        limit += length;
+        buffer.putBytes(progress, source, index, length);
+        progress += length;
         return this;
     }
 
@@ -487,7 +508,7 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     private void putByte(
         int value)
     {
-        buffer.putByte(limit, (byte) value);
-        limit++;
+        buffer.putByte(progress, (byte) value);
+        progress++;
     }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -126,6 +126,13 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     public JsonGeneratorImpl writeKey(
         String name)
     {
+        return writeKey((CharSequence) name);
+    }
+
+    @Override
+    public JsonGeneratorImpl writeKey(
+        CharSequence name)
+    {
         if (hasMembers[depth - 1])
         {
             putByte(',');
@@ -416,14 +423,14 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     }
 
     private void writeString(
-        String value)
+        CharSequence value)
     {
         putByte('"');
         int index = 0;
         int length = value.length();
         while (index < length)
         {
-            int codePoint = value.codePointAt(index);
+            int codePoint = Character.codePointAt(value, index);
             index += Character.charCount(codePoint);
             switch (codePoint)
             {

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -74,6 +74,13 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     }
 
     @Override
+    public void reset()
+    {
+        this.depth = 0;
+        this.afterKey = false;
+    }
+
+    @Override
     public int remaining()
     {
         return limit - progress;

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -56,23 +56,10 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     @Override
     public JsonGeneratorImpl wrap(
         MutableDirectBuffer buffer,
-        int offset)
-    {
-        this.buffer = buffer;
-        this.offset = offset;
-        this.progress = offset;
-        this.limit = buffer.capacity();
-        this.depth = 0;
-        this.afterKey = false;
-        return this;
-    }
-
-    @Override
-    public JsonGeneratorImpl wrap(
-        MutableDirectBuffer buffer,
         int offset,
         int limit)
     {
+        assert offset <= limit && limit <= buffer.capacity();
         this.buffer = buffer;
         this.offset = offset;
         this.progress = offset;

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -156,6 +156,13 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     public JsonGeneratorImpl write(
         String value)
     {
+        return write((CharSequence) value);
+    }
+
+    @Override
+    public JsonGeneratorImpl write(
+        CharSequence value)
+    {
         preValue();
         writeString(value);
         return this;
@@ -343,6 +350,13 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     public JsonGeneratorImpl writeNumber(
         String literal)
     {
+        return writeNumber((CharSequence) literal);
+    }
+
+    @Override
+    public JsonGeneratorImpl writeNumber(
+        CharSequence literal)
+    {
         preValue();
         writeAscii(literal);
         return this;
@@ -516,7 +530,7 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     }
 
     private void writeAscii(
-        String value)
+        CharSequence value)
     {
         for (int index = 0; index < value.length(); index++)
         {

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonNode.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonNode.java
@@ -30,10 +30,10 @@ import jakarta.json.stream.JsonParser.Event;
 import org.agrona.concurrent.UnsafeBuffer;
 
 import io.aklivity.zilla.runtime.common.json.DirectBufferInputStreamEx;
-import io.aklivity.zilla.runtime.common.json.StreamingJson;
+import io.aklivity.zilla.runtime.common.json.JsonEx;
 
 /**
- * A minimal, provider-free JSON tree parsed with {@link StreamingJson} so that {@code
+ * A minimal, provider-free JSON tree parsed with {@link JsonEx} so that {@code
  * common-json} can read a schema document using its own parser, without depending on a
  * {@code jakarta.json} provider. Used at schema-compile time only.
  */
@@ -55,7 +55,7 @@ final class JsonNode
         byte[] bytes = (json + " ").getBytes(UTF_8);
         DirectBufferInputStreamEx in = new DirectBufferInputStreamEx();
         in.wrap(new UnsafeBuffer(bytes), 0, bytes.length);
-        JsonParser parser = StreamingJson.createParser(in);
+        JsonParser parser = JsonEx.createParser(in);
         return read(parser, parser.next());
     }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -132,6 +132,19 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         return this;
     }
 
+    // Wraps the next input window of a chunked feed; last == true marks the final window, so its EOF is the
+    // terminal delimiter (completing a trailing scalar, rejecting a truncated value) rather than a frame
+    // boundary with more bytes to come.
+    public JsonParserEx wrap(
+        DirectBuffer buffer,
+        int offset,
+        int length,
+        boolean last)
+    {
+        tokenizer.terminal(last);
+        return wrap(buffer, offset, length);
+    }
+
     void reset()
     {
         tokenizer.reset();

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -263,7 +263,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
             break;
         default:
             lastEvent = JsonEvent.of(next());
-            if (lastEvent == JsonEvent.VALUE_STRING)
+            if (lastEvent == JsonEvent.VALUE_STRING || lastEvent == JsonEvent.VALUE_NUMBER)
             {
                 segmentSliceOffset = bufferOffset(tokenizer.valueStreamStart());
                 segmentSliceLength = (int) (tokenizer.valueStreamEnd() - tokenizer.valueStreamStart());
@@ -371,12 +371,6 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
 
     @Override
     public CharSequence getKey()
-    {
-        return tokenizer.stringView();
-    }
-
-    @Override
-    public CharSequence getStringView()
     {
         return tokenizer.stringView();
     }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -68,8 +68,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     {
         NONE,
         PENDING_START,
-        SCANNING,
-        DONE_PENDING_END
+        SCANNING
     }
 
     private enum DocState
@@ -147,7 +146,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     public boolean hasNext()
     {
         boolean result;
-        if (segmentState == SegmentState.PENDING_START || segmentState == SegmentState.DONE_PENDING_END)
+        if (segmentState == SegmentState.PENDING_START)
         {
             result = true;
         }
@@ -236,7 +235,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         {
             result = false;
         }
-        else if (segmentState == SegmentState.PENDING_START || segmentState == SegmentState.DONE_PENDING_END)
+        else if (segmentState == SegmentState.PENDING_START)
         {
             result = true;
         }
@@ -257,16 +256,10 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         switch (segmentState)
         {
         case PENDING_START:
-            event = scanSegment(bufferOffset(segmentStartOffset), JsonEvent.START_SEGMENT);
+            event = scanSegment(bufferOffset(segmentStartOffset));
             break;
         case SCANNING:
-            event = scanSegment(ownedInput.offset(), JsonEvent.CONTINUE_SEGMENT);
-            break;
-        case DONE_PENDING_END:
-            segmentSliceOffset = ownedInput.offset();
-            segmentSliceLength = 0;
-            segmentState = SegmentState.NONE;
-            event = JsonEvent.END_SEGMENT;
+            event = scanSegment(ownedInput.offset());
             break;
         default:
             lastEvent = JsonEvent.of(next());
@@ -284,7 +277,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
                     segmentDepth = 1;
                     segmentState = SegmentState.PENDING_START;
                     tokenizer.segmenting(true);
-                    event = scanSegment(bufferOffset(segmentStartOffset), JsonEvent.START_SEGMENT);
+                    event = scanSegment(bufferOffset(segmentStartOffset));
                 }
                 else
                 {
@@ -300,9 +293,11 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         return event;
     }
 
+    // Scans the segmented value's raw bytes, emitting one SEGMENT per fragment: when the frame is
+    // exhausted before the value closes it suspends as SCANNING (more fragments follow, deferredBytes
+    // true); when structural depth returns to zero the value is complete (deferredBytes false).
     private JsonEvent scanSegment(
-        int sliceStart,
-        JsonEvent frameEndEvent)
+        int sliceStart)
     {
         JsonEvent event = null;
         while (event == null)
@@ -312,7 +307,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
                 segmentSliceOffset = sliceStart;
                 segmentSliceLength = ownedInput.offset() + ownedInput.length() - sliceStart;
                 segmentState = SegmentState.SCANNING;
-                event = frameEndEvent;
+                event = JsonEvent.SEGMENT;
             }
             else
             {
@@ -332,16 +327,8 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
                     final int sliceEnd = bufferOffset(tokenizer.streamOffset());
                     segmentSliceOffset = sliceStart;
                     segmentSliceLength = sliceEnd - sliceStart;
-                    if (frameEndEvent == JsonEvent.START_SEGMENT)
-                    {
-                        segmentState = SegmentState.DONE_PENDING_END;
-                        event = JsonEvent.START_SEGMENT;
-                    }
-                    else
-                    {
-                        segmentState = SegmentState.NONE;
-                        event = JsonEvent.END_SEGMENT;
-                    }
+                    segmentState = SegmentState.NONE;
+                    event = JsonEvent.SEGMENT;
                 }
             }
         }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -372,7 +372,13 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     @Override
     public CharSequence getKey()
     {
-        return tokenizer.key();
+        return tokenizer.stringView();
+    }
+
+    @Override
+    public CharSequence getStringView()
+    {
+        return tokenizer.stringView();
     }
 
     @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -40,9 +40,9 @@ import org.agrona.concurrent.UnsafeBuffer;
 import io.aklivity.zilla.runtime.common.json.DirectBufferInputStreamEx;
 import io.aklivity.zilla.runtime.common.json.JsonController;
 import io.aklivity.zilla.runtime.common.json.JsonEvent;
+import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonParserEx;
 import io.aklivity.zilla.runtime.common.json.JsonSource;
-import io.aklivity.zilla.runtime.common.json.StreamingJson;
 import io.aklivity.zilla.runtime.common.json.internal.json.JsonValues;
 
 public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonController
@@ -90,8 +90,8 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         this.ownedInput = new DirectBufferInputStreamEx();
         this.in = ownedInput;
         this.tokenizer = new JsonTokenizer(
-            pathList(config, StreamingJson.PATH_INCLUDES),
-            pathList(config, StreamingJson.PATH_EXCLUDES),
+            pathList(config, JsonEx.PATH_INCLUDES),
+            pathList(config, JsonEx.PATH_EXCLUDES),
             tokenMaxBytes(config));
         this.location = new JsonLocationImpl(tokenizer);
     }
@@ -115,8 +115,8 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         // A DirectBufferInputStreamEx is a resumable frame source whose EOF is a frame boundary;
         // any other stream is one-shot, so its EOF is the terminal delimiter for a trailing number.
         this.tokenizer = new JsonTokenizer(
-            pathList(config, StreamingJson.PATH_INCLUDES),
-            pathList(config, StreamingJson.PATH_EXCLUDES),
+            pathList(config, JsonEx.PATH_INCLUDES),
+            pathList(config, JsonEx.PATH_EXCLUDES),
             tokenMaxBytes(config),
             !(in instanceof DirectBufferInputStreamEx));
         this.location = new JsonLocationImpl(tokenizer);
@@ -368,7 +368,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         if (value == null && !tokenizer.valueReadable())
         {
             throw new IllegalStateException("value not readable; configure path via " +
-                "StreamingJson.PATH_INCLUDES (or remove from PATH_EXCLUDES)");
+                "JsonEx.PATH_INCLUDES (or remove from PATH_EXCLUDES)");
         }
         return value;
     }
@@ -634,7 +634,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     private static int tokenMaxBytes(
         Map<String, ?> config)
     {
-        final Object raw = config.get(StreamingJson.TOKEN_MAX_BYTES);
+        final Object raw = config.get(JsonEx.TOKEN_MAX_BYTES);
         return raw == null ? Integer.MAX_VALUE : ((Number) raw).intValue();
     }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -277,6 +277,11 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
             break;
         default:
             lastEvent = JsonEvent.of(next());
+            if (lastEvent == JsonEvent.VALUE_STRING)
+            {
+                segmentSliceOffset = bufferOffset(tokenizer.valueStreamStart());
+                segmentSliceLength = (int) (tokenizer.valueStreamEnd() - tokenizer.valueStreamStart());
+            }
             if (armNextValue)
             {
                 armNextValue = false;

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -283,6 +283,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
                     segmentStartOffset = tokenizer.streamOffset() - 1;
                     segmentDepth = 1;
                     segmentState = SegmentState.PENDING_START;
+                    tokenizer.segmenting(true);
                     event = scanSegment(bufferOffset(segmentStartOffset), JsonEvent.START_SEGMENT);
                 }
                 else
@@ -327,6 +328,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
 
                 if (segmentDepth == 0)
                 {
+                    tokenizer.segmenting(false);
                     final int sliceEnd = bufferOffset(tokenizer.streamOffset());
                     segmentSliceOffset = sliceStart;
                     segmentSliceLength = sliceEnd - sliceStart;
@@ -354,11 +356,18 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
             segmentStartOffset = tokenizer.streamOffset() - 1;
             segmentState = SegmentState.PENDING_START;
             segmentDepth = 1;
+            tokenizer.segmenting(true);
         }
         else if (lastEvent == JsonEvent.START_DOCUMENT)
         {
             armNextValue = true;
         }
+    }
+
+    @Override
+    public boolean deferredBytes()
+    {
+        return segmentState == SegmentState.SCANNING;
     }
 
     @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -42,7 +42,6 @@ import io.aklivity.zilla.runtime.common.json.JsonController;
 import io.aklivity.zilla.runtime.common.json.JsonEvent;
 import io.aklivity.zilla.runtime.common.json.JsonParserEx;
 import io.aklivity.zilla.runtime.common.json.JsonSource;
-import io.aklivity.zilla.runtime.common.json.JsonStream;
 import io.aklivity.zilla.runtime.common.json.StreamingJson;
 import io.aklivity.zilla.runtime.common.json.internal.json.JsonValues;
 
@@ -121,12 +120,6 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
             tokenMaxBytes(config),
             !(in instanceof DirectBufferInputStreamEx));
         this.location = new JsonLocationImpl(tokenizer);
-    }
-
-    @Override
-    public JsonStream stream()
-    {
-        return new JsonStreamImpl(this);
     }
 
     @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
@@ -54,7 +54,8 @@ public final class JsonPipelineImpl implements JsonPipeline
     public Status feed(
         DirectBuffer buffer,
         int offset,
-        int length)
+        int length,
+        boolean last)
     {
         Status status = Status.ADVANCED;
         try
@@ -65,11 +66,17 @@ public final class JsonPipelineImpl implements JsonPipeline
             }
             else
             {
-                parser.wrap(buffer, offset, length);
+                parser.wrap(buffer, offset, length, last);
             }
             while (status == Status.ADVANCED && parser.hasNextEvent())
             {
                 status = root.feed(parser, parser, parser.nextEvent());
+            }
+            if (status == Status.ADVANCED)
+            {
+                // the window was consumed before the value completed: more input is needed, unless this was
+                // the final window, in which case the value is truncated
+                status = last ? Status.REJECTED : Status.STARVED;
             }
         }
         catch (JsonParsingException ex)

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
@@ -61,7 +61,7 @@ public final class JsonPipelineImpl implements JsonPipeline
         {
             if (suspended)
             {
-                status = root.resume();
+                status = root.resume(parser, parser);
             }
             else
             {

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
@@ -30,6 +30,8 @@ public final class JsonPipelineImpl implements JsonPipeline
     private final JsonParserImpl parser;
     private final JsonSink root;
 
+    private boolean suspended;
+
     public JsonPipelineImpl(
         JsonParserImpl parser,
         JsonSink root)
@@ -43,6 +45,7 @@ public final class JsonPipelineImpl implements JsonPipeline
     {
         parser.reset();
         root.reset();
+        suspended = false;
     }
 
     @Override
@@ -51,12 +54,16 @@ public final class JsonPipelineImpl implements JsonPipeline
         int offset,
         int length)
     {
-        parser.wrap(buffer, offset, length);
-        Status status = Status.PENDING;
-        while (status == Status.PENDING && parser.hasNextEvent())
+        if (!suspended)
+        {
+            parser.wrap(buffer, offset, length);
+        }
+        Status status = Status.RESUMABLE;
+        while (status == Status.RESUMABLE && parser.hasNextEvent())
         {
             status = root.feed(parser, parser, parser.nextEvent());
         }
+        suspended = status == Status.SUSPENDED;
         return status;
     }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
@@ -56,7 +56,7 @@ public final class JsonPipelineImpl implements JsonPipeline
         int offset,
         int length)
     {
-        Status status = Status.RESUMABLE;
+        Status status = Status.ADVANCED;
         try
         {
             if (suspended)
@@ -67,7 +67,7 @@ public final class JsonPipelineImpl implements JsonPipeline
             {
                 parser.wrap(buffer, offset, length);
             }
-            while (status == Status.RESUMABLE && parser.hasNextEvent())
+            while (status == Status.ADVANCED && parser.hasNextEvent())
             {
                 status = root.feed(parser, parser, parser.nextEvent());
             }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
@@ -59,7 +59,11 @@ public final class JsonPipelineImpl implements JsonPipeline
         Status status = Status.RESUMABLE;
         try
         {
-            if (!suspended)
+            if (suspended)
+            {
+                status = root.resume();
+            }
+            else
             {
                 parser.wrap(buffer, offset, length);
             }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
@@ -14,6 +14,8 @@
  */
 package io.aklivity.zilla.runtime.common.json.internal;
 
+import jakarta.json.stream.JsonParsingException;
+
 import org.agrona.DirectBuffer;
 
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
@@ -54,14 +56,21 @@ public final class JsonPipelineImpl implements JsonPipeline
         int offset,
         int length)
     {
-        if (!suspended)
-        {
-            parser.wrap(buffer, offset, length);
-        }
         Status status = Status.RESUMABLE;
-        while (status == Status.RESUMABLE && parser.hasNextEvent())
+        try
         {
-            status = root.feed(parser, parser, parser.nextEvent());
+            if (!suspended)
+            {
+                parser.wrap(buffer, offset, length);
+            }
+            while (status == Status.RESUMABLE && parser.hasNextEvent())
+            {
+                status = root.feed(parser, parser, parser.nextEvent());
+            }
+        }
+        catch (JsonParsingException ex)
+        {
+            status = Status.REJECTED;
         }
         suspended = status == Status.SUSPENDED;
         return status;

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
@@ -277,11 +277,15 @@ public final class JsonProjectorImpl implements JsonTransform
         JsonEvent event,
         JsonSink sink)
     {
-        if (event == JsonEvent.START_SEGMENT)
+        if (event == JsonEvent.SEGMENT)
         {
             segMode = SegMode.FORWARDING;
             deferredStart = null;
             forward(sink, source, event);
+            if (!source.deferredBytes())
+            {
+                finishSegment();
+            }
         }
         else
         {
@@ -299,17 +303,22 @@ public final class JsonProjectorImpl implements JsonTransform
         JsonSink sink)
     {
         forward(sink, source, event);
-        if (event == JsonEvent.END_SEGMENT)
+        if (!source.deferredBytes())
         {
-            segMode = SegMode.NONE;
-            if (containers == 0)
-            {
-                rootDone = true;
-            }
-            else
-            {
-                depth--;
-            }
+            finishSegment();
+        }
+    }
+
+    private void finishSegment()
+    {
+        segMode = SegMode.NONE;
+        if (containers == 0)
+        {
+            rootDone = true;
+        }
+        else
+        {
+            depth--;
         }
     }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
@@ -547,5 +547,11 @@ public final class JsonProjectorImpl implements JsonTransform
         {
             throw new UnsupportedOperationException();
         }
+
+        @Override
+        public boolean deferredBytes()
+        {
+            return false;
+        }
     }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
@@ -131,13 +131,13 @@ public final class JsonProjectorImpl implements JsonTransform
         {
             status = Status.REJECTED;
         }
-        else if (rootDone)
-        {
-            status = Status.COMPLETE;
-        }
         else if (downstream == Status.SUSPENDED)
         {
             status = Status.SUSPENDED;
+        }
+        else if (rootDone)
+        {
+            status = Status.COMPLETE;
         }
         else
         {

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
@@ -113,7 +113,7 @@ public final class JsonProjectorImpl implements JsonTransform
         JsonEvent event,
         JsonSink sink)
     {
-        downstream = Status.RESUMABLE;
+        downstream = Status.ADVANCED;
         if (segMode == SegMode.AWAITING)
         {
             onAwaiting(control, source, event, sink);
@@ -137,11 +137,11 @@ public final class JsonProjectorImpl implements JsonTransform
         }
         else if (rootDone)
         {
-            status = Status.COMPLETE;
+            status = Status.COMPLETED;
         }
         else
         {
-            status = Status.RESUMABLE;
+            status = Status.ADVANCED;
         }
         return status;
     }
@@ -168,7 +168,7 @@ public final class JsonProjectorImpl implements JsonTransform
         {
         case REJECTED -> 3;
         case SUSPENDED -> 2;
-        case COMPLETE -> 1;
+        case COMPLETED -> 1;
         default -> 0;
         };
     }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
@@ -69,6 +69,7 @@ public final class JsonProjectorImpl implements JsonTransform
     private String pendingKey;
     private boolean rootDone;
     private boolean downstreamDemand;
+    private Status downstream;
     private SegMode segMode = SegMode.NONE;
     private JsonEvent deferredStart;
 
@@ -112,6 +113,7 @@ public final class JsonProjectorImpl implements JsonTransform
         JsonEvent event,
         JsonSink sink)
     {
+        downstream = Status.RESUMABLE;
         if (segMode == SegMode.AWAITING)
         {
             onAwaiting(control, source, event, sink);
@@ -124,7 +126,51 @@ public final class JsonProjectorImpl implements JsonTransform
         {
             route(control, source, event, sink);
         }
-        return rootDone ? Status.COMPLETE : Status.PENDING;
+        Status status;
+        if (downstream == Status.REJECTED)
+        {
+            status = Status.REJECTED;
+        }
+        else if (rootDone)
+        {
+            status = Status.COMPLETE;
+        }
+        else if (downstream == Status.SUSPENDED)
+        {
+            status = Status.SUSPENDED;
+        }
+        else
+        {
+            status = Status.RESUMABLE;
+        }
+        return status;
+    }
+
+    // Forwards one event downstream, retaining the most terminal status seen across the (possibly
+    // several) downstream feeds a single upstream event triggers, so backpressure (SUSPENDED) and
+    // rejection (REJECTED) propagate while the value is still in progress.
+    private void forward(
+        JsonSink sink,
+        JsonSource source,
+        JsonEvent event)
+    {
+        Status status = sink.feed(downstreamControl, source, event);
+        if (rank(status) > rank(downstream))
+        {
+            downstream = status;
+        }
+    }
+
+    private static int rank(
+        Status status)
+    {
+        return switch (status)
+        {
+        case REJECTED -> 3;
+        case SUSPENDED -> 2;
+        case COMPLETE -> 1;
+        default -> 0;
+        };
     }
 
     private void route(
@@ -137,7 +183,7 @@ public final class JsonProjectorImpl implements JsonTransform
         {
         case START_DOCUMENT:
         case END_DOCUMENT:
-            sink.feed(downstreamControl, source, event);
+            forward(sink, source, event);
             break;
         case KEY_NAME:
             onKey(source);
@@ -178,7 +224,7 @@ public final class JsonProjectorImpl implements JsonTransform
     {
         if (pendingKey != null)
         {
-            sink.feed(downstreamControl, keySource.with(pendingKey), JsonEvent.KEY_NAME);
+            forward(sink, keySource.with(pendingKey), JsonEvent.KEY_NAME);
             pendingKey = null;
         }
     }
@@ -215,7 +261,7 @@ public final class JsonProjectorImpl implements JsonTransform
         else if (emit)
         {
             forwardPendingKey(sink);
-            sink.feed(downstreamControl, source, event);
+            forward(sink, source, event);
             pushFrame(event, true, d);
         }
         else
@@ -235,12 +281,12 @@ public final class JsonProjectorImpl implements JsonTransform
         {
             segMode = SegMode.FORWARDING;
             deferredStart = null;
-            sink.feed(downstreamControl, source, event);
+            forward(sink, source, event);
         }
         else
         {
             segMode = SegMode.NONE;
-            sink.feed(downstreamControl, source, deferredStart);
+            forward(sink, source, deferredStart);
             pushFrame(deferredStart, true, Decision.KEEP_ALL);
             deferredStart = null;
             route(control, source, event, sink);
@@ -252,7 +298,7 @@ public final class JsonProjectorImpl implements JsonTransform
         JsonEvent event,
         JsonSink sink)
     {
-        sink.feed(downstreamControl, source, event);
+        forward(sink, source, event);
         if (event == JsonEvent.END_SEGMENT)
         {
             segMode = SegMode.NONE;
@@ -275,7 +321,7 @@ public final class JsonProjectorImpl implements JsonTransform
         containers--;
         if (frameEmit[containers])
         {
-            sink.feed(downstreamControl, source, event);
+            forward(sink, source, event);
         }
         if (containers == 0)
         {
@@ -299,7 +345,7 @@ public final class JsonProjectorImpl implements JsonTransform
         if (emit)
         {
             forwardPendingKey(sink);
-            sink.feed(downstreamControl, source, event);
+            forward(sink, source, event);
         }
         else
         {

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
@@ -66,7 +66,7 @@ public final class JsonProjectorImpl implements JsonTransform
     private int depth;
     private int containers;
     private Decision keyDecision;
-    private String pendingKey;
+    private CharSequence pendingKey;
     private boolean rootDone;
     private boolean downstreamDemand;
     private Status downstream;
@@ -214,9 +214,9 @@ public final class JsonProjectorImpl implements JsonTransform
         boolean parentKeepAll = containers > 0 && frameKeepAll[containers - 1];
         Decision d = parentKeepAll ? Decision.KEEP_ALL : decide();
         keyDecision = d;
-        // Only a key whose value will be emitted is forwarded, so only then is a String materialized;
-        // SKIP keys (the majority) are matched by chars above and never allocate.
-        pendingKey = d == Decision.SKIP ? null : source.getString();
+        // A forwarded key reuses the char view already buffered above for path matching, so no key
+        // ever materializes a String — neither the SKIP majority nor the KEEP keys carried downstream.
+        pendingKey = d == Decision.SKIP ? null : key;
     }
 
     private void forwardPendingKey(
@@ -512,10 +512,10 @@ public final class JsonProjectorImpl implements JsonTransform
 
     private static final class KeySource implements JsonSource
     {
-        private String key;
+        private CharSequence key;
 
         private KeySource with(
-            String key)
+            CharSequence key)
         {
             this.key = key;
             return this;
@@ -524,7 +524,7 @@ public final class JsonProjectorImpl implements JsonTransform
         @Override
         public String getString()
         {
-            return key;
+            return key == null ? null : key.toString();
         }
 
         @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
@@ -998,6 +998,12 @@ public final class JsonSchemaImpl implements JsonSchema
         {
             throw new UnsupportedOperationException();
         }
+
+        @Override
+        public boolean deferredBytes()
+        {
+            return false;
+        }
     }
 
     private static String canonicalize(
@@ -1470,6 +1476,12 @@ public final class JsonSchemaImpl implements JsonSchema
         public DirectBuffer getSegment()
         {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean deferredBytes()
+        {
+            return false;
         }
     }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
@@ -1673,7 +1673,7 @@ public final class JsonSchemaImpl implements JsonSchema
             if (event.segmented() || event == JsonEvent.START_DOCUMENT || event == JsonEvent.END_DOCUMENT)
             {
                 status = downstream == Status.REJECTED ? Status.REJECTED
-                    : downstream == Status.SUSPENDED ? Status.SUSPENDED : Status.RESUMABLE;
+                    : downstream == Status.SUSPENDED ? Status.SUSPENDED : Status.ADVANCED;
             }
             else
             {
@@ -1684,11 +1684,11 @@ public final class JsonSchemaImpl implements JsonSchema
                 }
                 else if (verdict == Verdict.VALID)
                 {
-                    status = Status.COMPLETE;
+                    status = Status.COMPLETED;
                 }
                 else
                 {
-                    status = downstream == Status.SUSPENDED ? Status.SUSPENDED : Status.RESUMABLE;
+                    status = downstream == Status.SUSPENDED ? Status.SUSPENDED : Status.ADVANCED;
                 }
             }
             return status;

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
@@ -1668,18 +1668,28 @@ public final class JsonSchemaImpl implements JsonSchema
             JsonEvent event,
             JsonSink sink)
         {
-            sink.feed(decline, source, event);
+            Status downstream = sink.feed(decline, source, event);
             Status status;
             if (event.segmented() || event == JsonEvent.START_DOCUMENT || event == JsonEvent.END_DOCUMENT)
             {
-                status = Status.PENDING;
+                status = downstream == Status.REJECTED ? Status.REJECTED
+                    : downstream == Status.SUSPENDED ? Status.SUSPENDED : Status.RESUMABLE;
             }
             else
             {
                 Verdict verdict = eval.feed(toEvent(event), source);
-                status = verdict == Verdict.VALID
-                    ? Status.COMPLETE
-                    : verdict == Verdict.INVALID ? Status.REJECTED : Status.PENDING;
+                if (downstream == Status.REJECTED || verdict == Verdict.INVALID)
+                {
+                    status = Status.REJECTED;
+                }
+                else if (verdict == Verdict.VALID)
+                {
+                    status = Status.COMPLETE;
+                }
+                else
+                {
+                    status = downstream == Status.SUSPENDED ? Status.SUSPENDED : Status.RESUMABLE;
+                }
             }
             return status;
         }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -36,6 +36,9 @@ public final class JsonSinkImpl implements JsonSink
     private final JsonGeneratorEx generator;
     private final Delivery delivery;
     private int depth;
+    private int segmentWritten;
+    private DirectBuffer pendingSegment;
+    private JsonEvent pendingSegmentEvent;
 
     public JsonSinkImpl(
         JsonGeneratorEx generator)
@@ -103,16 +106,14 @@ public final class JsonSinkImpl implements JsonSink
             break;
         case START_SEGMENT:
             segment = source.getSegment();
-            generator.writeRaw(segment, 0, segment.capacity());
+            // emit the value's leading separator once, before its first content byte
+            generator.writeRaw(segment, 0, 0);
+            status = writeChunk(segment, event);
             break;
         case CONTINUE_SEGMENT:
-            segment = source.getSegment();
-            generator.writeRawContinue(segment, 0, segment.capacity());
-            break;
         case END_SEGMENT:
             segment = source.getSegment();
-            generator.writeRawContinue(segment, 0, segment.capacity());
-            status = scalarStatus();
+            status = writeChunk(segment, event);
             break;
         case START_DOCUMENT:
             if (delivery == Delivery.SEGMENTABLE)
@@ -126,18 +127,66 @@ public final class JsonSinkImpl implements JsonSink
             break;
         }
 
-        if (status == Status.RESUMABLE && generator.length() > 0 && generator.remaining() < HEADROOM)
-        {
-            status = Status.SUSPENDED;
-        }
-        return status;
+        return boundary(status);
+    }
+
+    @Override
+    public Status resume()
+    {
+        Status status = pendingSegment != null ? writeChunk(pendingSegment, pendingSegmentEvent) : Status.RESUMABLE;
+        return boundary(status);
     }
 
     @Override
     public void reset()
     {
         depth = 0;
+        segmentWritten = 0;
+        pendingSegment = null;
+        pendingSegmentEvent = null;
         generator.reset();
+    }
+
+    // Writes as much of the current segment slice as the bounded output allows, deferring the rest: when
+    // the slice does not fit it stashes the remainder and reports SUSPENDED so the driver drains and a
+    // later resume() continues from segmentWritten; once the slice is fully written the value boundary is
+    // reached.
+    private Status writeChunk(
+        DirectBuffer segment,
+        JsonEvent event)
+    {
+        int sliceLength = segment.capacity();
+        int length = Math.min(sliceLength - segmentWritten, generator.remaining());
+        int deferred = sliceLength - segmentWritten - length;
+        generator.writeSegment(segment, segmentWritten, length, deferred);
+        segmentWritten += length;
+        Status status;
+        if (deferred > 0)
+        {
+            pendingSegment = segment;
+            pendingSegmentEvent = event;
+            status = Status.SUSPENDED;
+        }
+        else
+        {
+            segmentWritten = 0;
+            pendingSegment = null;
+            status = event == JsonEvent.END_SEGMENT ? scalarStatus() : Status.RESUMABLE;
+        }
+        return status;
+    }
+
+    // Suspends at an event boundary once the bounded output nears its limit, so the next event's write
+    // starts against a freshly drained buffer.
+    private Status boundary(
+        Status status)
+    {
+        Status result = status;
+        if (status == Status.RESUMABLE && generator.length() > 0 && generator.remaining() < HEADROOM)
+        {
+            result = Status.SUSPENDED;
+        }
+        return result;
     }
 
     private Status scalarStatus()

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -26,7 +26,7 @@ import io.aklivity.zilla.runtime.common.json.JsonSource;
 
 /**
  * Terminal {@link JsonSink} that materializes each fed event into the corresponding {@code writeXxx}
- * call on the wrapped {@link JsonGeneratorEx}. Reaches {@link Status#COMPLETE} when the current
+ * call on the wrapped {@link JsonGeneratorEx}. Reaches {@link Status#COMPLETED} when the current
  * top-level value closes at depth zero.
  */
 public final class JsonSinkImpl implements JsonSink
@@ -59,7 +59,7 @@ public final class JsonSinkImpl implements JsonSink
         JsonSource source,
         JsonEvent event)
     {
-        Status status = Status.RESUMABLE;
+        Status status = Status.ADVANCED;
         DirectBuffer segment;
         switch (event)
         {
@@ -80,7 +80,7 @@ public final class JsonSinkImpl implements JsonSink
             depth--;
             if (depth == 0)
             {
-                status = Status.COMPLETE;
+                status = Status.COMPLETED;
             }
             break;
         case VALUE_STRING:
@@ -136,7 +136,7 @@ public final class JsonSinkImpl implements JsonSink
     {
         Status status = pendingSegmentEvent != null
             ? writeChunk(source.getSegment(), pendingSegmentEvent)
-            : Status.RESUMABLE;
+            : Status.ADVANCED;
         return boundary(status);
     }
 
@@ -172,7 +172,7 @@ public final class JsonSinkImpl implements JsonSink
         {
             segmentWritten = 0;
             pendingSegmentEvent = null;
-            status = event == JsonEvent.END_SEGMENT ? scalarStatus() : Status.RESUMABLE;
+            status = event == JsonEvent.END_SEGMENT ? scalarStatus() : Status.ADVANCED;
         }
         return status;
     }
@@ -183,7 +183,7 @@ public final class JsonSinkImpl implements JsonSink
         Status status)
     {
         Status result = status;
-        if (status == Status.RESUMABLE && generator.length() > 0 && generator.remaining() < HEADROOM)
+        if (status == Status.ADVANCED && generator.length() > 0 && generator.remaining() < HEADROOM)
         {
             result = Status.SUSPENDED;
         }
@@ -192,6 +192,6 @@ public final class JsonSinkImpl implements JsonSink
 
     private Status scalarStatus()
     {
-        return depth == 0 ? Status.COMPLETE : Status.RESUMABLE;
+        return depth == 0 ? Status.COMPLETED : Status.ADVANCED;
     }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -89,7 +89,7 @@ public final class JsonSinkImpl implements JsonSink
             if (!valueStarted && segment.capacity() < generator.remaining())
             {
                 // fits: re-encode normalized (a re-encode is never longer than the raw token)
-                generator.write(source.getString());
+                generator.write(source.getStringView());
                 status = scalarStatus();
             }
             else
@@ -104,7 +104,7 @@ public final class JsonSinkImpl implements JsonSink
             }
             break;
         case VALUE_NUMBER:
-            generator.writeNumber(source.getString());
+            generator.writeNumber(source.getStringView());
             status = scalarStatus();
             break;
         case VALUE_TRUE:

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -37,7 +37,6 @@ public final class JsonSinkImpl implements JsonSink
     private final Delivery delivery;
     private int depth;
     private int segmentWritten;
-    private DirectBuffer pendingSegment;
     private JsonEvent pendingSegmentEvent;
 
     public JsonSinkImpl(
@@ -131,9 +130,13 @@ public final class JsonSinkImpl implements JsonSink
     }
 
     @Override
-    public Status resume()
+    public Status resume(
+        JsonController control,
+        JsonSource source)
     {
-        Status status = pendingSegment != null ? writeChunk(pendingSegment, pendingSegmentEvent) : Status.RESUMABLE;
+        Status status = pendingSegmentEvent != null
+            ? writeChunk(source.getSegment(), pendingSegmentEvent)
+            : Status.RESUMABLE;
         return boundary(status);
     }
 
@@ -142,7 +145,6 @@ public final class JsonSinkImpl implements JsonSink
     {
         depth = 0;
         segmentWritten = 0;
-        pendingSegment = null;
         pendingSegmentEvent = null;
         generator.reset();
     }
@@ -163,14 +165,13 @@ public final class JsonSinkImpl implements JsonSink
         Status status;
         if (deferred > 0)
         {
-            pendingSegment = segment;
             pendingSegmentEvent = event;
             status = Status.SUSPENDED;
         }
         else
         {
             segmentWritten = 0;
-            pendingSegment = null;
+            pendingSegmentEvent = null;
             status = event == JsonEvent.END_SEGMENT ? scalarStatus() : Status.RESUMABLE;
         }
         return status;

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -65,7 +65,7 @@ public final class JsonSinkImpl implements JsonSink
         switch (event)
         {
         case KEY_NAME:
-            generator.writeKey(source.getString());
+            generator.writeKey(source.getKey());
             break;
         case START_OBJECT:
             generator.writeStartObject();

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -84,8 +84,22 @@ public final class JsonSinkImpl implements JsonSink
             }
             break;
         case VALUE_STRING:
-            generator.write(source.getString());
-            status = scalarStatus();
+            segment = source.getSegment();
+            if (segmentWritten == 0 && segment.capacity() < generator.remaining())
+            {
+                // fits: re-encode normalized (a re-encode is never longer than the raw token)
+                generator.write(source.getString());
+                status = scalarStatus();
+            }
+            else
+            {
+                // too large for the bound: splice the raw token bytes verbatim, fragmenting across chunks
+                if (segmentWritten == 0)
+                {
+                    generator.writeRaw(segment, 0, 0);
+                }
+                status = writeChunk(segment, event);
+            }
             break;
         case VALUE_NUMBER:
             generator.writeNumber(source.getString());
@@ -172,7 +186,9 @@ public final class JsonSinkImpl implements JsonSink
         {
             segmentWritten = 0;
             pendingSegmentEvent = null;
-            status = event == JsonEvent.END_SEGMENT ? scalarStatus() : Status.ADVANCED;
+            status = event == JsonEvent.END_SEGMENT || event == JsonEvent.VALUE_STRING
+                ? scalarStatus()
+                : Status.ADVANCED;
         }
         return status;
     }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -37,7 +37,8 @@ public final class JsonSinkImpl implements JsonSink
     private final Delivery delivery;
     private int depth;
     private int segmentWritten;
-    private JsonEvent pendingSegmentEvent;
+    private boolean valueStarted;
+    private boolean pendingSegment;
 
     public JsonSinkImpl(
         JsonGeneratorEx generator)
@@ -85,7 +86,7 @@ public final class JsonSinkImpl implements JsonSink
             break;
         case VALUE_STRING:
             segment = source.getSegment();
-            if (segmentWritten == 0 && segment.capacity() < generator.remaining())
+            if (!valueStarted && segment.capacity() < generator.remaining())
             {
                 // fits: re-encode normalized (a re-encode is never longer than the raw token)
                 generator.write(source.getString());
@@ -94,11 +95,12 @@ public final class JsonSinkImpl implements JsonSink
             else
             {
                 // too large for the bound: splice the raw token bytes verbatim, fragmenting across chunks
-                if (segmentWritten == 0)
+                if (!valueStarted)
                 {
                     generator.writeRaw(segment, 0, 0);
+                    valueStarted = true;
                 }
-                status = writeChunk(segment, event);
+                status = writeChunk(segment, source);
             }
             break;
         case VALUE_NUMBER:
@@ -117,16 +119,15 @@ public final class JsonSinkImpl implements JsonSink
             generator.writeNull();
             status = scalarStatus();
             break;
-        case START_SEGMENT:
+        case SEGMENT:
             segment = source.getSegment();
             // emit the value's leading separator once, before its first content byte
-            generator.writeRaw(segment, 0, 0);
-            status = writeChunk(segment, event);
-            break;
-        case CONTINUE_SEGMENT:
-        case END_SEGMENT:
-            segment = source.getSegment();
-            status = writeChunk(segment, event);
+            if (!valueStarted)
+            {
+                generator.writeRaw(segment, 0, 0);
+                valueStarted = true;
+            }
+            status = writeChunk(segment, source);
             break;
         case START_DOCUMENT:
             if (delivery == Delivery.SEGMENTABLE)
@@ -148,9 +149,7 @@ public final class JsonSinkImpl implements JsonSink
         JsonController control,
         JsonSource source)
     {
-        Status status = pendingSegmentEvent != null
-            ? writeChunk(source.getSegment(), pendingSegmentEvent)
-            : Status.ADVANCED;
+        Status status = pendingSegment ? writeChunk(source.getSegment(), source) : Status.ADVANCED;
         return boundary(status);
     }
 
@@ -159,36 +158,43 @@ public final class JsonSinkImpl implements JsonSink
     {
         depth = 0;
         segmentWritten = 0;
-        pendingSegmentEvent = null;
+        valueStarted = false;
+        pendingSegment = false;
         generator.reset();
     }
 
     // Writes as much of the current segment slice as the bounded output allows, deferring the rest: when
-    // the slice does not fit it stashes the remainder and reports SUSPENDED so the driver drains and a
-    // later resume() continues from segmentWritten; once the slice is fully written the value boundary is
-    // reached.
+    // the slice does not fit it stashes the remainder (pendingSegment) and reports SUSPENDED so the driver
+    // drains and a later resume() continues from segmentWritten. Once the slice is fully written the value
+    // continues (more fragments follow, source.deferredBytes()) or completes (the value boundary).
     private Status writeChunk(
         DirectBuffer segment,
-        JsonEvent event)
+        JsonSource source)
     {
         int sliceLength = segment.capacity();
         int length = Math.min(sliceLength - segmentWritten, generator.remaining());
-        int deferred = sliceLength - segmentWritten - length;
-        generator.writeSegment(segment, segmentWritten, length, deferred);
+        int outputDeferred = sliceLength - segmentWritten - length;
+        generator.writeSegment(segment, segmentWritten, length, outputDeferred);
         segmentWritten += length;
         Status status;
-        if (deferred > 0)
+        if (outputDeferred > 0)
         {
-            pendingSegmentEvent = event;
+            pendingSegment = true;
             status = Status.SUSPENDED;
         }
         else
         {
             segmentWritten = 0;
-            pendingSegmentEvent = null;
-            status = event == JsonEvent.END_SEGMENT || event == JsonEvent.VALUE_STRING
-                ? scalarStatus()
-                : Status.ADVANCED;
+            pendingSegment = false;
+            if (source.deferredBytes())
+            {
+                status = Status.ADVANCED;
+            }
+            else
+            {
+                valueStarted = false;
+                status = scalarStatus();
+            }
         }
         return status;
     }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -85,27 +85,17 @@ public final class JsonSinkImpl implements JsonSink
             }
             break;
         case VALUE_STRING:
-            segment = source.getSegment();
-            if (!valueStarted && segment.capacity() < generator.remaining())
-            {
-                // fits: re-encode normalized (a re-encode is never longer than the raw token)
-                generator.write(source.getStringView());
-                status = scalarStatus();
-            }
-            else
-            {
-                // too large for the bound: splice the raw token bytes verbatim, fragmenting across chunks
-                if (!valueStarted)
-                {
-                    generator.writeRaw(segment, 0, 0);
-                    valueStarted = true;
-                }
-                status = writeChunk(segment, source);
-            }
-            break;
         case VALUE_NUMBER:
-            generator.writeNumber(source.getStringView());
-            status = scalarStatus();
+        case SEGMENT:
+            // splice the kept leaf's raw token bytes verbatim, fragmenting across chunks; the value's
+            // leading separator is emitted once, before its first content byte
+            segment = source.getSegment();
+            if (!valueStarted)
+            {
+                generator.writeRaw(segment, 0, 0);
+                valueStarted = true;
+            }
+            status = writeChunk(segment, source);
             break;
         case VALUE_TRUE:
             generator.write(true);
@@ -118,16 +108,6 @@ public final class JsonSinkImpl implements JsonSink
         case VALUE_NULL:
             generator.writeNull();
             status = scalarStatus();
-            break;
-        case SEGMENT:
-            segment = source.getSegment();
-            // emit the value's leading separator once, before its first content byte
-            if (!valueStarted)
-            {
-                generator.writeRaw(segment, 0, 0);
-                valueStarted = true;
-            }
-            status = writeChunk(segment, source);
             break;
         case START_DOCUMENT:
             if (delivery == Delivery.SEGMENTABLE)

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -137,6 +137,7 @@ public final class JsonSinkImpl implements JsonSink
     public void reset()
     {
         depth = 0;
+        generator.reset();
     }
 
     private Status scalarStatus()

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -31,6 +31,8 @@ import io.aklivity.zilla.runtime.common.json.JsonSource;
  */
 public final class JsonSinkImpl implements JsonSink
 {
+    private static final int HEADROOM = 16;
+
     private final JsonGeneratorEx generator;
     private final Delivery delivery;
     private int depth;
@@ -55,7 +57,7 @@ public final class JsonSinkImpl implements JsonSink
         JsonSource source,
         JsonEvent event)
     {
-        Status status = Status.PENDING;
+        Status status = Status.RESUMABLE;
         DirectBuffer segment;
         switch (event)
         {
@@ -123,6 +125,11 @@ public final class JsonSinkImpl implements JsonSink
         default:
             break;
         }
+
+        if (status == Status.RESUMABLE && generator.length() > 0 && generator.remaining() < HEADROOM)
+        {
+            status = Status.SUSPENDED;
+        }
         return status;
     }
 
@@ -134,6 +141,6 @@ public final class JsonSinkImpl implements JsonSink
 
     private Status scalarStatus()
     {
-        return depth == 0 ? Status.COMPLETE : Status.PENDING;
+        return depth == 0 ? Status.COMPLETE : Status.RESUMABLE;
     }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonStreamImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonStreamImpl.java
@@ -89,12 +89,7 @@ public final class JsonStreamImpl implements JsonStream
         @Override
         public Status resume()
         {
-            Status status = downstream.resume();
-            if (status == Status.RESUMABLE)
-            {
-                status = transform.resume(downstream);
-            }
-            return status;
+            return transform.resume(downstream);
         }
 
         @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonStreamImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonStreamImpl.java
@@ -87,6 +87,17 @@ public final class JsonStreamImpl implements JsonStream
         }
 
         @Override
+        public Status resume()
+        {
+            Status status = downstream.resume();
+            if (status == Status.RESUMABLE)
+            {
+                status = transform.resume(downstream);
+            }
+            return status;
+        }
+
+        @Override
         public void reset()
         {
             transform.reset();

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonStreamImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonStreamImpl.java
@@ -87,9 +87,11 @@ public final class JsonStreamImpl implements JsonStream
         }
 
         @Override
-        public Status resume()
+        public Status resume(
+            JsonController control,
+            JsonSource source)
         {
-            return transform.resume(downstream);
+            return transform.resume(control, source, downstream);
         }
 
         @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -82,6 +82,9 @@ public final class JsonTokenizer
     private long valueStreamStart;
     private long valueStreamEnd;
     private boolean valueReadable = true;
+    // set while a segment scan is in progress: a value-string is then streamed across frames as raw
+    // bytes (no rewind to require it whole-in-frame, no decoded retention) rather than buffered whole.
+    private boolean segmenting;
 
     // scalar resume state (valid when resumeOp != NONE)
     private ResumeOp resumeOp = ResumeOp.NONE;
@@ -135,11 +138,20 @@ public final class JsonTokenizer
         valuePending = false;
         streamOffset = 0;
         valueReadable = true;
+        segmenting = false;
         resumeOp = ResumeOp.NONE;
         resumeEscape = false;
         resumeUnicodePending = 0;
         resumeUnicodeValue = 0;
         resumeLiteralIndex = 0;
+    }
+
+    // Tracks whether a segment scan is in progress so a value-string spanning frames is streamed as raw
+    // bytes instead of rewound (which would require it whole in one frame) or retained whole in scratch.
+    void segmenting(
+        boolean segmenting)
+    {
+        this.segmenting = segmenting;
     }
 
     public static final List<String> INCLUDE_ALL = null;
@@ -218,8 +230,11 @@ public final class JsonTokenizer
                 {
                     return true;
                 }
+                // While segmenting, a value-string spanning the frame is not rewound — its resume state
+                // is kept so the next frame continues it and the raw bytes stream as segments.
                 final boolean midReadableScalarScan =
-                    (resumeOp == ResumeOp.VALUE_STRING || resumeOp == ResumeOp.VALUE_NUMBER) && valueReadable;
+                    (resumeOp == ResumeOp.VALUE_STRING || resumeOp == ResumeOp.VALUE_NUMBER) &&
+                    valueReadable && !segmenting;
                 if (midReadableScalarScan)
                 {
                     in.reset();
@@ -869,7 +884,7 @@ public final class JsonTokenizer
     private void appendScratch(
         char c)
     {
-        if (valueReadable)
+        if (valueReadable && !streamingValue())
         {
             scratch.append(c);
         }
@@ -878,10 +893,17 @@ public final class JsonTokenizer
     private void appendCodePointScratch(
         int codePoint)
     {
-        if (valueReadable)
+        if (valueReadable && !streamingValue())
         {
             scratch.appendCodePoint(codePoint);
         }
+    }
+
+    // A value-string being streamed as raw segment bytes is not retained in scratch; keys and numbers
+    // still retain (keys for path matching, numbers for grammar validation).
+    private boolean streamingValue()
+    {
+        return segmenting && resumeOp == ResumeOp.VALUE_STRING;
     }
 
     private int decodeUtf8(

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -61,7 +61,7 @@ public final class JsonTokenizer
     private final List<String[]> pathExcludes;
     private final boolean pathFiltering;
     private final int tokenMaxBytes;
-    private final boolean terminalEof;
+    private boolean terminalEof;
 
     // path tracking — pre-allocated, no per-event allocation
     private final boolean[] pathInArray = new boolean[MAX_DEPTH];
@@ -152,6 +152,15 @@ public final class JsonTokenizer
         boolean segmenting)
     {
         this.segmenting = segmenting;
+    }
+
+    // Set per input window: when true this window's EOF is the terminal delimiter (one-shot or final
+    // window), so a trailing scalar completes at EOF and an incomplete value is rejected; when false EOF
+    // is a frame boundary with more bytes still to come.
+    void terminal(
+        boolean terminalEof)
+    {
+        this.terminalEof = terminalEof;
     }
 
     public static final List<String> INCLUDE_ALL = null;

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -271,10 +271,11 @@ public final class JsonTokenizer
         return pendingString;
     }
 
-    // Non-allocating key view, valid while positioned on a deferred KEY_NAME (the unescaped key chars
-    // are still in scratch because nobody has materialized them yet). Lets a downstream stage copy or
-    // compare the key without a String; returns the materialized value if it was already taken.
-    public CharSequence key()
+    // Non-allocating view of the current string token (a deferred KEY_NAME or a readable VALUE_STRING),
+    // valid while the unescaped chars are still in scratch because nobody has materialized them yet. Lets
+    // a downstream stage copy or compare the chars without a String; returns the materialized value if it
+    // was already taken.
+    public CharSequence stringView()
     {
         return valuePending ? scratch : pendingString;
     }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -285,9 +285,10 @@ public final class JsonTokenizer
         return streamOffset;
     }
 
-    // Stream-offset span of the most recent VALUE_STRING token, including its surrounding quotes. The
-    // EOF rewind for a readable scalar guarantees the whole token is contiguous in one frame, so this
-    // span maps to a single contiguous slice the sink can splice or fragment.
+    // Stream-offset span of the most recent readable scalar token (a VALUE_STRING including its
+    // surrounding quotes, or a VALUE_NUMBER lexeme). The EOF rewind for a readable scalar guarantees the
+    // whole token is contiguous in one frame, so this span maps to a single contiguous slice the sink can
+    // splice or fragment.
     public long valueStreamStart()
     {
         return valueStreamStart;
@@ -637,6 +638,7 @@ public final class JsonTokenizer
         default:
             if (c == '-' || c >= '0' && c <= '9')
             {
+                valueStreamStart = streamOffset - 1;
                 scratch.setLength(0);
                 if (valueReadable)
                 {
@@ -644,6 +646,7 @@ public final class JsonTokenizer
                 }
                 resumeOp = ResumeOp.VALUE_NUMBER;
                 continueNumberContent(in);
+                valueStreamEnd = streamOffset;
                 pendingEvent = JsonParser.Event.VALUE_NUMBER;
                 captureValue(valueReadable);
                 resumeOp = ResumeOp.NONE;

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -79,6 +79,8 @@ public final class JsonTokenizer
     private String pendingString;
     private boolean valuePending;
     private long streamOffset;
+    private long valueStreamStart;
+    private long valueStreamEnd;
     private boolean valueReadable = true;
 
     // scalar resume state (valid when resumeOp != NONE)
@@ -265,6 +267,19 @@ public final class JsonTokenizer
     public long streamOffset()
     {
         return streamOffset;
+    }
+
+    // Stream-offset span of the most recent VALUE_STRING token, including its surrounding quotes. The
+    // EOF rewind for a readable scalar guarantees the whole token is contiguous in one frame, so this
+    // span maps to a single contiguous slice the sink can splice or fragment.
+    public long valueStreamStart()
+    {
+        return valueStreamStart;
+    }
+
+    public long valueStreamEnd()
+    {
+        return valueStreamEnd;
     }
 
     public boolean done()
@@ -567,11 +582,13 @@ public final class JsonTokenizer
             pushPath(true);
             break;
         case '"':
+            valueStreamStart = streamOffset - 1;
             scratch.setLength(0);
             resumeEscape = false;
             resumeUnicodePending = 0;
             resumeOp = ResumeOp.VALUE_STRING;
             continueStringContent(in);
+            valueStreamEnd = streamOffset;
             pendingEvent = JsonParser.Event.VALUE_STRING;
             captureValue(valueReadable);
             resumeOp = ResumeOp.NONE;

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonEventTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonEventTest.java
@@ -40,11 +40,9 @@ class JsonEventTest
     }
 
     @Test
-    void shouldFlagSegmentEventsAsSegmented()
+    void shouldFlagSegmentEventAsSegmented()
     {
-        assertTrue(JsonEvent.START_SEGMENT.segmented());
-        assertTrue(JsonEvent.CONTINUE_SEGMENT.segmented());
-        assertTrue(JsonEvent.END_SEGMENT.segmented());
+        assertTrue(JsonEvent.SEGMENT.segmented());
     }
 
     @Test

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorExTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorExTest.java
@@ -172,6 +172,43 @@ class JsonGeneratorExTest
     }
 
     @Test
+    void shouldReportRemainingWithinBound()
+    {
+        MutableDirectBuffer buffer = new UnsafeBuffer(new byte[64]);
+        JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(buffer, 0, 16);
+        assertEquals(16, generator.remaining());
+        generator.writeStartArray().writeNumber("1");
+        assertEquals(2, generator.length());
+        assertEquals(14, generator.remaining());
+    }
+
+    @Test
+    void shouldPreserveContextAcrossBoundedRewrap()
+    {
+        MutableDirectBuffer first = new UnsafeBuffer(new byte[32]);
+        MutableDirectBuffer second = new UnsafeBuffer(new byte[32]);
+        JsonGeneratorEx generator = StreamingJson.createGenerator();
+
+        generator.wrap(first, 0, 32).writeStartArray().writeNumber("1");
+        String chunk1 = drain(generator, first);
+
+        generator.wrap(second, 0, 32).writeNumber("2").writeEnd();
+        String chunk2 = drain(generator, second);
+
+        assertEquals("[1,2]", chunk1 + chunk2);
+    }
+
+    @Test
+    void shouldResetContextOnTwoArgWrap()
+    {
+        MutableDirectBuffer buffer = new UnsafeBuffer(new byte[64]);
+        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        generator.wrap(buffer, 0).writeStartArray().writeNumber("1");
+        generator.wrap(buffer, 0).writeStartObject().writeEnd();
+        assertEquals("{}", drain(generator, buffer));
+    }
+
+    @Test
     void shouldWriteAtNonZeroOffset()
     {
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[64]);
@@ -188,6 +225,13 @@ class JsonGeneratorExTest
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[512]);
         JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(buffer, 0);
         writer.accept(generator);
+        return drain(generator, buffer);
+    }
+
+    private static String drain(
+        JsonGeneratorEx generator,
+        MutableDirectBuffer buffer)
+    {
         byte[] out = new byte[generator.length()];
         buffer.getBytes(0, out);
         return new String(out, UTF_8);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorExTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorExTest.java
@@ -199,6 +199,16 @@ class JsonGeneratorExTest
     }
 
     @Test
+    void shouldNotWriteBeyondLimit()
+    {
+        MutableDirectBuffer buffer = new UnsafeBuffer(new byte[64]);
+        JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(buffer, 0, 4);
+        // "[1,2" fills the usable region [0,4) exactly; the next write must not spill past the limit
+        assertThrows(AssertionError.class, () -> generator
+            .writeStartArray().writeNumber("1").writeNumber("2").writeNumber("3"));
+    }
+
+    @Test
     void shouldClearContextOnReset()
     {
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[64]);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorExTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorExTest.java
@@ -199,6 +199,17 @@ class JsonGeneratorExTest
     }
 
     @Test
+    void shouldClearContextOnReset()
+    {
+        MutableDirectBuffer buffer = new UnsafeBuffer(new byte[64]);
+        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        generator.wrap(buffer, 0, buffer.capacity()).writeStartArray().writeNumber("1");
+        generator.reset();
+        generator.wrap(buffer, 0, buffer.capacity()).writeStartObject().writeEnd();
+        assertEquals("{}", drain(generator, buffer));
+    }
+
+    @Test
     void shouldWriteAtNonZeroOffset()
     {
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[64]);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorExTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorExTest.java
@@ -166,7 +166,7 @@ class JsonGeneratorExTest
     void shouldReportLength()
     {
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[64]);
-        JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonGeneratorEx generator = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
         generator.writeStartObject().writeKey("a").writeNumber("1").writeEnd();
         assertEquals("{\"a\":1}".length(), generator.length());
     }
@@ -175,7 +175,7 @@ class JsonGeneratorExTest
     void shouldReportRemainingWithinBound()
     {
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[64]);
-        JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(buffer, 0, 16);
+        JsonGeneratorEx generator = JsonEx.createGenerator().wrap(buffer, 0, 16);
         assertEquals(16, generator.remaining());
         generator.writeStartArray().writeNumber("1");
         assertEquals(2, generator.length());
@@ -187,7 +187,7 @@ class JsonGeneratorExTest
     {
         MutableDirectBuffer first = new UnsafeBuffer(new byte[32]);
         MutableDirectBuffer second = new UnsafeBuffer(new byte[32]);
-        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        JsonGeneratorEx generator = JsonEx.createGenerator();
 
         generator.wrap(first, 0, 32).writeStartArray().writeNumber("1");
         String chunk1 = drain(generator, first);
@@ -202,7 +202,7 @@ class JsonGeneratorExTest
     void shouldNotWriteBeyondLimit()
     {
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[64]);
-        JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(buffer, 0, 4);
+        JsonGeneratorEx generator = JsonEx.createGenerator().wrap(buffer, 0, 4);
         // "[1,2" fills the usable region [0,4) exactly; the next write must not spill past the limit
         assertThrows(AssertionError.class, () -> generator
             .writeStartArray().writeNumber("1").writeNumber("2").writeNumber("3"));
@@ -212,7 +212,7 @@ class JsonGeneratorExTest
     void shouldClearContextOnReset()
     {
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[64]);
-        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        JsonGeneratorEx generator = JsonEx.createGenerator();
         generator.wrap(buffer, 0, buffer.capacity()).writeStartArray().writeNumber("1");
         generator.reset();
         generator.wrap(buffer, 0, buffer.capacity()).writeStartObject().writeEnd();
@@ -223,7 +223,7 @@ class JsonGeneratorExTest
     void shouldWriteAtNonZeroOffset()
     {
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[64]);
-        JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(buffer, 8, buffer.capacity());
+        JsonGeneratorEx generator = JsonEx.createGenerator().wrap(buffer, 8, buffer.capacity());
         generator.writeStartArray().writeNumber("1").writeEnd();
         byte[] out = new byte[generator.length()];
         buffer.getBytes(8, out);
@@ -234,7 +234,7 @@ class JsonGeneratorExTest
         Consumer<JsonGeneratorEx> writer)
     {
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[512]);
-        JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonGeneratorEx generator = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
         writer.accept(generator);
         return drain(generator, buffer);
     }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorExTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorExTest.java
@@ -166,7 +166,7 @@ class JsonGeneratorExTest
     void shouldReportLength()
     {
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[64]);
-        JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(buffer, 0);
+        JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
         generator.writeStartObject().writeKey("a").writeNumber("1").writeEnd();
         assertEquals("{\"a\":1}".length(), generator.length());
     }
@@ -199,20 +199,10 @@ class JsonGeneratorExTest
     }
 
     @Test
-    void shouldResetContextOnTwoArgWrap()
-    {
-        MutableDirectBuffer buffer = new UnsafeBuffer(new byte[64]);
-        JsonGeneratorEx generator = StreamingJson.createGenerator();
-        generator.wrap(buffer, 0).writeStartArray().writeNumber("1");
-        generator.wrap(buffer, 0).writeStartObject().writeEnd();
-        assertEquals("{}", drain(generator, buffer));
-    }
-
-    @Test
     void shouldWriteAtNonZeroOffset()
     {
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[64]);
-        JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(buffer, 8);
+        JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(buffer, 8, buffer.capacity());
         generator.writeStartArray().writeNumber("1").writeEnd();
         byte[] out = new byte[generator.length()];
         buffer.getBytes(8, out);
@@ -223,7 +213,7 @@ class JsonGeneratorExTest
         Consumer<JsonGeneratorEx> writer)
     {
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[512]);
-        JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(buffer, 0);
+        JsonGeneratorEx generator = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
         writer.accept(generator);
         return drain(generator, buffer);
     }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonLocationTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonLocationTest.java
@@ -23,7 +23,7 @@ import jakarta.json.stream.JsonParser;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
-class StreamingJsonLocationTest
+class JsonLocationTest
 {
     @Test
     void shouldReturnMinusOneForLineAndColumn()

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonParserDomTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonParserDomTest.java
@@ -141,6 +141,6 @@ class JsonParserDomTest
     private static JsonParser parserFor(
         String json)
     {
-        return StreamingJson.createParser(new ByteArrayInputStream(json.getBytes(UTF_8)));
+        return JsonEx.createParser(new ByteArrayInputStream(json.getBytes(UTF_8)));
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonParserTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonParserTest.java
@@ -44,7 +44,7 @@ import jakarta.json.stream.JsonParsingException;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
-class StreamingJsonParserTest
+class JsonParserTest
 {
     @Test
     void shouldParseFlatObject()

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonPipelineStarvedTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonPipelineStarvedTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
+
+class JsonPipelineStarvedTest
+{
+    private final MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
+
+    @Test
+    void shouldStarveWhenWindowConsumedMidValue()
+    {
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonSink.of(gen));
+        pipeline.reset();
+
+        byte[] f1 = "{\"a\":1,".getBytes(UTF_8);
+        Status status = pipeline.feed(new UnsafeBuffer(f1), 0, f1.length, false);
+
+        assertEquals(Status.STARVED, status);
+    }
+
+    @Test
+    void shouldCompleteAcrossWindowsAfterStarved()
+    {
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonSink.of(gen));
+        pipeline.reset();
+
+        byte[] f1 = "{\"a\":1,".getBytes(UTF_8);
+        byte[] f2 = "\"b\":2} ".getBytes(UTF_8);
+        assertEquals(Status.STARVED, pipeline.feed(new UnsafeBuffer(f1), 0, f1.length, false));
+        Status status = pipeline.feed(new UnsafeBuffer(f2), 0, f2.length, true);
+
+        assertEquals(Status.COMPLETED, status);
+        byte[] out = new byte[gen.length()];
+        buffer.getBytes(0, out);
+        assertEquals("{\"a\":1,\"b\":2}", new String(out, UTF_8));
+    }
+
+    @Test
+    void shouldRejectTruncatedStructureWhenLast()
+    {
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonSink.of(gen));
+        pipeline.reset();
+
+        // the object never closes and this is the final window: truncated, not merely starved
+        byte[] bytes = "{\"a\":1".getBytes(UTF_8);
+        Status status = pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length, true);
+
+        assertEquals(Status.REJECTED, status);
+    }
+
+    @Test
+    void shouldRejectTruncatedStringWhenLast()
+    {
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonSink.of(gen));
+        pipeline.reset();
+
+        // an unterminated string at terminal EOF is malformed
+        byte[] bytes = "{\"a\":\"abc".getBytes(UTF_8);
+        Status status = pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length, true);
+
+        assertEquals(Status.REJECTED, status);
+    }
+
+    @Test
+    void shouldCompleteWholeValueWithDefaultFeed()
+    {
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonSink.of(gen));
+        pipeline.reset();
+
+        // the three-argument shorthand is last == true: a whole value completes in one shot
+        byte[] bytes = "{\"a\":1}".getBytes(UTF_8);
+        Status status = pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length);
+
+        assertEquals(Status.COMPLETED, status);
+    }
+
+    @Test
+    void shouldCompleteTrailingScalarAtTerminalEof()
+    {
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonSink.of(gen));
+        pipeline.reset();
+
+        // a bare trailing number with no delimiter completes because last == true makes EOF terminal
+        byte[] bytes = "42".getBytes(UTF_8);
+        Status status = pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length);
+
+        assertEquals(Status.COMPLETED, status);
+        byte[] out = new byte[gen.length()];
+        buffer.getBytes(0, out);
+        assertEquals("42", new String(out, UTF_8));
+    }
+}

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentHardeningTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentHardeningTest.java
@@ -32,7 +32,7 @@ class JsonProjectorSegmentHardeningTest
     @Test
     void shouldSegmentDeeplyNestedKeptSubtreeAsSingleVerbatimValue()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0);
+        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = StreamingJson.createParser().stream()
             .transform(StreamingJson.projector(List.of("/a")))
             .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
@@ -51,11 +51,11 @@ class JsonProjectorSegmentHardeningTest
             .transform(StreamingJson.projector(List.of("/x")))
             .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
 
-        gen.wrap(buffer, 0);
+        gen.wrap(buffer, 0, buffer.capacity());
         run(pipeline, "{\"x\":{ \"v\" : 1 },\"y\":2} ");
         assertEquals("{\"x\":{ \"v\" : 1 }}", output(gen));
 
-        gen.wrap(buffer, 0);
+        gen.wrap(buffer, 0, buffer.capacity());
         run(pipeline, "{\"x\":[9 ,8]} ");
         assertEquals("{\"x\":[9 ,8]}", output(gen));
     }
@@ -63,7 +63,7 @@ class JsonProjectorSegmentHardeningTest
     @Test
     void shouldNormalizeNestedWhenNotOptedIn()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0);
+        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = StreamingJson.createParser().stream()
             .transform(StreamingJson.projector(List.of("/a")))
             .into(JsonSink.of(gen));

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentHardeningTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentHardeningTest.java
@@ -39,7 +39,7 @@ class JsonProjectorSegmentHardeningTest
 
         Status status = run(pipeline, "{\"a\":{ \"b\" : { \"c\" : [1, {\"d\": 2}] } },\"z\":9} ");
 
-        assertEquals(Status.COMPLETE, status);
+        assertEquals(Status.COMPLETED, status);
         assertEquals("{\"a\":{ \"b\" : { \"c\" : [1, {\"d\": 2}] } }}", output(gen));
     }
 
@@ -70,7 +70,7 @@ class JsonProjectorSegmentHardeningTest
 
         Status status = run(pipeline, "{\"a\":{ \"b\" : { \"c\" : [1, {\"d\": 2}] } },\"z\":9} ");
 
-        assertEquals(Status.COMPLETE, status);
+        assertEquals(Status.COMPLETED, status);
         assertEquals("{\"a\":{\"b\":{\"c\":[1,{\"d\":2}]}}}", output(gen));
     }
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentHardeningTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentHardeningTest.java
@@ -32,9 +32,9 @@ class JsonProjectorSegmentHardeningTest
     @Test
     void shouldSegmentDeeplyNestedKeptSubtreeAsSingleVerbatimValue()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
-            .transform(StreamingJson.projector(List.of("/a")))
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("/a")))
             .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
 
         Status status = run(pipeline, "{\"a\":{ \"b\" : { \"c\" : [1, {\"d\": 2}] } },\"z\":9} ");
@@ -46,9 +46,9 @@ class JsonProjectorSegmentHardeningTest
     @Test
     void shouldResetForReuseAcrossSegmentedValues()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator();
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
-            .transform(StreamingJson.projector(List.of("/x")))
+        JsonGeneratorEx gen = JsonEx.createGenerator();
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("/x")))
             .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
 
         gen.wrap(buffer, 0, buffer.capacity());
@@ -63,9 +63,9 @@ class JsonProjectorSegmentHardeningTest
     @Test
     void shouldNormalizeNestedWhenNotOptedIn()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
-            .transform(StreamingJson.projector(List.of("/a")))
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("/a")))
             .into(JsonSink.of(gen));
 
         Status status = run(pipeline, "{\"a\":{ \"b\" : { \"c\" : [1, {\"d\": 2}] } },\"z\":9} ");

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentHardeningTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentHardeningTest.java
@@ -33,7 +33,7 @@ class JsonProjectorSegmentHardeningTest
     void shouldSegmentDeeplyNestedKeptSubtreeAsSingleVerbatimValue()
     {
         JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(StreamingJson.projector(List.of("/a")))
             .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
 
@@ -47,7 +47,7 @@ class JsonProjectorSegmentHardeningTest
     void shouldResetForReuseAcrossSegmentedValues()
     {
         JsonGeneratorEx gen = StreamingJson.createGenerator();
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(StreamingJson.projector(List.of("/x")))
             .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
 
@@ -64,7 +64,7 @@ class JsonProjectorSegmentHardeningTest
     void shouldNormalizeNestedWhenNotOptedIn()
     {
         JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(StreamingJson.projector(List.of("/a")))
             .into(JsonSink.of(gen));
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
@@ -33,7 +33,7 @@ class JsonProjectorSegmentTest
     void shouldSegmentKeptSubtreeWhenSinkOptsIn()
     {
         JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(StreamingJson.projector(List.of("/a")))
             .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
 
@@ -47,7 +47,7 @@ class JsonProjectorSegmentTest
     void shouldNormalizeWhenSinkDoesNotOptIn()
     {
         JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(StreamingJson.projector(List.of("/a")))
             .into(JsonSink.of(gen));
 
@@ -61,7 +61,7 @@ class JsonProjectorSegmentTest
     void shouldSegmentRootIdentityWhenSinkOptsIn()
     {
         JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(StreamingJson.projector(List.of("")))
             .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
 
@@ -78,7 +78,7 @@ class JsonProjectorSegmentTest
         JsonTransform decliner = (control, source, event, sink) -> sink.feed(() ->
         {
         }, source, event);
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(decliner)
             .transform(StreamingJson.projector(List.of("/a")))
             .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
@@ -93,7 +93,7 @@ class JsonProjectorSegmentTest
     void shouldHandleArrayElementSegment()
     {
         JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(StreamingJson.projector(List.of("/items/0")))
             .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
@@ -32,9 +32,9 @@ class JsonProjectorSegmentTest
     @Test
     void shouldSegmentKeptSubtreeWhenSinkOptsIn()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
-            .transform(StreamingJson.projector(List.of("/a")))
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("/a")))
             .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
 
         Status status = run(pipeline, "{\"a\":{ \"b\" : 1 },\"z\":9} ");
@@ -46,9 +46,9 @@ class JsonProjectorSegmentTest
     @Test
     void shouldNormalizeWhenSinkDoesNotOptIn()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
-            .transform(StreamingJson.projector(List.of("/a")))
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("/a")))
             .into(JsonSink.of(gen));
 
         Status status = run(pipeline, "{\"a\":{ \"b\" : 1 },\"z\":9} ");
@@ -60,9 +60,9 @@ class JsonProjectorSegmentTest
     @Test
     void shouldSegmentRootIdentityWhenSinkOptsIn()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
-            .transform(StreamingJson.projector(List.of("")))
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("")))
             .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
 
         Status status = run(pipeline, "{ \"a\" : 1 } ");
@@ -74,13 +74,13 @@ class JsonProjectorSegmentTest
     @Test
     void shouldStaySegmentFreeAndValidWithValidatorUpstream()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonTransform decliner = (control, source, event, sink) -> sink.feed(() ->
         {
         }, source, event);
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(decliner)
-            .transform(StreamingJson.projector(List.of("/a")))
+            .transform(JsonEx.projector(List.of("/a")))
             .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
 
         Status status = run(pipeline, "{\"a\":{ \"b\" : 1 },\"z\":9} ");
@@ -92,9 +92,9 @@ class JsonProjectorSegmentTest
     @Test
     void shouldHandleArrayElementSegment()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
-            .transform(StreamingJson.projector(List.of("/items/0")))
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("/items/0")))
             .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
 
         Status status = run(pipeline, "{\"items\":[{ \"id\" : 1 },{\"id\":2}]} ");

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
@@ -32,7 +32,7 @@ class JsonProjectorSegmentTest
     @Test
     void shouldSegmentKeptSubtreeWhenSinkOptsIn()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0);
+        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = StreamingJson.createParser().stream()
             .transform(StreamingJson.projector(List.of("/a")))
             .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
@@ -46,7 +46,7 @@ class JsonProjectorSegmentTest
     @Test
     void shouldNormalizeWhenSinkDoesNotOptIn()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0);
+        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = StreamingJson.createParser().stream()
             .transform(StreamingJson.projector(List.of("/a")))
             .into(JsonSink.of(gen));
@@ -60,7 +60,7 @@ class JsonProjectorSegmentTest
     @Test
     void shouldSegmentRootIdentityWhenSinkOptsIn()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0);
+        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = StreamingJson.createParser().stream()
             .transform(StreamingJson.projector(List.of("")))
             .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
@@ -74,7 +74,7 @@ class JsonProjectorSegmentTest
     @Test
     void shouldStaySegmentFreeAndValidWithValidatorUpstream()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0);
+        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonTransform decliner = (control, source, event, sink) -> sink.feed(() ->
         {
         }, source, event);
@@ -92,7 +92,7 @@ class JsonProjectorSegmentTest
     @Test
     void shouldHandleArrayElementSegment()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0);
+        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = StreamingJson.createParser().stream()
             .transform(StreamingJson.projector(List.of("/items/0")))
             .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
@@ -39,7 +39,7 @@ class JsonProjectorSegmentTest
 
         Status status = run(pipeline, "{\"a\":{ \"b\" : 1 },\"z\":9} ");
 
-        assertEquals(Status.COMPLETE, status);
+        assertEquals(Status.COMPLETED, status);
         assertEquals("{\"a\":{ \"b\" : 1 }}", output(gen));
     }
 
@@ -53,7 +53,7 @@ class JsonProjectorSegmentTest
 
         Status status = run(pipeline, "{\"a\":{ \"b\" : 1 },\"z\":9} ");
 
-        assertEquals(Status.COMPLETE, status);
+        assertEquals(Status.COMPLETED, status);
         assertEquals("{\"a\":{\"b\":1}}", output(gen));
     }
 
@@ -67,7 +67,7 @@ class JsonProjectorSegmentTest
 
         Status status = run(pipeline, "{ \"a\" : 1 } ");
 
-        assertEquals(Status.COMPLETE, status);
+        assertEquals(Status.COMPLETED, status);
         assertEquals("{ \"a\" : 1 }", output(gen));
     }
 
@@ -85,7 +85,7 @@ class JsonProjectorSegmentTest
 
         Status status = run(pipeline, "{\"a\":{ \"b\" : 1 },\"z\":9} ");
 
-        assertEquals(Status.COMPLETE, status);
+        assertEquals(Status.COMPLETED, status);
         assertEquals("{\"a\":{\"b\":1}}", output(gen));
     }
 
@@ -99,7 +99,7 @@ class JsonProjectorSegmentTest
 
         Status status = run(pipeline, "{\"items\":[{ \"id\" : 1 },{\"id\":2}]} ");
 
-        assertEquals(Status.COMPLETE, status);
+        assertEquals(Status.COMPLETED, status);
         assertEquals("{\"items\":[{ \"id\" : 1 }]}", output(gen));
     }
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
@@ -58,6 +58,36 @@ class JsonProjectorSegmentTest
     }
 
     @Test
+    void shouldPreserveLeafStringEscapesVerbatimWhenStructured()
+    {
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("")))
+            .into(JsonSink.of(gen));
+
+        // structured delivery normalizes structure (whitespace) but preserves each leaf value's bytes,
+        // so the original A escape survives rather than collapsing to A
+        Status status = run(pipeline, "{ \"a\" : \"x\\u0041y\" } ");
+
+        assertEquals(Status.COMPLETED, status);
+        assertEquals("{\"a\":\"x\\u0041y\"}", output(gen));
+    }
+
+    @Test
+    void shouldPreserveLeafNumberFormVerbatimWhenStructured()
+    {
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("")))
+            .into(JsonSink.of(gen));
+
+        Status status = run(pipeline, "{ \"a\" : 1.0e2 } ");
+
+        assertEquals(Status.COMPLETED, status);
+        assertEquals("{\"a\":1.0e2}", output(gen));
+    }
+
+    @Test
     void shouldSegmentRootIdentityWhenSinkOptsIn()
     {
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
@@ -120,10 +120,10 @@ class JsonProjectorTest
         UnsafeBuffer in = new UnsafeBuffer(bytes);
 
         pipeline.reset();
-        assertEquals(Status.RESUMABLE, pipeline.feed(in, 0, 7));
+        assertEquals(Status.ADVANCED, pipeline.feed(in, 0, 7));
         Status status = pipeline.feed(in, 7, bytes.length - 7);
 
-        assertEquals(Status.COMPLETE, status);
+        assertEquals(Status.COMPLETED, status);
         byte[] out = new byte[gen.length()];
         buffer.getBytes(0, out);
         assertEquals("{\"a\":1,\"c\":3}", new String(out, UTF_8));

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
@@ -109,11 +109,11 @@ class JsonProjectorTest
     @Test
     void shouldProjectAcrossFramesWithoutReset()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator();
+        JsonGeneratorEx gen = JsonEx.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
         gen.wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
-            .transform(StreamingJson.projector(List.of("/a", "/c")))
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("/a", "/c")))
             .into(JsonSink.of(gen));
 
         byte[] bytes = "{\"a\":1,\"b\":2,\"c\":3} ".getBytes(UTF_8);
@@ -132,10 +132,10 @@ class JsonProjectorTest
     @Test
     void shouldResetForReuseAcrossValues()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator();
+        JsonGeneratorEx gen = JsonEx.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
-            .transform(StreamingJson.projector(List.of("/x")))
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("/x")))
             .into(JsonSink.of(gen));
 
         gen.wrap(buffer, 0, buffer.capacity());
@@ -167,11 +167,11 @@ class JsonProjectorTest
         List<String> retained,
         String input)
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator();
+        JsonGeneratorEx gen = JsonEx.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
         gen.wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
-            .transform(StreamingJson.projector(retained))
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(retained))
             .into(JsonSink.of(gen));
         feed(pipeline, input + " ");
         byte[] out = new byte[gen.length()];

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
@@ -111,7 +111,7 @@ class JsonProjectorTest
     {
         JsonGeneratorEx gen = StreamingJson.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
-        gen.wrap(buffer, 0);
+        gen.wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = StreamingJson.createParser().stream()
             .transform(StreamingJson.projector(List.of("/a", "/c")))
             .into(JsonSink.of(gen));
@@ -138,13 +138,13 @@ class JsonProjectorTest
             .transform(StreamingJson.projector(List.of("/x")))
             .into(JsonSink.of(gen));
 
-        gen.wrap(buffer, 0);
+        gen.wrap(buffer, 0, buffer.capacity());
         feed(pipeline, "{\"x\":1,\"y\":2} ");
         byte[] out1 = new byte[gen.length()];
         buffer.getBytes(0, out1);
         assertEquals("{\"x\":1}", new String(out1, UTF_8));
 
-        gen.wrap(buffer, 0);
+        gen.wrap(buffer, 0, buffer.capacity());
         feed(pipeline, "{\"x\":\"two\"} ");
         byte[] out2 = new byte[gen.length()];
         buffer.getBytes(0, out2);
@@ -169,7 +169,7 @@ class JsonProjectorTest
     {
         JsonGeneratorEx gen = StreamingJson.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
-        gen.wrap(buffer, 0);
+        gen.wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = StreamingJson.createParser().stream()
             .transform(StreamingJson.projector(retained))
             .into(JsonSink.of(gen));

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
@@ -112,7 +112,7 @@ class JsonProjectorTest
         JsonGeneratorEx gen = StreamingJson.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
         gen.wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(StreamingJson.projector(List.of("/a", "/c")))
             .into(JsonSink.of(gen));
 
@@ -134,7 +134,7 @@ class JsonProjectorTest
     {
         JsonGeneratorEx gen = StreamingJson.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(StreamingJson.projector(List.of("/x")))
             .into(JsonSink.of(gen));
 
@@ -170,7 +170,7 @@ class JsonProjectorTest
         JsonGeneratorEx gen = StreamingJson.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
         gen.wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(StreamingJson.projector(retained))
             .into(JsonSink.of(gen));
         feed(pipeline, input + " ");

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
@@ -120,7 +120,7 @@ class JsonProjectorTest
         UnsafeBuffer in = new UnsafeBuffer(bytes);
 
         pipeline.reset();
-        assertEquals(Status.ADVANCED, pipeline.feed(in, 0, 7));
+        assertEquals(Status.STARVED, pipeline.feed(in, 0, 7, false));
         Status status = pipeline.feed(in, 7, bytes.length - 7);
 
         assertEquals(Status.COMPLETED, status);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
@@ -120,7 +120,7 @@ class JsonProjectorTest
         UnsafeBuffer in = new UnsafeBuffer(bytes);
 
         pipeline.reset();
-        assertEquals(Status.PENDING, pipeline.feed(in, 0, 7));
+        assertEquals(Status.RESUMABLE, pipeline.feed(in, 0, 7));
         Status status = pipeline.feed(in, 7, bytes.length - 7);
 
         assertEquals(Status.COMPLETE, status);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaApplicatorTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaApplicatorTest.java
@@ -80,6 +80,6 @@ class JsonSchemaApplicatorTest
         byte[] bytes = text.getBytes(UTF_8);
         DirectBufferInputStreamEx in = new DirectBufferInputStreamEx();
         in.wrap(new UnsafeBuffer(bytes), 0, bytes.length);
-        return StreamingJson.createParser(in);
+        return JsonEx.createParser(in);
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaArrayTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaArrayTest.java
@@ -81,6 +81,6 @@ class JsonSchemaArrayTest
         byte[] bytes = text.getBytes(UTF_8);
         DirectBufferInputStreamEx in = new DirectBufferInputStreamEx();
         in.wrap(new UnsafeBuffer(bytes), 0, bytes.length);
-        return StreamingJson.createParser(in);
+        return JsonEx.createParser(in);
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaCombinatorTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaCombinatorTest.java
@@ -148,6 +148,6 @@ class JsonSchemaCombinatorTest
         byte[] bytes = text.getBytes(UTF_8);
         DirectBufferInputStreamEx in = new DirectBufferInputStreamEx();
         in.wrap(new UnsafeBuffer(bytes), 0, bytes.length);
-        return StreamingJson.createParser(in);
+        return JsonEx.createParser(in);
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaDependenciesTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaDependenciesTest.java
@@ -71,6 +71,6 @@ class JsonSchemaDependenciesTest
         byte[] bytes = text.getBytes(UTF_8);
         DirectBufferInputStreamEx in = new DirectBufferInputStreamEx();
         in.wrap(new UnsafeBuffer(bytes), 0, bytes.length);
-        return StreamingJson.createParser(in);
+        return JsonEx.createParser(in);
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaDependentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaDependentTest.java
@@ -74,6 +74,6 @@ class JsonSchemaDependentTest
         byte[] bytes = text.getBytes(UTF_8);
         DirectBufferInputStreamEx in = new DirectBufferInputStreamEx();
         in.wrap(new UnsafeBuffer(bytes), 0, bytes.length);
-        return StreamingJson.createParser(in);
+        return JsonEx.createParser(in);
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaDiagnosticsTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaDiagnosticsTest.java
@@ -242,6 +242,6 @@ class JsonSchemaDiagnosticsTest
         byte[] bytes = text.getBytes(UTF_8);
         DirectBufferInputStreamEx in = new DirectBufferInputStreamEx();
         in.wrap(new UnsafeBuffer(bytes), 0, bytes.length);
-        return StreamingJson.createParser(in);
+        return JsonEx.createParser(in);
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaDraftTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaDraftTest.java
@@ -133,6 +133,6 @@ class JsonSchemaDraftTest
         byte[] bytes = text.getBytes(UTF_8);
         DirectBufferInputStreamEx in = new DirectBufferInputStreamEx();
         in.wrap(new UnsafeBuffer(bytes), 0, bytes.length);
-        return StreamingJson.createParser(in);
+        return JsonEx.createParser(in);
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaRefResolutionTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaRefResolutionTest.java
@@ -112,6 +112,6 @@ class JsonSchemaRefResolutionTest
         byte[] bytes = text.getBytes(UTF_8);
         DirectBufferInputStreamEx in = new DirectBufferInputStreamEx();
         in.wrap(new UnsafeBuffer(bytes), 0, bytes.length);
-        return StreamingJson.createParser(in);
+        return JsonEx.createParser(in);
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaRefTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaRefTest.java
@@ -112,6 +112,6 @@ class JsonSchemaRefTest
         byte[] bytes = text.getBytes(UTF_8);
         DirectBufferInputStreamEx in = new DirectBufferInputStreamEx();
         in.wrap(new UnsafeBuffer(bytes), 0, bytes.length);
-        return StreamingJson.createParser(in);
+        return JsonEx.createParser(in);
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaTest.java
@@ -240,6 +240,6 @@ class JsonSchemaTest
         byte[] bytes = text.getBytes(UTF_8);
         DirectBufferInputStreamEx in = new DirectBufferInputStreamEx();
         in.wrap(new UnsafeBuffer(bytes), 0, bytes.length);
-        return StreamingJson.createParser(in);
+        return JsonEx.createParser(in);
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaUniqueItemsTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaUniqueItemsTest.java
@@ -73,6 +73,6 @@ class JsonSchemaUniqueItemsTest
         byte[] bytes = text.getBytes(UTF_8);
         DirectBufferInputStreamEx in = new DirectBufferInputStreamEx();
         in.wrap(new UnsafeBuffer(bytes), 0, bytes.length);
-        return StreamingJson.createParser(in);
+        return JsonEx.createParser(in);
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaValidatingParserTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaValidatingParserTest.java
@@ -139,6 +139,6 @@ class JsonSchemaValidatingParserTest
         byte[] bytes = text.getBytes(UTF_8);
         DirectBufferInputStreamEx in = new DirectBufferInputStreamEx();
         in.wrap(new UnsafeBuffer(bytes), 0, bytes.length);
-        return StreamingJson.createParser(in);
+        return JsonEx.createParser(in);
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSinkSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSinkSegmentTest.java
@@ -55,7 +55,7 @@ class JsonSinkSegmentTest
     {
         JsonGeneratorEx gen = StreamingJson.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
-        gen.wrap(buffer, 0);
+        gen.wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = StreamingJson.createParser().stream()
             .transform(segmentRoot)
             .into(JsonSink.of(gen));
@@ -75,7 +75,7 @@ class JsonSinkSegmentTest
     {
         JsonGeneratorEx gen = StreamingJson.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
-        gen.wrap(buffer, 0);
+        gen.wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = StreamingJson.createParser().stream()
             .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
 
@@ -94,7 +94,7 @@ class JsonSinkSegmentTest
     {
         JsonGeneratorEx gen = StreamingJson.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
-        gen.wrap(buffer, 0);
+        gen.wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = StreamingJson.createParser().stream()
             .transform(segmentRoot)
             .into(JsonSink.of(gen));
@@ -114,7 +114,7 @@ class JsonSinkSegmentTest
     {
         JsonGeneratorEx gen = StreamingJson.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
-        gen.wrap(buffer, 0);
+        gen.wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = StreamingJson.createParser().stream()
             .transform(segmentRoot)
             .into(JsonSink.of(gen));
@@ -134,7 +134,7 @@ class JsonSinkSegmentTest
     {
         JsonGeneratorEx gen = StreamingJson.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
-        gen.wrap(buffer, 0);
+        gen.wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = StreamingJson.createParser().stream()
             .transform(segmentRoot)
             .into(JsonSink.of(gen));

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSinkSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSinkSegmentTest.java
@@ -36,7 +36,7 @@ class JsonSinkSegmentTest
             JsonEvent event,
             JsonSink sink)
         {
-            Status status = Status.RESUMABLE;
+            Status status = Status.ADVANCED;
             if (!armed && (event == JsonEvent.START_OBJECT || event == JsonEvent.START_ARRAY))
             {
                 armed = true;
@@ -64,7 +64,7 @@ class JsonSinkSegmentTest
         pipeline.reset();
         Status status = pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length);
 
-        assertEquals(Status.COMPLETE, status);
+        assertEquals(Status.COMPLETED, status);
         byte[] out = new byte[gen.length()];
         buffer.getBytes(0, out);
         assertEquals("{ \"a\" : 1 }", new String(out, UTF_8));
@@ -83,7 +83,7 @@ class JsonSinkSegmentTest
         pipeline.reset();
         Status status = pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length);
 
-        assertEquals(Status.COMPLETE, status);
+        assertEquals(Status.COMPLETED, status);
         byte[] out = new byte[gen.length()];
         buffer.getBytes(0, out);
         assertEquals("{ \"a\" : [1, 2], \"b\" : 3 }", new String(out, UTF_8));
@@ -103,7 +103,7 @@ class JsonSinkSegmentTest
         pipeline.reset();
         Status status = pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length);
 
-        assertEquals(Status.COMPLETE, status);
+        assertEquals(Status.COMPLETED, status);
         byte[] out = new byte[gen.length()];
         buffer.getBytes(0, out);
         assertEquals("[ 1, 2 ]", new String(out, UTF_8));
@@ -123,7 +123,7 @@ class JsonSinkSegmentTest
         pipeline.reset();
         Status status = pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length);
 
-        assertEquals(Status.COMPLETE, status);
+        assertEquals(Status.COMPLETED, status);
         byte[] out = new byte[gen.length()];
         buffer.getBytes(0, out);
         assertEquals("{ \"x\" : [1 ,2] }", new String(out, UTF_8));
@@ -143,10 +143,10 @@ class JsonSinkSegmentTest
         byte[] second = "\"b\":2} ".getBytes(UTF_8);
 
         pipeline.reset();
-        assertEquals(Status.RESUMABLE, pipeline.feed(new UnsafeBuffer(first), 0, first.length));
+        assertEquals(Status.ADVANCED, pipeline.feed(new UnsafeBuffer(first), 0, first.length));
         Status status = pipeline.feed(new UnsafeBuffer(second), 0, second.length);
 
-        assertEquals(Status.COMPLETE, status);
+        assertEquals(Status.COMPLETED, status);
         byte[] out = new byte[gen.length()];
         buffer.getBytes(0, out);
         assertEquals("{\"a\":1,\"b\":2}", new String(out, UTF_8));

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSinkSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSinkSegmentTest.java
@@ -143,7 +143,7 @@ class JsonSinkSegmentTest
         byte[] second = "\"b\":2} ".getBytes(UTF_8);
 
         pipeline.reset();
-        assertEquals(Status.ADVANCED, pipeline.feed(new UnsafeBuffer(first), 0, first.length));
+        assertEquals(Status.STARVED, pipeline.feed(new UnsafeBuffer(first), 0, first.length, false));
         Status status = pipeline.feed(new UnsafeBuffer(second), 0, second.length);
 
         assertEquals(Status.COMPLETED, status);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSinkSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSinkSegmentTest.java
@@ -36,7 +36,7 @@ class JsonSinkSegmentTest
             JsonEvent event,
             JsonSink sink)
         {
-            Status status = Status.PENDING;
+            Status status = Status.RESUMABLE;
             if (!armed && (event == JsonEvent.START_OBJECT || event == JsonEvent.START_ARRAY))
             {
                 armed = true;
@@ -143,7 +143,7 @@ class JsonSinkSegmentTest
         byte[] second = "\"b\":2} ".getBytes(UTF_8);
 
         pipeline.reset();
-        assertEquals(Status.PENDING, pipeline.feed(new UnsafeBuffer(first), 0, first.length));
+        assertEquals(Status.RESUMABLE, pipeline.feed(new UnsafeBuffer(first), 0, first.length));
         Status status = pipeline.feed(new UnsafeBuffer(second), 0, second.length);
 
         assertEquals(Status.COMPLETE, status);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSinkSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSinkSegmentTest.java
@@ -53,10 +53,10 @@ class JsonSinkSegmentTest
     @Test
     void shouldWriteSegmentedObjectVerbatim()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator();
+        JsonGeneratorEx gen = JsonEx.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
         gen.wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(segmentRoot)
             .into(JsonSink.of(gen));
 
@@ -73,10 +73,10 @@ class JsonSinkSegmentTest
     @Test
     void shouldSegmentWholeDocumentWithBareSegmentableSink()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator();
+        JsonGeneratorEx gen = JsonEx.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
         gen.wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
 
         byte[] bytes = "{ \"a\" : [1, 2], \"b\" : 3 } ".getBytes(UTF_8);
@@ -92,10 +92,10 @@ class JsonSinkSegmentTest
     @Test
     void shouldWriteSegmentedArrayVerbatim()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator();
+        JsonGeneratorEx gen = JsonEx.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
         gen.wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(segmentRoot)
             .into(JsonSink.of(gen));
 
@@ -112,10 +112,10 @@ class JsonSinkSegmentTest
     @Test
     void shouldWriteSegmentedNestedWhitespaceVerbatim()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator();
+        JsonGeneratorEx gen = JsonEx.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
         gen.wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(segmentRoot)
             .into(JsonSink.of(gen));
 
@@ -132,10 +132,10 @@ class JsonSinkSegmentTest
     @Test
     void shouldCompleteAcrossFrames()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator();
+        JsonGeneratorEx gen = JsonEx.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
         gen.wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(segmentRoot)
             .into(JsonSink.of(gen));
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSinkSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSinkSegmentTest.java
@@ -56,7 +56,7 @@ class JsonSinkSegmentTest
         JsonGeneratorEx gen = StreamingJson.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
         gen.wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(segmentRoot)
             .into(JsonSink.of(gen));
 
@@ -76,7 +76,7 @@ class JsonSinkSegmentTest
         JsonGeneratorEx gen = StreamingJson.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
         gen.wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
 
         byte[] bytes = "{ \"a\" : [1, 2], \"b\" : 3 } ".getBytes(UTF_8);
@@ -95,7 +95,7 @@ class JsonSinkSegmentTest
         JsonGeneratorEx gen = StreamingJson.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
         gen.wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(segmentRoot)
             .into(JsonSink.of(gen));
 
@@ -115,7 +115,7 @@ class JsonSinkSegmentTest
         JsonGeneratorEx gen = StreamingJson.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
         gen.wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(segmentRoot)
             .into(JsonSink.of(gen));
 
@@ -135,7 +135,7 @@ class JsonSinkSegmentTest
         JsonGeneratorEx gen = StreamingJson.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
         gen.wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(segmentRoot)
             .into(JsonSink.of(gen));
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorChainTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorChainTest.java
@@ -113,7 +113,7 @@ class JsonValidatorChainTest
         UnsafeBuffer in = new UnsafeBuffer(bytes);
 
         pipeline.reset();
-        assertEquals(Status.ADVANCED, pipeline.feed(in, 0, 8));
+        assertEquals(Status.STARVED, pipeline.feed(in, 0, 8, false));
         Status status = pipeline.feed(in, 8, bytes.length - 8);
 
         assertEquals(Status.COMPLETED, status);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorChainTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorChainTest.java
@@ -44,7 +44,7 @@ class JsonValidatorChainTest
     {
         JsonSchema schema = JsonSchema.of(OBJECT_SCHEMA);
         JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(schema.validator())
             .into(JsonSink.of(gen));
 
@@ -59,7 +59,7 @@ class JsonValidatorChainTest
     {
         JsonSchema schema = JsonSchema.of(OBJECT_SCHEMA);
         JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(schema.validator())
             .transform(StreamingJson.projector(List.of("/id")))
             .into(JsonSink.of(gen));
@@ -75,7 +75,7 @@ class JsonValidatorChainTest
     {
         JsonSchema schema = JsonSchema.of(OBJECT_SCHEMA);
         JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(schema.validator())
             .transform(StreamingJson.projector(List.of("/id")))
             .into(JsonSink.of(gen));
@@ -91,7 +91,7 @@ class JsonValidatorChainTest
     {
         JsonSchema schema = JsonSchema.of(OBJECT_SCHEMA);
         JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(schema.validator())
             .into(JsonSink.of(gen));
 
@@ -105,7 +105,7 @@ class JsonValidatorChainTest
     {
         JsonSchema schema = JsonSchema.of(OBJECT_SCHEMA);
         JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(schema.validator())
             .into(JsonSink.of(gen));
 
@@ -125,7 +125,7 @@ class JsonValidatorChainTest
     {
         JsonSchema schema = JsonSchema.of(OBJECT_SCHEMA);
         JsonGeneratorEx gen = StreamingJson.createGenerator();
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(schema.validator())
             .into(JsonSink.of(gen));
 
@@ -142,7 +142,7 @@ class JsonValidatorChainTest
     {
         JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonTransform passthrough = (control, source, event, sink) -> sink.feed(control, source, event);
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(passthrough)
             .into(JsonSink.of(gen));
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorChainTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorChainTest.java
@@ -43,7 +43,7 @@ class JsonValidatorChainTest
     void shouldForwardFullStreamWhenValid()
     {
         JsonSchema schema = JsonSchema.of(OBJECT_SCHEMA);
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0);
+        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = StreamingJson.createParser().stream()
             .transform(schema.validator())
             .into(JsonSink.of(gen));
@@ -58,7 +58,7 @@ class JsonValidatorChainTest
     void shouldValidateFullStreamWhileProjectingSubset()
     {
         JsonSchema schema = JsonSchema.of(OBJECT_SCHEMA);
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0);
+        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = StreamingJson.createParser().stream()
             .transform(schema.validator())
             .transform(StreamingJson.projector(List.of("/id")))
@@ -74,7 +74,7 @@ class JsonValidatorChainTest
     void shouldRejectMissingRequiredAfterEmitting()
     {
         JsonSchema schema = JsonSchema.of(OBJECT_SCHEMA);
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0);
+        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = StreamingJson.createParser().stream()
             .transform(schema.validator())
             .transform(StreamingJson.projector(List.of("/id")))
@@ -90,7 +90,7 @@ class JsonValidatorChainTest
     void shouldRejectTypeViolation()
     {
         JsonSchema schema = JsonSchema.of(OBJECT_SCHEMA);
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0);
+        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = StreamingJson.createParser().stream()
             .transform(schema.validator())
             .into(JsonSink.of(gen));
@@ -104,7 +104,7 @@ class JsonValidatorChainTest
     void shouldResumeMidValueWithoutReset()
     {
         JsonSchema schema = JsonSchema.of(OBJECT_SCHEMA);
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0);
+        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = StreamingJson.createParser().stream()
             .transform(schema.validator())
             .into(JsonSink.of(gen));
@@ -129,18 +129,18 @@ class JsonValidatorChainTest
             .transform(schema.validator())
             .into(JsonSink.of(gen));
 
-        gen.wrap(buffer, 0);
+        gen.wrap(buffer, 0, buffer.capacity());
         assertEquals(Status.COMPLETE, run(pipeline, "{\"id\":1,\"name\":\"a\"} "));
         assertEquals("{\"id\":1,\"name\":\"a\"}", output(gen));
 
-        gen.wrap(buffer, 0);
+        gen.wrap(buffer, 0, buffer.capacity());
         assertEquals(Status.REJECTED, run(pipeline, "{\"id\":2} "));
     }
 
     @Test
     void shouldForwardThroughDefaultResetTransform()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0);
+        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonTransform passthrough = (control, source, event, sink) -> sink.feed(control, source, event);
         JsonPipeline pipeline = StreamingJson.createParser().stream()
             .transform(passthrough)

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorChainTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorChainTest.java
@@ -43,8 +43,8 @@ class JsonValidatorChainTest
     void shouldForwardFullStreamWhenValid()
     {
         JsonSchema schema = JsonSchema.of(OBJECT_SCHEMA);
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(schema.validator())
             .into(JsonSink.of(gen));
 
@@ -58,10 +58,10 @@ class JsonValidatorChainTest
     void shouldValidateFullStreamWhileProjectingSubset()
     {
         JsonSchema schema = JsonSchema.of(OBJECT_SCHEMA);
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(schema.validator())
-            .transform(StreamingJson.projector(List.of("/id")))
+            .transform(JsonEx.projector(List.of("/id")))
             .into(JsonSink.of(gen));
 
         Status status = run(pipeline, "{\"id\":1,\"name\":\"x\"} ");
@@ -74,10 +74,10 @@ class JsonValidatorChainTest
     void shouldRejectMissingRequiredAfterEmitting()
     {
         JsonSchema schema = JsonSchema.of(OBJECT_SCHEMA);
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(schema.validator())
-            .transform(StreamingJson.projector(List.of("/id")))
+            .transform(JsonEx.projector(List.of("/id")))
             .into(JsonSink.of(gen));
 
         Status status = run(pipeline, "{\"id\":1} ");
@@ -90,8 +90,8 @@ class JsonValidatorChainTest
     void shouldRejectTypeViolation()
     {
         JsonSchema schema = JsonSchema.of(OBJECT_SCHEMA);
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(schema.validator())
             .into(JsonSink.of(gen));
 
@@ -104,8 +104,8 @@ class JsonValidatorChainTest
     void shouldResumeMidValueWithoutReset()
     {
         JsonSchema schema = JsonSchema.of(OBJECT_SCHEMA);
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(schema.validator())
             .into(JsonSink.of(gen));
 
@@ -124,8 +124,8 @@ class JsonValidatorChainTest
     void shouldReuseChainAcrossValues()
     {
         JsonSchema schema = JsonSchema.of(OBJECT_SCHEMA);
-        JsonGeneratorEx gen = StreamingJson.createGenerator();
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonGeneratorEx gen = JsonEx.createGenerator();
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(schema.validator())
             .into(JsonSink.of(gen));
 
@@ -140,9 +140,9 @@ class JsonValidatorChainTest
     @Test
     void shouldForwardThroughDefaultResetTransform()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonTransform passthrough = (control, source, event, sink) -> sink.feed(control, source, event);
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(passthrough)
             .into(JsonSink.of(gen));
 
@@ -188,7 +188,7 @@ class JsonValidatorChainTest
     {
         JsonSchema schema = JsonSchema.of("{\"type\":\"integer\",\"minimum\":0}");
         JsonParser parser = schema.newParser(true,
-            StreamingJson.createParserFactory(Map.of()).createParser(streamFor("7 ")));
+            JsonEx.createParserFactory(Map.of()).createParser(streamFor("7 ")));
 
         Event event = parser.next();
 
@@ -216,7 +216,7 @@ class JsonValidatorChainTest
     private static JsonParser parserFor(
         String text)
     {
-        return StreamingJson.createParser(streamFor(text));
+        return JsonEx.createParser(streamFor(text));
     }
 
     private static InputStream streamFor(

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorChainTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorChainTest.java
@@ -113,7 +113,7 @@ class JsonValidatorChainTest
         UnsafeBuffer in = new UnsafeBuffer(bytes);
 
         pipeline.reset();
-        assertEquals(Status.PENDING, pipeline.feed(in, 0, 8));
+        assertEquals(Status.RESUMABLE, pipeline.feed(in, 0, 8));
         Status status = pipeline.feed(in, 8, bytes.length - 8);
 
         assertEquals(Status.COMPLETE, status);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorChainTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorChainTest.java
@@ -50,7 +50,7 @@ class JsonValidatorChainTest
 
         Status status = run(pipeline, "{\"id\":1,\"name\":\"x\"} ");
 
-        assertEquals(Status.COMPLETE, status);
+        assertEquals(Status.COMPLETED, status);
         assertEquals("{\"id\":1,\"name\":\"x\"}", output(gen));
     }
 
@@ -66,7 +66,7 @@ class JsonValidatorChainTest
 
         Status status = run(pipeline, "{\"id\":1,\"name\":\"x\"} ");
 
-        assertEquals(Status.COMPLETE, status);
+        assertEquals(Status.COMPLETED, status);
         assertEquals("{\"id\":1}", output(gen));
     }
 
@@ -113,10 +113,10 @@ class JsonValidatorChainTest
         UnsafeBuffer in = new UnsafeBuffer(bytes);
 
         pipeline.reset();
-        assertEquals(Status.RESUMABLE, pipeline.feed(in, 0, 8));
+        assertEquals(Status.ADVANCED, pipeline.feed(in, 0, 8));
         Status status = pipeline.feed(in, 8, bytes.length - 8);
 
-        assertEquals(Status.COMPLETE, status);
+        assertEquals(Status.COMPLETED, status);
         assertEquals("{\"id\":1,\"name\":\"x\"}", output(gen));
     }
 
@@ -130,7 +130,7 @@ class JsonValidatorChainTest
             .into(JsonSink.of(gen));
 
         gen.wrap(buffer, 0, buffer.capacity());
-        assertEquals(Status.COMPLETE, run(pipeline, "{\"id\":1,\"name\":\"a\"} "));
+        assertEquals(Status.COMPLETED, run(pipeline, "{\"id\":1,\"name\":\"a\"} "));
         assertEquals("{\"id\":1,\"name\":\"a\"}", output(gen));
 
         gen.wrap(buffer, 0, buffer.capacity());
@@ -148,7 +148,7 @@ class JsonValidatorChainTest
 
         Status status = run(pipeline, "{\"id\":1} ");
 
-        assertEquals(Status.COMPLETE, status);
+        assertEquals(Status.COMPLETED, status);
         assertEquals("{\"id\":1}", output(gen));
     }
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/StreamingJsonLocationTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/StreamingJsonLocationTest.java
@@ -63,6 +63,6 @@ class StreamingJsonLocationTest
         byte[] bytes = text.getBytes(UTF_8);
         DirectBufferInputStreamEx in = new DirectBufferInputStreamEx();
         in.wrap(new UnsafeBuffer(bytes), 0, bytes.length);
-        return StreamingJson.createParser(in);
+        return JsonEx.createParser(in);
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/StreamingJsonParserTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/StreamingJsonParserTest.java
@@ -146,7 +146,7 @@ class StreamingJsonParserTest
             UnsafeBuffer buffer = new UnsafeBuffer(full);
 
             in.wrap(buffer, 0, split);
-            JsonParser parser = StreamingJson.createParser(in);
+            JsonParser parser = JsonEx.createParser(in);
             while (parser.hasNext())
             {
                 parser.next();
@@ -169,7 +169,7 @@ class StreamingJsonParserTest
         UnsafeBuffer buffer = new UnsafeBuffer(full);
         DirectBufferInputStreamEx in = new DirectBufferInputStreamEx();
         in.wrap(buffer, 0, 1);
-        JsonParser parser = StreamingJson.createParser(in);
+        JsonParser parser = JsonEx.createParser(in);
 
         int events = 0;
         for (int i = 1; i <= full.length; i++)
@@ -469,7 +469,7 @@ class StreamingJsonParserTest
             }
         };
 
-        assertThrows(IllegalArgumentException.class, () -> StreamingJson.createParser(in));
+        assertThrows(IllegalArgumentException.class, () -> JsonEx.createParser(in));
     }
 
     @Test
@@ -501,7 +501,7 @@ class StreamingJsonParserTest
             }
         };
 
-        JsonParser parser = StreamingJson.createParser(in);
+        JsonParser parser = JsonEx.createParser(in);
         JsonParsingException ex = assertThrows(JsonParsingException.class, parser::hasNext);
         assertNotNull(ex.getCause());
     }
@@ -682,7 +682,7 @@ class StreamingJsonParserTest
             UnsafeBuffer buffer = new UnsafeBuffer(full);
             DirectBufferInputStreamEx in = new DirectBufferInputStreamEx();
             in.wrap(buffer, 0, split);
-            JsonParser parser = StreamingJson.createParser(in);
+            JsonParser parser = JsonEx.createParser(in);
             while (parser.hasNext())
             {
                 parser.next();
@@ -705,7 +705,7 @@ class StreamingJsonParserTest
             UnsafeBuffer buffer = new UnsafeBuffer(full);
             DirectBufferInputStreamEx in = new DirectBufferInputStreamEx();
             in.wrap(buffer, 0, split);
-            JsonParser parser = StreamingJson.createParser(in);
+            JsonParser parser = JsonEx.createParser(in);
             while (parser.hasNext())
             {
                 parser.next();
@@ -738,6 +738,6 @@ class StreamingJsonParserTest
     {
         DirectBufferInputStreamEx in = new DirectBufferInputStreamEx();
         in.wrap(new UnsafeBuffer(bytes), 0, bytes.length);
-        return StreamingJson.createParser(in);
+        return JsonEx.createParser(in);
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/bench/JsonPipelineBM.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/bench/JsonPipelineBM.java
@@ -183,7 +183,7 @@ public class JsonPipelineBM
         UnsafeBuffer buffer,
         int length)
     {
-        generator.wrap(outputBuffer, 0);
+        generator.wrap(outputBuffer, 0, outputBuffer.capacity());
         pipeline.reset();
         pipeline.feed(buffer, 0, length);
         return generator.length();

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/bench/JsonPipelineBM.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/bench/JsonPipelineBM.java
@@ -102,22 +102,22 @@ public class JsonPipelineBM
     @Setup(Level.Trial)
     public void init()
     {
-        scalarLeavesPipeline = StreamingJson.createParser().stream()
+        scalarLeavesPipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(StreamingJson.projector(List.of("/id", "/active"))).into(structuredSink);
 
-        keptContainerStructuredPipeline = StreamingJson.createParser().stream()
+        keptContainerStructuredPipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(StreamingJson.projector(List.of("/meta"))).into(structuredSink);
-        keptContainerSegmentedPipeline = StreamingJson.createParser().stream()
+        keptContainerSegmentedPipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(StreamingJson.projector(List.of("/meta"))).into(segmentableSink);
 
-        rootIdentityStructuredPipeline = StreamingJson.createParser().stream()
+        rootIdentityStructuredPipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(StreamingJson.projector(List.of(""))).into(structuredSink);
-        rootIdentitySegmentedPipeline = StreamingJson.createParser().stream()
+        rootIdentitySegmentedPipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(StreamingJson.projector(List.of(""))).into(segmentableSink);
 
-        mostlySkippedStructuredPipeline = StreamingJson.createParser().stream()
+        mostlySkippedStructuredPipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(StreamingJson.projector(List.of("/keep"))).into(structuredSink);
-        mostlySkippedSegmentedPipeline = StreamingJson.createParser().stream()
+        mostlySkippedSegmentedPipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(StreamingJson.projector(List.of("/keep"))).into(segmentableSink);
 
         byte[] flatBytes = FLAT_OBJECT.getBytes(UTF_8);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/bench/JsonPipelineBM.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/bench/JsonPipelineBM.java
@@ -37,11 +37,11 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonSink;
 import io.aklivity.zilla.runtime.common.json.JsonSink.Delivery;
-import io.aklivity.zilla.runtime.common.json.StreamingJson;
 
 /**
  * Compares the {@code common-json} streaming pipeline, parser through generator, under structured
@@ -77,7 +77,7 @@ public class JsonPipelineBM
         "\"drop2\":[0,1,2,3,4,5,6,7,8,9],\"drop3\":{\"a\":\"b\",\"c\":\"d\"}} ";
 
     private final MutableDirectBuffer outputBuffer = new UnsafeBuffer(new byte[16 * 1024]);
-    private final JsonGeneratorEx generator = StreamingJson.createGenerator();
+    private final JsonGeneratorEx generator = JsonEx.createGenerator();
     private final JsonSink structuredSink = JsonSink.of(generator);
     private final JsonSink segmentableSink = JsonSink.of(generator, Delivery.SEGMENTABLE);
 
@@ -102,23 +102,23 @@ public class JsonPipelineBM
     @Setup(Level.Trial)
     public void init()
     {
-        scalarLeavesPipeline = StreamingJson.stream(StreamingJson.createParser())
-            .transform(StreamingJson.projector(List.of("/id", "/active"))).into(structuredSink);
+        scalarLeavesPipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("/id", "/active"))).into(structuredSink);
 
-        keptContainerStructuredPipeline = StreamingJson.stream(StreamingJson.createParser())
-            .transform(StreamingJson.projector(List.of("/meta"))).into(structuredSink);
-        keptContainerSegmentedPipeline = StreamingJson.stream(StreamingJson.createParser())
-            .transform(StreamingJson.projector(List.of("/meta"))).into(segmentableSink);
+        keptContainerStructuredPipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("/meta"))).into(structuredSink);
+        keptContainerSegmentedPipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("/meta"))).into(segmentableSink);
 
-        rootIdentityStructuredPipeline = StreamingJson.stream(StreamingJson.createParser())
-            .transform(StreamingJson.projector(List.of(""))).into(structuredSink);
-        rootIdentitySegmentedPipeline = StreamingJson.stream(StreamingJson.createParser())
-            .transform(StreamingJson.projector(List.of(""))).into(segmentableSink);
+        rootIdentityStructuredPipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of(""))).into(structuredSink);
+        rootIdentitySegmentedPipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of(""))).into(segmentableSink);
 
-        mostlySkippedStructuredPipeline = StreamingJson.stream(StreamingJson.createParser())
-            .transform(StreamingJson.projector(List.of("/keep"))).into(structuredSink);
-        mostlySkippedSegmentedPipeline = StreamingJson.stream(StreamingJson.createParser())
-            .transform(StreamingJson.projector(List.of("/keep"))).into(segmentableSink);
+        mostlySkippedStructuredPipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("/keep"))).into(structuredSink);
+        mostlySkippedSegmentedPipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("/keep"))).into(segmentableSink);
 
         byte[] flatBytes = FLAT_OBJECT.getBytes(UTF_8);
         byte[] nestedBytes = NESTED_OBJECT.getBytes(UTF_8);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/bench/JsonSchemaBM.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/bench/JsonSchemaBM.java
@@ -37,8 +37,8 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import io.aklivity.zilla.runtime.common.json.DirectBufferInputStreamEx;
+import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonSchema;
-import io.aklivity.zilla.runtime.common.json.StreamingJson;
 
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.Throughput)
@@ -193,7 +193,7 @@ public class JsonSchemaBM
         int length)
     {
         inputRO.wrap(buffer, 0, length);
-        return StreamingJson.createParser(inputRO);
+        return JsonEx.createParser(inputRO);
     }
 
     public static void main(

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserDocumentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserDocumentTest.java
@@ -61,8 +61,7 @@ public class JsonParserDocumentTest
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.START_OBJECT, parser.nextEvent());
         parser.segmentable();
-        assertEquals(JsonEvent.START_SEGMENT, parser.nextEvent());
-        assertEquals(JsonEvent.END_SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
         assertEquals(JsonEvent.END_DOCUMENT, parser.nextEvent());
         assertFalse(parser.hasNextEvent());
     }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserFactoryImplTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserFactoryImplTest.java
@@ -34,7 +34,7 @@ import jakarta.json.stream.JsonParserFactory;
 
 import org.junit.jupiter.api.Test;
 
-import io.aklivity.zilla.runtime.common.json.StreamingJson;
+import io.aklivity.zilla.runtime.common.json.JsonEx;
 
 public class JsonParserFactoryImplTest
 {
@@ -42,9 +42,9 @@ public class JsonParserFactoryImplTest
     public void shouldCreateParserForInputStreamWithSharedConfig()
     {
         final Map<String, Object> config = Map.of(
-            StreamingJson.PATH_INCLUDES, List.of("/jsonrpc"),
-            StreamingJson.TOKEN_MAX_BYTES, 1024);
-        final JsonParserFactory factory = StreamingJson.createParserFactory(config);
+            JsonEx.PATH_INCLUDES, List.of("/jsonrpc"),
+            JsonEx.TOKEN_MAX_BYTES, 1024);
+        final JsonParserFactory factory = JsonEx.createParserFactory(config);
 
         final InputStream in1 = new BufferedInputStream(
             new ByteArrayInputStream("{\"jsonrpc\":\"2.0\"}".getBytes(UTF_8)));
@@ -66,15 +66,15 @@ public class JsonParserFactoryImplTest
     public void shouldExposeConfigInUse()
     {
         final Map<String, Object> config = Map.of(
-            StreamingJson.PATH_INCLUDES, List.of("/jsonrpc"));
-        final JsonParserFactory factory = StreamingJson.createParserFactory(config);
+            JsonEx.PATH_INCLUDES, List.of("/jsonrpc"));
+        final JsonParserFactory factory = JsonEx.createParserFactory(config);
         assertSame(config, factory.getConfigInUse());
     }
 
     @Test
     public void shouldCreateParserForInputStreamWithCharset()
     {
-        final JsonParserFactory factory = StreamingJson.createParserFactory(Map.of());
+        final JsonParserFactory factory = JsonEx.createParserFactory(Map.of());
         final InputStream in = new BufferedInputStream(
             new ByteArrayInputStream("{}".getBytes(UTF_8)));
         try (JsonParser parser = factory.createParser(in, UTF_8))
@@ -86,7 +86,7 @@ public class JsonParserFactoryImplTest
     @Test
     public void shouldCreateParserForReaderSource()
     {
-        final JsonParserFactory factory = StreamingJson.createParserFactory(Map.of());
+        final JsonParserFactory factory = JsonEx.createParserFactory(Map.of());
         try (JsonParser parser = factory.createParser(new StringReader("{\"a\":1}")))
         {
             assertEquals(JsonParser.Event.START_OBJECT, parser.next());
@@ -98,7 +98,7 @@ public class JsonParserFactoryImplTest
     @Test
     public void shouldCreateParserForJsonObjectSource()
     {
-        final JsonParserFactory factory = StreamingJson.createParserFactory(Map.of());
+        final JsonParserFactory factory = JsonEx.createParserFactory(Map.of());
         final JsonObject object = JsonProvider.provider().createObjectBuilder().add("a", 1).build();
         try (JsonParser parser = factory.createParser(object))
         {
@@ -111,7 +111,7 @@ public class JsonParserFactoryImplTest
     @Test
     public void shouldCreateParserForJsonArraySource()
     {
-        final JsonParserFactory factory = StreamingJson.createParserFactory(Map.of());
+        final JsonParserFactory factory = JsonEx.createParserFactory(Map.of());
         final JsonArray array = JsonProvider.provider().createArrayBuilder().add(1).add(2).build();
         try (JsonParser parser = factory.createParser(array))
         {

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserSegmentHardeningTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserSegmentHardeningTest.java
@@ -17,6 +17,7 @@ package io.aklivity.zilla.runtime.common.json.internal;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -35,21 +36,24 @@ public class JsonParserSegmentHardeningTest
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.START_OBJECT, parser.nextEvent());
         parser.segmentable();
-        assertEquals(JsonEvent.START_SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
         final String first = segment(parser);
         assertEquals("{\"a\":1,", first);
+        assertTrue(parser.deferredBytes());
         assertFalse(parser.hasNextEvent());
 
         wrap(parser, "\"b\":2,");
-        assertEquals(JsonEvent.CONTINUE_SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
         final String second = segment(parser);
         assertEquals("\"b\":2,", second);
+        assertTrue(parser.deferredBytes());
         assertFalse(parser.hasNextEvent());
 
         wrap(parser, "\"c\":3} ");
-        assertEquals(JsonEvent.END_SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
         final String third = segment(parser);
         assertEquals("\"c\":3}", third);
+        assertFalse(parser.deferredBytes());
         assertEquals(JsonEvent.END_DOCUMENT, parser.nextEvent());
 
         assertEquals("{\"a\":1,\"b\":2,\"c\":3}", first + second + third);
@@ -64,9 +68,9 @@ public class JsonParserSegmentHardeningTest
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.START_OBJECT, parser.nextEvent());
         parser.segmentable();
-        assertEquals(JsonEvent.START_SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
         assertEquals("{}", segment(parser));
-        assertEquals(JsonEvent.END_SEGMENT, parser.nextEvent());
+        assertFalse(parser.deferredBytes());
         assertEquals(JsonEvent.END_DOCUMENT, parser.nextEvent());
     }
 
@@ -79,9 +83,9 @@ public class JsonParserSegmentHardeningTest
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.START_ARRAY, parser.nextEvent());
         parser.segmentable();
-        assertEquals(JsonEvent.START_SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
         assertEquals("[]", segment(parser));
-        assertEquals(JsonEvent.END_SEGMENT, parser.nextEvent());
+        assertFalse(parser.deferredBytes());
         assertEquals(JsonEvent.END_DOCUMENT, parser.nextEvent());
     }
 
@@ -94,9 +98,9 @@ public class JsonParserSegmentHardeningTest
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.START_OBJECT, parser.nextEvent());
         parser.segmentable();
-        assertEquals(JsonEvent.START_SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
         assertEquals("{\"a\":1}", segment(parser));
-        assertEquals(JsonEvent.END_SEGMENT, parser.nextEvent());
+        assertFalse(parser.deferredBytes());
         assertEquals(JsonEvent.END_DOCUMENT, parser.nextEvent());
 
         parser.reset();
@@ -121,8 +125,9 @@ public class JsonParserSegmentHardeningTest
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.START_OBJECT, parser.nextEvent());
         parser.segmentable();
-        assertEquals(JsonEvent.START_SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
         assertEquals("{\"a\":1,", segment(parser));
+        assertTrue(parser.deferredBytes());
         assertFalse(parser.hasNextEvent());
 
         parser.reset();

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserSegmentTest.java
@@ -17,6 +17,7 @@ package io.aklivity.zilla.runtime.common.json.internal;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -35,10 +36,9 @@ public class JsonParserSegmentTest
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.START_OBJECT, parser.nextEvent());
         parser.segmentable();
-        assertEquals(JsonEvent.START_SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
         assertEquals("{\"a\":1}", segment(parser));
-        assertEquals(JsonEvent.END_SEGMENT, parser.nextEvent());
-        assertEquals("", segment(parser));
+        assertFalse(parser.deferredBytes());
     }
 
     @Test
@@ -50,9 +50,9 @@ public class JsonParserSegmentTest
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.START_OBJECT, parser.nextEvent());
         parser.segmentable();
-        assertEquals(JsonEvent.START_SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
         assertEquals("{\"a\":\"}{\"}", segment(parser));
-        assertEquals(JsonEvent.END_SEGMENT, parser.nextEvent());
+        assertFalse(parser.deferredBytes());
     }
 
     @Test
@@ -64,9 +64,9 @@ public class JsonParserSegmentTest
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.START_ARRAY, parser.nextEvent());
         parser.segmentable();
-        assertEquals(JsonEvent.START_SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
         assertEquals("[1,2,3]", segment(parser));
-        assertEquals(JsonEvent.END_SEGMENT, parser.nextEvent());
+        assertFalse(parser.deferredBytes());
     }
 
     @Test
@@ -81,9 +81,9 @@ public class JsonParserSegmentTest
         assertEquals("a", parser.getString());
         assertEquals(JsonEvent.START_OBJECT, parser.nextEvent());
         parser.segmentable();
-        assertEquals(JsonEvent.START_SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
         assertEquals("{\"x\":1}", segment(parser));
-        assertEquals(JsonEvent.END_SEGMENT, parser.nextEvent());
+        assertFalse(parser.deferredBytes());
         assertEquals(JsonEvent.KEY_NAME, parser.nextEvent());
         assertEquals("b", parser.getString());
         assertEquals(JsonEvent.VALUE_NUMBER, parser.nextEvent());
@@ -100,15 +100,17 @@ public class JsonParserSegmentTest
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.START_OBJECT, parser.nextEvent());
         parser.segmentable();
-        assertEquals(JsonEvent.START_SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
         final String first = segment(parser);
         assertEquals("{\"a\":1,", first);
+        assertTrue(parser.deferredBytes());
         assertFalse(parser.hasNext());
 
         wrap(parser, "\"b\":2} ");
-        assertEquals(JsonEvent.END_SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
         final String second = segment(parser);
         assertEquals("\"b\":2}", second);
+        assertFalse(parser.deferredBytes());
 
         assertEquals("{\"a\":1,\"b\":2}", first + second);
     }
@@ -133,9 +135,9 @@ public class JsonParserSegmentTest
 
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         parser.segmentable();
-        assertEquals(JsonEvent.START_SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
         assertEquals("{ \"a\" : 1 }", segment(parser));
-        assertEquals(JsonEvent.END_SEGMENT, parser.nextEvent());
+        assertFalse(parser.deferredBytes());
         assertEquals(JsonEvent.END_DOCUMENT, parser.nextEvent());
     }
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -153,6 +153,19 @@ class JsonPipelineChunkingTest
     }
 
     @Test
+    void shouldFragmentLargeNumberValueStructured()
+    {
+        JsonGeneratorEx generator = JsonEx.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[256]);
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .into(JsonSink.of(generator));
+
+        // a single numeric property value far larger than BOUND, in structured delivery
+        String json = "{\"data\":" + "1".repeat(96) + "}";
+        assertEquals(json, chunked(pipeline, generator, output, json));
+    }
+
+    @Test
     void shouldFragmentValueLargerThanBound()
     {
         JsonGeneratorEx generator = JsonEx.createGenerator();

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -119,8 +119,7 @@ class JsonPipelineChunkingTest
         List<Boolean> deferred = new ArrayList<>();
         JsonTransform probe = (control, source, event, sink) ->
         {
-            if (event == JsonEvent.START_SEGMENT || event == JsonEvent.CONTINUE_SEGMENT ||
-                event == JsonEvent.END_SEGMENT)
+            if (event == JsonEvent.SEGMENT)
             {
                 deferred.add(source.deferredBytes());
             }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json.internal;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
+import io.aklivity.zilla.runtime.common.json.JsonPipeline;
+import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
+import io.aklivity.zilla.runtime.common.json.JsonSink;
+import io.aklivity.zilla.runtime.common.json.StreamingJson;
+
+class JsonPipelineChunkingTest
+{
+    private static final int BOUND = 32;
+
+    @Test
+    void shouldChunkLargeArrayThroughTerminalSink()
+    {
+        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
+        JsonPipeline pipeline = StreamingJson.createParser().stream()
+            .into(JsonSink.of(generator));
+
+        String json = "[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19]";
+        assertEquals(json, chunked(pipeline, generator, output, json));
+    }
+
+    @Test
+    void shouldChunkLargeObjectThroughTerminalSink()
+    {
+        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
+        JsonPipeline pipeline = StreamingJson.createParser().stream()
+            .into(JsonSink.of(generator));
+
+        String json = "{\"k0\":0,\"k1\":1,\"k2\":2,\"k3\":3,\"k4\":4,\"k5\":5,\"k6\":6,\"k7\":7,\"k8\":8,\"k9\":9}";
+        assertEquals(json, chunked(pipeline, generator, output, json));
+    }
+
+    @Test
+    void shouldChunkThroughProjectorTransform()
+    {
+        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
+        JsonPipeline pipeline = StreamingJson.createParser().stream()
+            .transform(StreamingJson.projector(List.of("")))
+            .into(JsonSink.of(generator));
+
+        String json = "{\"id\":1,\"items\":[10,11,12,13,14,15,16,17,18,19],\"ok\":true}";
+        assertEquals(json, chunked(pipeline, generator, output, json));
+    }
+
+    @Test
+    void shouldCompleteWithoutSuspendWhenWithinBound()
+    {
+        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
+        JsonPipeline pipeline = StreamingJson.createParser().stream()
+            .into(JsonSink.of(generator));
+
+        byte[] bytes = "[1,2,3] ".getBytes(UTF_8);
+        pipeline.reset();
+        generator.wrap(output, 0, 128);
+        Status status = pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length);
+
+        assertEquals(Status.COMPLETE, status);
+        byte[] out = new byte[generator.length()];
+        output.getBytes(0, out);
+        assertEquals("[1,2,3]", new String(out, UTF_8));
+    }
+
+    // Drives a value through the pipeline with the generator bounded at BOUND, draining and re-targeting
+    // (context preserved) on each SUSPENDED, and concatenating the drained chunks into one document.
+    private static String chunked(
+        JsonPipeline pipeline,
+        JsonGeneratorEx generator,
+        MutableDirectBuffer output,
+        String json)
+    {
+        byte[] bytes = (json + " ").getBytes(UTF_8);
+        UnsafeBuffer in = new UnsafeBuffer(bytes);
+        StringBuilder result = new StringBuilder();
+        pipeline.reset();
+        generator.wrap(output, 0, BOUND);
+        int suspends = 0;
+        int guard = 0;
+        Status status;
+        do
+        {
+            status = pipeline.feed(in, 0, bytes.length);
+            byte[] chunk = new byte[generator.length()];
+            output.getBytes(0, chunk);
+            result.append(new String(chunk, UTF_8));
+            if (status == Status.SUSPENDED)
+            {
+                suspends++;
+                generator.wrap(output, 0, BOUND);
+            }
+            guard++;
+        }
+        while (status == Status.SUSPENDED && guard < 10_000);
+        assertEquals(Status.COMPLETE, status);
+        assertTrue(suspends >= 1, "expected at least one SUSPENDED chunk boundary");
+        return result.toString();
+    }
+}

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -128,7 +128,7 @@ class JsonPipelineChunkingTest
         generator.wrap(output, 0, 128);
         Status status = pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length);
 
-        assertEquals(Status.COMPLETE, status);
+        assertEquals(Status.COMPLETED, status);
         byte[] out = new byte[generator.length()];
         output.getBytes(0, out);
         assertEquals("[1,2,3]", new String(out, UTF_8));
@@ -164,7 +164,7 @@ class JsonPipelineChunkingTest
             guard++;
         }
         while (status == Status.SUSPENDED && guard < 10_000);
-        assertEquals(Status.COMPLETE, status);
+        assertEquals(Status.COMPLETED, status);
         assertTrue(suspends >= 1, "expected at least one SUSPENDED chunk boundary");
         return result.toString();
     }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -16,14 +16,17 @@ package io.aklivity.zilla.runtime.common.json.internal;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
+import io.aklivity.zilla.runtime.common.json.JsonEvent;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
@@ -84,6 +87,57 @@ class JsonPipelineChunkingTest
 
         String json = "{\"k0\":0,\"k1\":1,\"k2\":2,\"k3\":3,\"k4\":4,\"k5\":5,\"k6\":6,\"k7\":7,\"k8\":8,\"k9\":9}";
         assertEquals(json, chunked(pipeline, generator, output, json));
+    }
+
+    @Test
+    void shouldStreamStringValueAcrossInputFrames()
+    {
+        JsonGeneratorEx generator = JsonEx.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[256]);
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .into(JsonSink.of(generator, JsonSink.Delivery.SEGMENTABLE));
+        generator.wrap(output, 0, output.capacity());
+        pipeline.reset();
+
+        // a single string value split mid-token across two input frames (larger than the input window)
+        byte[] f1 = "{\"data\":\"aaaaaaaaaa".getBytes(UTF_8);
+        byte[] f2 = "bbbbbbbbbb\"} ".getBytes(UTF_8);
+        assertEquals(Status.ADVANCED, pipeline.feed(new UnsafeBuffer(f1), 0, f1.length));
+        Status status = pipeline.feed(new UnsafeBuffer(f2), 0, f2.length);
+
+        assertEquals(Status.COMPLETED, status);
+        byte[] out = new byte[generator.length()];
+        output.getBytes(0, out);
+        assertEquals("{\"data\":\"aaaaaaaaaabbbbbbbbbb\"}", new String(out, UTF_8));
+    }
+
+    @Test
+    void shouldReportDeferredBytesWhileStreamingAcrossFrames()
+    {
+        JsonGeneratorEx generator = JsonEx.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[256]);
+        List<Boolean> deferred = new ArrayList<>();
+        JsonTransform probe = (control, source, event, sink) ->
+        {
+            if (event == JsonEvent.START_SEGMENT || event == JsonEvent.CONTINUE_SEGMENT ||
+                event == JsonEvent.END_SEGMENT)
+            {
+                deferred.add(source.deferredBytes());
+            }
+            return sink.feed(control, source, event);
+        };
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(probe)
+            .into(JsonSink.of(generator, JsonSink.Delivery.SEGMENTABLE));
+        generator.wrap(output, 0, output.capacity());
+        pipeline.reset();
+
+        pipeline.feed(new UnsafeBuffer("{\"data\":\"aaaaaaaaaa".getBytes(UTF_8)), 0, 19);
+        pipeline.feed(new UnsafeBuffer("bbbbbbbbbb\"} ".getBytes(UTF_8)), 0, 13);
+
+        // first fragment is mid-stream (more deferred); the closing fragment completes the value
+        assertTrue(deferred.get(0));
+        assertFalse(deferred.get(deferred.size() - 1));
     }
 
     @Test

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -102,7 +102,7 @@ class JsonPipelineChunkingTest
         // a single string value split mid-token across two input frames (larger than the input window)
         byte[] f1 = "{\"data\":\"aaaaaaaaaa".getBytes(UTF_8);
         byte[] f2 = "bbbbbbbbbb\"} ".getBytes(UTF_8);
-        assertEquals(Status.ADVANCED, pipeline.feed(new UnsafeBuffer(f1), 0, f1.length));
+        assertEquals(Status.STARVED, pipeline.feed(new UnsafeBuffer(f1), 0, f1.length, false));
         Status status = pipeline.feed(new UnsafeBuffer(f2), 0, f2.length);
 
         assertEquals(Status.COMPLETED, status);
@@ -131,7 +131,7 @@ class JsonPipelineChunkingTest
         generator.wrap(output, 0, output.capacity());
         pipeline.reset();
 
-        pipeline.feed(new UnsafeBuffer("{\"data\":\"aaaaaaaaaa".getBytes(UTF_8)), 0, 19);
+        pipeline.feed(new UnsafeBuffer("{\"data\":\"aaaaaaaaaa".getBytes(UTF_8)), 0, 19, false);
         pipeline.feed(new UnsafeBuffer("bbbbbbbbbb\"} ".getBytes(UTF_8)), 0, 13);
 
         // first fragment is mid-stream (more deferred); the closing fragment completes the value

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -87,6 +87,19 @@ class JsonPipelineChunkingTest
     }
 
     @Test
+    void shouldFragmentLargeStringValueStructured()
+    {
+        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[256]);
+        JsonPipeline pipeline = StreamingJson.createParser().stream()
+            .into(JsonSink.of(generator));
+
+        // a single string property value far larger than BOUND, in structured delivery
+        String json = "{\"data\":\"" + "x".repeat(96) + "\"}";
+        assertEquals(json, chunked(pipeline, generator, output, json));
+    }
+
+    @Test
     void shouldFragmentValueLargerThanBound()
     {
         JsonGeneratorEx generator = StreamingJson.createGenerator();

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -24,13 +24,13 @@ import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
+import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
 import io.aklivity.zilla.runtime.common.json.JsonSchema;
 import io.aklivity.zilla.runtime.common.json.JsonSink;
 import io.aklivity.zilla.runtime.common.json.JsonTransform;
-import io.aklivity.zilla.runtime.common.json.StreamingJson;
 
 class JsonPipelineChunkingTest
 {
@@ -39,9 +39,9 @@ class JsonPipelineChunkingTest
     @Test
     void shouldChunkLargeArrayThroughTerminalSink()
     {
-        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .into(JsonSink.of(generator));
 
         String json = "[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19]";
@@ -51,9 +51,9 @@ class JsonPipelineChunkingTest
     @Test
     void shouldChunkLargeObjectThroughTerminalSink()
     {
-        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .into(JsonSink.of(generator));
 
         String json = "{\"k0\":0,\"k1\":1,\"k2\":2,\"k3\":3,\"k4\":4,\"k5\":5,\"k6\":6,\"k7\":7,\"k8\":8,\"k9\":9}";
@@ -63,10 +63,10 @@ class JsonPipelineChunkingTest
     @Test
     void shouldChunkThroughProjectorTransform()
     {
-        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
-            .transform(StreamingJson.projector(List.of("")))
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("")))
             .into(JsonSink.of(generator));
 
         String json = "{\"id\":1,\"items\":[10,11,12,13,14,15,16,17,18,19],\"ok\":true}";
@@ -76,9 +76,9 @@ class JsonPipelineChunkingTest
     @Test
     void shouldChunkThroughValidatorTransform()
     {
-        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(JsonSchema.of("{\"type\":\"object\"}").validator())
             .into(JsonSink.of(generator));
 
@@ -89,9 +89,9 @@ class JsonPipelineChunkingTest
     @Test
     void shouldFragmentLargeStringValueStructured()
     {
-        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[256]);
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .into(JsonSink.of(generator));
 
         // a single string property value far larger than BOUND, in structured delivery
@@ -102,9 +102,9 @@ class JsonPipelineChunkingTest
     @Test
     void shouldFragmentValueLargerThanBound()
     {
-        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[256]);
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .into(JsonSink.of(generator, JsonSink.Delivery.SEGMENTABLE));
 
         // one top-level array whose verbatim form far exceeds BOUND, delivered as a single segment that
@@ -116,10 +116,10 @@ class JsonPipelineChunkingTest
     @Test
     void shouldFragmentValueThroughForwardingTransform()
     {
-        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[256]);
         JsonTransform passthrough = (control, source, event, sink) -> sink.feed(control, source, event);
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(passthrough)
             .into(JsonSink.of(generator, JsonSink.Delivery.SEGMENTABLE));
 
@@ -131,9 +131,9 @@ class JsonPipelineChunkingTest
     @Test
     void shouldCompleteWithoutSuspendWhenWithinBound()
     {
-        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .into(JsonSink.of(generator));
 
         byte[] bytes = "[1,2,3] ".getBytes(UTF_8);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -29,6 +29,7 @@ import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
 import io.aklivity.zilla.runtime.common.json.JsonSchema;
 import io.aklivity.zilla.runtime.common.json.JsonSink;
+import io.aklivity.zilla.runtime.common.json.JsonTransform;
 import io.aklivity.zilla.runtime.common.json.StreamingJson;
 
 class JsonPipelineChunkingTest
@@ -82,6 +83,35 @@ class JsonPipelineChunkingTest
             .into(JsonSink.of(generator));
 
         String json = "{\"k0\":0,\"k1\":1,\"k2\":2,\"k3\":3,\"k4\":4,\"k5\":5,\"k6\":6,\"k7\":7,\"k8\":8,\"k9\":9}";
+        assertEquals(json, chunked(pipeline, generator, output, json));
+    }
+
+    @Test
+    void shouldFragmentValueLargerThanBound()
+    {
+        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[256]);
+        JsonPipeline pipeline = StreamingJson.createParser().stream()
+            .into(JsonSink.of(generator, JsonSink.Delivery.SEGMENTABLE));
+
+        // one top-level array whose verbatim form far exceeds BOUND, delivered as a single segment that
+        // must be fragmented across many chunks
+        String json = "[\"aaaaaaaa\",\"bbbbbbbb\",\"cccccccc\",\"dddddddd\",\"eeeeeeee\",\"ffffffff\"]";
+        assertEquals(json, chunked(pipeline, generator, output, json));
+    }
+
+    @Test
+    void shouldFragmentValueThroughForwardingTransform()
+    {
+        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[256]);
+        JsonTransform passthrough = (control, source, event, sink) -> sink.feed(control, source, event);
+        JsonPipeline pipeline = StreamingJson.createParser().stream()
+            .transform(passthrough)
+            .into(JsonSink.of(generator, JsonSink.Delivery.SEGMENTABLE));
+
+        // the resume cascade must continue the in-flight fragment through the transform stage
+        String json = "[\"aaaaaaaa\",\"bbbbbbbb\",\"cccccccc\",\"dddddddd\",\"eeeeeeee\",\"ffffffff\"]";
         assertEquals(json, chunked(pipeline, generator, output, json));
     }
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -41,7 +41,7 @@ class JsonPipelineChunkingTest
     {
         JsonGeneratorEx generator = StreamingJson.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .into(JsonSink.of(generator));
 
         String json = "[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19]";
@@ -53,7 +53,7 @@ class JsonPipelineChunkingTest
     {
         JsonGeneratorEx generator = StreamingJson.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .into(JsonSink.of(generator));
 
         String json = "{\"k0\":0,\"k1\":1,\"k2\":2,\"k3\":3,\"k4\":4,\"k5\":5,\"k6\":6,\"k7\":7,\"k8\":8,\"k9\":9}";
@@ -65,7 +65,7 @@ class JsonPipelineChunkingTest
     {
         JsonGeneratorEx generator = StreamingJson.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(StreamingJson.projector(List.of("")))
             .into(JsonSink.of(generator));
 
@@ -78,7 +78,7 @@ class JsonPipelineChunkingTest
     {
         JsonGeneratorEx generator = StreamingJson.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(JsonSchema.of("{\"type\":\"object\"}").validator())
             .into(JsonSink.of(generator));
 
@@ -91,7 +91,7 @@ class JsonPipelineChunkingTest
     {
         JsonGeneratorEx generator = StreamingJson.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[256]);
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .into(JsonSink.of(generator));
 
         // a single string property value far larger than BOUND, in structured delivery
@@ -104,7 +104,7 @@ class JsonPipelineChunkingTest
     {
         JsonGeneratorEx generator = StreamingJson.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[256]);
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .into(JsonSink.of(generator, JsonSink.Delivery.SEGMENTABLE));
 
         // one top-level array whose verbatim form far exceeds BOUND, delivered as a single segment that
@@ -119,7 +119,7 @@ class JsonPipelineChunkingTest
         JsonGeneratorEx generator = StreamingJson.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[256]);
         JsonTransform passthrough = (control, source, event, sink) -> sink.feed(control, source, event);
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(passthrough)
             .into(JsonSink.of(generator, JsonSink.Delivery.SEGMENTABLE));
 
@@ -133,7 +133,7 @@ class JsonPipelineChunkingTest
     {
         JsonGeneratorEx generator = StreamingJson.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .into(JsonSink.of(generator));
 
         byte[] bytes = "[1,2,3] ".getBytes(UTF_8);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
+import io.aklivity.zilla.runtime.common.json.JsonSchema;
 import io.aklivity.zilla.runtime.common.json.JsonSink;
 import io.aklivity.zilla.runtime.common.json.StreamingJson;
 
@@ -68,6 +69,19 @@ class JsonPipelineChunkingTest
             .into(JsonSink.of(generator));
 
         String json = "{\"id\":1,\"items\":[10,11,12,13,14,15,16,17,18,19],\"ok\":true}";
+        assertEquals(json, chunked(pipeline, generator, output, json));
+    }
+
+    @Test
+    void shouldChunkThroughValidatorTransform()
+    {
+        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
+        JsonPipeline pipeline = StreamingJson.createParser().stream()
+            .transform(JsonSchema.of("{\"type\":\"object\"}").validator())
+            .into(JsonSink.of(generator));
+
+        String json = "{\"k0\":0,\"k1\":1,\"k2\":2,\"k3\":3,\"k4\":4,\"k5\":5,\"k6\":6,\"k7\":7,\"k8\":8,\"k9\":9}";
         assertEquals(json, chunked(pipeline, generator, output, json));
     }
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineRejectTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineRejectTest.java
@@ -36,7 +36,7 @@ class JsonPipelineRejectTest
     {
         JsonGeneratorEx generator = StreamingJson.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .into(JsonSink.of(generator));
 
         byte[] bytes = "[1 2]".getBytes(UTF_8);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineRejectTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineRejectTest.java
@@ -21,11 +21,11 @@ import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
+import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
 import io.aklivity.zilla.runtime.common.json.JsonSink;
-import io.aklivity.zilla.runtime.common.json.StreamingJson;
 
 class JsonPipelineRejectTest
 {
@@ -34,9 +34,9 @@ class JsonPipelineRejectTest
     @Test
     void shouldRejectMalformedJson()
     {
-        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .into(JsonSink.of(generator));
 
         byte[] bytes = "[1 2]".getBytes(UTF_8);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineRejectTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineRejectTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json.internal;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
+import io.aklivity.zilla.runtime.common.json.JsonPipeline;
+import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
+import io.aklivity.zilla.runtime.common.json.JsonSink;
+import io.aklivity.zilla.runtime.common.json.StreamingJson;
+
+class JsonPipelineRejectTest
+{
+    // Malformed JSON is a rejection of the value, surfaced as the terminal REJECTED status rather than
+    // an exception escaping feed() — mirroring how the protobuf pipeline maps a decode failure.
+    @Test
+    void shouldRejectMalformedJson()
+    {
+        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
+        JsonPipeline pipeline = StreamingJson.createParser().stream()
+            .into(JsonSink.of(generator));
+
+        byte[] bytes = "[1 2]".getBytes(UTF_8);
+        generator.wrap(output, 0, output.capacity());
+        pipeline.reset();
+        Status status = pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length);
+
+        assertEquals(Status.REJECTED, status);
+    }
+}

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineResetTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineResetTest.java
@@ -43,7 +43,7 @@ class JsonPipelineResetTest
 
         generator.wrap(buffer, 0, buffer.capacity());
         pipeline.reset();
-        assertEquals(Status.ADVANCED, pipeline.feed(new UnsafeBuffer("[1,".getBytes(UTF_8)), 0, 3));
+        assertEquals(Status.STARVED, pipeline.feed(new UnsafeBuffer("[1,".getBytes(UTF_8)), 0, 3, false));
 
         pipeline.reset();
         generator.wrap(buffer, 0, buffer.capacity());

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineResetTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineResetTest.java
@@ -38,7 +38,7 @@ class JsonPipelineResetTest
     {
         JsonGeneratorEx generator = StreamingJson.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .into(JsonSink.of(generator));
 
         generator.wrap(buffer, 0, buffer.capacity());

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineResetTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineResetTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json.internal;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
+import io.aklivity.zilla.runtime.common.json.JsonPipeline;
+import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
+import io.aklivity.zilla.runtime.common.json.JsonSink;
+import io.aklivity.zilla.runtime.common.json.StreamingJson;
+
+class JsonPipelineResetTest
+{
+    // Models a pooled generator returned to the pool mid-value: the first caller abandons a partial
+    // array (leaving open structure in the generator), and a second caller checks the instance back out
+    // and, per the pooling discipline, resets the pipeline before reuse. The reset must clear the stale
+    // generator context so the next value is emitted clean (no leaked separator from the open array).
+    @Test
+    void shouldClearGeneratorContextOnResetForReuse()
+    {
+        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
+        JsonPipeline pipeline = StreamingJson.createParser().stream()
+            .into(JsonSink.of(generator));
+
+        generator.wrap(buffer, 0, buffer.capacity());
+        pipeline.reset();
+        assertEquals(Status.RESUMABLE, pipeline.feed(new UnsafeBuffer("[1,".getBytes(UTF_8)), 0, 3));
+
+        pipeline.reset();
+        generator.wrap(buffer, 0, buffer.capacity());
+        byte[] bytes = "{\"b\":2} ".getBytes(UTF_8);
+        Status status = pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length);
+
+        assertEquals(Status.COMPLETE, status);
+        byte[] out = new byte[generator.length()];
+        buffer.getBytes(0, out);
+        assertEquals("{\"b\":2}", new String(out, UTF_8));
+    }
+}

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineResetTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineResetTest.java
@@ -43,14 +43,14 @@ class JsonPipelineResetTest
 
         generator.wrap(buffer, 0, buffer.capacity());
         pipeline.reset();
-        assertEquals(Status.RESUMABLE, pipeline.feed(new UnsafeBuffer("[1,".getBytes(UTF_8)), 0, 3));
+        assertEquals(Status.ADVANCED, pipeline.feed(new UnsafeBuffer("[1,".getBytes(UTF_8)), 0, 3));
 
         pipeline.reset();
         generator.wrap(buffer, 0, buffer.capacity());
         byte[] bytes = "{\"b\":2} ".getBytes(UTF_8);
         Status status = pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length);
 
-        assertEquals(Status.COMPLETE, status);
+        assertEquals(Status.COMPLETED, status);
         byte[] out = new byte[generator.length()];
         buffer.getBytes(0, out);
         assertEquals("{\"b\":2}", new String(out, UTF_8));

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineResetTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineResetTest.java
@@ -21,11 +21,11 @@ import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
+import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
 import io.aklivity.zilla.runtime.common.json.JsonSink;
-import io.aklivity.zilla.runtime.common.json.StreamingJson;
 
 class JsonPipelineResetTest
 {
@@ -36,9 +36,9 @@ class JsonPipelineResetTest
     @Test
     void shouldClearGeneratorContextOnResetForReuse()
     {
-        JsonGeneratorEx generator = StreamingJson.createGenerator();
+        JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .into(JsonSink.of(generator));
 
         generator.wrap(buffer, 0, buffer.capacity());

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaConformanceTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaConformanceTest.java
@@ -36,9 +36,9 @@ import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.TestFactory;
 
 import io.aklivity.zilla.runtime.common.json.DirectBufferInputStreamEx;
+import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonSchema;
 import io.aklivity.zilla.runtime.common.json.JsonSchema.Draft;
-import io.aklivity.zilla.runtime.common.json.StreamingJson;
 
 /**
  * Runs the vendored subset of the official JSON Schema Test Suite (see
@@ -369,6 +369,6 @@ class JsonSchemaConformanceTest
         byte[] bytes = text.getBytes(UTF_8);
         DirectBufferInputStreamEx in = new DirectBufferInputStreamEx();
         in.wrap(new UnsafeBuffer(bytes), 0, bytes.length);
-        return StreamingJson.createParser(in);
+        return JsonEx.createParser(in);
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaPathsTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaPathsTest.java
@@ -108,7 +108,7 @@ class JsonSchemaPathsTest
     {
         JsonGeneratorEx gen = StreamingJson.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
-        gen.wrap(buffer, 0);
+        gen.wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = StreamingJson.createParser().stream()
             .transform(StreamingJson.projector(JsonSchemaPaths.retained(
                 "{\"type\":\"object\",\"properties\":{" +

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaPathsTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaPathsTest.java
@@ -109,7 +109,7 @@ class JsonSchemaPathsTest
         JsonGeneratorEx gen = StreamingJson.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
         gen.wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.createParser().stream()
+        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
             .transform(StreamingJson.projector(JsonSchemaPaths.retained(
                 "{\"type\":\"object\",\"properties\":{" +
                 "\"items\":{\"type\":\"array\",\"items\":{\"type\":\"object\"," +

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaPathsTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaPathsTest.java
@@ -23,10 +23,10 @@ import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
+import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonSink;
-import io.aklivity.zilla.runtime.common.json.StreamingJson;
 
 class JsonSchemaPathsTest
 {
@@ -106,11 +106,11 @@ class JsonSchemaPathsTest
     @Test
     void shouldDriveProjectorEndToEnd()
     {
-        JsonGeneratorEx gen = StreamingJson.createGenerator();
+        JsonGeneratorEx gen = JsonEx.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
         gen.wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = StreamingJson.stream(StreamingJson.createParser())
-            .transform(StreamingJson.projector(JsonSchemaPaths.retained(
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(JsonSchemaPaths.retained(
                 "{\"type\":\"object\",\"properties\":{" +
                 "\"items\":{\"type\":\"array\",\"items\":{\"type\":\"object\"," +
                 "\"properties\":{\"id\":{\"type\":\"integer\"}}}}}}")))

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerPathTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerPathTest.java
@@ -31,7 +31,7 @@ import jakarta.json.stream.JsonParsingException;
 
 import org.junit.jupiter.api.Test;
 
-import io.aklivity.zilla.runtime.common.json.StreamingJson;
+import io.aklivity.zilla.runtime.common.json.JsonEx;
 
 public class JsonTokenizerPathTest
 {
@@ -188,8 +188,8 @@ public class JsonTokenizerPathTest
             new ByteArrayInputStream(json.getBytes(UTF_8)));
 
         final Map<String, Object> config = Map.of(
-            StreamingJson.PATH_INCLUDES, List.of("/tools/-/name"));
-        final JsonParser parser = StreamingJson.createParserFactory(config).createParser(in);
+            JsonEx.PATH_INCLUDES, List.of("/tools/-/name"));
+        final JsonParser parser = JsonEx.createParserFactory(config).createParser(in);
 
         boolean sawNonReadableValue = false;
         while (parser.hasNext())


### PR DESCRIPTION
## Description

Extends `common-json` with a resumable, bounded streaming pipeline that pumps a
parser through transforms (projection, schema validation) into a generator sink,
in fixed memory with an input window in and an output window out.

### Back-pressure on two axes

`feed(buffer, offset, length, last)` (with a three-arg `last == true` shorthand)
returns:
- **`SUSPENDED`** — the bounded generator filled; drain, re-target, re-feed the
  **same** window to resume (structural context preserved).
- **`STARVED`** — the input window was consumed mid-value; feed the **next**
  window. Returned only when `last == false`.
- **`COMPLETED`** — the value finished cleanly.
- **`REJECTED`** — malformed input, or a value left incomplete under `last == true`
  (truncation).
- `ADVANCED` is now an internal sink-to-pump signal only.

### Verbatim value fidelity

The structured sink normalizes **structure** (inter-token whitespace stripped)
but splices each kept **leaf value** byte-for-byte, preserving original string
escapes and numeric lexemes. Values larger than the output window — strings and
numbers alike — fragment across bounded buffers as raw segments
(`writeRaw`/`writeSegment`), and string values larger than the input window
stream across frames.

### Zero-allocation projection

Object keys and scalar values flow through the pipeline as non-owning
`CharSequence`/segment views rather than materialized `String`s, so projection
and re-encode run allocation-free — the structured `JsonPipelineBM` benchmarks
report ~0 B/op.

### API & cleanup

- `StreamingJson` entry point renamed to `JsonEx`; streaming tests renamed
  (`JsonParserTest`, `JsonLocationTest`).
- Streaming pipeline documented in `README.md`.

### Testing

New `JsonPipelineChunkingTest`, `JsonPipelineStarvedTest`, `JsonPipelineRejectTest`,
`JsonPipelineResetTest` plus updated projector/sink/segment suites; the full
JSON Test Suite conformance set passes. 4,740 unit tests green; checkstyle and
JaCoCo clean; JMH allocation benchmarks at ~0 B/op.

https://claude.ai/code/session_01A7w84TfbTu1uqKu3JMkipj