### PR TITLE
Support fragmented JSON values across input windows

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -41,7 +41,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import jakarta.json.stream.JsonParser;
-import jakarta.json.stream.JsonParserFactory;
 
 import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
@@ -77,7 +76,6 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpResetExFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.ResetFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.SignalFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.WindowFW;
-import io.aklivity.zilla.runtime.common.json.DirectBufferInputStreamEx;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonParserEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
@@ -198,8 +196,6 @@ public final class McpClientFactory implements McpStreamFactory
     private final McpFlushExFW.Builder mcpFlushExRW = new McpFlushExFW.Builder();
     private final McpResetExFW.Builder mcpResetExRW = new McpResetExFW.Builder();
 
-    private final DirectBufferInputStreamEx responseInputRO = new DirectBufferInputStreamEx();
-
     private final EngineContext context;
     private final MutableDirectBuffer writeBuffer;
     private final MutableDirectBuffer extBuffer;
@@ -230,8 +226,6 @@ public final class McpClientFactory implements McpStreamFactory
     private static final int SSE_SMALL_VALUE = 3;
     private static final int SSE_IGNORE_VALUE = 4;
 
-    private final JsonParserFactory responseParserFactory;
-    private final JsonParserFactory requestParserFactory;
     private final Matcher bearerChallengeMatcher = BEARER_CHALLENGE_PATTERN.matcher("");
 
     private final McpConfiguration config;
@@ -269,8 +263,6 @@ public final class McpClientFactory implements McpStreamFactory
         this.signaler = context.signaler();
         this.clientName = config.clientName();
         this.clientVersion = config.clientVersion();
-        this.responseParserFactory = JsonEx.createParserFactory(Map.of());
-        this.requestParserFactory = JsonEx.createParserFactory(Map.of());
 
         final Int2ObjectHashMap<McpSessionIdResolver> resolvers = new Int2ObjectHashMap<>();
         resolvers.put(KIND_TOOLS_LIST, ex -> ex.toolsList().sessionId().asString());
@@ -4278,11 +4270,10 @@ public final class McpClientFactory implements McpStreamFactory
                 return;
             }
 
-            responseInputRO.wrap(resultBuffer, 0, resultLimit);
-
             int bits = 0;
-            try (JsonParser parser = responseParserFactory.createParser(responseInputRO))
+            try (JsonParserEx parser = JsonEx.createParser())
             {
+                parser.wrap(resultBuffer, 0, resultLimit);
                 int depth = 0;
                 boolean inCapabilities = false;
                 String primitive = null;

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -79,6 +79,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.SignalFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.WindowFW;
 import io.aklivity.zilla.runtime.common.json.DirectBufferInputStreamEx;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
+import io.aklivity.zilla.runtime.common.json.JsonParserEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
@@ -231,7 +232,6 @@ public final class McpClientFactory implements McpStreamFactory
 
     private final JsonParserFactory responseParserFactory;
     private final JsonParserFactory requestParserFactory;
-    private final DirectBufferInputStreamEx requestInputRO = new DirectBufferInputStreamEx();
     private final Matcher bearerChallengeMatcher = BEARER_CHALLENGE_PATTERN.matcher("");
 
     private final McpConfiguration config;
@@ -398,13 +398,18 @@ public final class McpClientFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = requestInputRO;
-        input.wrap(buffer, progress, limit - progress);
         if (stream.paramsParser == null)
         {
-            stream.paramsParser = requestParserFactory.createParser(input);
+            stream.paramsParser = JsonEx.createParser(Map.of());
+            stream.paramsParser.wrap(buffer, progress, limit - progress);
+            stream.paramsParserProgress = offset - progress;
         }
-        final JsonParser parser = stream.paramsParser;
+        else
+        {
+            final int delta = (int) (stream.paramsParser.getLocation().getStreamOffset() - stream.paramsParserProgress);
+            stream.paramsParser.wrap(buffer, offset + delta, limit - offset - delta);
+        }
+        final JsonParserEx parser = stream.paramsParser;
         while (stream.decoder != decodeRequestEnd && parser.hasNext())
         {
             final JsonParser.Event event = parser.next();
@@ -419,8 +424,6 @@ public final class McpClientFactory implements McpStreamFactory
                 stream.paramsDepth--;
                 if (stream.paramsDepth == 0)
                 {
-                    parser.close();
-                    stream.paramsParser = null;
                     stream.state = McpState.openedInitial(stream.state);
                     stream.http.doEncodeRequestEnd(traceId, authorization);
                     stream.decoder = decodeRequestEnd;
@@ -430,7 +433,14 @@ public final class McpClientFactory implements McpStreamFactory
                 break;
             }
         }
-        return limit - input.available();
+        progress = offset + (int) (parser.getLocation().getStreamOffset() - stream.paramsParserProgress);
+        stream.paramsParserProgress += progress - offset;
+        if (stream.decoder == decodeRequestEnd)
+        {
+            parser.close();
+            stream.paramsParser = null;
+        }
+        return progress;
     }
 
     private int decodeRequestEnd(
@@ -458,17 +468,15 @@ public final class McpClientFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = responseInputRO;
-        input.wrap(buffer, progress, limit - progress);
-
-        http.decodableJson = responseParserFactory.createParser(input);
+        http.decodableJson = JsonEx.createParser(Map.of());
+        http.decodableJson.wrap(buffer, progress, limit - progress);
         http.decoder = decodeJsonRpcStart;
         // Map parser stream-offset 0 to buffer position `progress`.
         // The decodeJsonRpc* methods use offset + decodedX - decodedParserProgress as buffer position,
         // so set decodedParserProgress = offset - progress to align.
         http.decodedParserProgress = offset - progress;
 
-        progress = limit - input.available();
+        progress = offset + (int) (http.decodableJson.getLocation().getStreamOffset() - http.decodedParserProgress);
 
         return progress;
     }
@@ -484,7 +492,6 @@ public final class McpClientFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = responseInputRO;
         JsonParser parser = http.decodableJson;
 
         decode:
@@ -500,7 +507,7 @@ public final class McpClientFactory implements McpStreamFactory
 
             http.decoder = decodeJsonRpcNext;
 
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - http.decodedParserProgress);
         }
 
         return progress;
@@ -517,7 +524,6 @@ public final class McpClientFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = responseInputRO;
         JsonParser parser = http.decodableJson;
 
         decode:
@@ -559,7 +565,7 @@ public final class McpClientFactory implements McpStreamFactory
                 break decode;
             }
 
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - http.decodedParserProgress);
         }
 
         return progress;
@@ -576,7 +582,6 @@ public final class McpClientFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = responseInputRO;
         JsonParser parser = http.decodableJson;
 
         decode:
@@ -592,7 +597,7 @@ public final class McpClientFactory implements McpStreamFactory
             http.decodableJson = null;
             http.decoder = http.sseMode ? decodeSseEventEnd : decodeIgnore;
 
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - http.decodedParserProgress);
         }
 
         return progress;
@@ -609,7 +614,6 @@ public final class McpClientFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = responseInputRO;
         JsonParser parser = http.decodableJson;
 
         decode:
@@ -626,7 +630,7 @@ public final class McpClientFactory implements McpStreamFactory
 
             http.decoder = decodeJsonRpcNext;
 
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - http.decodedParserProgress);
         }
 
         return progress;
@@ -643,7 +647,6 @@ public final class McpClientFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = responseInputRO;
         JsonParser parser = http.decodableJson;
 
         decode:
@@ -661,7 +664,7 @@ public final class McpClientFactory implements McpStreamFactory
             http.sseEventJsonId = parser.getString();
             http.decoder = decodeJsonRpcNext;
 
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - http.decodedParserProgress);
         }
 
         return progress;
@@ -807,7 +810,6 @@ public final class McpClientFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = responseInputRO;
         JsonParser parser = http.decodableJson;
 
         decode:
@@ -830,7 +832,7 @@ public final class McpClientFactory implements McpStreamFactory
                 http.sseEventMethod = method;
             }
             http.decoder = decodeJsonRpcNext;
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - http.decodedParserProgress);
         }
 
         return progress;
@@ -847,7 +849,6 @@ public final class McpClientFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = responseInputRO;
         JsonParser parser = http.decodableJson;
 
         decode:
@@ -861,7 +862,7 @@ public final class McpClientFactory implements McpStreamFactory
                 break decode;
             }
             http.decoder = decodeJsonRpcParamsNext;
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - http.decodedParserProgress);
         }
 
         return progress;
@@ -878,7 +879,6 @@ public final class McpClientFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = responseInputRO;
         JsonParser parser = http.decodableJson;
 
         decode:
@@ -925,7 +925,7 @@ public final class McpClientFactory implements McpStreamFactory
                 break decode;
             }
 
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - http.decodedParserProgress);
         }
 
         return progress;
@@ -942,7 +942,6 @@ public final class McpClientFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = responseInputRO;
         JsonParser parser = http.decodableJson;
 
         if (parser.hasNext())
@@ -950,7 +949,7 @@ public final class McpClientFactory implements McpStreamFactory
             parser.next();
             http.sseProgressToken = parser.getString();
             http.decoder = decodeJsonRpcParamsNext;
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - http.decodedParserProgress);
         }
 
         return progress;
@@ -967,7 +966,6 @@ public final class McpClientFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = responseInputRO;
         JsonParser parser = http.decodableJson;
 
         if (parser.hasNext())
@@ -975,7 +973,7 @@ public final class McpClientFactory implements McpStreamFactory
             parser.next();
             http.sseProgress = parser.getLong();
             http.decoder = decodeJsonRpcParamsNext;
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - http.decodedParserProgress);
         }
 
         return progress;
@@ -992,7 +990,6 @@ public final class McpClientFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = responseInputRO;
         JsonParser parser = http.decodableJson;
 
         if (parser.hasNext())
@@ -1000,7 +997,7 @@ public final class McpClientFactory implements McpStreamFactory
             parser.next();
             http.sseProgressTotal = parser.getLong();
             http.decoder = decodeJsonRpcParamsNext;
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - http.decodedParserProgress);
         }
 
         return progress;
@@ -1017,7 +1014,6 @@ public final class McpClientFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = responseInputRO;
         JsonParser parser = http.decodableJson;
 
         if (parser.hasNext())
@@ -1025,7 +1021,7 @@ public final class McpClientFactory implements McpStreamFactory
             parser.next();
             http.sseProgressMessage = parser.getString();
             http.decoder = decodeJsonRpcParamsNext;
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - http.decodedParserProgress);
         }
 
         return progress;
@@ -1042,7 +1038,6 @@ public final class McpClientFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = responseInputRO;
         JsonParser parser = http.decodableJson;
 
         if (parser.hasNext())
@@ -1050,7 +1045,7 @@ public final class McpClientFactory implements McpStreamFactory
             parser.next();
             http.sseElicitationId = parser.getString();
             http.decoder = decodeJsonRpcParamsNext;
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - http.decodedParserProgress);
         }
 
         return progress;
@@ -1067,7 +1062,6 @@ public final class McpClientFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = responseInputRO;
         JsonParser parser = http.decodableJson;
 
         if (parser.hasNext())
@@ -1075,7 +1069,7 @@ public final class McpClientFactory implements McpStreamFactory
             parser.next();
             http.sseElicitUrl = parser.getString();
             http.decoder = decodeJsonRpcParamsNext;
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - http.decodedParserProgress);
         }
 
         return progress;
@@ -1092,7 +1086,6 @@ public final class McpClientFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = responseInputRO;
         JsonParser parser = http.decodableJson;
 
         if (parser.hasNext())
@@ -1100,7 +1093,7 @@ public final class McpClientFactory implements McpStreamFactory
             parser.next();
             http.sseElicitMode = parser.getString();
             http.decoder = decodeJsonRpcParamsNext;
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - http.decodedParserProgress);
         }
 
         return progress;
@@ -1510,6 +1503,9 @@ public final class McpClientFactory implements McpStreamFactory
         private int replyMax;
         private long replyBud;
         private int replyPad;
+
+        protected int decodeSlot = NO_SLOT;
+        protected int decodeSlotOffset;
 
         int state;
 
@@ -2093,12 +2089,23 @@ public final class McpClientFactory implements McpStreamFactory
             }
         }
 
-        private void cleanupApp(
+        protected void cleanupApp(
             long traceId,
             long authorization)
         {
             doAppReset(traceId, authorization);
             doAppAbort(traceId, authorization);
+            cleanupDecodeSlot();
+        }
+
+        protected void cleanupDecodeSlot()
+        {
+            if (decodeSlot != NO_SLOT)
+            {
+                decodePool.release(decodeSlot);
+                decodeSlot = NO_SLOT;
+                decodeSlotOffset = 0;
+            }
         }
     }
 
@@ -2667,7 +2674,8 @@ public final class McpClientFactory implements McpStreamFactory
         long timeout;
         private HttpEventStream sse;
 
-        JsonParser paramsParser;
+        JsonParserEx paramsParser;
+        long paramsParserProgress;
         int paramsDepth;
 
         private boolean pendingAuth;
@@ -3282,8 +3290,45 @@ public final class McpClientFactory implements McpStreamFactory
                 final OctetsFW payload = data.payload();
                 if (payload != null && payload.sizeof() > 0)
                 {
-                    decoder.decode(this, data.traceId(), data.authorization(),
-                        0L, 0, payload.buffer(), payload.offset(), payload.offset(), payload.limit());
+                    DirectBuffer buffer = payload.buffer();
+                    int offset = payload.offset();
+                    int limit = payload.limit();
+
+                    if (decodeSlot != NO_SLOT)
+                    {
+                        final MutableDirectBuffer slot = decodePool.buffer(decodeSlot);
+                        slot.putBytes(decodeSlotOffset, payload.buffer(), payload.offset(), payload.sizeof());
+                        decodeSlotOffset += payload.sizeof();
+                        buffer = slot;
+                        offset = 0;
+                        limit = decodeSlotOffset;
+                    }
+
+                    final int progress = decoder.decode(this, data.traceId(), data.authorization(),
+                        0L, 0, buffer, offset, offset, limit);
+
+                    if (progress < limit)
+                    {
+                        if (decodeSlot == NO_SLOT)
+                        {
+                            decodeSlot = decodePool.acquire(initialId);
+                        }
+
+                        if (decodeSlot == NO_SLOT)
+                        {
+                            cleanupApp(data.traceId(), data.authorization());
+                        }
+                        else
+                        {
+                            final MutableDirectBuffer slot = decodePool.buffer(decodeSlot);
+                            slot.putBytes(0, buffer, progress, limit - progress);
+                            decodeSlotOffset = limit - progress;
+                        }
+                    }
+                    else
+                    {
+                        cleanupDecodeSlot();
+                    }
                 }
             }
         }
@@ -3451,7 +3496,7 @@ public final class McpClientFactory implements McpStreamFactory
         protected int decodeSlotReserved;
 
         protected HttpResponseDecoder decoder;
-        protected JsonParser decodableJson;
+        protected JsonParserEx decodableJson;
         protected int decodedResultProgress;
         protected int decodedParserProgress;
         protected HttpResponseDecoder decodedSkipObjectThen;
@@ -3700,8 +3745,7 @@ public final class McpClientFactory implements McpStreamFactory
                 if (decodableJson != null)
                 {
                     final int delta = (int) (decodableJson.getLocation().getStreamOffset() - decodedParserProgress);
-                    final DirectBufferInputStreamEx input = responseInputRO;
-                    input.wrap(buffer, offset + delta, limit - offset - delta);
+                    decodableJson.wrap(buffer, offset + delta, limit - offset - delta);
                 }
 
                 decodeNet(traceId, authorization, budgetId, reserved, buffer, offset, limit);
@@ -4570,8 +4614,7 @@ public final class McpClientFactory implements McpStreamFactory
                 if (decodableJson != null)
                 {
                     final int delta = (int) (decodableJson.getLocation().getStreamOffset() - decodedParserProgress);
-                    final DirectBufferInputStreamEx input = responseInputRO;
-                    input.wrap(buffer, offset + delta, limit - offset - delta);
+                    decodableJson.wrap(buffer, offset + delta, limit - offset - delta);
                 }
 
                 decodeNet(traceId, authorization, budgetId, reserved, buffer, offset, limit);

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -32,7 +32,6 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeg
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
 
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -225,20 +224,6 @@ public final class McpClientFactory implements McpStreamFactory
     private final String clientName;
     private final String clientVersion;
 
-    private static final List<String> CLIENT_JSON_PATH_INCLUDES = List.of(
-        "/jsonrpc",
-        "/id",
-        "/method",
-        "/protocolVersion",
-        "/params/progressToken",
-        "/params/progress",
-        "/params/total",
-        "/params/message",
-        "/params/elicitationId",
-        "/params/url",
-        "/params/mode",
-        "/params/status");
-
     private static final int SSE_LINE_START = 0;
     private static final int SSE_FIELD_NAME = 1;
     private static final int SSE_AFTER_COLON = 2;
@@ -286,10 +271,8 @@ public final class McpClientFactory implements McpStreamFactory
         this.clientName = config.clientName();
         this.clientVersion = config.clientVersion();
         this.responseParserFactory = JsonEx.createParserFactory(Map.of(
-            JsonParserEx.PATH_INCLUDES, CLIENT_JSON_PATH_INCLUDES,
             JsonParserEx.TOKEN_MAX_BYTES, decodeMax));
         this.requestParserFactory = JsonEx.createParserFactory(Map.of(
-            JsonParserEx.PATH_INCLUDES, List.of(),
             JsonParserEx.TOKEN_MAX_BYTES, encodeMax));
 
         final Int2ObjectHashMap<McpSessionIdResolver> resolvers = new Int2ObjectHashMap<>();

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -43,7 +43,6 @@ import java.util.regex.Pattern;
 import jakarta.json.stream.JsonParser;
 
 import org.agrona.DirectBuffer;
-import org.agrona.ExpandableArrayBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.Int2ObjectHashMap;
 import org.agrona.collections.Long2ObjectHashMap;
@@ -773,6 +772,11 @@ public final class McpClientFactory implements McpStreamFactory
                 {
                     http.decodedResultErrorKey = true;
                 }
+            }
+
+            if (http.decodedSkipObjectThen == decodeJsonRpcResultEnd)
+            {
+                http.onDecodeResultEvent(event, parser, http.decodedSkipObjectDepth);
             }
         }
 
@@ -3552,6 +3556,13 @@ public final class McpClientFactory implements McpStreamFactory
             int offset,
             int limit);
 
+        void onDecodeResultEvent(
+            JsonParser.Event event,
+            JsonParser parser,
+            int depth)
+        {
+        }
+
         protected void cleanupDecodeSlot()
         {
             if (decodeSlot != NO_SLOT)
@@ -4183,8 +4194,10 @@ public final class McpClientFactory implements McpStreamFactory
 
     private final class HttpInitializeRequest extends HttpStream
     {
-        private final ExpandableArrayBuffer resultBuffer = new ExpandableArrayBuffer();
-        private int resultLimit;
+        private boolean inCapabilities;
+        private String capabilityCategory;
+        private boolean expectVersion;
+        private boolean expectListChanged;
 
         HttpInitializeRequest(
             McpStream mcp)
@@ -4254,95 +4267,82 @@ public final class McpClientFactory implements McpStreamFactory
             int offset,
             int limit)
         {
-            final int length = limit - offset;
-            resultBuffer.putBytes(resultLimit, buffer, offset, length);
-            resultLimit += length;
             return limit;
         }
 
         @Override
-        void onResponseComplete(
-            long traceId,
-            long authorization)
+        void onDecodeResultEvent(
+            JsonParser.Event event,
+            JsonParser parser,
+            int depth)
         {
-            if (resultLimit == 0)
+            switch (event)
             {
-                return;
-            }
-
-            int bits = 0;
-            try (JsonParserEx parser = JsonEx.createParser())
-            {
-                parser.wrap(resultBuffer, 0, resultLimit);
-                int depth = 0;
-                boolean inCapabilities = false;
-                String primitive = null;
-
-                while (parser.hasNext())
+            case KEY_NAME:
+                final String key = parser.getString();
+                if (depth == 1 && JSON_KEY_PROTOCOL_VERSION.equals(key))
                 {
-                    final JsonParser.Event event = parser.next();
-                    switch (event)
+                    expectVersion = true;
+                }
+                else if (depth == 1 && JSON_KEY_CAPABILITIES.equals(key))
+                {
+                    inCapabilities = true;
+                }
+                else if (depth == 2 && inCapabilities)
+                {
+                    capabilityCategory = key;
+                }
+                else if (depth == 3 && capabilityCategory != null && JSON_KEY_LIST_CHANGED.equals(key))
+                {
+                    expectListChanged = true;
+                }
+                break;
+            case VALUE_STRING:
+                if (expectVersion && mcp instanceof McpLifecycleStream lifecycle)
+                {
+                    lifecycle.negotiatedVersion = parser.getString();
+                }
+                expectVersion = false;
+                expectListChanged = false;
+                break;
+            case VALUE_TRUE:
+                if (expectListChanged && capabilityCategory != null)
+                {
+                    switch (capabilityCategory)
                     {
-                    case START_OBJECT:
-                        depth++;
+                    case JSON_KEY_TOOLS:
+                        mcp.serverCapabilities |= SERVER_TOOLS_LIST_CHANGED.value();
                         break;
-                    case END_OBJECT:
-                        depth--;
-                        if (depth == 2 && primitive != null)
-                        {
-                            primitive = null;
-                        }
-                        if (depth == 1 && inCapabilities)
-                        {
-                            inCapabilities = false;
-                        }
+                    case JSON_KEY_PROMPTS:
+                        mcp.serverCapabilities |= SERVER_PROMPTS_LIST_CHANGED.value();
                         break;
-                    case KEY_NAME:
-                        final String key = parser.getString();
-                        if (depth == 1 && JSON_KEY_PROTOCOL_VERSION.equals(key))
-                        {
-                            if (parser.hasNext() && parser.next() == JsonParser.Event.VALUE_STRING &&
-                                mcp instanceof McpLifecycleStream lifecycle)
-                            {
-                                lifecycle.negotiatedVersion = parser.getString();
-                            }
-                        }
-                        else if (depth == 1 && JSON_KEY_CAPABILITIES.equals(key))
-                        {
-                            inCapabilities = true;
-                        }
-                        else if (depth == 2 && inCapabilities)
-                        {
-                            primitive = key;
-                        }
-                        else if (depth == 3 && primitive != null && JSON_KEY_LIST_CHANGED.equals(key))
-                        {
-                            if (parser.hasNext() && parser.next() == JsonParser.Event.VALUE_TRUE)
-                            {
-                                switch (primitive)
-                                {
-                                case JSON_KEY_TOOLS:
-                                    bits |= SERVER_TOOLS_LIST_CHANGED.value();
-                                    break;
-                                case JSON_KEY_PROMPTS:
-                                    bits |= SERVER_PROMPTS_LIST_CHANGED.value();
-                                    break;
-                                case JSON_KEY_RESOURCES:
-                                    bits |= SERVER_RESOURCES_LIST_CHANGED.value();
-                                    break;
-                                default:
-                                    break;
-                                }
-                            }
-                        }
+                    case JSON_KEY_RESOURCES:
+                        mcp.serverCapabilities |= SERVER_RESOURCES_LIST_CHANGED.value();
                         break;
                     default:
                         break;
                     }
                 }
+                expectVersion = false;
+                expectListChanged = false;
+                break;
+            case END_OBJECT:
+                if (depth == 2)
+                {
+                    capabilityCategory = null;
+                }
+                else if (depth == 1)
+                {
+                    inCapabilities = false;
+                }
+                expectVersion = false;
+                expectListChanged = false;
+                break;
+            default:
+                expectVersion = false;
+                expectListChanged = false;
+                break;
             }
-
-            mcp.serverCapabilities |= bits;
         }
     }
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -79,7 +79,6 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.SignalFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.WindowFW;
 import io.aklivity.zilla.runtime.common.json.DirectBufferInputStreamEx;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
-import io.aklivity.zilla.runtime.common.json.JsonParserEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
@@ -270,10 +269,8 @@ public final class McpClientFactory implements McpStreamFactory
         this.signaler = context.signaler();
         this.clientName = config.clientName();
         this.clientVersion = config.clientVersion();
