### PR TITLE
fix(common-json): project kept scalar leaves fragmented across input windows

### DIFF
--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
@@ -72,6 +72,8 @@ public final class JsonProjectorImpl implements JsonTransform
     private Status downstream;
     private SegMode segMode = SegMode.NONE;
     private JsonEvent deferredStart;
+    private boolean scalarPending;
+    private boolean scalarEmit;
 
     private enum SegMode
     {
@@ -99,6 +101,8 @@ public final class JsonProjectorImpl implements JsonTransform
         downstreamDemand = false;
         segMode = SegMode.NONE;
         deferredStart = null;
+        scalarPending = false;
+        scalarEmit = false;
     }
 
     private void onDownstreamSegmentable()
@@ -348,18 +352,48 @@ public final class JsonProjectorImpl implements JsonTransform
         JsonEvent event,
         JsonSink sink)
     {
-        Decision d = enterValue();
-        boolean parentEmit = containers == 0 || frameEmit[containers - 1];
-        boolean emit = parentEmit && d == Decision.KEEP_ALL;
-        if (emit)
+        if (scalarPending)
         {
-            forwardPendingKey(sink);
-            forward(sink, source, event);
+            // a continuation fragment of a kept/dropped scalar value split across input windows: the value
+            // was already entered on its first fragment, so forward (if kept) without re-entering and only
+            // account for the consumed value once its closing fragment arrives (deferredBytes false)
+            if (scalarEmit)
+            {
+                forward(sink, source, event);
+            }
+            if (!source.deferredBytes())
+            {
+                finishScalar();
+            }
         }
         else
         {
-            pendingKey = null;
+            Decision d = enterValue();
+            boolean parentEmit = containers == 0 || frameEmit[containers - 1];
+            scalarEmit = parentEmit && d == Decision.KEEP_ALL;
+            if (scalarEmit)
+            {
+                forwardPendingKey(sink);
+                forward(sink, source, event);
+            }
+            else
+            {
+                pendingKey = null;
+            }
+            if (source.deferredBytes())
+            {
+                scalarPending = true;
+            }
+            else
+            {
+                finishScalar();
+            }
         }
+    }
+
+    private void finishScalar()
+    {
+        scalarPending = false;
         if (containers == 0)
         {
             rootDone = true;

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
@@ -134,6 +134,41 @@ class JsonProjectorSegmentTest
         assertEquals("{\"items\":[{ \"id\" : 1 }]}", output(gen));
     }
 
+    @Test
+    void shouldDecodeKeptScalarLeafFragmentedAcrossWindows()
+    {
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("/a")))
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.DECODED)));
+
+        // a retained scalar leaf far larger than the input window: it fragments across windows and the
+        // DECODED sink rejoins the fragments; the dropped sibling /b also fragments and must not be emitted
+        String value = "x".repeat(40);
+        String json = "{\"a\":\"" + value + "\",\"b\":\"" + "y".repeat(40) + "\"} ";
+        byte[] bytes = json.getBytes(UTF_8);
+        pipeline.reset();
+
+        int committed = 0;
+        int offset = 0;
+        Status status = Status.STARVED;
+        int guard = 0;
+        while (guard++ < 10_000)
+        {
+            offset = Math.min(offset + 8, bytes.length);
+            boolean last = offset >= bytes.length;
+            status = pipeline.feed(new UnsafeBuffer(bytes), committed, offset - committed, last);
+            committed = (int) pipeline.position();
+            if (status == Status.COMPLETED || status == Status.REJECTED)
+            {
+                break;
+            }
+        }
+
+        assertEquals(Status.COMPLETED, status);
+        assertEquals("{\"a\":\"" + value + "\"}", output(gen));
+    }
+
     private String output(
         JsonGeneratorEx gen)
     {


### PR DESCRIPTION
## Summary

`JsonProjectorImpl.onScalar` finalized a kept (or dropped) scalar value on its **first** event — decrementing `depth` / setting `rootDone` — without checking `source.deferredBytes()`. Under `Delivery.DECODED` (added in #1880), an over-window scalar is fragmented into multiple `VALUE_STRING`/`VALUE_NUMBER` events, so finalizing on the first fragment corrupted the projector's descent bookkeeping (`depth` driven negative → `ArrayIndexOutOfBoundsException`). As a result a **retained scalar leaf larger than the input window could not be projected** — the projector only streamed kept *containers* (`onAwaiting`/`onForwarding`, which already check `deferredBytes()`), never a kept scalar *leaf*.

## Fix

Make `onScalar` fragment-aware, mirroring the container segment paths:

- track the in-flight scalar with `scalarPending` / `scalarEmit`;
- on the **first** fragment: enter the value, decide keep/drop, forward the kept key + fragment;
- on **continuation** fragments: forward (if kept) without re-entering;
- account for the consumed value **once**, on its closing fragment (`!deferredBytes()`), via `finishScalar()`.

This applies equally to kept and dropped scalar leaves (a dropped over-window scalar must also consume all its fragments without re-entering) and to scalar array elements.

## Tests

Added `JsonProjectorSegmentTest#shouldDecodeKeptScalarLeafFragmentedAcrossWindows`: a retained scalar leaf (and a dropped sibling) far larger than the input window, fed in 8-byte windows under `DECODED`, driven with the `pipeline.position()` watermark.

- Before the fix: `ArrayIndexOutOfBoundsException: Index -4` (depth corruption).
- After the fix: passes; output is the pruned document with the leaf rejoined.

Full `common-json` build green — 4768 tests, checkstyle, license, coverage.

## Motivation

This is the missing projector capability behind the deferred large-payload streaming for `binding-mcp-http` (#1832): both proxy legs prune a document to schema paths while one retained leaf (an order `status`, a PR `body`) far exceeds one buffer slot. With this fix the binding can drive a plain `projector → DECODED` pipeline for fragmented scalar leaves.

Refs #1880.

https://claude.ai/code/session_01AEpU8rooKSEqf6EuU8ri1i

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEpU8rooKSEqf6EuU8ri1i)_