### PR TITLE
Add Docker Hub authentication and ZPM cache to CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,17 @@ jobs:
           !~/.m2/repository/io/aklivity/zilla
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
+    - name: Cache ZPM test artifacts
+      uses: actions/cache@v5
+      with:
+        path: manager/target/zpm/cache
+        key: zpm-${{ runner.os }}-${{ hashFiles('manager/src/conf/install/zpm.json') }}
+        restore-keys: zpm-${{ runner.os }}-
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build with Maven
       run: ./mvnw -B -U -nsu -ntp -Ddocker.logStdout -Dfailsafe.skipAfterFailureCount=1 -Ddocker.verbose install jacoco:report-aggregate
       env:
@@ -104,6 +115,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           sparse-checkout: examples/${{ matrix.dir }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Restore cached Docker images
         uses: actions/cache@v5


### PR DESCRIPTION
## Description

This change enhances the GitHub Actions CI workflows to improve build reliability and performance:

1. **Docker Hub Authentication**: Added Docker Hub login steps to both the main build job and the examples job using stored secrets (`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`). This prevents rate limiting issues when pulling Docker images during CI runs.

2. **ZPM Test Artifacts Caching**: Added a new cache step for ZPM (Zilla Package Manager) test artifacts in the main build job. The cache is keyed by the `zpm.json` configuration file, allowing test artifacts to be reused across builds when the ZPM configuration hasn't changed.

These changes improve CI pipeline stability and reduce build times by avoiding unnecessary Docker image pulls and ZPM artifact regeneration.

## Test Plan

CI workflows will be validated on the next build run. The Docker Hub authentication will prevent rate-limiting errors, and the ZPM cache will be exercised during the Maven build phase.

https://claude.ai/code/session_011KvxeAe7AU7Yth334fT5eV