-        this.responseParserFactory = JsonEx.createParserFactory(Map.of(
-            JsonParserEx.TOKEN_MAX_BYTES, decodeMax));
-        this.requestParserFactory = JsonEx.createParserFactory(Map.of(
-            JsonParserEx.TOKEN_MAX_BYTES, encodeMax));
+        this.responseParserFactory = JsonEx.createParserFactory(Map.of());
+        this.requestParserFactory = JsonEx.createParserFactory(Map.of());
 
         final Int2ObjectHashMap<McpSessionIdResolver> resolvers = new Int2ObjectHashMap<>();
         resolvers.put(KIND_TOOLS_LIST, ex -> ex.toolsList().sessionId().asString());

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyListFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyListFactory.java
@@ -51,8 +51,8 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.EndFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.ResetFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.WindowFW;
-import io.aklivity.zilla.runtime.common.json.DirectBufferInputStreamEx;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
+import io.aklivity.zilla.runtime.common.json.JsonParserEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
@@ -71,7 +71,6 @@ abstract class McpProxyListFactory implements BindingHandler
     private final ResetFW resetRO = new ResetFW();
     private final McpBeginExFW mcpBeginExRO = new McpBeginExFW();
     private final OctetsFW emptyRO = new OctetsFW().wrap(new UnsafeBuffer(), 0, 0);
-    private final DirectBufferInputStreamEx inputRO = new DirectBufferInputStreamEx();
     private final DirectBuffer listReplyCloseRO =
         new UnsafeBuffer("]}".getBytes(StandardCharsets.UTF_8));
     private final DirectBuffer listReplySeparatorRO =
@@ -262,7 +261,7 @@ abstract class McpProxyListFactory implements BindingHandler
         private int replyMax;
         private int replyPad;
 
-        private JsonParser decodableJson;
+        private JsonParserEx decodableJson;
         private long decodedParserProgress;       // absolute streamOffset of buffer[offset] passed to decode
         private int decodeDepth;                  // JSON nesting depth in the reply envelope
         private int decodeItemDepth;              // JSON nesting depth within the current item
@@ -597,7 +596,7 @@ abstract class McpProxyListFactory implements BindingHandler
             if (decodableJson != null)
             {
                 final int delta = (int) (decodableJson.getLocation().getStreamOffset() - decodedParserProgress);
-                inputRO.wrap(buffer, offset + delta, limit - offset - delta);
+                decodableJson.wrap(buffer, offset + delta, limit - offset - delta);
             }
 
             McpListClientDecoder previous = null;
@@ -728,8 +727,8 @@ abstract class McpProxyListFactory implements BindingHandler
             return limit;
         }
 
-        inputRO.wrap(buffer, progress, limit - progress);
-        client.decodableJson = listItemParserFactory.createParser(inputRO);
+        client.decodableJson = JsonEx.createParser(Map.of());
+        client.decodableJson.wrap(buffer, progress, limit - progress);
         client.arrayKey = arrayKey();
         client.idKey = idKey();
         client.decoder = decodeReply;

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyListFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyListFactory.java
@@ -53,7 +53,6 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.ResetFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.WindowFW;
 import io.aklivity.zilla.runtime.common.json.DirectBufferInputStreamEx;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
-import io.aklivity.zilla.runtime.common.json.JsonParserEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
@@ -118,8 +117,7 @@ abstract class McpProxyListFactory implements BindingHandler
         McpConfiguration config,
         EngineContext context,
         LongFunction<McpBindingConfig> supplyBinding,
-        int kind,
-        List<String> pathIncludes)
+        int kind)
     {
         this.writeBuffer = context.writeBuffer();
         this.codecBuffer = new UnsafeBuffer(new byte[context.writeBuffer().capacity()]);
@@ -133,8 +131,7 @@ abstract class McpProxyListFactory implements BindingHandler
         this.mcpTypeId = context.supplyTypeId(MCP_TYPE_NAME);
         this.supplyBinding = supplyBinding;
         this.kind = kind;
-        this.listItemParserFactory = JsonEx.createParserFactory(
-            Map.of(JsonParserEx.PATH_INCLUDES, pathIncludes));
+        this.listItemParserFactory = JsonEx.createParserFactory(Map.of());
     }
 
     @Override

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyPromptsListFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyPromptsListFactory.java
@@ -17,7 +17,6 @@ package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
 
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.function.LongFunction;
 
 import org.agrona.DirectBuffer;
@@ -31,8 +30,6 @@ import io.aklivity.zilla.runtime.engine.EngineContext;
 
 final class McpProxyPromptsListFactory extends McpProxyListFactory
 {
-    private static final List<String> PROMPTS_LIST_ITEM_JSON_PATH_INCLUDES = List.of("/prompts/-/name");
-
     private final DirectBuffer prelude =
         new UnsafeBuffer("{\"prompts\":[".getBytes(StandardCharsets.UTF_8));
 
@@ -41,7 +38,7 @@ final class McpProxyPromptsListFactory extends McpProxyListFactory
         EngineContext context,
         LongFunction<McpBindingConfig> supplyBinding)
     {
-        super(config, context, supplyBinding, McpBeginExFW.KIND_PROMPTS_LIST, PROMPTS_LIST_ITEM_JSON_PATH_INCLUDES);
+        super(config, context, supplyBinding, McpBeginExFW.KIND_PROMPTS_LIST);
     }
 
     @Override

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyResourcesListFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyResourcesListFactory.java
@@ -17,7 +17,6 @@ package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
 
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.function.LongFunction;
 
 import org.agrona.DirectBuffer;
@@ -31,8 +30,6 @@ import io.aklivity.zilla.runtime.engine.EngineContext;
 
 final class McpProxyResourcesListFactory extends McpProxyListFactory
 {
-    private static final List<String> RESOURCES_LIST_ITEM_JSON_PATH_INCLUDES = List.of("/resources/-/uri");
-
     private final DirectBuffer prelude =
         new UnsafeBuffer("{\"resources\":[".getBytes(StandardCharsets.UTF_8));
 
@@ -41,7 +38,7 @@ final class McpProxyResourcesListFactory extends McpProxyListFactory
         EngineContext context,
         LongFunction<McpBindingConfig> supplyBinding)
     {
-        super(config, context, supplyBinding, McpBeginExFW.KIND_RESOURCES_LIST, RESOURCES_LIST_ITEM_JSON_PATH_INCLUDES);
+        super(config, context, supplyBinding, McpBeginExFW.KIND_RESOURCES_LIST);
     }
 
     @Override

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyToolsListFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyToolsListFactory.java
@@ -17,7 +17,6 @@ package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.function.LongFunction;
 
 import org.agrona.DirectBuffer;
@@ -31,8 +30,6 @@ import io.aklivity.zilla.runtime.engine.EngineContext;
 
 final class McpProxyToolsListFactory extends McpProxyListFactory
 {
-    private static final List<String> TOOLS_LIST_ITEM_JSON_PATH_INCLUDES = List.of("/tools/-/name");
-
     private final DirectBuffer prelude =
         new UnsafeBuffer("{\"tools\":[".getBytes(StandardCharsets.UTF_8));
 
@@ -41,7 +38,7 @@ final class McpProxyToolsListFactory extends McpProxyListFactory
         EngineContext context,
         LongFunction<McpBindingConfig> supplyBinding)
     {
-        super(config, context, supplyBinding, McpBeginExFW.KIND_TOOLS_LIST, TOOLS_LIST_ITEM_JSON_PATH_INCLUDES);
+        super(config, context, supplyBinding, McpBeginExFW.KIND_TOOLS_LIST);
     }
 
     @Override

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -76,6 +76,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.SignalFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.WindowFW;
 import io.aklivity.zilla.runtime.common.json.DirectBufferInputStreamEx;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
+import io.aklivity.zilla.runtime.common.json.JsonParserEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
@@ -222,8 +223,6 @@ public final class McpServerFactory implements McpStreamFactory
     private final int decodeMax;
     private final int encodeMax;
     private final int sessionIdAttempts;
-
-    private final DirectBufferInputStreamEx inputRO = new DirectBufferInputStreamEx();
 
     private final JsonParserFactory parserFactory;
 
@@ -547,18 +546,20 @@ public final class McpServerFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = inputRO;
-        input.wrap(buffer, progress, limit - progress);
-
         server.decodedId = null;
         server.decodedMethod = null;
         server.decodedMethodParam = null;
         server.decodedProgressToken = null;
         server.decodedAction = null;
-        server.decodableJson = parserFactory.createParser(input);
+        server.decodableJson = JsonEx.createParser(Map.of());
+        server.decodableJson.wrap(buffer, progress, limit - progress);
         server.decoder = decodeJsonRpcStart;
+        // Map parser stream-offset 0 to buffer position `progress`.
+        // The decodeJsonRpc* methods use offset + decodedX - decodedParserProgress as buffer position,
+        // so set decodedParserProgress = offset - progress to align.
+        server.decodedParserProgress = offset - progress;
 
-        progress = limit - input.available();
+        progress = offset + (int) (server.decodableJson.getLocation().getStreamOffset() - server.decodedParserProgress);
 
         return progress;
     }
@@ -574,7 +575,6 @@ public final class McpServerFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = inputRO;
         JsonParser parser = server.decodableJson;
 
         decode:
@@ -590,7 +590,7 @@ public final class McpServerFactory implements McpStreamFactory
 
             server.decoder = decodeJsonRpcNext;
 
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - server.decodedParserProgress);
         }
 
         return progress;
@@ -607,7 +607,6 @@ public final class McpServerFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = inputRO;
         JsonParser parser = server.decodableJson;
 
         decode:
@@ -655,7 +654,7 @@ public final class McpServerFactory implements McpStreamFactory
                 break decode;
             }
 
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - server.decodedParserProgress);
         }
 
         return progress;
@@ -672,7 +671,6 @@ public final class McpServerFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = inputRO;
         JsonParser parser = server.decodableJson;
 
         decode:
@@ -705,7 +703,7 @@ public final class McpServerFactory implements McpStreamFactory
                 server.onDecodeRequestId(server.decodedId);
             }
 
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - server.decodedParserProgress);
         }
 
         return progress;
@@ -722,7 +720,6 @@ public final class McpServerFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = inputRO;
         JsonParser parser = server.decodableJson;
 
         decode:
@@ -738,7 +735,7 @@ public final class McpServerFactory implements McpStreamFactory
 
             server.decoder = decodeJsonRpcResultNext;
 
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - server.decodedParserProgress);
         }
 
         return progress;
@@ -755,7 +752,6 @@ public final class McpServerFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = inputRO;
         JsonParser parser = server.decodableJson;
 
         decode:
@@ -786,7 +782,7 @@ public final class McpServerFactory implements McpStreamFactory
                 break decode;
             }
 
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - server.decodedParserProgress);
         }
 
         return progress;
@@ -803,7 +799,6 @@ public final class McpServerFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = inputRO;
         JsonParser parser = server.decodableJson;
 
         decode:
@@ -820,7 +815,7 @@ public final class McpServerFactory implements McpStreamFactory
             server.decodedAction = parser.getString();
             server.decoder = decodeJsonRpcResultNext;
 
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - server.decodedParserProgress);
         }
 
         return progress;
@@ -837,7 +832,6 @@ public final class McpServerFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = inputRO;
         JsonParser parser = server.decodableJson;
 
         decode:
@@ -854,7 +848,7 @@ public final class McpServerFactory implements McpStreamFactory
 
             server.decoder = decodeJsonRpcNext;
 
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - server.decodedParserProgress);
         }
 
         return progress;
@@ -871,7 +865,6 @@ public final class McpServerFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = inputRO;
         JsonParser parser = server.decodableJson;
 
         decode:
@@ -890,7 +883,7 @@ public final class McpServerFactory implements McpStreamFactory
             server.decodedId = id;
             server.decoder = decodeJsonRpcNext;
 
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - server.decodedParserProgress);
         }
 
         return progress;
@@ -907,7 +900,6 @@ public final class McpServerFactory implements McpStreamFactory
         int progress,
         int limit)
     {
-        DirectBufferInputStreamEx input = inputRO;
         JsonParser parser = server.decodableJson;
 
         decode:
@@ -980,7 +972,7 @@ public final class McpServerFactory implements McpStreamFactory
             server.decodedMethod = method;
             server.decoder = decodeJsonRpcNext;
 
-            progress = limit - input.available();
+            progress = offset + (int) (parser.getLocation().getStreamOffset() - server.decodedParserProgress);
         }
 
         return progress;
@@ -1417,7 +1409,7 @@ public final class McpServerFactory implements McpStreamFactory
         private boolean sseUpgrade;
         private boolean responseStarted;
 
-        private JsonParser decodableJson;
+        private JsonParserEx decodableJson;
         private String decodedMethod;
         private String decodedMethodParam;
         private String decodedId;
@@ -1566,8 +1558,7 @@ public final class McpServerFactory implements McpStreamFactory
                 if (decodableJson != null)
                 {
                     final int delta = (int) (decodableJson.getLocation().getStreamOffset() - decodedParserProgress);
-                    final DirectBufferInputStreamEx input = inputRO;
-                    input.wrap(buffer, offset + delta, limit - offset - delta);
+                    decodableJson.wrap(buffer, offset + delta, limit - offset - delta);
                 }
 
                 decodeNet(traceId, authorization, budgetId, reserved, buffer, offset, limit);

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -76,7 +76,6 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.SignalFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.WindowFW;
 import io.aklivity.zilla.runtime.common.json.DirectBufferInputStreamEx;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
-import io.aklivity.zilla.runtime.common.json.JsonParserEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
@@ -283,8 +282,7 @@ public final class McpServerFactory implements McpStreamFactory
         this.encodeMax = encodePool.slotCapacity();
         this.sessionIdAttempts = config.sessionIdAttempts();
         this.sessions = new Object2ObjectHashMap<>();
-        this.parserFactory = JsonEx.createParserFactory(Map.of(
-            JsonParserEx.TOKEN_MAX_BYTES, decodeMax));
+        this.parserFactory = JsonEx.createParserFactory(Map.of());
     }
 
     @Override

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -23,7 +23,6 @@ import static java.lang.Integer.toUnsignedLong;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.LongUnaryOperator;
@@ -227,14 +226,6 @@ public final class McpServerFactory implements McpStreamFactory
 
     private final DirectBufferInputStreamEx inputRO = new DirectBufferInputStreamEx();
 
-    private static final List<String> SERVER_JSON_PATH_INCLUDES = List.of(
-        "/jsonrpc",
-        "/id",
-        "/method",
-        "/params/name",
-        "/params/uri",
-        "/params/_meta/progressToken",
-        "/result/action");
     private final JsonParserFactory parserFactory;
 
     private final McpServerDecoder decodeJsonRpc = this::decodeJsonRpc;
@@ -293,7 +284,6 @@ public final class McpServerFactory implements McpStreamFactory
         this.sessionIdAttempts = config.sessionIdAttempts();
         this.sessions = new Object2ObjectHashMap<>();
         this.parserFactory = JsonEx.createParserFactory(Map.of(
-            JsonParserEx.PATH_INCLUDES, SERVER_JSON_PATH_INCLUDES,
             JsonParserEx.TOKEN_MAX_BYTES, decodeMax));
     }
 

--- a/runtime/common-json/README.md
+++ b/runtime/common-json/README.md
@@ -13,9 +13,9 @@ keeps parse, transform, and serialize on a single pass with no intermediate DOM.
 `wrap(buffer, offset, length)`, then driven with the standard `hasNext()` / `next()`. It also
 implements `jakarta.json.stream.JsonParser`, so `JsonEx.createParser(in)` works anywhere a
 one-shot pull parser is expected. Every value is readable on demand (decoded lazily via
-`getString()`, or spliced verbatim via `getSegment()`); `TOKEN_MAX_BYTES` bounds a single value to
-the caller's slot, delivering anything larger as `deferredBytes()` fragments rather than buffering
-it whole.
+`getString()`, or spliced verbatim via `getSegment()`); the input window (`wrap`/`feed`) is the
+fragmentation bound — a value that fits the window is delivered whole, while one that fills the
+window is delivered as `deferredBytes()` fragments rather than buffered whole.
 
 ```java
 JsonParserEx parser = JsonEx.createParser().wrap(buffer, offset, length);

--- a/runtime/common-json/README.md
+++ b/runtime/common-json/README.md
@@ -12,9 +12,10 @@ keeps parse, transform, and serialize on a single pass with no intermediate DOM.
 `JsonEx.createParser()` returns a resumable pull cursor fed one frame at a time via
 `wrap(buffer, offset, length)`, then driven with the standard `hasNext()` / `next()`. It also
 implements `jakarta.json.stream.JsonParser`, so `JsonEx.createParser(in)` works anywhere a
-one-shot pull parser is expected. `PATH_INCLUDES` / `PATH_EXCLUDES` config bounds which paths are
-materialized (so deep values can be scanned and discarded without allocating), and `TOKEN_MAX_BYTES`
-fails fast on a single value that cannot make progress under reset semantics.
+one-shot pull parser is expected. Every value is readable on demand (decoded lazily via
+`getString()`, or spliced verbatim via `getSegment()`); `TOKEN_MAX_BYTES` bounds a single value to
+the caller's slot, delivering anything larger as `deferredBytes()` fragments rather than buffering
+it whole.
 
 ```java
 JsonParserEx parser = JsonEx.createParser().wrap(buffer, offset, length);

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonEx.java
@@ -58,9 +58,8 @@ public final class JsonEx
     }
 
     /**
-     * Variant of {@link #createParser()} taking parser config (e.g. {@link JsonParserEx#TOKEN_MAX_BYTES});
-     * the returned parser starts empty and is fed via {@link
-     * JsonParserEx#wrap(org.agrona.DirectBuffer, int, int)}.
+     * Variant of {@link #createParser()} taking parser config; the returned parser starts empty and is
+     * fed via {@link JsonParserEx#wrap(org.agrona.DirectBuffer, int, int)}.
      */
     public static JsonParserEx createParser(
         Map<String, ?> config)

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonEx.java
@@ -58,8 +58,8 @@ public final class JsonEx
     }
 
     /**
-     * Variant of {@link #createParser()} taking parser config (e.g. {@link JsonParserEx#PATH_INCLUDES},
-     * {@link JsonParserEx#TOKEN_MAX_BYTES}); the returned parser starts empty and is fed via {@link
+     * Variant of {@link #createParser()} taking parser config (e.g. {@link JsonParserEx#TOKEN_MAX_BYTES});
+     * the returned parser starts empty and is fed via {@link
      * JsonParserEx#wrap(org.agrona.DirectBuffer, int, int)}.
      */
     public static JsonParserEx createParser(

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonEx.java
@@ -24,6 +24,7 @@ import io.aklivity.zilla.runtime.common.json.internal.JsonGeneratorImpl;
 import io.aklivity.zilla.runtime.common.json.internal.JsonParserFactoryImpl;
 import io.aklivity.zilla.runtime.common.json.internal.JsonParserImpl;
 import io.aklivity.zilla.runtime.common.json.internal.JsonProjectorImpl;
+import io.aklivity.zilla.runtime.common.json.internal.JsonSinkImpl;
 import io.aklivity.zilla.runtime.common.json.internal.JsonStreamImpl;
 
 /**
@@ -99,6 +100,30 @@ public final class JsonEx
         Map<String, ?> config)
     {
         return new JsonGeneratorImpl(config);
+    }
+
+    /**
+     * Returns a terminal {@link JsonSink} that materializes each fed event into the corresponding
+     * {@code writeXxx} call on {@code generator} (structured delivery). The supplied generator must
+     * already be wrapped over its target buffer; reuse a single instance per worker thread.
+     */
+    public static JsonSink createSink(
+        JsonGeneratorEx generator)
+    {
+        return new JsonSinkImpl(generator);
+    }
+
+    /**
+     * Variant of {@link #createSink(JsonGeneratorEx)} taking sink config; the {@link JsonSink#DELIVERY}
+     * key selects the {@link JsonSink.Delivery} mode (absent ⇒ {@link JsonSink.Delivery#STRUCTURED}).
+     */
+    public static JsonSink createSink(
+        JsonGeneratorEx generator,
+        Map<String, ?> config)
+    {
+        final Object delivery = config.get(JsonSink.DELIVERY);
+        return new JsonSinkImpl(generator,
+            delivery instanceof JsonSink.Delivery mode ? mode : JsonSink.Delivery.STRUCTURED);
     }
 
     /**

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEx.java
@@ -170,6 +170,30 @@ public interface JsonGeneratorEx extends JsonGenerator
     JsonGeneratorEx write(
         CharSequence value);
 
+    /**
+     * Whether a {@link #write(CharSequence, Completion)} call finishes the string value or leaves it
+     * open for further fragments.
+     */
+    enum Completion
+    {
+        COMPLETE,
+        INCOMPLETE
+    }
+
+    /**
+     * Writes a string value that may arrive in fragments. The generator owns the surrounding quotes
+     * and escaping: the opening quote is emitted before the first fragment, each fragment's chars are
+     * escaped and encoded as they are read, and the closing quote is emitted when {@code completion} is
+     * {@link Completion#COMPLETE}. Pass {@link Completion#INCOMPLETE} while the source reports more
+     * deferred bytes so a value delivered across several fragments forms a single quoted string without
+     * the caller concatenating. {@code write(value, COMPLETE)} is equivalent to
+     * {@link #write(CharSequence)}. The {@link Completion} argument disambiguates this overload from the
+     * inherited {@code write(String, boolean)} key/value pair when the value is a {@code String}.
+     */
+    JsonGeneratorEx write(
+        CharSequence value,
+        Completion completion);
+
     @Override
     JsonGeneratorEx write(
         BigDecimal value);

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEx.java
@@ -106,6 +106,18 @@ public interface JsonGeneratorEx extends JsonGenerator
         CharSequence literal);
 
     /**
+     * Emits a numeric literal that may arrive in fragments. The leading structural separator is emitted
+     * before the first fragment; each fragment's lexeme chars are appended verbatim (numbers carry no
+     * quoting or trailing delimiter). Pass {@link Completion#INCOMPLETE} while the source reports more
+     * deferred bytes and {@link Completion#COMPLETE} on the final fragment, so a number delivered across
+     * several windows forms one literal without the caller concatenating.
+     * {@code writeNumber(literal, COMPLETE)} is equivalent to {@link #writeNumber(CharSequence)}.
+     */
+    JsonGeneratorEx writeNumber(
+        CharSequence literal,
+        Completion completion);
+
+    /**
      * Splices a pre-encoded JSON value from {@code source} verbatim as the next value, with no
      * re-encoding.
      */

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonParserEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonParserEx.java
@@ -30,31 +30,13 @@ import org.agrona.DirectBuffer;
 public interface JsonParserEx extends JsonParser
 {
     /**
-     * Config key whose value is a {@code List<String>} of JSON Pointer (RFC 6901) syntax
-     * identifying document paths whose values must be readable via {@link JsonParser#getString()}
-     * after the corresponding event. The convention {@code -} as an array-index segment is treated
-     * as a wildcard matching any index (parser-internal extension to RFC 6901).
+     * Config key whose value is an {@code Integer} bounding the decoded bytes a single value may reach
+     * before the parser delivers it as a sequence of fragments rather than buffering it whole: each
+     * fragment carries the chars that fit the bound and {@code deferredBytes()} stays {@code true} until
+     * the value completes. Set to the caller's slot capacity so values larger than the slot are
+     * fragmented rather than forcing whole-value reassembly.
      * <p>
-     * Defaults to "every path included" when absent. When specified, only listed paths
-     * (minus any matched by {@link #PATH_EXCLUDES}) are readable; values at all other
-     * paths are scanned and discarded, and {@code getString()} on those throws.
-     */
-    String PATH_INCLUDES = "io.aklivity.zilla.runtime.common.json.path.includes";
-
-    /**
-     * Config key whose value is a {@code List<String>} of JSON Pointer (RFC 6901) syntax
-     * identifying document paths whose values are NOT required to be readable, even if
-     * matched by {@link #PATH_INCLUDES}. Excludes have final veto.
-     */
-    String PATH_EXCLUDES = "io.aklivity.zilla.runtime.common.json.path.excludes";
-
-    /**
-     * Config key whose value is an {@code Integer} bounding the number of bytes the parser
-     * will scan for a single included value before throwing {@link
-     * jakarta.json.stream.JsonParsingException}. Set to the caller's slot capacity to fail
-     * fast on values that cannot make progress under reset semantics.
-     * <p>
-     * Defaults to unbounded (no enforcement) when absent.
+     * Defaults to unbounded (never fragment) when absent.
      */
     String TOKEN_MAX_BYTES = "io.aklivity.zilla.runtime.common.json.token.max.bytes";
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonParserEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonParserEx.java
@@ -30,20 +30,17 @@ import org.agrona.DirectBuffer;
 public interface JsonParserEx extends JsonParser
 {
     /**
-     * Config key whose value is an {@code Integer} bounding the decoded bytes a single value may reach
-     * before the parser delivers it as a sequence of fragments rather than buffering it whole: each
-     * fragment carries the chars that fit the bound and {@code deferredBytes()} stays {@code true} until
-     * the value completes. Set to the caller's slot capacity so values larger than the slot are
-     * fragmented rather than forcing whole-value reassembly.
+     * Borrows {@code buffer} as the input window for the next pump, starting at {@code offset} for
+     * {@code length} bytes. The buffer is read in place for the duration of the pump.
      * <p>
-     * Defaults to unbounded (never fragment) when absent.
-     */
-    String TOKEN_MAX_BYTES = "io.aklivity.zilla.runtime.common.json.token.max.bytes";
-
-    /**
-     * Borrows {@code buffer} as the input for the next pump, starting at {@code offset} for {@code length}
-     * bytes. The buffer is read in place for the duration of the pump; resume state carried in the parser
-     * bridges values that span frames.
+     * The window is also the fragmentation bound: a value that fits the window is delivered whole; a
+     * value whose own bytes fill the window without completing is delivered as fragments — the same
+     * structured event repeated with {@code deferredBytes()} {@code true} until the value completes.
+     * The caller carries any unconsumed tail (up to {@code position()}) into the next window, so a
+     * value that merely straddles a window boundary is reassembled whole. Consequently a single whole
+     * {@code getString()} and {@code getInt()}/{@code getLong()} are valid only for a value that fits
+     * one window; a larger value is read by accumulating {@code getString()} fragments (or splicing
+     * {@code getSegment()}), and a fragmented number via {@code getBigDecimal()}/{@code getBigInteger()}.
      */
     JsonParserEx wrap(
         DirectBuffer buffer,

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonPipeline.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonPipeline.java
@@ -70,4 +70,12 @@ public interface JsonPipeline
         int offset,
         int length,
         boolean last);
+
+    /**
+     * The aggregate count of input bytes consumed since {@link #reset()} — the watermark up to which the
+     * caller may drop bytes before re-presenting the remainder. Advances on {@link Status#STARVED} (a
+     * partial trailing unit, e.g. a multibyte character split across a frame, is left unconsumed for the
+     * caller to carry); held steady while {@link Status#SUSPENDED}.
+     */
+    long position();
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSink.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSink.java
@@ -28,13 +28,18 @@ public interface JsonSink
 {
     /**
      * Delivery mode a terminal sink requests. {@link #STRUCTURED} consumes structured events and
-     * renders normalized output; {@link #SEGMENTABLE} opts in to verbatim segment delivery for kept
-     * values (best-effort, demand-gated) by calling {@link JsonController#segmentable()}.
+     * renders output by splicing each value's verbatim token bytes (chunked across bounded output);
+     * {@link #SEGMENTABLE} opts in to verbatim segment delivery for kept values (best-effort,
+     * demand-gated) by calling {@link JsonController#segmentable()}; {@link #DECODED} renders each
+     * scalar from its decoded {@code getString()} via {@link JsonGeneratorEx#write(CharSequence,
+     * boolean)}, letting the generator own quoting/escaping so a value delivered as fragments forms a
+     * single string without the sink concatenating.
      */
     enum Delivery
     {
         STRUCTURED,
-        SEGMENTABLE
+        SEGMENTABLE,
+        DECODED
     }
 
     JsonPipeline.Status feed(

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSink.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSink.java
@@ -14,8 +14,6 @@
  */
 package io.aklivity.zilla.runtime.common.json;
 
-import io.aklivity.zilla.runtime.common.json.internal.JsonSinkImpl;
-
 /**
  * The consume end of a {@link JsonStream} pipeline. Each {@link #feed(JsonController, JsonSource, JsonEvent)}
  * delivers one event (with {@code source} positioned to read its scalar, or its bytes when the event is
@@ -26,6 +24,12 @@ import io.aklivity.zilla.runtime.common.json.internal.JsonSinkImpl;
  */
 public interface JsonSink
 {
+    /**
+     * Config key (for {@link JsonEx#createSink(JsonGeneratorEx, java.util.Map)}) whose value is the
+     * {@link Delivery} mode the terminal sink requests; absent ⇒ {@link Delivery#STRUCTURED}.
+     */
+    String DELIVERY = "io.aklivity.zilla.runtime.common.json.sink.delivery";
+
     /**
      * Delivery mode a terminal sink requests. {@link #STRUCTURED} consumes structured events and
      * renders output by splicing each value's verbatim token bytes (chunked across bounded output);
@@ -64,27 +68,5 @@ public interface JsonSink
 
     default void reset()
     {
-    }
-
-    /**
-     * A terminal sink that materializes each fed event into the corresponding {@code writeXxx} call on
-     * {@code generator}. The supplied generator must already be wrapped over its target buffer.
-     */
-    static JsonSink of(
-        JsonGeneratorEx generator)
-    {
-        return new JsonSinkImpl(generator);
-    }
-
-    /**
-     * A terminal sink with the given {@link Delivery} mode: {@link Delivery#SEGMENTABLE} opts in to
-     * verbatim segment delivery for kept values; {@link Delivery#STRUCTURED} renders normalized
-     * structured output. The supplied generator must already be wrapped over its target buffer.
-     */
-    static JsonSink of(
-        JsonGeneratorEx generator,
-        Delivery delivery)
-    {
-        return new JsonSinkImpl(generator, delivery);
     }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -58,6 +58,7 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     private int consumed;
     private boolean afterKey;
     private boolean stringOpen;
+    private boolean numberOpen;
 
     public JsonGeneratorImpl()
     {
@@ -105,6 +106,7 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         this.depth = 0;
         this.afterKey = false;
         this.stringOpen = false;
+        this.numberOpen = false;
     }
 
     @Override
@@ -404,6 +406,24 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     {
         preValue();
         writeAscii(literal);
+        return this;
+    }
+
+    @Override
+    public JsonGeneratorImpl writeNumber(
+        CharSequence literal,
+        Completion completion)
+    {
+        if (!numberOpen)
+        {
+            preValue();
+            numberOpen = true;
+        }
+        writeAscii(literal);
+        if (completion == Completion.COMPLETE)
+        {
+            numberOpen = false;
+        }
         return this;
     }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -56,9 +56,9 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     private int limit;
     private int depth;
     private int consumed;
-    private boolean afterKey;
-    private boolean stringOpen;
-    private boolean numberOpen;
+    // at most one of these positions holds at a time: a value is expected after a key, or an
+    // incomplete string/number fragment is open awaiting its remaining fragments
+    private Pending pending = Pending.NONE;
 
     public JsonGeneratorImpl()
     {
@@ -104,9 +104,7 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     public void reset()
     {
         this.depth = 0;
-        this.afterKey = false;
-        this.stringOpen = false;
-        this.numberOpen = false;
+        this.pending = Pending.NONE;
     }
 
     @Override
@@ -167,7 +165,7 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         hasMembers[depth - 1] = true;
         writeString(name);
         putByte.accept(':');
-        afterKey = true;
+        pending = Pending.AFTER_KEY;
         return this;
     }
 
@@ -200,17 +198,17 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         CharSequence value,
         Completion completion)
     {
-        if (!stringOpen)
+        if (pending != Pending.STRING)
         {
             preValue();
             putByte.accept('"');
-            stringOpen = true;
+            pending = Pending.STRING;
         }
         writeStringBody(value);
         if (completion == Completion.COMPLETE)
         {
             putByte.accept('"');
-            stringOpen = false;
+            pending = Pending.NONE;
         }
         return this;
     }
@@ -414,15 +412,15 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         CharSequence literal,
         Completion completion)
     {
-        if (!numberOpen)
+        if (pending != Pending.NUMBER)
         {
             preValue();
-            numberOpen = true;
+            pending = Pending.NUMBER;
         }
         writeAscii(literal);
         if (completion == Completion.COMPLETE)
         {
-            numberOpen = false;
+            pending = Pending.NONE;
         }
         return this;
     }
@@ -465,14 +463,14 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         inArray[depth] = array;
         hasMembers[depth] = false;
         depth++;
-        afterKey = false;
+        pending = Pending.NONE;
     }
 
     private void preValue()
     {
-        if (afterKey)
+        if (pending == Pending.AFTER_KEY)
         {
-            afterKey = false;
+            pending = Pending.NONE;
         }
         else if (depth > 0 && inArray[depth - 1])
         {
@@ -713,5 +711,13 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
             DirectBuffer source,
             int index,
             int length);
+    }
+
+    private enum Pending
+    {
+        NONE,
+        AFTER_KEY,
+        STRING,
+        NUMBER
     }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -28,6 +28,7 @@ import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
+import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx.Completion;
 
 /**
  * Streaming, compact {@link JsonGeneratorEx} that writes directly into a {@link
@@ -56,6 +57,7 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     private int depth;
     private int consumed;
     private boolean afterKey;
+    private boolean stringOpen;
 
     public JsonGeneratorImpl()
     {
@@ -102,6 +104,7 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     {
         this.depth = 0;
         this.afterKey = false;
+        this.stringOpen = false;
     }
 
     @Override
@@ -187,6 +190,26 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     {
         preValue();
         writeString(value);
+        return this;
+    }
+
+    @Override
+    public JsonGeneratorImpl write(
+        CharSequence value,
+        Completion completion)
+    {
+        if (!stringOpen)
+        {
+            preValue();
+            putByte.accept('"');
+            stringOpen = true;
+        }
+        writeStringBody(value);
+        if (completion == Completion.COMPLETE)
+        {
+            putByte.accept('"');
+            stringOpen = false;
+        }
         return this;
     }
 
@@ -445,6 +468,13 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         CharSequence value)
     {
         putByte.accept('"');
+        writeStringBody(value);
+        putByte.accept('"');
+    }
+
+    private void writeStringBody(
+        CharSequence value)
+    {
         int index = 0;
         int length = value.length();
         while (index < length)
@@ -493,7 +523,6 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
                 break;
             }
         }
-        putByte.accept('"');
     }
 
     private void writeUtf8(

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.util.AbstractMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -88,8 +87,6 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         this.ownedInput = new DirectBufferInputStreamEx();
         this.in = ownedInput;
         this.tokenizer = new JsonTokenizer(
-            pathList(config, JsonParserEx.PATH_INCLUDES),
-            pathList(config, JsonParserEx.PATH_EXCLUDES),
             tokenMaxBytes(config));
         this.location = new JsonLocationImpl(tokenizer);
     }
@@ -113,8 +110,6 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         // A DirectBufferInputStreamEx is a resumable frame source whose EOF is a frame boundary;
         // any other stream is one-shot, so its EOF is the terminal delimiter for a trailing number.
         this.tokenizer = new JsonTokenizer(
-            pathList(config, JsonParserEx.PATH_INCLUDES),
-            pathList(config, JsonParserEx.PATH_EXCLUDES),
             tokenMaxBytes(config),
             !(in instanceof DirectBufferInputStreamEx));
         this.location = new JsonLocationImpl(tokenizer);
@@ -372,13 +367,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     @Override
     public String getString()
     {
-        final String value = tokenizer.stringValue();
-        if (value == null && !tokenizer.valueReadable())
-        {
-            throw new IllegalStateException("value not readable; configure path via " +
-                "JsonParserEx.PATH_INCLUDES (or remove from PATH_EXCLUDES)");
-        }
-        return value;
+        return tokenizer.stringValue();
     }
 
     @Override
@@ -629,14 +618,6 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
             }
             return advanced;
         }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static List<String> pathList(
-        Map<String, ?> config,
-        String key)
-    {
-        return (List<String>) config.get(key);
     }
 
     private static int tokenMaxBytes(

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -383,38 +383,51 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     @Override
     public boolean isIntegralNumber()
     {
-        String v = tokenizer.stringValue();
+        final CharSequence v = numberLexeme();
         if (v == null)
         {
             throw new IllegalStateException("Not a number");
         }
-        for (int i = 0; i < v.length(); i++)
+        boolean integral = true;
+        for (int i = 0; integral && i < v.length(); i++)
         {
-            char c = v.charAt(i);
-            if (c == '.' || c == 'e' || c == 'E')
-            {
-                return false;
-            }
+            final char c = v.charAt(i);
+            integral = c != '.' && c != 'e' && c != 'E';
         }
-        return true;
+        return integral;
     }
 
     @Override
     public int getInt()
     {
+        if (tokenizer.numberFragmented())
+        {
+            throw new IllegalStateException("number spans multiple windows; use getBigDecimal()");
+        }
         return Integer.parseInt(tokenizer.stringValue());
     }
 
     @Override
     public long getLong()
     {
+        if (tokenizer.numberFragmented())
+        {
+            throw new IllegalStateException("number spans multiple windows; use getBigDecimal()");
+        }
         return Long.parseLong(tokenizer.stringValue());
     }
 
     @Override
     public BigDecimal getBigDecimal()
     {
-        return new BigDecimal(tokenizer.stringValue());
+        return new BigDecimal(numberLexeme().toString());
+    }
+
+    // The current number's full lexeme: a fragmented number's is accumulated in the tokenizer across
+    // its fragments; an unfragmented one is the current scratch value.
+    private CharSequence numberLexeme()
+    {
+        return tokenizer.numberFragmented() ? tokenizer.numberLexeme() : tokenizer.stringValue();
     }
 
     @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -86,8 +86,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     {
         this.ownedInput = new DirectBufferInputStreamEx();
         this.in = ownedInput;
-        this.tokenizer = new JsonTokenizer(
-            tokenMaxBytes(config));
+        this.tokenizer = new JsonTokenizer();
         this.location = new JsonLocationImpl(tokenizer);
     }
 
@@ -110,7 +109,6 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         // A DirectBufferInputStreamEx is a resumable frame source whose EOF is a frame boundary;
         // any other stream is one-shot, so its EOF is the terminal delimiter for a trailing number.
         this.tokenizer = new JsonTokenizer(
-            tokenMaxBytes(config),
             !(in instanceof DirectBufferInputStreamEx));
         this.location = new JsonLocationImpl(tokenizer);
     }
@@ -122,6 +120,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         int length)
     {
         frameBaseStreamOffset = tokenizer.streamOffset();
+        tokenizer.window(length);
         ownedInput.wrap(buffer, offset, length);
         return this;
     }
@@ -625,10 +624,4 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         }
     }
 
-    private static int tokenMaxBytes(
-        Map<String, ?> config)
-    {
-        final Object raw = config.get(JsonParserEx.TOKEN_MAX_BYTES);
-        return raw == null ? Integer.MAX_VALUE : ((Number) raw).intValue();
-    }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -139,6 +139,11 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         return wrap(buffer, offset, length);
     }
 
+    public long position()
+    {
+        return tokenizer.streamOffset();
+    }
+
     void reset()
     {
         tokenizer.reset();

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -361,7 +361,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     @Override
     public boolean deferredBytes()
     {
-        return segmentState == SegmentState.SCANNING;
+        return segmentState == SegmentState.SCANNING || tokenizer.fragmenting();
     }
 
     @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
@@ -51,6 +51,12 @@ public final class JsonPipelineImpl implements JsonPipeline
     }
 
     @Override
+    public long position()
+    {
+        return parser.position();
+    }
+
+    @Override
     public Status feed(
         DirectBuffer buffer,
         int offset,

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -158,13 +158,14 @@ public final class JsonSinkImpl implements JsonSink
         JsonEvent event)
     {
         final boolean deferred = source.deferredBytes();
+        final Completion completion = deferred ? Completion.INCOMPLETE : Completion.COMPLETE;
         if (event == JsonEvent.VALUE_NUMBER)
         {
-            generator.writeNumber(source.getString());
+            generator.writeNumber(source.getString(), completion);
         }
         else
         {
-            generator.write(source.getString(), deferred ? Completion.INCOMPLETE : Completion.COMPLETE);
+            generator.write(source.getString(), completion);
         }
         return deferred ? Status.ADVANCED : scalarStatus();
     }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -19,6 +19,7 @@ import org.agrona.DirectBuffer;
 import io.aklivity.zilla.runtime.common.json.JsonController;
 import io.aklivity.zilla.runtime.common.json.JsonEvent;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
+import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx.Completion;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
 import io.aklivity.zilla.runtime.common.json.JsonSink;
 import io.aklivity.zilla.runtime.common.json.JsonSink.Delivery;
@@ -87,15 +88,24 @@ public final class JsonSinkImpl implements JsonSink
         case VALUE_STRING:
         case VALUE_NUMBER:
         case SEGMENT:
-            // splice the kept leaf's raw token bytes verbatim, fragmenting across chunks; the value's
-            // leading separator is emitted once, before its first content byte
-            segment = source.getSegment();
-            if (!valueStarted)
+            if (delivery == Delivery.DECODED && event != JsonEvent.SEGMENT)
             {
-                generator.writeRaw(segment, 0, 0);
-                valueStarted = true;
+                // render from the decoded value; the generator owns quoting/escaping and joins
+                // fragments (deferredBytes) into one string, so the sink does no concatenation
+                status = writeDecoded(source, event);
             }
-            status = writeChunk(segment, source);
+            else
+            {
+                // splice the kept leaf's raw token bytes verbatim, fragmenting across chunks; the value's
+                // leading separator is emitted once, before its first content byte
+                segment = source.getSegment();
+                if (!valueStarted)
+                {
+                    generator.writeRaw(segment, 0, 0);
+                    valueStarted = true;
+                }
+                status = writeChunk(segment, source);
+            }
             break;
         case VALUE_TRUE:
             generator.write(true);
@@ -141,6 +151,22 @@ public final class JsonSinkImpl implements JsonSink
         valueStarted = false;
         pendingSegment = false;
         generator.reset();
+    }
+
+    private Status writeDecoded(
+        JsonSource source,
+        JsonEvent event)
+    {
+        final boolean deferred = source.deferredBytes();
+        if (event == JsonEvent.VALUE_NUMBER)
+        {
+            generator.writeNumber(source.getString());
+        }
+        else
+        {
+            generator.write(source.getString(), deferred ? Completion.INCOMPLETE : Completion.COMPLETE);
+        }
+        return deferred ? Status.ADVANCED : scalarStatus();
     }
 
     private Status writeChunk(

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonStrings.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonStrings.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json.internal;
+
+import jakarta.json.stream.JsonParsingException;
+
+import org.agrona.DirectBuffer;
+
+// Decodes the raw body of a JSON string (the bytes between the surrounding quotes, escapes and
+// UTF-8 intact) into a StringBuilder, applying JSON unescaping. The tokenizer validates the body
+// during the scan, so this slice-based decode assumes well-formed input and exists to materialize a
+// value lazily on demand without retaining decoded chars during the scan.
+final class JsonStrings
+{
+    private JsonStrings()
+    {
+    }
+
+    static void unescape(
+        DirectBuffer buffer,
+        int offset,
+        int length,
+        StringBuilder out)
+    {
+        final int limit = offset + length;
+        int index = offset;
+        while (index < limit)
+        {
+            final int c = buffer.getByte(index) & 0xff;
+            index++;
+            if (c == '\\')
+            {
+                index = unescapeEscape(buffer, index, out);
+            }
+            else if (c < 0x80)
+            {
+                out.append((char) c);
+            }
+            else
+            {
+                index = appendUtf8(buffer, index, c, out);
+            }
+        }
+    }
+
+    private static int unescapeEscape(
+        DirectBuffer buffer,
+        int index,
+        StringBuilder out)
+    {
+        int progress = index;
+        final int e = buffer.getByte(progress) & 0xff;
+        progress++;
+        switch (e)
+        {
+        case '"':
+            out.append('"');
+            break;
+        case '\\':
+            out.append('\\');
+            break;
+        case '/':
+            out.append('/');
+            break;
+        case 'b':
+            out.append('\b');
+            break;
+        case 'f':
+            out.append('\f');
+            break;
+        case 'n':
+            out.append('\n');
+            break;
+        case 'r':
+            out.append('\r');
+            break;
+        case 't':
+            out.append('\t');
+            break;
+        case 'u':
+            int value = 0;
+            for (int k = 0; k < 4; k++)
+            {
+                value = (value << 4) | hexDigit(buffer.getByte(progress) & 0xff);
+                progress++;
+            }
+            out.append((char) value);
+            break;
+        default:
+            throw new JsonParsingException("Invalid escape: \\" + (char) e, null);
+        }
+        return progress;
+    }
+
+    private static int appendUtf8(
+        DirectBuffer buffer,
+        int index,
+        int first,
+        StringBuilder out)
+    {
+        int remaining;
+        int code;
+        if ((first & 0xe0) == 0xc0)
+        {
+            code = first & 0x1f;
+            remaining = 1;
+        }
+        else if ((first & 0xf0) == 0xe0)
+        {
+            code = first & 0x0f;
+            remaining = 2;
+        }
+        else if ((first & 0xf8) == 0xf0)
+        {
+            code = first & 0x07;
+            remaining = 3;
+        }
+        else
+        {
+            throw new JsonParsingException("Invalid UTF-8 lead byte: " + first, null);
+        }
+        int progress = index;
+        for (int k = 0; k < remaining; k++)
+        {
+            final int cont = buffer.getByte(progress) & 0xff;
+            progress++;
+            code = (code << 6) | (cont & 0x3f);
+        }
+        out.appendCodePoint(code);
+        return progress;
+    }
+
+    private static int hexDigit(
+        int c)
+    {
+        final int value;
+        if (c >= '0' && c <= '9')
+        {
+            value = c - '0';
+        }
+        else if (c >= 'a' && c <= 'f')
+        {
+            value = c - 'a' + 10;
+        }
+        else if (c >= 'A' && c <= 'F')
+        {
+            value = c - 'A' + 10;
+        }
+        else
+        {
+            throw new JsonParsingException("Invalid hex digit: " + c, null);
+        }
+        return value;
+    }
+}

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -51,14 +51,13 @@ public final class JsonTokenizer
     }
 
     private static final int MAX_DEPTH = 64;
-    // upper bound on the bytes of a single decoded unit (a UTF-8 char is at most 4 bytes, a
-    // backslash-u escape is 6); the fragment-boundary mark rewinds across at most one such unit
-    private static final int MAX_UNIT_BYTES = 8;
 
     private final Deque<ParseState> stack = new ArrayDeque<>();
     private final StringBuilder scratch = new StringBuilder();
-    private final int tokenMaxBytes;
     private boolean terminalEof;
+    // byte length of the current input window; a value whose own bytes reach this length without
+    // completing fills the window and is delivered as fragments rather than reassembled across windows.
+    private int windowLength = Integer.MAX_VALUE;
 
     // path tracking — pre-allocated, no per-event allocation
     private final boolean[] pathInArray = new boolean[MAX_DEPTH];
@@ -83,12 +82,11 @@ public final class JsonTokenizer
     // set while a segment scan is in progress: a value-string is then streamed across frames as raw
     // bytes (no rewind to require it whole-in-frame, no decoded retention) rather than buffered whole.
     private boolean segmenting;
-    // set while a value-string larger than tokenMaxBytes is being delivered as a sequence of
-    // fragments: each fragment carries the decoded chars that fit the slot, deferredBytes() stays true
-    // until the closing quote. A partial char/escape at a frame boundary is left unconsumed (rewound
-    // to unitStartOffset) for the caller's decode slot to re-present, so no partial state crosses wrap.
+    // set while a value-string that fills the input window is being delivered as a sequence of
+    // fragments: each fragment carries the decoded chars scanned so far, deferredBytes() stays true
+    // until the closing quote. A partial char/escape at a window boundary is left unconsumed (rewound
+    // to unitStartOffset) for the caller to re-present, so no partial state crosses a wrap.
     private boolean fragmenting;
-    private boolean stringComplete;
     private long unitStartOffset;
 
     // scalar resume state (valid when resumeOp != NONE)
@@ -100,13 +98,7 @@ public final class JsonTokenizer
 
     public JsonTokenizer()
     {
-        this(Integer.MAX_VALUE);
-    }
-
-    public JsonTokenizer(
-        int tokenMaxBytes)
-    {
-        this(tokenMaxBytes, false);
+        this(false);
     }
 
     // terminalEof distinguishes a one-shot stream (EOF is the final delimiter) from the chunked
@@ -114,10 +106,8 @@ public final class JsonTokenizer
     // only matters for numbers, which unlike strings and the true/false/null literals are not
     // self-terminating and need a following non-digit byte to know they have ended.
     public JsonTokenizer(
-        int tokenMaxBytes,
         boolean terminalEof)
     {
-        this.tokenMaxBytes = tokenMaxBytes;
         this.terminalEof = terminalEof;
         for (int i = 0; i < MAX_DEPTH; i++)
         {
@@ -138,7 +128,6 @@ public final class JsonTokenizer
         fragmentStart = 0;
         segmenting = false;
         fragmenting = false;
-        stringComplete = false;
         resumeOp = ResumeOp.NONE;
         resumeEscape = false;
         resumeUnicodePending = 0;
@@ -163,6 +152,14 @@ public final class JsonTokenizer
         this.terminalEof = terminalEof;
     }
 
+    // Set per input window: its byte length is the fragmentation bound — a value whose own bytes reach
+    // it without completing is delivered as fragments instead of reassembled across windows.
+    void window(
+        int length)
+    {
+        this.windowLength = length;
+    }
+
     public boolean advance(
         InputStream in) throws IOException
     {
@@ -181,13 +178,6 @@ public final class JsonTokenizer
 
         while (pendingEvent == null && state != ParseState.DOC_DONE)
         {
-            // Snapshot at the start of each iteration. On EOF mid-readable-scalar-scan we rewind
-            // to drop any partial scratch and let the caller retry once more bytes are appended.
-            // For other parse steps (KEY_NAME, structural separators, non-readable values) the
-            // existing internal-resume state carries across frames without needing rewind.
-            final long iterStart = streamOffset;
-            in.mark(tokenMaxBytes == Integer.MAX_VALUE ? Integer.MAX_VALUE : tokenMaxBytes);
-
             try
             {
                 if (resumeOp != ResumeOp.NONE)
@@ -205,44 +195,56 @@ public final class JsonTokenizer
                 {
                     return true;
                 }
-                // While segmenting, a value-string spanning the frame is not rewound — its resume state
-                // is kept so the next frame continues it and the raw bytes stream as segments.
-                final boolean midScalar =
-                    (resumeOp == ResumeOp.VALUE_STRING || resumeOp == ResumeOp.VALUE_NUMBER) && !segmenting;
-                boolean delivered = false;
-                if (midScalar && fragmenting && resumeOp == ResumeOp.VALUE_STRING)
-                {
-                    // mid-fragmentation: ship the chars accumulated so far and leave the partial unit's
-                    // bytes unconsumed (rewound to its start) for the decode slot to re-present.
-                    in.reset();
-                    streamOffset = unitStartOffset;
-                    resumeEscape = false;
-                    resumeUnicodePending = 0;
-                    resumeUnicodeValue = 0;
-                    if (scratch.length() > 0)
-                    {
-                        valueStreamStart = fragmentStart;
-                        valueStreamEnd = streamOffset;
-                        pendingEvent = JsonParser.Event.VALUE_STRING;
-                        pendingString = takeScratch();
-                        valuePending = false;
-                        delivered = true;
-                    }
-                }
-                else if (midScalar)
-                {
-                    in.reset();
-                    streamOffset = iterStart;
-                    scratch.setLength(0);
-                    resumeOp = ResumeOp.NONE;
-                    resumeEscape = false;
-                    resumeUnicodePending = 0;
-                    resumeUnicodeValue = 0;
-                }
-                return delivered;
+                return onScalarStarved();
             }
         }
         return true;
+    }
+
+    // The window was exhausted mid-scalar. A value-string whose own bytes fill the window (or one
+    // already fragmenting) ships its decoded-so-far as a fragment, leaving the partial unit for the
+    // caller to re-present via position(); a smaller value (or a number, or the terminal window) is
+    // rewound to its start so the caller carries it whole into a fuller next window. Keys and
+    // segmented value-strings keep their resume state and simply wait for more input. Returns true
+    // iff a fragment event was produced.
+    private boolean onScalarStarved()
+    {
+        final boolean midScalar =
+            (resumeOp == ResumeOp.VALUE_STRING || resumeOp == ResumeOp.VALUE_NUMBER) && !segmenting;
+        boolean delivered = false;
+        if (midScalar)
+        {
+            final long valueBytes = streamOffset - valueStreamStart;
+            final boolean fragmentString = resumeOp == ResumeOp.VALUE_STRING && !terminalEof &&
+                (fragmenting || valueBytes >= windowLength);
+            if (fragmentString)
+            {
+                streamOffset = unitStartOffset;
+                resumeEscape = false;
+                resumeUnicodePending = 0;
+                resumeUnicodeValue = 0;
+                fragmenting = true;
+                if (scratch.length() > 0)
+                {
+                    valueStreamStart = fragmentStart;
+                    valueStreamEnd = streamOffset;
+                    pendingEvent = JsonParser.Event.VALUE_STRING;
+                    pendingString = takeScratch();
+                    valuePending = false;
+                    delivered = true;
+                }
+            }
+            else
+            {
+                streamOffset = valueStreamStart;
+                scratch.setLength(0);
+                resumeOp = ResumeOp.NONE;
+                resumeEscape = false;
+                resumeUnicodePending = 0;
+                resumeUnicodeValue = 0;
+            }
+        }
+        return delivered;
     }
 
     public JsonParser.Event event()
@@ -454,27 +456,19 @@ public final class JsonTokenizer
         pendingString = null;
     }
 
-    // Completes a VALUE_STRING scan: a finished string (closing quote seen) is captured lazily and the
-    // parse state advances; a slot-bound fragment is materialized eagerly (freeing scratch for the next
-    // fragment) with the value left in progress so the next advance() continues it.
+    // Completes a VALUE_STRING scan: continueStringContent only returns here once the closing quote is
+    // seen (otherwise it throws EOFException and onScalarStarved decides fragment-vs-reassemble), so the
+    // string is whole — the final fragment of a fragmented value, or a value that fit one window. It is
+    // captured lazily and the parse state advances.
     private void finishStringValue()
     {
         valueStreamStart = fragmentStart;
         valueStreamEnd = streamOffset;
         pendingEvent = JsonParser.Event.VALUE_STRING;
-        if (stringComplete)
-        {
-            captureValue();
-            fragmenting = false;
-            resumeOp = ResumeOp.NONE;
-            afterValueConsumed();
-        }
-        else
-        {
-            pendingString = takeScratch();
-            valuePending = false;
-            fragmenting = true;
-        }
+        captureValue();
+        fragmenting = false;
+        resumeOp = ResumeOp.NONE;
+        afterValueConsumed();
     }
 
     private String takeScratch()
@@ -768,15 +762,13 @@ public final class JsonTokenizer
     private void continueStringContent(
         InputStream in) throws IOException
     {
-        stringComplete = false;
         while (true)
         {
-            // While fragmenting, mark each unit boundary so an EOF mid-char/escape rewinds here: the
-            // chars decoded so far ship as a fragment and the partial unit's bytes stay unconsumed for
-            // the decode slot to re-present on the next frame.
-            if (fragmenting && !resumeEscape && resumeUnicodePending == 0)
+            // Track each complete-unit boundary so an EOF mid-char/escape can rewind here: the chars
+            // decoded so far ship as a fragment and the partial unit's bytes stay unconsumed
+            // (position() reports unitStartOffset) for the caller to re-present on the next window.
+            if (!resumeEscape && resumeUnicodePending == 0)
             {
-                in.mark(MAX_UNIT_BYTES);
                 unitStartOffset = streamOffset;
             }
             int c = readByte(in);
@@ -824,7 +816,6 @@ public final class JsonTokenizer
             }
             else if (c == '"')
             {
-                stringComplete = true;
                 return;
             }
             else if (c == '\\')
@@ -842,12 +833,6 @@ public final class JsonTokenizer
             else
             {
                 appendCodePointScratch(decodeUtf8(in, c));
-            }
-            // suspend with a full fragment once a complete unit pushes scratch to the slot bound
-            if (!resumeEscape && resumeUnicodePending == 0 &&
-                tokenMaxBytes != Integer.MAX_VALUE && scratch.length() >= tokenMaxBytes)
-            {
-                return;
             }
         }
     }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -80,7 +80,6 @@ public final class JsonTokenizer
     // value returns [fragmentStart, valueStreamEnd] so each fragment's verbatim bytes splice back to
     // the whole token (fragment 1 includes the opening quote, the final fragment the closing quote)
     private long fragmentStart;
-    private boolean valueReadable = true;
     // set while a segment scan is in progress: a value-string is then streamed across frames as raw
     // bytes (no rewind to require it whole-in-frame, no decoded retention) rather than buffered whole.
     private boolean segmenting;
@@ -137,7 +136,6 @@ public final class JsonTokenizer
         valuePending = false;
         streamOffset = 0;
         fragmentStart = 0;
-        valueReadable = true;
         segmenting = false;
         fragmenting = false;
         stringComplete = false;
@@ -310,11 +308,6 @@ public final class JsonTokenizer
         return pathDepth > 0 && pathInArray[pathDepth - 1];
     }
 
-    public boolean valueReadable()
-    {
-        return valueReadable;
-    }
-
     // True while a value-string is being delivered in fragments and more fragments follow the current
     // event; drives the parser's deferredBytes() for over-slot scalars.
     public boolean fragmenting()
@@ -428,7 +421,7 @@ public final class JsonTokenizer
         case VALUE_NUMBER:
             continueNumberContent(in);
             pendingEvent = JsonParser.Event.VALUE_NUMBER;
-            captureValue(valueReadable);
+            captureValue();
             resumeOp = ResumeOp.NONE;
             afterValueConsumed();
             break;
@@ -455,10 +448,9 @@ public final class JsonTokenizer
         }
     }
 
-    private void captureValue(
-        boolean readable)
+    private void captureValue()
     {
-        valuePending = readable;
+        valuePending = true;
         pendingString = null;
     }
 
@@ -472,7 +464,7 @@ public final class JsonTokenizer
         pendingEvent = JsonParser.Event.VALUE_STRING;
         if (stringComplete)
         {
-            captureValue(valueReadable);
+            captureValue();
             fragmenting = false;
             resumeOp = ResumeOp.NONE;
             afterValueConsumed();
@@ -568,7 +560,6 @@ public final class JsonTokenizer
         InputStream in,
         int c) throws IOException
     {
-        valueReadable = true;
         switch (c)
         {
         case '{':
@@ -620,15 +611,12 @@ public final class JsonTokenizer
             {
                 valueStreamStart = streamOffset - 1;
                 scratch.setLength(0);
-                if (valueReadable)
-                {
-                    scratch.append((char) c);
-                }
+                scratch.append((char) c);
                 resumeOp = ResumeOp.VALUE_NUMBER;
                 continueNumberContent(in);
                 valueStreamEnd = streamOffset;
                 pendingEvent = JsonParser.Event.VALUE_NUMBER;
-                captureValue(valueReadable);
+                captureValue();
                 resumeOp = ResumeOp.NONE;
                 afterValueConsumed();
             }
@@ -647,8 +635,6 @@ public final class JsonTokenizer
         {
             throw new JsonParsingException("Expected '\"' for key but got: " + describe(c), null);
         }
-        // keys must always be readable so path matching can compare them
-        valueReadable = true;
         scratch.setLength(0);
         resumeEscape = false;
         resumeUnicodePending = 0;
@@ -869,7 +855,7 @@ public final class JsonTokenizer
     private void appendScratch(
         char c)
     {
-        if (valueReadable && !streamingValue())
+        if (!streamingValue())
         {
             scratch.append(c);
         }
@@ -878,7 +864,7 @@ public final class JsonTokenizer
     private void appendCodePointScratch(
         int codePoint)
     {
-        if (valueReadable && !streamingValue())
+        if (!streamingValue())
         {
             scratch.appendCodePoint(codePoint);
         }
@@ -976,61 +962,58 @@ public final class JsonTokenizer
         }
     }
 
-    // RFC 8259 number grammar: -?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][+-]?[0-9]+)?. Only enforced for
-    // readable values, where scratch holds the complete lexeme; filtered-out values are discarded.
+    // RFC 8259 number grammar: -?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][+-]?[0-9]+)?. scratch holds the
+    // complete lexeme (numbers are always retained in scratch for validation and lazy materialization).
     private void validateNumber()
     {
-        if (valueReadable)
+        final int length = scratch.length();
+        int index = 0;
+        boolean valid = length > 0;
+        if (valid && scratch.charAt(index) == '-')
         {
-            final int length = scratch.length();
-            int index = 0;
-            boolean valid = length > 0;
-            if (valid && scratch.charAt(index) == '-')
+            index++;
+        }
+        final int intStart = index;
+        if (index < length && scratch.charAt(index) == '0')
+        {
+            index++;
+        }
+        else
+        {
+            while (index < length && isDigit(scratch.charAt(index)))
             {
                 index++;
             }
-            final int intStart = index;
-            if (index < length && scratch.charAt(index) == '0')
+        }
+        valid &= index > intStart;
+        if (valid && index < length && scratch.charAt(index) == '.')
+        {
+            index++;
+            final int fracStart = index;
+            while (index < length && isDigit(scratch.charAt(index)))
             {
                 index++;
             }
-            else
-            {
-                while (index < length && isDigit(scratch.charAt(index)))
-                {
-                    index++;
-                }
-            }
-            valid &= index > intStart;
-            if (valid && index < length && scratch.charAt(index) == '.')
+            valid &= index > fracStart;
+        }
+        if (valid && index < length && (scratch.charAt(index) == 'e' || scratch.charAt(index) == 'E'))
+        {
+            index++;
+            if (index < length && (scratch.charAt(index) == '+' || scratch.charAt(index) == '-'))
             {
                 index++;
-                final int fracStart = index;
-                while (index < length && isDigit(scratch.charAt(index)))
-                {
-                    index++;
-                }
-                valid &= index > fracStart;
             }
-            if (valid && index < length && (scratch.charAt(index) == 'e' || scratch.charAt(index) == 'E'))
+            final int expStart = index;
+            while (index < length && isDigit(scratch.charAt(index)))
             {
                 index++;
-                if (index < length && (scratch.charAt(index) == '+' || scratch.charAt(index) == '-'))
-                {
-                    index++;
-                }
-                final int expStart = index;
-                while (index < length && isDigit(scratch.charAt(index)))
-                {
-                    index++;
-                }
-                valid &= index > expStart;
             }
-            valid &= index == length;
-            if (!valid)
-            {
-                throw new JsonParsingException("Invalid JSON number: " + scratch, null);
-            }
+            valid &= index > expStart;
+        }
+        valid &= index == length;
+        if (!valid)
+        {
+            throw new JsonParsingException("Invalid JSON number: " + scratch, null);
         }
     }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -14,7 +14,6 @@
  */
 package io.aklivity.zilla.runtime.common.json.internal;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayDeque;
@@ -95,6 +94,10 @@ public final class JsonTokenizer
     // getLong() then throw (the value would overflow) and getBigDecimal() reads the accumulated lexeme.
     private boolean numberFragmented;
 
+    // set when a read hits the end of the current input window mid-token: the scan unwinds logically
+    // (no exception) and advance() routes to onScalarStarved; reset at the top of each advance()
+    private boolean starved;
+
     // scalar resume state (valid when resumeOp != NONE)
     private ResumeOp resumeOp = ResumeOp.NONE;
     private boolean resumeEscape;
@@ -136,6 +139,7 @@ public final class JsonTokenizer
         fragmentStart = 0;
         segmenting = false;
         fragmenting = false;
+        starved = false;
         resumeOp = ResumeOp.NONE;
         resumeEscape = false;
         resumeUnicodePending = 0;
@@ -171,6 +175,8 @@ public final class JsonTokenizer
     public boolean advance(
         InputStream in) throws IOException
     {
+        starved = false;
+
         if (state == ParseState.DOC_DONE)
         {
             if (terminalEof)
@@ -184,29 +190,24 @@ public final class JsonTokenizer
         pendingString = null;
         valuePending = false;
 
-        while (pendingEvent == null && state != ParseState.DOC_DONE)
+        boolean produced = true;
+        while (!starved && pendingEvent == null && state != ParseState.DOC_DONE)
         {
-            try
+            if (resumeOp != ResumeOp.NONE)
             {
-                if (resumeOp != ResumeOp.NONE)
-                {
-                    resumeScan(in);
-                }
-                else
-                {
-                    advanceOne(in);
-                }
+                resumeScan(in);
             }
-            catch (EOFException ex)
+            else
             {
-                if (pendingEvent != null)
-                {
-                    return true;
-                }
-                return onScalarStarved();
+                advanceOne(in);
             }
         }
-        return true;
+
+        if (starved && pendingEvent == null)
+        {
+            produced = onScalarStarved();
+        }
+        return produced;
     }
 
     // The window was exhausted mid-scalar. A value-string whose own bytes fill the window (or one
@@ -238,8 +239,10 @@ public final class JsonTokenizer
                     valueStreamStart = fragmentStart;
                     valueStreamEnd = streamOffset;
                     pendingEvent = JsonParser.Event.VALUE_STRING;
-                    pendingString = takeScratch();
-                    valuePending = false;
+                    // capture lazily: a verbatim/segmented consumer reads only getSegment() and never
+                    // materializes the decoded chars, so leave them in scratch (cleared when the next
+                    // fragment resumes) and let stringValue() take them on demand
+                    captureValue();
                     delivered = true;
                 }
             }
@@ -255,8 +258,7 @@ public final class JsonTokenizer
                     valueStreamStart = fragmentStart;
                     valueStreamEnd = streamOffset;
                     pendingEvent = JsonParser.Event.VALUE_NUMBER;
-                    pendingString = takeScratch();
-                    valuePending = false;
+                    captureValue();
                     delivered = true;
                 }
             }
@@ -449,38 +451,60 @@ public final class JsonTokenizer
         {
         case KEY_STRING:
             continueStringContent(in);
-            pendingEvent = JsonParser.Event.KEY_NAME;
-            captureKey();
-            resumeOp = ResumeOp.NONE;
-            state = ParseState.OBJ_AFTER_KEY;
+            if (!starved)
+            {
+                pendingEvent = JsonParser.Event.KEY_NAME;
+                captureKey();
+                resumeOp = ResumeOp.NONE;
+                state = ParseState.OBJ_AFTER_KEY;
+            }
             break;
         case VALUE_STRING:
+            // discard the prior fragment's chars (already shipped, captured lazily) before decoding the
+            // next fragment into scratch
+            scratch.setLength(0);
             fragmentStart = streamOffset;
             continueStringContent(in);
-            finishStringValue();
+            if (!starved)
+            {
+                finishStringValue();
+            }
             break;
         case VALUE_NUMBER:
+            scratch.setLength(0);
             fragmentStart = streamOffset;
             continueNumberContent(in);
-            finishNumberValue();
+            if (!starved)
+            {
+                finishNumberValue();
+            }
             break;
         case VALUE_TRUE:
             continueLiteral(in, "true");
-            pendingEvent = JsonParser.Event.VALUE_TRUE;
-            resumeOp = ResumeOp.NONE;
-            afterValueConsumed();
+            if (!starved)
+            {
+                pendingEvent = JsonParser.Event.VALUE_TRUE;
+                resumeOp = ResumeOp.NONE;
+                afterValueConsumed();
+            }
             break;
         case VALUE_FALSE:
             continueLiteral(in, "false");
-            pendingEvent = JsonParser.Event.VALUE_FALSE;
-            resumeOp = ResumeOp.NONE;
-            afterValueConsumed();
+            if (!starved)
+            {
+                pendingEvent = JsonParser.Event.VALUE_FALSE;
+                resumeOp = ResumeOp.NONE;
+                afterValueConsumed();
+            }
             break;
         case VALUE_NULL:
             continueLiteral(in, "null");
-            pendingEvent = JsonParser.Event.VALUE_NULL;
-            resumeOp = ResumeOp.NONE;
-            afterValueConsumed();
+            if (!starved)
+            {
+                pendingEvent = JsonParser.Event.VALUE_NULL;
+                resumeOp = ResumeOp.NONE;
+                afterValueConsumed();
+            }
             break;
         default:
             throw new IllegalStateException("Unexpected resumeOp: " + resumeOp);
@@ -543,20 +567,26 @@ public final class JsonTokenizer
         InputStream in) throws IOException
     {
         int c = skipWhitespace(in);
-        parseValue(in, c);
+        if (!starved)
+        {
+            parseValue(in, c);
+        }
     }
 
     private void consumeValueOrEnd(
         InputStream in) throws IOException
     {
         int c = skipWhitespace(in);
-        if (c == ']')
+        if (!starved)
         {
-            emitEnd(JsonParser.Event.END_ARRAY);
-        }
-        else
-        {
-            parseValue(in, c);
+            if (c == ']')
+            {
+                emitEnd(JsonParser.Event.END_ARRAY);
+            }
+            else
+            {
+                parseValue(in, c);
+            }
         }
     }
 
@@ -564,20 +594,26 @@ public final class JsonTokenizer
         InputStream in) throws IOException
     {
         int c = skipWhitespace(in);
-        parseKey(in, c);
+        if (!starved)
+        {
+            parseKey(in, c);
+        }
     }
 
     private void consumeKeyOrEnd(
         InputStream in) throws IOException
     {
         int c = skipWhitespace(in);
-        if (c == '}')
+        if (!starved)
         {
-            emitEnd(JsonParser.Event.END_OBJECT);
-        }
-        else
-        {
-            parseKey(in, c);
+            if (c == '}')
+            {
+                emitEnd(JsonParser.Event.END_OBJECT);
+            }
+            else
+            {
+                parseKey(in, c);
+            }
         }
     }
 
@@ -585,11 +621,14 @@ public final class JsonTokenizer
         InputStream in) throws IOException
     {
         int c = skipWhitespace(in);
-        if (c != ':')
+        if (!starved)
         {
-            throw new JsonParsingException("Expected ':' but got: " + describe(c), null);
+            if (c != ':')
+            {
+                throw new JsonParsingException("Expected ':' but got: " + describe(c), null);
+            }
+            state = ParseState.OBJ_AFTER_COLON;
         }
-        state = ParseState.OBJ_AFTER_COLON;
     }
 
     private void consumeSeparatorOrEnd(
@@ -597,17 +636,20 @@ public final class JsonTokenizer
         boolean inObject) throws IOException
     {
         int c = skipWhitespace(in);
-        if (c == ',')
+        if (!starved)
         {
-            state = inObject ? ParseState.OBJ_AFTER_COMMA : ParseState.ARR_AFTER_COMMA;
-        }
-        else if (inObject && c == '}' || !inObject && c == ']')
-        {
-            emitEnd(inObject ? JsonParser.Event.END_OBJECT : JsonParser.Event.END_ARRAY);
-        }
-        else
-        {
-            throw new JsonParsingException("Expected ',' or closing bracket but got: " + describe(c), null);
+            if (c == ',')
+            {
+                state = inObject ? ParseState.OBJ_AFTER_COMMA : ParseState.ARR_AFTER_COMMA;
+            }
+            else if (inObject && c == '}' || !inObject && c == ']')
+            {
+                emitEnd(inObject ? JsonParser.Event.END_OBJECT : JsonParser.Event.END_ARRAY);
+            }
+            else
+            {
+                throw new JsonParsingException("Expected ',' or closing bracket but got: " + describe(c), null);
+            }
         }
     }
 
@@ -635,31 +677,43 @@ public final class JsonTokenizer
             resumeUnicodePending = 0;
             resumeOp = ResumeOp.VALUE_STRING;
             continueStringContent(in);
-            finishStringValue();
+            if (!starved)
+            {
+                finishStringValue();
+            }
             break;
         case 't':
             resumeLiteralIndex = 1;
             resumeOp = ResumeOp.VALUE_TRUE;
             continueLiteral(in, "true");
-            pendingEvent = JsonParser.Event.VALUE_TRUE;
-            resumeOp = ResumeOp.NONE;
-            afterValueConsumed();
+            if (!starved)
+            {
+                pendingEvent = JsonParser.Event.VALUE_TRUE;
+                resumeOp = ResumeOp.NONE;
+                afterValueConsumed();
+            }
             break;
         case 'f':
             resumeLiteralIndex = 1;
             resumeOp = ResumeOp.VALUE_FALSE;
             continueLiteral(in, "false");
-            pendingEvent = JsonParser.Event.VALUE_FALSE;
-            resumeOp = ResumeOp.NONE;
-            afterValueConsumed();
+            if (!starved)
+            {
+                pendingEvent = JsonParser.Event.VALUE_FALSE;
+                resumeOp = ResumeOp.NONE;
+                afterValueConsumed();
+            }
             break;
         case 'n':
             resumeLiteralIndex = 1;
             resumeOp = ResumeOp.VALUE_NULL;
             continueLiteral(in, "null");
-            pendingEvent = JsonParser.Event.VALUE_NULL;
-            resumeOp = ResumeOp.NONE;
-            afterValueConsumed();
+            if (!starved)
+            {
+                pendingEvent = JsonParser.Event.VALUE_NULL;
+                resumeOp = ResumeOp.NONE;
+                afterValueConsumed();
+            }
             break;
         default:
             if (c == '-' || c >= '0' && c <= '9')
@@ -672,7 +726,10 @@ public final class JsonTokenizer
                 scratch.append((char) c);
                 resumeOp = ResumeOp.VALUE_NUMBER;
                 continueNumberContent(in);
-                finishNumberValue();
+                if (!starved)
+                {
+                    finishNumberValue();
+                }
             }
             else
             {
@@ -694,10 +751,13 @@ public final class JsonTokenizer
         resumeUnicodePending = 0;
         resumeOp = ResumeOp.KEY_STRING;
         continueStringContent(in);
-        pendingEvent = JsonParser.Event.KEY_NAME;
-        captureKey();
-        resumeOp = ResumeOp.NONE;
-        state = ParseState.OBJ_AFTER_KEY;
+        if (!starved)
+        {
+            pendingEvent = JsonParser.Event.KEY_NAME;
+            captureKey();
+            resumeOp = ResumeOp.NONE;
+            state = ParseState.OBJ_AFTER_KEY;
+        }
     }
 
     // Keys are always deferred (left in scratch, materialized lazily by stringValue()), so a key that
@@ -781,14 +841,10 @@ public final class JsonTokenizer
     private void enforceEndOfInput(
         InputStream in) throws IOException
     {
-        try
+        int c = skipWhitespace(in);
+        if (c != -1)
         {
-            int c = skipWhitespace(in);
             throw new JsonParsingException("Unexpected trailing content: " + describe(c), null);
-        }
-        catch (EOFException ex)
-        {
-            // clean end of input
         }
     }
 
@@ -808,21 +864,25 @@ public final class JsonTokenizer
         InputStream in,
         String expected) throws IOException
     {
-        while (resumeLiteralIndex < expected.length())
+        while (!starved && resumeLiteralIndex < expected.length())
         {
             int c = readByte(in);
-            if (c != expected.charAt(resumeLiteralIndex))
+            if (!starved)
             {
-                throw new JsonParsingException("Unexpected character in literal: " + describe(c), null);
+                if (c != expected.charAt(resumeLiteralIndex))
+                {
+                    throw new JsonParsingException("Unexpected character in literal: " + describe(c), null);
+                }
+                resumeLiteralIndex++;
             }
-            resumeLiteralIndex++;
         }
     }
 
     private void continueStringContent(
         InputStream in) throws IOException
     {
-        while (true)
+        boolean complete = false;
+        while (!complete && !starved)
         {
             // Track each complete-unit boundary so an EOF mid-char/escape can rewind here: the chars
             // decoded so far ship as a fragment and the partial unit's bytes stay unconsumed
@@ -832,67 +892,74 @@ public final class JsonTokenizer
                 unitStartOffset = streamOffset;
             }
             int c = readByte(in);
-            if (resumeUnicodePending > 0)
+            if (!starved)
             {
-                resumeUnicodeValue = (resumeUnicodeValue << 4) | hexDigit(c);
-                resumeUnicodePending--;
-                if (resumeUnicodePending == 0)
+                if (resumeUnicodePending > 0)
                 {
-                    appendScratch((char) resumeUnicodeValue);
+                    resumeUnicodeValue = (resumeUnicodeValue << 4) | hexDigit(c);
+                    resumeUnicodePending--;
+                    if (resumeUnicodePending == 0)
+                    {
+                        appendScratch((char) resumeUnicodeValue);
+                    }
                 }
-            }
-            else if (resumeEscape)
-            {
-                resumeEscape = false;
-                switch (c)
+                else if (resumeEscape)
                 {
-                case '"':
-                case '\\':
-                case '/':
+                    resumeEscape = false;
+                    switch (c)
+                    {
+                    case '"':
+                    case '\\':
+                    case '/':
+                        appendScratch((char) c);
+                        break;
+                    case 'b':
+                        appendScratch('\b');
+                        break;
+                    case 'f':
+                        appendScratch('\f');
+                        break;
+                    case 'n':
+                        appendScratch('\n');
+                        break;
+                    case 'r':
+                        appendScratch('\r');
+                        break;
+                    case 't':
+                        appendScratch('\t');
+                        break;
+                    case 'u':
+                        resumeUnicodePending = 4;
+                        resumeUnicodeValue = 0;
+                        break;
+                    default:
+                        throw new JsonParsingException("Invalid escape: \\" + describe(c), null);
+                    }
+                }
+                else if (c == '"')
+                {
+                    complete = true;
+                }
+                else if (c == '\\')
+                {
+                    resumeEscape = true;
+                }
+                else if (c < 0x20)
+                {
+                    throw new JsonParsingException("Unescaped control character in string: " + describe(c), null);
+                }
+                else if (c < 0x80)
+                {
                     appendScratch((char) c);
-                    break;
-                case 'b':
-                    appendScratch('\b');
-                    break;
-                case 'f':
-                    appendScratch('\f');
-                    break;
-                case 'n':
-                    appendScratch('\n');
-                    break;
-                case 'r':
-                    appendScratch('\r');
-                    break;
-                case 't':
-                    appendScratch('\t');
-                    break;
-                case 'u':
-                    resumeUnicodePending = 4;
-                    resumeUnicodeValue = 0;
-                    break;
-                default:
-                    throw new JsonParsingException("Invalid escape: \\" + describe(c), null);
                 }
-            }
-            else if (c == '"')
-            {
-                return;
-            }
-            else if (c == '\\')
-            {
-                resumeEscape = true;
-            }
-            else if (c < 0x20)
-            {
-                throw new JsonParsingException("Unescaped control character in string: " + describe(c), null);
-            }
-            else if (c < 0x80)
-            {
-                appendScratch((char) c);
-            }
-            else
-            {
-                appendCodePointScratch(decodeUtf8(in, c));
+                else
+                {
+                    int codePoint = decodeUtf8(in, c);
+                    if (!starved)
+                    {
+                        appendCodePointScratch(codePoint);
+                    }
+                }
             }
         }
     }
@@ -947,14 +1014,17 @@ public final class JsonTokenizer
         {
             throw new JsonParsingException("Invalid UTF-8 lead byte: " + describe(first), null);
         }
-        for (int i = 0; i < remaining; i++)
+        for (int i = 0; !starved && i < remaining; i++)
         {
             int cont = readByte(in);
-            if ((cont & 0xc0) != 0x80)
+            if (!starved)
             {
-                throw new JsonParsingException("Invalid UTF-8 continuation: " + describe(cont), null);
+                if ((cont & 0xc0) != 0x80)
+                {
+                    throw new JsonParsingException("Invalid UTF-8 continuation: " + describe(cont), null);
+                }
+                code = (code << 6) | (cont & 0x3f);
             }
-            code = (code << 6) | (cont & 0x3f);
         }
         return code;
     }
@@ -980,19 +1050,18 @@ public final class JsonTokenizer
     private void continueNumberContent(
         InputStream in) throws IOException
     {
-        while (true)
+        boolean complete = false;
+        while (!complete && !starved)
         {
             in.mark(1);
             int c = in.read();
             if (c == -1)
             {
-                if (terminalEof)
-                {
-                    return;
-                }
-                throw new EOFException();
+                // terminal window: EOF ends the number; otherwise the window is exhausted mid-number
+                starved = !terminalEof;
+                complete = terminalEof;
             }
-            if (c >= '0' && c <= '9' || c == '.' || c == '-' || c == '+' || c == 'e' || c == 'E')
+            else if (c >= '0' && c <= '9' || c == '.' || c == '-' || c == '+' || c == 'e' || c == 'E')
             {
                 streamOffset++;
                 appendScratch((char) c);
@@ -1000,7 +1069,7 @@ public final class JsonTokenizer
             else
             {
                 in.reset();
-                return;
+                complete = true;
             }
         }
     }
@@ -1073,9 +1142,12 @@ public final class JsonTokenizer
         int c = in.read();
         if (c == -1)
         {
-            throw new EOFException();
+            starved = true;
         }
-        streamOffset++;
+        else
+        {
+            streamOffset++;
+        }
         return c;
     }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -19,8 +19,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.List;
-import java.util.Optional;
 
 import jakarta.json.stream.JsonParser;
 import jakarta.json.stream.JsonParsingException;
@@ -53,12 +51,9 @@ public final class JsonTokenizer
     }
 
     private static final int MAX_DEPTH = 64;
-    private static final String WILDCARD_INDEX = "-";
 
     private final Deque<ParseState> stack = new ArrayDeque<>();
     private final StringBuilder scratch = new StringBuilder();
-    private final List<String[]> pathIncludes;
-    private final List<String[]> pathExcludes;
     private final int tokenMaxBytes;
     private boolean terminalEof;
 
@@ -92,15 +87,13 @@ public final class JsonTokenizer
 
     public JsonTokenizer()
     {
-        this(null, null, Integer.MAX_VALUE);
+        this(Integer.MAX_VALUE);
     }
 
     public JsonTokenizer(
-        List<String> pathIncludes,
-        List<String> pathExcludes,
         int tokenMaxBytes)
     {
-        this(pathIncludes, pathExcludes, tokenMaxBytes, false);
+        this(tokenMaxBytes, false);
     }
 
     // terminalEof distinguishes a one-shot stream (EOF is the final delimiter) from the chunked
@@ -108,13 +101,9 @@ public final class JsonTokenizer
     // only matters for numbers, which unlike strings and the true/false/null literals are not
     // self-terminating and need a following non-digit byte to know they have ended.
     public JsonTokenizer(
-        List<String> pathIncludes,
-        List<String> pathExcludes,
         int tokenMaxBytes,
         boolean terminalEof)
     {
-        this.pathIncludes = compilePaths(pathIncludes);
-        this.pathExcludes = compilePaths(pathExcludes);
         this.tokenMaxBytes = tokenMaxBytes;
         this.terminalEof = terminalEof;
         for (int i = 0; i < MAX_DEPTH; i++)
@@ -157,40 +146,6 @@ public final class JsonTokenizer
         boolean terminalEof)
     {
         this.terminalEof = terminalEof;
-    }
-
-    public static final List<String> INCLUDE_ALL = null;
-
-    private static List<String[]> compilePaths(
-        List<String> paths)
-    {
-        return Optional.ofNullable(paths)
-            .map(JsonTokenizer::compilePathList)
-            .orElse(null);
-    }
-
-    private static List<String[]> compilePathList(
-        List<String> paths)
-    {
-        return paths.isEmpty()
-            ? List.of()
-            : paths.stream().map(JsonTokenizer::compilePath).toList();
-    }
-
-    private static String[] compilePath(
-        String path)
-    {
-        if (path.isEmpty())
-        {
-            return new String[0];
-        }
-        // RFC 6901: leading '/', segments separated by '/', '~1' decodes to '/', '~0' to '~'
-        final String[] parts = path.substring(1).split("/", -1);
-        for (int i = 0; i < parts.length; i++)
-        {
-            parts[i] = parts[i].replace("~1", "/").replace("~0", "~");
-        }
-        return parts;
     }
 
     public boolean advance(
@@ -344,86 +299,6 @@ public final class JsonTokenizer
             }
         }
         return path.toString();
-    }
-
-    private boolean currentPathReadable()
-    {
-        // null pathIncludes means include all; empty list means include none;
-        // non-empty list restricts to matching paths
-        final boolean included = pathIncludes == null || pathMatchesAny(pathIncludes);
-        // excludes have final veto
-        return included && (pathExcludes == null || !pathMatchesAny(pathExcludes));
-    }
-
-    private boolean pathMatchesAny(
-        List<String[]> paths)
-    {
-        outer:
-        for (String[] target : paths)
-        {
-            if (target.length != pathDepth)
-            {
-                continue;
-            }
-            for (int i = 0; i < pathDepth; i++)
-            {
-                final String expected = target[i];
-                final boolean matched;
-                if (WILDCARD_INDEX.equals(expected))
-                {
-                    matched = true;
-                }
-                else if (pathInArray[i])
-                {
-                    matched = matchesIndex(expected, pathIndex[i]);
-                }
-                else
-                {
-                    matched = pathKeySet[i] && charsEqual(expected, pathKeyChars[i]);
-                }
-                if (!matched)
-                {
-                    continue outer;
-                }
-            }
-            return true;
-        }
-        return false;
-    }
-
-    private static boolean charsEqual(
-        String segment,
-        CharSequence key)
-    {
-        boolean matches = segment.length() == key.length();
-        for (int i = 0; matches && i < segment.length(); i++)
-        {
-            matches = segment.charAt(i) == key.charAt(i);
-        }
-        return matches;
-    }
-
-    private static boolean matchesIndex(
-        String segment,
-        int index)
-    {
-        boolean matches = !segment.isEmpty() && (segment.length() == 1 || segment.charAt(0) != '0');
-        int value = 0;
-        for (int i = 0; matches && i < segment.length(); i++)
-        {
-            final char c = segment.charAt(i);
-            matches = c >= '0' && c <= '9';
-            if (matches)
-            {
-                final int digit = c - '0';
-                matches = value <= (Integer.MAX_VALUE - digit) / 10;
-                if (matches)
-                {
-                    value = value * 10 + digit;
-                }
-            }
-        }
-        return matches && value == index;
     }
 
     private void pushPath(
@@ -629,7 +504,7 @@ public final class JsonTokenizer
         InputStream in,
         int c) throws IOException
     {
-        valueReadable = currentPathReadable();
+        valueReadable = true;
         switch (c)
         {
         case '{':

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -51,6 +51,9 @@ public final class JsonTokenizer
     }
 
     private static final int MAX_DEPTH = 64;
+    // upper bound on the bytes of a single decoded unit (a UTF-8 char is at most 4 bytes, a
+    // backslash-u escape is 6); the fragment-boundary mark rewinds across at most one such unit
+    private static final int MAX_UNIT_BYTES = 8;
 
     private final Deque<ParseState> stack = new ArrayDeque<>();
     private final StringBuilder scratch = new StringBuilder();
@@ -77,6 +80,13 @@ public final class JsonTokenizer
     // set while a segment scan is in progress: a value-string is then streamed across frames as raw
     // bytes (no rewind to require it whole-in-frame, no decoded retention) rather than buffered whole.
     private boolean segmenting;
+    // set while a value-string larger than tokenMaxBytes is being delivered as a sequence of
+    // fragments: each fragment carries the decoded chars that fit the slot, deferredBytes() stays true
+    // until the closing quote. A partial char/escape at a frame boundary is left unconsumed (rewound
+    // to unitStartOffset) for the caller's decode slot to re-present, so no partial state crosses wrap.
+    private boolean fragmenting;
+    private boolean stringComplete;
+    private long unitStartOffset;
 
     // scalar resume state (valid when resumeOp != NONE)
     private ResumeOp resumeOp = ResumeOp.NONE;
@@ -124,6 +134,8 @@ public final class JsonTokenizer
         streamOffset = 0;
         valueReadable = true;
         segmenting = false;
+        fragmenting = false;
+        stringComplete = false;
         resumeOp = ResumeOp.NONE;
         resumeEscape = false;
         resumeUnicodePending = 0;
@@ -192,10 +204,27 @@ public final class JsonTokenizer
                 }
                 // While segmenting, a value-string spanning the frame is not rewound — its resume state
                 // is kept so the next frame continues it and the raw bytes stream as segments.
-                final boolean midReadableScalarScan =
-                    (resumeOp == ResumeOp.VALUE_STRING || resumeOp == ResumeOp.VALUE_NUMBER) &&
-                    valueReadable && !segmenting;
-                if (midReadableScalarScan)
+                final boolean midScalar =
+                    (resumeOp == ResumeOp.VALUE_STRING || resumeOp == ResumeOp.VALUE_NUMBER) && !segmenting;
+                boolean delivered = false;
+                if (midScalar && fragmenting && resumeOp == ResumeOp.VALUE_STRING)
+                {
+                    // mid-fragmentation: ship the chars accumulated so far and leave the partial unit's
+                    // bytes unconsumed (rewound to its start) for the decode slot to re-present.
+                    in.reset();
+                    streamOffset = unitStartOffset;
+                    resumeEscape = false;
+                    resumeUnicodePending = 0;
+                    resumeUnicodeValue = 0;
+                    if (scratch.length() > 0)
+                    {
+                        pendingEvent = JsonParser.Event.VALUE_STRING;
+                        pendingString = takeScratch();
+                        valuePending = false;
+                        delivered = true;
+                    }
+                }
+                else if (midScalar)
                 {
                     in.reset();
                     streamOffset = iterStart;
@@ -205,7 +234,7 @@ public final class JsonTokenizer
                     resumeUnicodePending = 0;
                     resumeUnicodeValue = 0;
                 }
-                return false;
+                return delivered;
             }
         }
         return true;
@@ -277,6 +306,13 @@ public final class JsonTokenizer
     public boolean valueReadable()
     {
         return valueReadable;
+    }
+
+    // True while a value-string is being delivered in fragments and more fragments follow the current
+    // event; drives the parser's deferredBytes() for over-slot scalars.
+    public boolean fragmenting()
+    {
+        return fragmenting;
     }
 
     public String currentPath()
@@ -379,10 +415,7 @@ public final class JsonTokenizer
             break;
         case VALUE_STRING:
             continueStringContent(in);
-            pendingEvent = JsonParser.Event.VALUE_STRING;
-            captureValue(valueReadable);
-            resumeOp = ResumeOp.NONE;
-            afterValueConsumed();
+            finishStringValue();
             break;
         case VALUE_NUMBER:
             continueNumberContent(in);
@@ -419,6 +452,28 @@ public final class JsonTokenizer
     {
         valuePending = readable;
         pendingString = null;
+    }
+
+    // Completes a VALUE_STRING scan: a finished string (closing quote seen) is captured lazily and the
+    // parse state advances; a slot-bound fragment is materialized eagerly (freeing scratch for the next
+    // fragment) with the value left in progress so the next advance() continues it.
+    private void finishStringValue()
+    {
+        valueStreamEnd = streamOffset;
+        pendingEvent = JsonParser.Event.VALUE_STRING;
+        if (stringComplete)
+        {
+            captureValue(valueReadable);
+            fragmenting = false;
+            resumeOp = ResumeOp.NONE;
+            afterValueConsumed();
+        }
+        else
+        {
+            pendingString = takeScratch();
+            valuePending = false;
+            fragmenting = true;
+        }
     }
 
     private String takeScratch()
@@ -524,11 +579,7 @@ public final class JsonTokenizer
             resumeUnicodePending = 0;
             resumeOp = ResumeOp.VALUE_STRING;
             continueStringContent(in);
-            valueStreamEnd = streamOffset;
-            pendingEvent = JsonParser.Event.VALUE_STRING;
-            captureValue(valueReadable);
-            resumeOp = ResumeOp.NONE;
-            afterValueConsumed();
+            finishStringValue();
             break;
         case 't':
             resumeLiteralIndex = 1;
@@ -721,8 +772,17 @@ public final class JsonTokenizer
     private void continueStringContent(
         InputStream in) throws IOException
     {
+        stringComplete = false;
         while (true)
         {
+            // While fragmenting, mark each unit boundary so an EOF mid-char/escape rewinds here: the
+            // chars decoded so far ship as a fragment and the partial unit's bytes stay unconsumed for
+            // the decode slot to re-present on the next frame.
+            if (fragmenting && !resumeEscape && resumeUnicodePending == 0)
+            {
+                in.mark(MAX_UNIT_BYTES);
+                unitStartOffset = streamOffset;
+            }
             int c = readByte(in);
             if (resumeUnicodePending > 0)
             {
@@ -732,9 +792,8 @@ public final class JsonTokenizer
                 {
                     appendScratch((char) resumeUnicodeValue);
                 }
-                continue;
             }
-            if (resumeEscape)
+            else if (resumeEscape)
             {
                 resumeEscape = false;
                 switch (c)
@@ -766,10 +825,10 @@ public final class JsonTokenizer
                 default:
                     throw new JsonParsingException("Invalid escape: \\" + describe(c), null);
                 }
-                continue;
             }
-            if (c == '"')
+            else if (c == '"')
             {
+                stringComplete = true;
                 return;
             }
             else if (c == '\\')
@@ -786,8 +845,13 @@ public final class JsonTokenizer
             }
             else
             {
-                int codePoint = decodeUtf8(in, c);
-                appendCodePointScratch(codePoint);
+                appendCodePointScratch(decodeUtf8(in, c));
+            }
+            // suspend with a full fragment once a complete unit pushes scratch to the slot bound
+            if (!resumeEscape && resumeUnicodePending == 0 &&
+                tokenMaxBytes != Integer.MAX_VALUE && scratch.length() >= tokenMaxBytes)
+            {
+                return;
             }
         }
     }
@@ -975,14 +1039,6 @@ public final class JsonTokenizer
             throw new EOFException();
         }
         streamOffset++;
-        if (valueReadable &&
-            (resumeOp == ResumeOp.VALUE_STRING || resumeOp == ResumeOp.VALUE_NUMBER) &&
-            scratch.length() >= tokenMaxBytes)
-        {
-            throw new JsonParsingException(
-                "value at " + currentPath() + " exceeds max " + tokenMaxBytes + " bytes",
-                null);
-        }
         return c;
     }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -59,16 +59,13 @@ public final class JsonTokenizer
     private final StringBuilder scratch = new StringBuilder();
     private final List<String[]> pathIncludes;
     private final List<String[]> pathExcludes;
-    private final boolean pathFiltering;
     private final int tokenMaxBytes;
     private boolean terminalEof;
 
     // path tracking — pre-allocated, no per-event allocation
     private final boolean[] pathInArray = new boolean[MAX_DEPTH];
-    // pathKey holds the key String only when path filtering is configured (the filter compares keys
-    // eagerly); pathKeyChars mirrors it allocation-free for currentPath() in the deferred (no-filter)
-    // mode, where keys are not materialized into Strings.
-    private final String[] pathKey = new String[MAX_DEPTH];
+    // pathKeyChars mirrors each object key allocation-free; path matching and currentPath() compare
+    // against it as a CharSequence so keys are never materialized into Strings just to track the path.
     private final StringBuilder[] pathKeyChars = new StringBuilder[MAX_DEPTH];
     private final boolean[] pathKeySet = new boolean[MAX_DEPTH];
     private final int[] pathIndex = new int[MAX_DEPTH];
@@ -118,7 +115,6 @@ public final class JsonTokenizer
     {
         this.pathIncludes = compilePaths(pathIncludes);
         this.pathExcludes = compilePaths(pathExcludes);
-        this.pathFiltering = this.pathIncludes != null || this.pathExcludes != null;
         this.tokenMaxBytes = tokenMaxBytes;
         this.terminalEof = terminalEof;
         for (int i = 0; i < MAX_DEPTH; i++)
@@ -342,10 +338,6 @@ public final class JsonTokenizer
             {
                 path.append(pathIndex[i]);
             }
-            else if (pathKey[i] != null)
-            {
-                path.append(pathKey[i].replace("~", "~0").replace("/", "~1"));
-            }
             else if (pathKeySet[i])
             {
                 path.append(pathKeyChars[i].toString().replace("~", "~0").replace("/", "~1"));
@@ -375,11 +367,21 @@ public final class JsonTokenizer
             }
             for (int i = 0; i < pathDepth; i++)
             {
-                final String segment = pathInArray[i]
-                    ? Integer.toString(pathIndex[i])
-                    : pathKey[i];
                 final String expected = target[i];
-                if (!WILDCARD_INDEX.equals(expected) && !expected.equals(segment))
+                final boolean matched;
+                if (WILDCARD_INDEX.equals(expected))
+                {
+                    matched = true;
+                }
+                else if (pathInArray[i])
+                {
+                    matched = matchesIndex(expected, pathIndex[i]);
+                }
+                else
+                {
+                    matched = pathKeySet[i] && charsEqual(expected, pathKeyChars[i]);
+                }
+                if (!matched)
                 {
                     continue outer;
                 }
@@ -387,6 +389,41 @@ public final class JsonTokenizer
             return true;
         }
         return false;
+    }
+
+    private static boolean charsEqual(
+        String segment,
+        CharSequence key)
+    {
+        boolean matches = segment.length() == key.length();
+        for (int i = 0; matches && i < segment.length(); i++)
+        {
+            matches = segment.charAt(i) == key.charAt(i);
+        }
+        return matches;
+    }
+
+    private static boolean matchesIndex(
+        String segment,
+        int index)
+    {
+        boolean matches = !segment.isEmpty() && (segment.length() == 1 || segment.charAt(0) != '0');
+        int value = 0;
+        for (int i = 0; matches && i < segment.length(); i++)
+        {
+            final char c = segment.charAt(i);
+            matches = c >= '0' && c <= '9';
+            if (matches)
+            {
+                final int digit = c - '0';
+                matches = value <= (Integer.MAX_VALUE - digit) / 10;
+                if (matches)
+                {
+                    value = value * 10 + digit;
+                }
+            }
+        }
+        return matches && value == index;
     }
 
     private void pushPath(
@@ -397,7 +434,6 @@ public final class JsonTokenizer
             throw new JsonParsingException("JSON depth exceeds " + MAX_DEPTH, null);
         }
         pathInArray[pathDepth] = inArray;
-        pathKey[pathDepth] = null;
         pathKeySet[pathDepth] = false;
         pathIndex[pathDepth] = 0;
         pathDepth++;
@@ -406,7 +442,6 @@ public final class JsonTokenizer
     private void popPath()
     {
         pathDepth--;
-        pathKey[pathDepth] = null;
         pathKeySet[pathDepth] = false;
     }
 
@@ -689,32 +724,20 @@ public final class JsonTokenizer
         state = ParseState.OBJ_AFTER_KEY;
     }
 
-    // Keys are normally deferred (left in scratch, materialized lazily by stringValue()), so a key
-    // that is never read by a downstream stage allocates no String. When the tokenizer is itself
-    // configured with a path filter it must compare keys eagerly via pathKey[], so in that mode the
-    // key is materialized up front and the per-depth pathKey slot is set.
+    // Keys are always deferred (left in scratch, materialized lazily by stringValue()), so a key that
+    // is never read by a downstream stage allocates no String. The chars are mirrored into the
+    // per-depth pathKeyChars slot so path matching and currentPath() can compare them as a
+    // CharSequence without materializing a String — even when path filtering is configured.
     private void captureKey()
     {
-        if (pathFiltering)
+        valuePending = true;
+        pendingString = null;
+        if (pathDepth > 0 && !pathInArray[pathDepth - 1])
         {
-            pendingString = takeScratch();
-            valuePending = false;
-            if (pathDepth > 0 && !pathInArray[pathDepth - 1])
-            {
-                pathKey[pathDepth - 1] = pendingString;
-            }
-        }
-        else
-        {
-            valuePending = true;
-            pendingString = null;
-            if (pathDepth > 0 && !pathInArray[pathDepth - 1])
-            {
-                final StringBuilder keyChars = pathKeyChars[pathDepth - 1];
-                keyChars.setLength(0);
-                keyChars.append(scratch);
-                pathKeySet[pathDepth - 1] = true;
-            }
+            final StringBuilder keyChars = pathKeyChars[pathDepth - 1];
+            keyChars.setLength(0);
+            keyChars.append(scratch);
+            pathKeySet[pathDepth - 1] = true;
         }
     }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -76,6 +76,10 @@ public final class JsonTokenizer
     private long streamOffset;
     private long valueStreamStart;
     private long valueStreamEnd;
+    // raw stream offset where the current value-string fragment began; getSegment() of a fragmented
+    // value returns [fragmentStart, valueStreamEnd] so each fragment's verbatim bytes splice back to
+    // the whole token (fragment 1 includes the opening quote, the final fragment the closing quote)
+    private long fragmentStart;
     private boolean valueReadable = true;
     // set while a segment scan is in progress: a value-string is then streamed across frames as raw
     // bytes (no rewind to require it whole-in-frame, no decoded retention) rather than buffered whole.
@@ -132,6 +136,7 @@ public final class JsonTokenizer
         pendingString = null;
         valuePending = false;
         streamOffset = 0;
+        fragmentStart = 0;
         valueReadable = true;
         segmenting = false;
         fragmenting = false;
@@ -218,6 +223,8 @@ public final class JsonTokenizer
                     resumeUnicodeValue = 0;
                     if (scratch.length() > 0)
                     {
+                        valueStreamStart = fragmentStart;
+                        valueStreamEnd = streamOffset;
                         pendingEvent = JsonParser.Event.VALUE_STRING;
                         pendingString = takeScratch();
                         valuePending = false;
@@ -414,6 +421,7 @@ public final class JsonTokenizer
             state = ParseState.OBJ_AFTER_KEY;
             break;
         case VALUE_STRING:
+            fragmentStart = streamOffset;
             continueStringContent(in);
             finishStringValue();
             break;
@@ -459,6 +467,7 @@ public final class JsonTokenizer
     // fragment) with the value left in progress so the next advance() continues it.
     private void finishStringValue()
     {
+        valueStreamStart = fragmentStart;
         valueStreamEnd = streamOffset;
         pendingEvent = JsonParser.Event.VALUE_STRING;
         if (stringComplete)
@@ -574,6 +583,7 @@ public final class JsonTokenizer
             break;
         case '"':
             valueStreamStart = streamOffset - 1;
+            fragmentStart = streamOffset - 1;
             scratch.setLength(0);
             resumeEscape = false;
             resumeUnicodePending = 0;

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -54,6 +54,9 @@ public final class JsonTokenizer
 
     private final Deque<ParseState> stack = new ArrayDeque<>();
     private final StringBuilder scratch = new StringBuilder();
+    // accumulates the full lexeme of a fragmented number across its fragments (scratch holds only the
+    // current fragment); getBigDecimal() reads this on the final fragment to read the value whole.
+    private final StringBuilder numberLexeme = new StringBuilder();
     private boolean terminalEof;
     // byte length of the current input window; a value whose own bytes reach this length without
     // completing fills the window and is delivered as fragments rather than reassembled across windows.
@@ -75,9 +78,9 @@ public final class JsonTokenizer
     private long streamOffset;
     private long valueStreamStart;
     private long valueStreamEnd;
-    // raw stream offset where the current value-string fragment began; getSegment() of a fragmented
-    // value returns [fragmentStart, valueStreamEnd] so each fragment's verbatim bytes splice back to
-    // the whole token (fragment 1 includes the opening quote, the final fragment the closing quote)
+    // raw stream offset where the current value (string or number) fragment began; getSegment() of a
+    // fragmented value returns [fragmentStart, valueStreamEnd] so each fragment's verbatim bytes splice
+    // back to the whole token (fragment 1 includes the opening quote, the final fragment the closing one)
     private long fragmentStart;
     // set while a segment scan is in progress: a value-string is then streamed across frames as raw
     // bytes (no rewind to require it whole-in-frame, no decoded retention) rather than buffered whole.
@@ -88,6 +91,9 @@ public final class JsonTokenizer
     // to unitStartOffset) for the caller to re-present, so no partial state crosses a wrap.
     private boolean fragmenting;
     private long unitStartOffset;
+    // true once the current/just-completed number was delivered in more than one fragment: getInt()/
+    // getLong() then throw (the value would overflow) and getBigDecimal() reads the accumulated lexeme.
+    private boolean numberFragmented;
 
     // scalar resume state (valid when resumeOp != NONE)
     private ResumeOp resumeOp = ResumeOp.NONE;
@@ -119,6 +125,8 @@ public final class JsonTokenizer
     {
         stack.clear();
         scratch.setLength(0);
+        numberLexeme.setLength(0);
+        numberFragmented = false;
         pathDepth = 0;
         state = ParseState.DOC_START;
         pendingEvent = null;
@@ -215,10 +223,11 @@ public final class JsonTokenizer
         if (midScalar)
         {
             final long valueBytes = streamOffset - valueStreamStart;
-            final boolean fragmentString = resumeOp == ResumeOp.VALUE_STRING && !terminalEof &&
-                (fragmenting || valueBytes >= windowLength);
-            if (fragmentString)
+            final boolean fragment = !terminalEof && (fragmenting || valueBytes >= windowLength);
+            if (fragment && resumeOp == ResumeOp.VALUE_STRING)
             {
+                // string: rewind to the last complete code-point/escape boundary, leaving the partial
+                // unit for the caller to carry; ship the chars decoded so far
                 streamOffset = unitStartOffset;
                 resumeEscape = false;
                 resumeUnicodePending = 0;
@@ -234,8 +243,26 @@ public final class JsonTokenizer
                     delivered = true;
                 }
             }
+            else if (fragment)
+            {
+                // number: every digit is a complete unit so nothing is rewound; accumulate the whole
+                // lexeme and ship the digits scanned so far
+                fragmenting = true;
+                numberFragmented = true;
+                if (scratch.length() > 0)
+                {
+                    numberLexeme.append(scratch);
+                    valueStreamStart = fragmentStart;
+                    valueStreamEnd = streamOffset;
+                    pendingEvent = JsonParser.Event.VALUE_NUMBER;
+                    pendingString = takeScratch();
+                    valuePending = false;
+                    delivered = true;
+                }
+            }
             else
             {
+                // value fits a window (or terminal): rewind to its start and reassemble whole next window
                 streamOffset = valueStreamStart;
                 scratch.setLength(0);
                 resumeOp = ResumeOp.NONE;
@@ -315,6 +342,18 @@ public final class JsonTokenizer
     public boolean fragmenting()
     {
         return fragmenting;
+    }
+
+    // True when the current/just-completed number was delivered in more than one fragment, so its whole
+    // lexeme is in numberLexeme() rather than the current scratch.
+    public boolean numberFragmented()
+    {
+        return numberFragmented;
+    }
+
+    public CharSequence numberLexeme()
+    {
+        return numberLexeme;
     }
 
     public String currentPath()
@@ -421,11 +460,9 @@ public final class JsonTokenizer
             finishStringValue();
             break;
         case VALUE_NUMBER:
+            fragmentStart = streamOffset;
             continueNumberContent(in);
-            pendingEvent = JsonParser.Event.VALUE_NUMBER;
-            captureValue();
-            resumeOp = ResumeOp.NONE;
-            afterValueConsumed();
+            finishNumberValue();
             break;
         case VALUE_TRUE:
             continueLiteral(in, "true");
@@ -465,6 +502,30 @@ public final class JsonTokenizer
         valueStreamStart = fragmentStart;
         valueStreamEnd = streamOffset;
         pendingEvent = JsonParser.Event.VALUE_STRING;
+        captureValue();
+        fragmenting = false;
+        resumeOp = ResumeOp.NONE;
+        afterValueConsumed();
+    }
+
+    // Completes a VALUE_NUMBER scan: continueNumberContent only returns here once the number terminator
+    // (or the terminal window's EOF) is seen, so the number is whole. A fragmented number's full lexeme
+    // is validated from numberLexeme (the final fragment's digits appended); an unfragmented one from
+    // scratch. Captured lazily and the parse state advances.
+    private void finishNumberValue()
+    {
+        if (numberFragmented)
+        {
+            numberLexeme.append(scratch);
+            validateNumber(numberLexeme);
+        }
+        else
+        {
+            validateNumber(scratch);
+        }
+        valueStreamStart = fragmentStart;
+        valueStreamEnd = streamOffset;
+        pendingEvent = JsonParser.Event.VALUE_NUMBER;
         captureValue();
         fragmenting = false;
         resumeOp = ResumeOp.NONE;
@@ -604,15 +665,14 @@ public final class JsonTokenizer
             if (c == '-' || c >= '0' && c <= '9')
             {
                 valueStreamStart = streamOffset - 1;
+                fragmentStart = streamOffset - 1;
+                numberLexeme.setLength(0);
+                numberFragmented = false;
                 scratch.setLength(0);
                 scratch.append((char) c);
                 resumeOp = ResumeOp.VALUE_NUMBER;
                 continueNumberContent(in);
-                valueStreamEnd = streamOffset;
-                pendingEvent = JsonParser.Event.VALUE_NUMBER;
-                captureValue();
-                resumeOp = ResumeOp.NONE;
-                afterValueConsumed();
+                finishNumberValue();
             }
             else
             {
@@ -928,7 +988,6 @@ public final class JsonTokenizer
             {
                 if (terminalEof)
                 {
-                    validateNumber();
                     return;
                 }
                 throw new EOFException();
@@ -941,7 +1000,6 @@ public final class JsonTokenizer
             else
             {
                 in.reset();
-                validateNumber();
                 return;
             }
         }
@@ -949,47 +1007,48 @@ public final class JsonTokenizer
 
     // RFC 8259 number grammar: -?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][+-]?[0-9]+)?. scratch holds the
     // complete lexeme (numbers are always retained in scratch for validation and lazy materialization).
-    private void validateNumber()
+    private void validateNumber(
+        CharSequence lexeme)
     {
-        final int length = scratch.length();
+        final int length = lexeme.length();
         int index = 0;
         boolean valid = length > 0;
-        if (valid && scratch.charAt(index) == '-')
+        if (valid && lexeme.charAt(index) == '-')
         {
             index++;
         }
         final int intStart = index;
-        if (index < length && scratch.charAt(index) == '0')
+        if (index < length && lexeme.charAt(index) == '0')
         {
             index++;
         }
         else
         {
-            while (index < length && isDigit(scratch.charAt(index)))
+            while (index < length && isDigit(lexeme.charAt(index)))
             {
                 index++;
             }
         }
         valid &= index > intStart;
-        if (valid && index < length && scratch.charAt(index) == '.')
+        if (valid && index < length && lexeme.charAt(index) == '.')
         {
             index++;
             final int fracStart = index;
-            while (index < length && isDigit(scratch.charAt(index)))
+            while (index < length && isDigit(lexeme.charAt(index)))
             {
                 index++;
             }
             valid &= index > fracStart;
         }
-        if (valid && index < length && (scratch.charAt(index) == 'e' || scratch.charAt(index) == 'E'))
+        if (valid && index < length && (lexeme.charAt(index) == 'e' || lexeme.charAt(index) == 'E'))
         {
             index++;
-            if (index < length && (scratch.charAt(index) == '+' || scratch.charAt(index) == '-'))
+            if (index < length && (lexeme.charAt(index) == '+' || lexeme.charAt(index) == '-'))
             {
                 index++;
             }
             final int expStart = index;
-            while (index < length && isDigit(scratch.charAt(index)))
+            while (index < length && isDigit(lexeme.charAt(index)))
             {
                 index++;
             }
@@ -998,7 +1057,7 @@ public final class JsonTokenizer
         valid &= index == length;
         if (!valid)
         {
-            throw new JsonParsingException("Invalid JSON number: " + scratch, null);
+            throw new JsonParsingException("Invalid JSON number: " + lexeme, null);
         }
     }
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorExTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorExTest.java
@@ -28,6 +28,8 @@ import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
+import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx.Completion;
+
 class JsonGeneratorExTest
 {
     @Test
@@ -228,6 +230,28 @@ class JsonGeneratorExTest
         byte[] out = new byte[generator.length()];
         buffer.getBytes(8, out);
         assertEquals("[1]", new String(out, UTF_8));
+    }
+
+    @Test
+    void shouldWriteDeferredStringAcrossFragments()
+    {
+        assertEquals("[\"abcd\"]", generate(g -> g
+            .writeStartArray()
+            .write("ab", Completion.INCOMPLETE)
+            .write("cd", Completion.COMPLETE)
+            .writeEnd()));
+    }
+
+    @Test
+    void shouldWriteDeferredStringWithEscapesAcrossFragments()
+    {
+        // a fragment boundary between escapable chars must still produce one correctly escaped string
+        assertEquals(
+            generate(g -> g.writeStartArray().write("a\"b\nc").writeEnd()),
+            generate(g -> g.writeStartArray()
+                .write("a\"b", Completion.INCOMPLETE)
+                .write("\nc", Completion.COMPLETE)
+                .writeEnd()));
     }
 
     private static String generate(

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonPipelineStarvedTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonPipelineStarvedTest.java
@@ -31,7 +31,7 @@ class JsonPipelineStarvedTest
     void shouldStarveWhenWindowConsumedMidValue()
     {
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonSink.of(gen));
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonEx.createSink(gen));
         pipeline.reset();
 
         byte[] f1 = "{\"a\":1,".getBytes(UTF_8);
@@ -44,7 +44,7 @@ class JsonPipelineStarvedTest
     void shouldCompleteAcrossWindowsAfterStarved()
     {
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonSink.of(gen));
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonEx.createSink(gen));
         pipeline.reset();
 
         byte[] f1 = "{\"a\":1,".getBytes(UTF_8);
@@ -62,7 +62,7 @@ class JsonPipelineStarvedTest
     void shouldRejectTruncatedStructureWhenLast()
     {
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonSink.of(gen));
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonEx.createSink(gen));
         pipeline.reset();
 
         // the object never closes and this is the final window: truncated, not merely starved
@@ -76,7 +76,7 @@ class JsonPipelineStarvedTest
     void shouldRejectTruncatedStringWhenLast()
     {
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonSink.of(gen));
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonEx.createSink(gen));
         pipeline.reset();
 
         // an unterminated string at terminal EOF is malformed
@@ -90,7 +90,7 @@ class JsonPipelineStarvedTest
     void shouldCompleteWholeValueWithDefaultFeed()
     {
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonSink.of(gen));
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonEx.createSink(gen));
         pipeline.reset();
 
         // the three-argument shorthand is last == true: a whole value completes in one shot
@@ -104,7 +104,7 @@ class JsonPipelineStarvedTest
     void shouldCompleteTrailingScalarAtTerminalEof()
     {
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonSink.of(gen));
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonEx.createSink(gen));
         pipeline.reset();
 
         // a bare trailing number with no delimiter completes because last == true makes EOF terminal

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentHardeningTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentHardeningTest.java
@@ -18,6 +18,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
+import java.util.Map;
 
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -35,7 +36,7 @@ class JsonProjectorSegmentHardeningTest
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(JsonEx.projector(List.of("/a")))
-            .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.SEGMENTABLE)));
 
         Status status = run(pipeline, "{\"a\":{ \"b\" : { \"c\" : [1, {\"d\": 2}] } },\"z\":9} ");
 
@@ -49,7 +50,7 @@ class JsonProjectorSegmentHardeningTest
         JsonGeneratorEx gen = JsonEx.createGenerator();
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(JsonEx.projector(List.of("/x")))
-            .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.SEGMENTABLE)));
 
         gen.wrap(buffer, 0, buffer.capacity());
         run(pipeline, "{\"x\":{ \"v\" : 1 },\"y\":2} ");
@@ -66,7 +67,7 @@ class JsonProjectorSegmentHardeningTest
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(JsonEx.projector(List.of("/a")))
-            .into(JsonSink.of(gen));
+            .into(JsonEx.createSink(gen));
 
         Status status = run(pipeline, "{\"a\":{ \"b\" : { \"c\" : [1, {\"d\": 2}] } },\"z\":9} ");
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
@@ -18,6 +18,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
+import java.util.Map;
 
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -35,7 +36,7 @@ class JsonProjectorSegmentTest
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(JsonEx.projector(List.of("/a")))
-            .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.SEGMENTABLE)));
 
         Status status = run(pipeline, "{\"a\":{ \"b\" : 1 },\"z\":9} ");
 
@@ -49,7 +50,7 @@ class JsonProjectorSegmentTest
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(JsonEx.projector(List.of("/a")))
-            .into(JsonSink.of(gen));
+            .into(JsonEx.createSink(gen));
 
         Status status = run(pipeline, "{\"a\":{ \"b\" : 1 },\"z\":9} ");
 
@@ -63,7 +64,7 @@ class JsonProjectorSegmentTest
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(JsonEx.projector(List.of("")))
-            .into(JsonSink.of(gen));
+            .into(JsonEx.createSink(gen));
 
         // structured delivery normalizes structure (whitespace) but preserves each leaf value's bytes,
         // so the original A escape survives rather than collapsing to A
@@ -79,7 +80,7 @@ class JsonProjectorSegmentTest
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(JsonEx.projector(List.of("")))
-            .into(JsonSink.of(gen));
+            .into(JsonEx.createSink(gen));
 
         Status status = run(pipeline, "{ \"a\" : 1.0e2 } ");
 
@@ -93,7 +94,7 @@ class JsonProjectorSegmentTest
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(JsonEx.projector(List.of("")))
-            .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.SEGMENTABLE)));
 
         Status status = run(pipeline, "{ \"a\" : 1 } ");
 
@@ -111,7 +112,7 @@ class JsonProjectorSegmentTest
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(decliner)
             .transform(JsonEx.projector(List.of("/a")))
-            .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.SEGMENTABLE)));
 
         Status status = run(pipeline, "{\"a\":{ \"b\" : 1 },\"z\":9} ");
 
@@ -125,7 +126,7 @@ class JsonProjectorSegmentTest
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(JsonEx.projector(List.of("/items/0")))
-            .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.SEGMENTABLE)));
 
         Status status = run(pipeline, "{\"items\":[{ \"id\" : 1 },{\"id\":2}]} ");
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
@@ -114,7 +114,7 @@ class JsonProjectorTest
         gen.wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(JsonEx.projector(List.of("/a", "/c")))
-            .into(JsonSink.of(gen));
+            .into(JsonEx.createSink(gen));
 
         byte[] bytes = "{\"a\":1,\"b\":2,\"c\":3} ".getBytes(UTF_8);
         UnsafeBuffer in = new UnsafeBuffer(bytes);
@@ -136,7 +136,7 @@ class JsonProjectorTest
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(JsonEx.projector(List.of("/x")))
-            .into(JsonSink.of(gen));
+            .into(JsonEx.createSink(gen));
 
         gen.wrap(buffer, 0, buffer.capacity());
         feed(pipeline, "{\"x\":1,\"y\":2} ");
@@ -172,7 +172,7 @@ class JsonProjectorTest
         gen.wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(JsonEx.projector(retained))
-            .into(JsonSink.of(gen));
+            .into(JsonEx.createSink(gen));
         feed(pipeline, input + " ");
         byte[] out = new byte[gen.length()];
         buffer.getBytes(0, out);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSinkSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSinkSegmentTest.java
@@ -17,6 +17,8 @@ package io.aklivity.zilla.runtime.common.json;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Map;
+
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
@@ -58,7 +60,7 @@ class JsonSinkSegmentTest
         gen.wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(segmentRoot)
-            .into(JsonSink.of(gen));
+            .into(JsonEx.createSink(gen));
 
         byte[] bytes = "{ \"a\" : 1 } ".getBytes(UTF_8);
         pipeline.reset();
@@ -77,7 +79,7 @@ class JsonSinkSegmentTest
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
         gen.wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
-            .into(JsonSink.of(gen, JsonSink.Delivery.SEGMENTABLE));
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.SEGMENTABLE)));
 
         byte[] bytes = "{ \"a\" : [1, 2], \"b\" : 3 } ".getBytes(UTF_8);
         pipeline.reset();
@@ -97,7 +99,7 @@ class JsonSinkSegmentTest
         gen.wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(segmentRoot)
-            .into(JsonSink.of(gen));
+            .into(JsonEx.createSink(gen));
 
         byte[] bytes = "[ 1, 2 ] ".getBytes(UTF_8);
         pipeline.reset();
@@ -117,7 +119,7 @@ class JsonSinkSegmentTest
         gen.wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(segmentRoot)
-            .into(JsonSink.of(gen));
+            .into(JsonEx.createSink(gen));
 
         byte[] bytes = "{ \"x\" : [1 ,2] } ".getBytes(UTF_8);
         pipeline.reset();
@@ -137,7 +139,7 @@ class JsonSinkSegmentTest
         gen.wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(segmentRoot)
-            .into(JsonSink.of(gen));
+            .into(JsonEx.createSink(gen));
 
         byte[] first = "{\"a\":1,".getBytes(UTF_8);
         byte[] second = "\"b\":2} ".getBytes(UTF_8);
@@ -150,5 +152,15 @@ class JsonSinkSegmentTest
         byte[] out = new byte[gen.length()];
         buffer.getBytes(0, out);
         assertEquals("{\"a\":1,\"b\":2}", new String(out, UTF_8));
+    }
+
+    @Test
+    void shouldUseDefaultResumeAndResetForForwardingSink()
+    {
+        // a stage that only forwards events relies on the JsonSink default resume/reset:
+        // reset is a no-op and resume reports nothing pending
+        JsonSink sink = (control, source, event) -> Status.ADVANCED;
+        sink.reset();
+        assertEquals(Status.ADVANCED, sink.resume(null, null));
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorChainTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorChainTest.java
@@ -46,7 +46,7 @@ class JsonValidatorChainTest
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(schema.validator())
-            .into(JsonSink.of(gen));
+            .into(JsonEx.createSink(gen));
 
         Status status = run(pipeline, "{\"id\":1,\"name\":\"x\"} ");
 
@@ -62,7 +62,7 @@ class JsonValidatorChainTest
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(schema.validator())
             .transform(JsonEx.projector(List.of("/id")))
-            .into(JsonSink.of(gen));
+            .into(JsonEx.createSink(gen));
 
         Status status = run(pipeline, "{\"id\":1,\"name\":\"x\"} ");
 
@@ -78,7 +78,7 @@ class JsonValidatorChainTest
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(schema.validator())
             .transform(JsonEx.projector(List.of("/id")))
-            .into(JsonSink.of(gen));
+            .into(JsonEx.createSink(gen));
 
         Status status = run(pipeline, "{\"id\":1} ");
 
@@ -93,7 +93,7 @@ class JsonValidatorChainTest
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(schema.validator())
-            .into(JsonSink.of(gen));
+            .into(JsonEx.createSink(gen));
 
         Status status = run(pipeline, "{\"id\":\"x\",\"name\":\"y\"} ");
 
@@ -107,7 +107,7 @@ class JsonValidatorChainTest
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(schema.validator())
-            .into(JsonSink.of(gen));
+            .into(JsonEx.createSink(gen));
 
         byte[] bytes = "{\"id\":1,\"name\":\"x\"} ".getBytes(UTF_8);
         UnsafeBuffer in = new UnsafeBuffer(bytes);
@@ -127,7 +127,7 @@ class JsonValidatorChainTest
         JsonGeneratorEx gen = JsonEx.createGenerator();
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(schema.validator())
-            .into(JsonSink.of(gen));
+            .into(JsonEx.createSink(gen));
 
         gen.wrap(buffer, 0, buffer.capacity());
         assertEquals(Status.COMPLETED, run(pipeline, "{\"id\":1,\"name\":\"a\"} "));
@@ -144,7 +144,7 @@ class JsonValidatorChainTest
         JsonTransform passthrough = (control, source, event, sink) -> sink.feed(control, source, event);
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(passthrough)
-            .into(JsonSink.of(gen));
+            .into(JsonEx.createSink(gen));
 
         Status status = run(pipeline, "{\"id\":1} ");
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/bench/JsonPipelineBM.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/bench/JsonPipelineBM.java
@@ -18,6 +18,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.util.List;
+import java.util.Map;
 
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -85,9 +86,9 @@ public class JsonPipelineBM
 
     private final MutableDirectBuffer outputBuffer = new UnsafeBuffer(new byte[16 * 1024]);
     private final JsonGeneratorEx generator = JsonEx.createGenerator();
-    private final JsonSink structuredSink = JsonSink.of(generator);
-    private final JsonSink segmentableSink = JsonSink.of(generator, Delivery.SEGMENTABLE);
-    private final JsonSink decodedSink = JsonSink.of(generator, Delivery.DECODED);
+    private final JsonSink structuredSink = JsonEx.createSink(generator);
+    private final JsonSink segmentableSink = JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, Delivery.SEGMENTABLE));
+    private final JsonSink decodedSink = JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, Delivery.DECODED));
 
     private JsonPipeline scalarLeavesPipeline;
     private JsonPipeline keptContainerStructuredPipeline;

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/bench/JsonPipelineBM.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/bench/JsonPipelineBM.java
@@ -40,6 +40,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
+import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
 import io.aklivity.zilla.runtime.common.json.JsonSink;
 import io.aklivity.zilla.runtime.common.json.JsonSink.Delivery;
 
@@ -76,10 +77,17 @@ public class JsonPipelineBM
         "\"keep\":{\"id\":99,\"name\":\"retain\",\"extra\":\"more-text-here\",\"nested\":{\"p\":1,\"q\":2}}," +
         "\"drop2\":[0,1,2,3,4,5,6,7,8,9],\"drop3\":{\"a\":\"b\",\"c\":\"d\"}} ";
 
+    // values far larger than FRAGMENT_WINDOW so windowed feeding forces the fragmenting path
+    private static final String LARGE_STRING = "{\"data\":\"" + "x".repeat(512) + "\"}";
+    private static final String LARGE_NUMBER = "{\"data\":" + "1".repeat(512) + "}";
+
+    private static final int FRAGMENT_WINDOW = 64;
+
     private final MutableDirectBuffer outputBuffer = new UnsafeBuffer(new byte[16 * 1024]);
     private final JsonGeneratorEx generator = JsonEx.createGenerator();
     private final JsonSink structuredSink = JsonSink.of(generator);
     private final JsonSink segmentableSink = JsonSink.of(generator, Delivery.SEGMENTABLE);
+    private final JsonSink decodedSink = JsonSink.of(generator, Delivery.DECODED);
 
     private JsonPipeline scalarLeavesPipeline;
     private JsonPipeline keptContainerStructuredPipeline;
@@ -88,16 +96,24 @@ public class JsonPipelineBM
     private JsonPipeline rootIdentitySegmentedPipeline;
     private JsonPipeline mostlySkippedStructuredPipeline;
     private JsonPipeline mostlySkippedSegmentedPipeline;
+    private JsonPipeline fragmentStringStructuredPipeline;
+    private JsonPipeline fragmentStringSegmentedPipeline;
+    private JsonPipeline fragmentStringDecodedPipeline;
+    private JsonPipeline fragmentNumberDecodedPipeline;
 
     private UnsafeBuffer flatBuffer;
     private UnsafeBuffer nestedBuffer;
     private UnsafeBuffer rootIdentityBuffer;
     private UnsafeBuffer mostlySkippedBuffer;
+    private UnsafeBuffer largeStringBuffer;
+    private UnsafeBuffer largeNumberBuffer;
 
     private int flatLength;
     private int nestedLength;
     private int rootIdentityLength;
     private int mostlySkippedLength;
+    private int largeStringLength;
+    private int largeNumberLength;
 
     @Setup(Level.Trial)
     public void init()
@@ -120,20 +136,32 @@ public class JsonPipelineBM
         mostlySkippedSegmentedPipeline = JsonEx.stream(JsonEx.createParser())
             .transform(JsonEx.projector(List.of("/keep"))).into(segmentableSink);
 
+        // no transform: an over-window value fragments and is rendered straight to the sink
+        fragmentStringStructuredPipeline = JsonEx.stream(JsonEx.createParser()).into(structuredSink);
+        fragmentStringSegmentedPipeline = JsonEx.stream(JsonEx.createParser()).into(segmentableSink);
+        fragmentStringDecodedPipeline = JsonEx.stream(JsonEx.createParser()).into(decodedSink);
+        fragmentNumberDecodedPipeline = JsonEx.stream(JsonEx.createParser()).into(decodedSink);
+
         byte[] flatBytes = FLAT_OBJECT.getBytes(UTF_8);
         byte[] nestedBytes = NESTED_OBJECT.getBytes(UTF_8);
         byte[] rootIdentityBytes = ROOT_IDENTITY.getBytes(UTF_8);
         byte[] mostlySkippedBytes = MOSTLY_SKIPPED.getBytes(UTF_8);
+        byte[] largeStringBytes = LARGE_STRING.getBytes(UTF_8);
+        byte[] largeNumberBytes = LARGE_NUMBER.getBytes(UTF_8);
 
         flatBuffer = new UnsafeBuffer(flatBytes);
         nestedBuffer = new UnsafeBuffer(nestedBytes);
         rootIdentityBuffer = new UnsafeBuffer(rootIdentityBytes);
         mostlySkippedBuffer = new UnsafeBuffer(mostlySkippedBytes);
+        largeStringBuffer = new UnsafeBuffer(largeStringBytes);
+        largeNumberBuffer = new UnsafeBuffer(largeNumberBytes);
 
         flatLength = flatBytes.length;
         nestedLength = nestedBytes.length;
         rootIdentityLength = rootIdentityBytes.length;
         mostlySkippedLength = mostlySkippedBytes.length;
+        largeStringLength = largeStringBytes.length;
+        largeNumberLength = largeNumberBytes.length;
     }
 
     @Benchmark
@@ -178,6 +206,30 @@ public class JsonPipelineBM
         return run(mostlySkippedSegmentedPipeline, mostlySkippedBuffer, mostlySkippedLength);
     }
 
+    @Benchmark
+    public int fragmentStringSegmented()
+    {
+        return runWindowed(fragmentStringSegmentedPipeline, largeStringBuffer, largeStringLength, FRAGMENT_WINDOW);
+    }
+
+    @Benchmark
+    public int fragmentStringStructured()
+    {
+        return runWindowed(fragmentStringStructuredPipeline, largeStringBuffer, largeStringLength, FRAGMENT_WINDOW);
+    }
+
+    @Benchmark
+    public int fragmentStringDecoded()
+    {
+        return runWindowed(fragmentStringDecodedPipeline, largeStringBuffer, largeStringLength, FRAGMENT_WINDOW);
+    }
+
+    @Benchmark
+    public int fragmentNumberDecoded()
+    {
+        return runWindowed(fragmentNumberDecodedPipeline, largeNumberBuffer, largeNumberLength, FRAGMENT_WINDOW);
+    }
+
     private int run(
         JsonPipeline pipeline,
         UnsafeBuffer buffer,
@@ -187,6 +239,34 @@ public class JsonPipelineBM
         pipeline.reset();
         pipeline.feed(buffer, 0, length);
         return generator.length();
+    }
+
+    // Feeds an over-window value in fixed window-sized steps, advancing the committed watermark to
+    // position() on each STARVED so the trailing partial unit carries into the next window; reuses the
+    // field buffer so the fragmenting path's only allocations are the ones under measurement.
+    private int runWindowed(
+        JsonPipeline pipeline,
+        UnsafeBuffer buffer,
+        int length,
+        int window)
+    {
+        generator.wrap(outputBuffer, 0, outputBuffer.capacity());
+        pipeline.reset();
+        int committed = 0;
+        int offset = 0;
+        Status status = Status.STARVED;
+        while (offset < length)
+        {
+            offset = Math.min(offset + window, length);
+            boolean last = offset >= length;
+            status = pipeline.feed(buffer, committed, offset - committed, last);
+            if (status != Status.STARVED)
+            {
+                break;
+            }
+            committed = (int) pipeline.position();
+        }
+        return status == Status.COMPLETED ? generator.length() : -1;
     }
 
     public static void main(

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorEscapeChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorEscapeChunkingTest.java
@@ -101,9 +101,9 @@ class JsonGeneratorEscapeChunkingTest
         JsonPipeline pipeline = project
             ? JsonEx.stream(JsonEx.createParser())
                 .transform(JsonEx.projector(List.of("/keep")))
-                .into(JsonSink.of(generator, JsonSink.Delivery.SEGMENTABLE))
+                .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.SEGMENTABLE)))
             : JsonEx.stream(JsonEx.createParser())
-                .into(JsonSink.of(generator, JsonSink.Delivery.SEGMENTABLE));
+                .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.SEGMENTABLE)));
 
         byte[] bytes = (json + " ").getBytes(UTF_8);
         UnsafeBuffer in = new UnsafeBuffer(bytes);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserFactoryImplTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserFactoryImplTest.java
@@ -34,15 +34,13 @@ import jakarta.json.stream.JsonParserFactory;
 import org.junit.jupiter.api.Test;
 
 import io.aklivity.zilla.runtime.common.json.JsonEx;
-import io.aklivity.zilla.runtime.common.json.JsonParserEx;
 
 public class JsonParserFactoryImplTest
 {
     @Test
     public void shouldCreateParserForInputStreamWithSharedConfig()
     {
-        final Map<String, Object> config = Map.of(
-            JsonParserEx.TOKEN_MAX_BYTES, 1024);
+        final Map<String, Object> config = Map.of();
         final JsonParserFactory factory = JsonEx.createParserFactory(config);
 
         final InputStream in1 = new BufferedInputStream(
@@ -64,8 +62,7 @@ public class JsonParserFactoryImplTest
     @Test
     public void shouldExposeConfigInUse()
     {
-        final Map<String, Object> config = Map.of(
-            JsonParserEx.TOKEN_MAX_BYTES, 1024);
+        final Map<String, Object> config = Map.of("io.aklivity.zilla.example", 1);
         final JsonParserFactory factory = JsonEx.createParserFactory(config);
         assertSame(config, factory.getConfigInUse());
     }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserFactoryImplTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserFactoryImplTest.java
@@ -23,7 +23,6 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.StringReader;
-import java.util.List;
 import java.util.Map;
 
 import jakarta.json.JsonArray;
@@ -43,7 +42,6 @@ public class JsonParserFactoryImplTest
     public void shouldCreateParserForInputStreamWithSharedConfig()
     {
         final Map<String, Object> config = Map.of(
-            JsonParserEx.PATH_INCLUDES, List.of("/jsonrpc"),
             JsonParserEx.TOKEN_MAX_BYTES, 1024);
         final JsonParserFactory factory = JsonEx.createParserFactory(config);
 
@@ -67,7 +65,7 @@ public class JsonParserFactoryImplTest
     public void shouldExposeConfigInUse()
     {
         final Map<String, Object> config = Map.of(
-            JsonParserEx.PATH_INCLUDES, List.of("/jsonrpc"));
+            JsonParserEx.TOKEN_MAX_BYTES, 1024);
         final JsonParserFactory factory = JsonEx.createParserFactory(config);
         assertSame(config, factory.getConfigInUse());
     }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import io.aklivity.zilla.runtime.common.json.JsonEvent;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
+import io.aklivity.zilla.runtime.common.json.JsonParserEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
 import io.aklivity.zilla.runtime.common.json.JsonSchema;
@@ -211,6 +213,43 @@ class JsonPipelineChunkingTest
         byte[] out = new byte[generator.length()];
         output.getBytes(0, out);
         assertEquals("[1,2,3]", new String(out, UTF_8));
+    }
+
+    @Test
+    void shouldReconstructInputFragmentedStringValueDecoded()
+    {
+        // tokenMaxBytes fragments the over-slot value; the DECODED sink re-renders each fragment via
+        // generator.write(getString(), deferredBytes()) with no concatenation
+        String json = "{\"data\":\"" + "x".repeat(40) + "\"}";
+        assertEquals(json, feedFragmented(json, JsonSink.Delivery.DECODED));
+    }
+
+    @Test
+    void shouldReconstructInputFragmentedStringValueVerbatim()
+    {
+        // same fragmented value, verbatim path: each fragment's getSegment() raw bytes splice back to
+        // the whole token
+        String json = "{\"data\":\"" + "x".repeat(40) + "\"}";
+        assertEquals(json, feedFragmented(json, JsonSink.Delivery.STRUCTURED));
+    }
+
+    private static String feedFragmented(
+        String json,
+        JsonSink.Delivery delivery)
+    {
+        JsonGeneratorEx generator = JsonEx.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[512]);
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser(Map.of(JsonParserEx.TOKEN_MAX_BYTES, 8)))
+            .into(JsonSink.of(generator, delivery));
+        generator.wrap(output, 0, output.capacity());
+        pipeline.reset();
+
+        byte[] bytes = (json + " ").getBytes(UTF_8);
+        Status status = pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length);
+        assertEquals(Status.COMPLETED, status);
+        byte[] out = new byte[generator.length()];
+        output.getBytes(0, out);
+        return new String(out, UTF_8);
     }
 
     // Drives a value through the pipeline with the generator bounded at BOUND, draining and re-targeting

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -19,8 +19,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+
+import jakarta.json.stream.JsonParser;
 
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -263,6 +266,79 @@ class JsonPipelineChunkingTest
         byte[] out = new byte[generator.length()];
         output.getBytes(0, out);
         assertEquals(json, new String(out, UTF_8));
+    }
+
+    @Test
+    void shouldReconstructWindowFragmentedNumberValueDecoded()
+    {
+        String json = "{\"n\":" + "1".repeat(40) + "}";
+        assertEquals(json, feedWindowed(json, JsonSink.Delivery.DECODED, 8));
+    }
+
+    @Test
+    void shouldReconstructWindowFragmentedNumberValueVerbatim()
+    {
+        String json = "{\"n\":" + "1".repeat(40) + "}";
+        assertEquals(json, feedWindowed(json, JsonSink.Delivery.STRUCTURED, 8));
+    }
+
+    @Test
+    void shouldReadWindowFragmentedNumberAsBigDecimalAndRejectGetInt()
+    {
+        // a number far longer than long range fragments across small windows; getBigDecimal() reads the
+        // whole value from the accumulated lexeme, while getInt()/getLong() reject the fragmented number
+        String bigNumber = "12345678901234567890123456789012";
+        String json = "{\"n\":" + bigNumber + "}";
+
+        JsonGeneratorEx generator = JsonEx.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[256]);
+        List<BigDecimal> wholes = new ArrayList<>();
+        List<Boolean> intRejected = new ArrayList<>();
+        JsonTransform probe = (control, source, event, sink) ->
+        {
+            if (event == JsonEvent.VALUE_NUMBER && !source.deferredBytes())
+            {
+                final JsonParser number = (JsonParser) source;
+                wholes.add(number.getBigDecimal());
+                boolean rejected = false;
+                try
+                {
+                    number.getInt();
+                }
+                catch (IllegalStateException ex)
+                {
+                    rejected = true;
+                }
+                intRejected.add(rejected);
+            }
+            return sink.feed(control, source, event);
+        };
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(probe)
+            .into(JsonSink.of(generator, JsonSink.Delivery.DECODED));
+        generator.wrap(output, 0, output.capacity());
+        pipeline.reset();
+
+        byte[] msg = (json + " ").getBytes(UTF_8);
+        int committed = 0;
+        int offset = 0;
+        Status status = Status.STARVED;
+        int guard = 0;
+        while (guard++ < 100_000)
+        {
+            offset = Math.min(offset + 8, msg.length);
+            boolean last = offset >= msg.length;
+            status = pipeline.feed(new UnsafeBuffer(msg), committed, offset - committed, last);
+            if (status != Status.STARVED)
+            {
+                break;
+            }
+            assertFalse(last, "last window must not starve");
+            committed = (int) pipeline.position();
+        }
+        assertEquals(Status.COMPLETED, status);
+        assertEquals(new BigDecimal(bigNumber), wholes.get(0));
+        assertTrue(intRejected.get(0), "getInt() must reject a fragmented number");
     }
 
     // Feeds the document in fixed-size windows, carrying the unconsumed tail (up to position()) across

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.Test;
 import io.aklivity.zilla.runtime.common.json.JsonEvent;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
-import io.aklivity.zilla.runtime.common.json.JsonParserEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
 import io.aklivity.zilla.runtime.common.json.JsonSchema;
@@ -216,47 +214,48 @@ class JsonPipelineChunkingTest
     }
 
     @Test
-    void shouldReconstructInputFragmentedStringValueDecoded()
+    void shouldReconstructWindowFragmentedStringValueDecoded()
     {
-        // tokenMaxBytes fragments the over-slot value; the DECODED sink re-renders each fragment via
-        // generator.write(getString(), deferredBytes()) with no concatenation
+        // small feed windows fragment the over-window value; the DECODED sink re-renders each fragment
+        // via generator.write(getString(), Completion) with no concatenation
         String json = "{\"data\":\"" + "x".repeat(40) + "\"}";
-        assertEquals(json, feedFragmented(json, JsonSink.Delivery.DECODED));
+        assertEquals(json, feedWindowed(json, JsonSink.Delivery.DECODED, 8));
     }
 
     @Test
-    void shouldReconstructInputFragmentedStringValueVerbatim()
+    void shouldReconstructWindowFragmentedStringValueVerbatim()
     {
         // same fragmented value, verbatim path: each fragment's getSegment() raw bytes splice back to
         // the whole token
         String json = "{\"data\":\"" + "x".repeat(40) + "\"}";
-        assertEquals(json, feedFragmented(json, JsonSink.Delivery.STRUCTURED));
+        assertEquals(json, feedWindowed(json, JsonSink.Delivery.STRUCTURED, 8));
     }
 
     @Test
-    void shouldReconstructFragmentedValueWithMultibyteAcrossFrames()
+    void shouldReconstructFragmentedValueWithMultibyteAcrossWindow()
     {
-        // an over-slot value whose 2-byte 'é' straddles the input window while fragmenting: the parser
-        // leaves the partial char unconsumed (position() < window) and the caller carries the tail
+        // a top-level string fills the first window and fragments; the window ends on the lead byte of
+        // 'é', so the parser leaves the partial char unconsumed (position() < window) and the caller
+        // carries the tail into the next window
         JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[512]);
-        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser(Map.of(JsonParserEx.TOKEN_MAX_BYTES, 8)))
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .into(JsonSink.of(generator, JsonSink.Delivery.DECODED));
         generator.wrap(output, 0, output.capacity());
         pipeline.reset();
 
-        String json = "{\"data\":\"" + "x".repeat(10) + "é" + "y".repeat(10) + "\"}";
+        String json = "\"" + "x".repeat(10) + "é" + "y".repeat(10) + "\"";
         byte[] msg = (json + " ").getBytes(UTF_8);
-        int firstWindow = -1;
-        for (int i = 0; i < msg.length && firstWindow < 0; i++)
+        int w1 = -1;
+        for (int i = 0; i < msg.length && w1 < 0; i++)
         {
             if ((msg[i] & 0xff) == 0xc3)
             {
-                firstWindow = i + 1; // window ends on the lead byte of 'é', splitting the char
+                w1 = i + 1; // window ends on the lead byte of 'é', splitting the char
             }
         }
 
-        assertEquals(Status.STARVED, pipeline.feed(new UnsafeBuffer(msg), 0, firstWindow, false));
+        assertEquals(Status.STARVED, pipeline.feed(new UnsafeBuffer(msg), 0, w1, false));
         int committed = (int) pipeline.position();
         assertEquals(Status.COMPLETED,
             pipeline.feed(new UnsafeBuffer(msg), committed, msg.length - committed, true));
@@ -266,19 +265,36 @@ class JsonPipelineChunkingTest
         assertEquals(json, new String(out, UTF_8));
     }
 
-    private static String feedFragmented(
+    // Feeds the document in fixed-size windows, carrying the unconsumed tail (up to position()) across
+    // feeds the way a real caller does; a value that fills a window is fragmented and reconstructed.
+    private static String feedWindowed(
         String json,
-        JsonSink.Delivery delivery)
+        JsonSink.Delivery delivery,
+        int window)
     {
         JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[512]);
-        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser(Map.of(JsonParserEx.TOKEN_MAX_BYTES, 8)))
-            .into(JsonSink.of(generator, delivery));
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonSink.of(generator, delivery));
         generator.wrap(output, 0, output.capacity());
         pipeline.reset();
 
-        byte[] bytes = (json + " ").getBytes(UTF_8);
-        Status status = pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length);
+        byte[] msg = (json + " ").getBytes(UTF_8);
+        int committed = 0;
+        int offset = 0;
+        Status status = Status.STARVED;
+        int guard = 0;
+        while (guard++ < 100_000)
+        {
+            offset = Math.min(offset + window, msg.length);
+            boolean last = offset >= msg.length;
+            status = pipeline.feed(new UnsafeBuffer(msg), committed, offset - committed, last);
+            if (status != Status.STARVED)
+            {
+                break;
+            }
+            assertFalse(last, "last window must not starve");
+            committed = (int) pipeline.position();
+        }
         assertEquals(Status.COMPLETED, status);
         byte[] out = new byte[generator.length()];
         output.getBytes(0, out);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -233,6 +233,39 @@ class JsonPipelineChunkingTest
         assertEquals(json, feedFragmented(json, JsonSink.Delivery.STRUCTURED));
     }
 
+    @Test
+    void shouldReconstructFragmentedValueWithMultibyteAcrossFrames()
+    {
+        // an over-slot value whose 2-byte 'é' straddles the input window while fragmenting: the parser
+        // leaves the partial char unconsumed (position() < window) and the caller carries the tail
+        JsonGeneratorEx generator = JsonEx.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[512]);
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser(Map.of(JsonParserEx.TOKEN_MAX_BYTES, 8)))
+            .into(JsonSink.of(generator, JsonSink.Delivery.DECODED));
+        generator.wrap(output, 0, output.capacity());
+        pipeline.reset();
+
+        String json = "{\"data\":\"" + "x".repeat(10) + "é" + "y".repeat(10) + "\"}";
+        byte[] msg = (json + " ").getBytes(UTF_8);
+        int firstWindow = -1;
+        for (int i = 0; i < msg.length && firstWindow < 0; i++)
+        {
+            if ((msg[i] & 0xff) == 0xc3)
+            {
+                firstWindow = i + 1; // window ends on the lead byte of 'é', splitting the char
+            }
+        }
+
+        assertEquals(Status.STARVED, pipeline.feed(new UnsafeBuffer(msg), 0, firstWindow, false));
+        int committed = (int) pipeline.position();
+        assertEquals(Status.COMPLETED,
+            pipeline.feed(new UnsafeBuffer(msg), committed, msg.length - committed, true));
+
+        byte[] out = new byte[generator.length()];
+        output.getBytes(0, out);
+        assertEquals(json, new String(out, UTF_8));
+    }
+
     private static String feedFragmented(
         String json,
         JsonSink.Delivery delivery)

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import jakarta.json.stream.JsonParser;
 
@@ -48,7 +49,7 @@ class JsonPipelineChunkingTest
         JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
-            .into(JsonSink.of(generator));
+            .into(JsonEx.createSink(generator));
 
         String json = "[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19]";
         assertEquals(json, chunked(pipeline, generator, output, json));
@@ -60,7 +61,7 @@ class JsonPipelineChunkingTest
         JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
-            .into(JsonSink.of(generator));
+            .into(JsonEx.createSink(generator));
 
         String json = "{\"k0\":0,\"k1\":1,\"k2\":2,\"k3\":3,\"k4\":4,\"k5\":5,\"k6\":6,\"k7\":7,\"k8\":8,\"k9\":9}";
         assertEquals(json, chunked(pipeline, generator, output, json));
@@ -73,7 +74,7 @@ class JsonPipelineChunkingTest
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(JsonEx.projector(List.of("")))
-            .into(JsonSink.of(generator));
+            .into(JsonEx.createSink(generator));
 
         String json = "{\"id\":1,\"items\":[10,11,12,13,14,15,16,17,18,19],\"ok\":true}";
         assertEquals(json, chunked(pipeline, generator, output, json));
@@ -86,7 +87,7 @@ class JsonPipelineChunkingTest
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(JsonSchema.of("{\"type\":\"object\"}").validator())
-            .into(JsonSink.of(generator));
+            .into(JsonEx.createSink(generator));
 
         String json = "{\"k0\":0,\"k1\":1,\"k2\":2,\"k3\":3,\"k4\":4,\"k5\":5,\"k6\":6,\"k7\":7,\"k8\":8,\"k9\":9}";
         assertEquals(json, chunked(pipeline, generator, output, json));
@@ -98,7 +99,7 @@ class JsonPipelineChunkingTest
         JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[256]);
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
-            .into(JsonSink.of(generator, JsonSink.Delivery.SEGMENTABLE));
+            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.SEGMENTABLE)));
         generator.wrap(output, 0, output.capacity());
         pipeline.reset();
 
@@ -130,7 +131,7 @@ class JsonPipelineChunkingTest
         };
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(probe)
-            .into(JsonSink.of(generator, JsonSink.Delivery.SEGMENTABLE));
+            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.SEGMENTABLE)));
         generator.wrap(output, 0, output.capacity());
         pipeline.reset();
 
@@ -148,7 +149,7 @@ class JsonPipelineChunkingTest
         JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[256]);
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
-            .into(JsonSink.of(generator));
+            .into(JsonEx.createSink(generator));
 
         // a single string property value far larger than BOUND, in structured delivery
         String json = "{\"data\":\"" + "x".repeat(96) + "\"}";
@@ -161,7 +162,7 @@ class JsonPipelineChunkingTest
         JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[256]);
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
-            .into(JsonSink.of(generator));
+            .into(JsonEx.createSink(generator));
 
         // a single numeric property value far larger than BOUND, in structured delivery
         String json = "{\"data\":" + "1".repeat(96) + "}";
@@ -174,7 +175,7 @@ class JsonPipelineChunkingTest
         JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[256]);
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
-            .into(JsonSink.of(generator, JsonSink.Delivery.SEGMENTABLE));
+            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.SEGMENTABLE)));
 
         // one top-level array whose verbatim form far exceeds BOUND, delivered as a single segment that
         // must be fragmented across many chunks
@@ -190,7 +191,7 @@ class JsonPipelineChunkingTest
         JsonTransform passthrough = (control, source, event, sink) -> sink.feed(control, source, event);
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(passthrough)
-            .into(JsonSink.of(generator, JsonSink.Delivery.SEGMENTABLE));
+            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.SEGMENTABLE)));
 
         // the resume cascade must continue the in-flight fragment through the transform stage
         String json = "[\"aaaaaaaa\",\"bbbbbbbb\",\"cccccccc\",\"dddddddd\",\"eeeeeeee\",\"ffffffff\"]";
@@ -203,7 +204,7 @@ class JsonPipelineChunkingTest
         JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
-            .into(JsonSink.of(generator));
+            .into(JsonEx.createSink(generator));
 
         byte[] bytes = "[1,2,3] ".getBytes(UTF_8);
         pipeline.reset();
@@ -243,7 +244,7 @@ class JsonPipelineChunkingTest
         JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[512]);
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
-            .into(JsonSink.of(generator, JsonSink.Delivery.DECODED));
+            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.DECODED)));
         generator.wrap(output, 0, output.capacity());
         pipeline.reset();
 
@@ -315,7 +316,7 @@ class JsonPipelineChunkingTest
         };
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(probe)
-            .into(JsonSink.of(generator, JsonSink.Delivery.DECODED));
+            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.DECODED)));
         generator.wrap(output, 0, output.capacity());
         pipeline.reset();
 
@@ -350,7 +351,8 @@ class JsonPipelineChunkingTest
     {
         JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[512]);
-        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonSink.of(generator, delivery));
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, delivery)));
         generator.wrap(output, 0, output.capacity());
         pipeline.reset();
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineRejectTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineRejectTest.java
@@ -25,7 +25,6 @@ import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
-import io.aklivity.zilla.runtime.common.json.JsonSink;
 
 class JsonPipelineRejectTest
 {
@@ -37,7 +36,7 @@ class JsonPipelineRejectTest
         JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
-            .into(JsonSink.of(generator));
+            .into(JsonEx.createSink(generator));
 
         byte[] bytes = "[1 2]".getBytes(UTF_8);
         generator.wrap(output, 0, output.capacity());

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineResetTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineResetTest.java
@@ -25,7 +25,6 @@ import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
-import io.aklivity.zilla.runtime.common.json.JsonSink;
 
 class JsonPipelineResetTest
 {
@@ -39,7 +38,7 @@ class JsonPipelineResetTest
         JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
-            .into(JsonSink.of(generator));
+            .into(JsonEx.createSink(generator));
 
         generator.wrap(buffer, 0, buffer.capacity());
         pipeline.reset();

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaPathsTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaPathsTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
-import io.aklivity.zilla.runtime.common.json.JsonSink;
 
 class JsonSchemaPathsTest
 {
@@ -114,7 +113,7 @@ class JsonSchemaPathsTest
                 "{\"type\":\"object\",\"properties\":{" +
                 "\"items\":{\"type\":\"array\",\"items\":{\"type\":\"object\"," +
                 "\"properties\":{\"id\":{\"type\":\"integer\"}}}}}}")))
-            .into(JsonSink.of(gen));
+            .into(JsonEx.createSink(gen));
         pipeline.reset();
         byte[] bytes = "{\"items\":[{\"id\":1,\"x\":9},{\"id\":2}],\"k\":0} ".getBytes(UTF_8);
         pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonStringsTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonStringsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json.internal;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+public class JsonStringsTest
+{
+    private String unescape(
+        String body)
+    {
+        final byte[] bytes = body.getBytes(UTF_8);
+        final UnsafeBuffer buffer = new UnsafeBuffer(bytes);
+        final StringBuilder out = new StringBuilder();
+        JsonStrings.unescape(buffer, 0, bytes.length, out);
+        return out.toString();
+    }
+
+    @Test
+    public void shouldDecodePlainAscii()
+    {
+        assertEquals("hello world", unescape("hello world"));
+    }
+
+    @Test
+    public void shouldDecodeSimpleEscapes()
+    {
+        assertEquals("a\nb\tc\r\"\\/\b\f", unescape("a\\nb\\tc\\r\\\"\\\\\\/\\b\\f"));
+    }
+
+    @Test
+    public void shouldDecodeUnicodeEscape()
+    {
+        assertEquals("é", unescape("\\u00e9"));
+    }
+
+    @Test
+    public void shouldDecodeSurrogatePairEscape()
+    {
+        // U+1F600 GRINNING FACE as a UTF-16 surrogate-pair escape
+        assertEquals("😀", unescape("\\ud83d\\ude00"));
+    }
+
+    @Test
+    public void shouldDecodeRawUtf8Multibyte()
+    {
+        assertEquals("café é € 😀",
+            unescape("café é € 😀"));
+    }
+
+    @Test
+    public void shouldDecodeAtNonZeroOffset()
+    {
+        final byte[] bytes = "XXa\\nbYY".getBytes(UTF_8);
+        final UnsafeBuffer buffer = new UnsafeBuffer(bytes);
+        final StringBuilder out = new StringBuilder();
+        JsonStrings.unescape(buffer, 2, 4, out);
+        assertEquals("a\nb", out.toString());
+    }
+}

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerPathTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerPathTest.java
@@ -16,8 +16,6 @@ package io.aklivity.zilla.runtime.common.json.internal;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -107,33 +105,6 @@ public class JsonTokenizerPathTest
             tokenizer.clearEvent();
         }
         assertEquals("/a~1b/c~0d", observedPathAtNumber);
-    }
-
-    @Test
-    public void shouldFragmentValueExceedingTokenMaxBytes() throws IOException
-    {
-        final JsonTokenizer tokenizer = new JsonTokenizer(8);
-
-        final String json = "{\"payload\":\"abcdefghijklmnopqrst\"}";
-        final InputStream in = new BufferedInputStream(
-            new ByteArrayInputStream(json.getBytes(UTF_8)));
-
-        final StringBuilder assembled = new StringBuilder();
-        int fragments = 0;
-        boolean lastDeferred = true;
-        while (tokenizer.advance(in))
-        {
-            if (tokenizer.event() == JsonParser.Event.VALUE_STRING)
-            {
-                assembled.append(tokenizer.stringValue());
-                fragments++;
-                lastDeferred = tokenizer.fragmenting();
-            }
-            tokenizer.clearEvent();
-        }
-        assertEquals("abcdefghijklmnopqrst", assembled.toString());
-        assertTrue(fragments > 1, "expected multiple fragments, got " + fragments);
-        assertFalse(lastDeferred, "final fragment should not defer");
     }
 
     @Test

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerPathTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerPathTest.java
@@ -16,7 +16,8 @@ package io.aklivity.zilla.runtime.common.json.internal;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -26,7 +27,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.json.stream.JsonParser;
-import jakarta.json.stream.JsonParsingException;
 
 import org.junit.jupiter.api.Test;
 
@@ -110,7 +110,7 @@ public class JsonTokenizerPathTest
     }
 
     @Test
-    public void shouldThrowWhenValueExceedsTokenMaxBytes() throws IOException
+    public void shouldFragmentValueExceedingTokenMaxBytes() throws IOException
     {
         final JsonTokenizer tokenizer = new JsonTokenizer(8);
 
@@ -118,13 +118,22 @@ public class JsonTokenizerPathTest
         final InputStream in = new BufferedInputStream(
             new ByteArrayInputStream(json.getBytes(UTF_8)));
 
-        assertThrows(JsonParsingException.class, () ->
+        final StringBuilder assembled = new StringBuilder();
+        int fragments = 0;
+        boolean lastDeferred = true;
+        while (tokenizer.advance(in))
         {
-            while (tokenizer.advance(in))
+            if (tokenizer.event() == JsonParser.Event.VALUE_STRING)
             {
-                tokenizer.clearEvent();
+                assembled.append(tokenizer.stringValue());
+                fragments++;
+                lastDeferred = tokenizer.fragmenting();
             }
-        });
+            tokenizer.clearEvent();
+        }
+        assertEquals("abcdefghijklmnopqrst", assembled.toString());
+        assertTrue(fragments > 1, "expected multiple fragments, got " + fragments);
+        assertFalse(lastDeferred, "final fragment should not defer");
     }
 
     @Test

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerPathTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerPathTest.java
@@ -144,6 +144,34 @@ public class JsonTokenizerPathTest
     }
 
     @Test
+    public void shouldMatchObjectKeysAndArrayIndexesViaCharSequence() throws IOException
+    {
+        // exercises the allocation-free matcher: object keys compared as CharSequence (pathKeyChars),
+        // array indexes compared numerically, plus wildcard and explicit-index matching
+        final List<String> includes = List.of("/users/-/id", "/meta/count", "/list/1");
+        final JsonTokenizer tokenizer =
+            new JsonTokenizer(includes, List.of(), Integer.MAX_VALUE);
+
+        final String json = "{\"users\":[{\"id\":1,\"name\":\"a\"},{\"id\":2}]," +
+            "\"meta\":{\"count\":5,\"other\":9},\"list\":[10,11,12]}";
+        final InputStream in = new BufferedInputStream(
+            new ByteArrayInputStream(json.getBytes(UTF_8)));
+
+        final List<String> readable = new ArrayList<>();
+        while (tokenizer.advance(in))
+        {
+            final JsonParser.Event ev = tokenizer.event();
+            if ((ev == JsonParser.Event.VALUE_NUMBER || ev == JsonParser.Event.VALUE_STRING) &&
+                tokenizer.valueReadable())
+            {
+                readable.add(tokenizer.stringValue());
+            }
+            tokenizer.clearEvent();
+        }
+        assertEquals(List.of("1", "2", "5", "11"), readable);
+    }
+
+    @Test
     public void shouldSuppressScratchForNonReadableValues() throws IOException
     {
         final List<String> includes = List.of("/tools/-/name");

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerPathTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerPathTest.java
@@ -24,15 +24,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import jakarta.json.stream.JsonParser;
 import jakarta.json.stream.JsonParsingException;
 
 import org.junit.jupiter.api.Test;
-
-import io.aklivity.zilla.runtime.common.json.JsonEx;
-import io.aklivity.zilla.runtime.common.json.JsonParserEx;
 
 public class JsonTokenizerPathTest
 {
@@ -92,40 +88,10 @@ public class JsonTokenizerPathTest
     }
 
     @Test
-    public void shouldCompilePathsAndMatchExpectedValues() throws IOException
+    public void shouldTrackPathWithEscapedSlashAndTilde() throws IOException
     {
-        final List<String> includes = List.of(
-            "",                       // root
-            "/tools/-/name",          // wildcard array index
-            "/tools/-/title");
-        final List<String> excludes = List.of(
-            "/tools/-/title");        // excludes win for title
-
-        final JsonTokenizer tokenizer =
-            new JsonTokenizer(includes, excludes, 1024);
-
-        final String json = "{\"tools\":[{\"name\":\"X\",\"title\":\"T\"},{\"name\":\"Y\"}]}";
-        final InputStream in = new BufferedInputStream(
-            new ByteArrayInputStream(json.getBytes(UTF_8)));
-
-        int eventCount = 0;
-        while (tokenizer.advance(in))
-        {
-            eventCount++;
-            tokenizer.clearEvent();
-        }
-        assertEquals(15, eventCount);
-    }
-
-    @Test
-    public void shouldMatchPathSegmentWithEscapedSlashAndTilde() throws IOException
-    {
-        // RFC 6901 escapes: "~1" decodes to "/", "~0" decodes to "~"
-        final List<String> includes = List.of(
-            "/a~1b/c~0d");            // path of "/a/b" then "c~d"
-
-        final JsonTokenizer tokenizer =
-            new JsonTokenizer(includes, List.of(), Integer.MAX_VALUE);
+        // RFC 6901 escapes in currentPath(): "/" encodes to "~1", "~" encodes to "~0"
+        final JsonTokenizer tokenizer = new JsonTokenizer();
 
         final String json = "{\"a/b\":{\"c~d\":42}}";
         final InputStream in = new BufferedInputStream(
@@ -144,107 +110,9 @@ public class JsonTokenizerPathTest
     }
 
     @Test
-    public void shouldMatchObjectKeysAndArrayIndexesViaCharSequence() throws IOException
+    public void shouldThrowWhenValueExceedsTokenMaxBytes() throws IOException
     {
-        // exercises the allocation-free matcher: object keys compared as CharSequence (pathKeyChars),
-        // array indexes compared numerically, plus wildcard and explicit-index matching
-        final List<String> includes = List.of("/users/-/id", "/meta/count", "/list/1");
-        final JsonTokenizer tokenizer =
-            new JsonTokenizer(includes, List.of(), Integer.MAX_VALUE);
-
-        final String json = "{\"users\":[{\"id\":1,\"name\":\"a\"},{\"id\":2}]," +
-            "\"meta\":{\"count\":5,\"other\":9},\"list\":[10,11,12]}";
-        final InputStream in = new BufferedInputStream(
-            new ByteArrayInputStream(json.getBytes(UTF_8)));
-
-        final List<String> readable = new ArrayList<>();
-        while (tokenizer.advance(in))
-        {
-            final JsonParser.Event ev = tokenizer.event();
-            if ((ev == JsonParser.Event.VALUE_NUMBER || ev == JsonParser.Event.VALUE_STRING) &&
-                tokenizer.valueReadable())
-            {
-                readable.add(tokenizer.stringValue());
-            }
-            tokenizer.clearEvent();
-        }
-        assertEquals(List.of("1", "2", "5", "11"), readable);
-    }
-
-    @Test
-    public void shouldSuppressScratchForNonReadableValues() throws IOException
-    {
-        final List<String> includes = List.of("/tools/-/name");
-        final JsonTokenizer tokenizer =
-            new JsonTokenizer(includes, List.of(), Integer.MAX_VALUE);
-
-        final String json = "{\"tools\":[{\"name\":\"X\",\"description\":\"a quite long description\"}]}";
-        final InputStream in = new BufferedInputStream(
-            new ByteArrayInputStream(json.getBytes(UTF_8)));
-
-        final List<String> readableValues = new ArrayList<>();
-        final List<JsonParser.Event> nonReadableValueEvents = new ArrayList<>();
-        while (tokenizer.advance(in))
-        {
-            final JsonParser.Event ev = tokenizer.event();
-            switch (ev)
-            {
-            case VALUE_STRING:
-            case VALUE_NUMBER:
-                if (tokenizer.valueReadable())
-                {
-                    readableValues.add(tokenizer.stringValue());
-                }
-                else
-                {
-                    nonReadableValueEvents.add(ev);
-                }
-                break;
-            default:
-                break;
-            }
-            tokenizer.clearEvent();
-        }
-        assertEquals(List.of("X"), readableValues);
-        assertEquals(1, nonReadableValueEvents.size());
-    }
-
-    @Test
-    public void shouldThrowFromGetStringForNonReadableValueAtParserLevel() throws IOException
-    {
-        final String json = "{\"tools\":[{\"name\":\"X\",\"description\":\"a long description\"}]}";
-        final BufferedInputStream in = new BufferedInputStream(
-            new ByteArrayInputStream(json.getBytes(UTF_8)));
-
-        final Map<String, Object> config = Map.of(
-            JsonParserEx.PATH_INCLUDES, List.of("/tools/-/name"));
-        final JsonParser parser = JsonEx.createParserFactory(config).createParser(in);
-
-        boolean sawNonReadableValue = false;
-        while (parser.hasNext())
-        {
-            final JsonParser.Event ev = parser.next();
-            if (ev == JsonParser.Event.KEY_NAME && "description".equals(parser.getString()))
-            {
-                final JsonParser.Event next = parser.next();
-                assertEquals(JsonParser.Event.VALUE_STRING, next);
-                assertThrows(IllegalStateException.class, parser::getString);
-                sawNonReadableValue = true;
-                break;
-            }
-        }
-        if (!sawNonReadableValue)
-        {
-            throw new AssertionError("did not reach the non-readable value");
-        }
-    }
-
-    @Test
-    public void shouldThrowWhenReadableValueExceedsTokenMaxBytes() throws IOException
-    {
-        final List<String> includes = List.of("/payload");
-        final JsonTokenizer tokenizer =
-            new JsonTokenizer(includes, List.of(), 8);
+        final JsonTokenizer tokenizer = new JsonTokenizer(8);
 
         final String json = "{\"payload\":\"abcdefghijklmnopqrst\"}";
         final InputStream in = new BufferedInputStream(
@@ -260,33 +128,9 @@ public class JsonTokenizerPathTest
     }
 
     @Test
-    public void shouldNotThrowWhenExcludedValueExceedsTokenMaxBytes() throws IOException
+    public void shouldHandleArrayDocument() throws IOException
     {
-        final List<String> excludes = List.of("/payload");
-        final JsonTokenizer tokenizer =
-            new JsonTokenizer(JsonTokenizer.INCLUDE_ALL, excludes, 8);
-
-        final String json = "{\"payload\":\"abcdefghijklmnopqrst\",\"id\":1}";
-        final InputStream in = new BufferedInputStream(
-            new ByteArrayInputStream(json.getBytes(UTF_8)));
-
-        Long observedId = null;
-        while (tokenizer.advance(in))
-        {
-            if (tokenizer.event() == JsonParser.Event.VALUE_NUMBER && tokenizer.valueReadable())
-            {
-                observedId = Long.parseLong(tokenizer.stringValue());
-            }
-            tokenizer.clearEvent();
-        }
-        assertEquals(1L, observedId);
-    }
-
-    @Test
-    public void shouldHandleEmptyConfigAsLegacyBehavior() throws IOException
-    {
-        final JsonTokenizer tokenizer =
-            new JsonTokenizer(List.of(), List.of(), Integer.MAX_VALUE);
+        final JsonTokenizer tokenizer = new JsonTokenizer();
 
         final String json = "[1,2,3]";
         final InputStream in = new BufferedInputStream(


### PR DESCRIPTION
## Description

This change refactors the JSON tokenizer to support streaming large values (strings and numbers) that exceed a single input window without requiring reassembly across frames. Previously, the parser would rewind and retry when a value didn't fit in the current window. Now it can deliver values as fragments, enabling efficient streaming of arbitrarily large JSON values.

### Key Changes

**JsonTokenizer.java**
- Removed path filtering logic (`pathIncludes`, `pathExcludes`, `pathFiltering`) — this feature is no longer supported
- Removed `tokenMaxBytes` configuration parameter
- Added `windowLength` field to track the current input window size
- Added `numberLexeme` StringBuilder to accumulate fragmented number lexemes across windows
- Added `fragmenting` and `numberFragmented` flags to track fragmentation state
- Added `fragmentStart` and `unitStartOffset` to track fragment boundaries
- Replaced `valueReadable()` with `fragmenting()` to indicate ongoing fragmented delivery
- New `window(int length)` method to set the input window size per frame
- New `onScalarStarved()` method implementing the fragmentation logic:
  - For strings: rewinds to the last complete code-point/escape boundary and delivers decoded chars so far
  - For numbers: accumulates the lexeme and delivers digits scanned so far
  - For values fitting in a window: rewinds to reassemble whole in the next window
- Simplified constructor signatures (removed path and tokenMaxBytes parameters)

**JsonStrings.java** (new file)
- Extracted string unescaping logic into a reusable utility class
- Decodes JSON string bodies (between quotes) with escape sequence handling
- Supports UTF-8 multibyte characters and Unicode escapes

**JsonParserImpl.java**
- Removed path filtering configuration handling
- Added `window(int length)` call in `wrap()` to inform tokenizer of window size
- Added `position()` method to expose current stream offset
- Updated `deferredBytes()` to include `tokenizer.fragmenting()` state
- Removed `valueReadable()` check from `getString()` (path filtering removed)

**JsonGeneratorEx.java & JsonGeneratorImpl.java**
- Added `Completion` enum to distinguish incomplete vs. complete fragments
- New `write(CharSequence, Completion)` method for deferred string fragments
- New `writeNumber(CharSequence, Completion)` method for deferred number fragments
- Generator now tracks `stringOpen` and `numberOpen` state to handle fragmented values

**JsonSinkImpl.java**
- Updated to handle `Delivery.DECODED` mode for fragmented values
- Renders decoded values from fragments without concatenation
- Maintains verbatim segment delivery for `Delivery.STRUCTURED` mode

**Test Changes**
- Added `JsonStringsTest` covering string unescaping with escapes, Unicode, UTF-8 multibyte, and offset handling
- Added `JsonPipelineChunkingTest` tests for fragmented string/number reconstruction across windows
- Removed path filtering tests from `JsonTokenizerPathTest` (feature removed)
- Updated remaining path tests to use simplified tokenizer constructor

### Motivation

This enables efficient streaming of large JSON values without buffering them whole in memory. Values that exceed the input window are delivered as fragments, allowing the parser to process them incrementally while maintaining correct semantics for both decoded (unescaped) and verbatim (raw bytes) delivery modes.

### Breaking Changes

- Removed `JsonParserEx.PATH_INCLUDES` and `JsonParserEx.PATH_EXCLUDES` configuration options
- Removed `JsonTokenizer` constructors taking path and tokenMaxBytes parameters
- Removed `valueReadable()` method from tokenizer (replaced with `fragmenting()`)

https://claude.ai/code/session_01DCYLhQmFrTkg4UZaxZ6wvp