### PR TITLE
feat(common-json): stream kept scalar leaves via append-only consumed pushback

### DIFF
--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonController.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonController.java
@@ -22,21 +22,14 @@ package io.aklivity.zilla.runtime.common.json;
  * caller determines which by observing the events that follow — there is no return value, because a
  * mediating upstream cannot know the outcome at call time. A mediating {@link JsonTransform} supplies
  * its own {@code JsonController} to its downstream; a non-mediating stage passes its own through.
- * <p>
- * A terminal stage that splices a kept value's verbatim bytes also calls {@link #consumed(int)} after
- * each segment chunk, reporting how many <em>source</em> bytes it actually took, so the upstream advances
- * its {@code position()} by exactly that count and re-exposes the value remainder on resume. A mediating
- * stage forwards {@code consumed} to its own upstream, the same way it relays {@code segmentable}.
  */
 public interface JsonController
 {
     void segmentable();
 
     /**
-     * Reports that {@code sourceBytes} source bytes of the current verbatim segment were consumed by the
-     * terminal write, always on a UTF-8 character and JSON escape-sequence boundary. The upstream advances
-     * its {@code position()} by this count so the next pull/resume re-exposes the value remainder. The
-     * default is a no-op for upstreams that do not track segment consumption.
+     * Reports {@code sourceBytes} source bytes consumed by a verbatim segment write so the upstream
+     * advances its {@code position()} and re-exposes the value remainder on resume.
      */
     default void consumed(
         int sourceBytes)

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonController.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonController.java
@@ -22,8 +22,24 @@ package io.aklivity.zilla.runtime.common.json;
  * caller determines which by observing the events that follow — there is no return value, because a
  * mediating upstream cannot know the outcome at call time. A mediating {@link JsonTransform} supplies
  * its own {@code JsonController} to its downstream; a non-mediating stage passes its own through.
+ * <p>
+ * A terminal stage that splices a kept value's verbatim bytes also calls {@link #consumed(int)} after
+ * each segment chunk, reporting how many <em>source</em> bytes it actually took, so the upstream advances
+ * its {@code position()} by exactly that count and re-exposes the value remainder on resume. A mediating
+ * stage forwards {@code consumed} to its own upstream, the same way it relays {@code segmentable}.
  */
 public interface JsonController
 {
     void segmentable();
+
+    /**
+     * Reports that {@code sourceBytes} source bytes of the current verbatim segment were consumed by the
+     * terminal write, always on a UTF-8 character and JSON escape-sequence boundary. The upstream advances
+     * its {@code position()} by this count so the next pull/resume re-exposes the value remainder. The
+     * default is a no-op for upstreams that do not track segment consumption.
+     */
+    default void consumed(
+        int sourceBytes)
+    {
+    }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -590,18 +590,33 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         }
     }
 
+    // Copies whole source units only: a unit is a whole UTF-8 character or a whole JSON escape sequence
+    // (a two-byte backslash escape or a six-byte backslash-u escape), never a partial multibyte char or
+    // split escape. Stops before a unit that does not fit the output bound; consumed() advances by the
+    // source bytes taken, always on a unit boundary.
     private int writeRawSegment(
         DirectBuffer source,
         int index,
         int length)
     {
-        int written = Math.min(length, limit - progress);
-        buffer.putBytes(progress, source, index, written);
-        progress += written;
+        int written = 0;
+        while (written < length)
+        {
+            int unit = unitLength(source, index + written, length - written);
+            if (limit - progress < unit)
+            {
+                break;
+            }
+            buffer.putBytes(progress, source, index + written, unit);
+            progress += unit;
+            written += unit;
+        }
         consumed += written;
         return written;
     }
 
+    // Escapes whole source units only (see writeRawSegment): each unit's escaped output is emitted
+    // atomically, stopping before a unit whose escaped width would exceed the output bound.
     private int writeEscapedSegment(
         DirectBuffer source,
         int index,
@@ -610,16 +625,74 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         int written = 0;
         while (written < length)
         {
-            int value = source.getByte(index + written) & 0xff;
-            if (limit - progress < escapedWidth(value))
+            int unit = unitLength(source, index + written, length - written);
+            if (limit - progress < escapedUnitWidth(source, index + written, unit))
             {
                 break;
             }
-            putEscaped(value);
-            written++;
+            for (int i = 0; i < unit; i++)
+            {
+                putEscaped(source.getByte(index + written + i) & 0xff);
+            }
+            written += unit;
         }
         consumed += written;
         return written;
+    }
+
+    // Byte length of the next source unit at index: a JSON escape sequence (backslash-X is 2 bytes,
+    // backslash-u-XXXX is 6 bytes) is one unit, a UTF-8 character is one unit of 1-4 bytes per its lead
+    // byte. A unit whose bytes are not all available within length is reported as the available remainder
+    // so it is held back, not split.
+    private static int unitLength(
+        DirectBuffer source,
+        int index,
+        int length)
+    {
+        int first = source.getByte(index) & 0xff;
+        int unit;
+        if (first == '\\')
+        {
+            int next = length > 1 ? source.getByte(index + 1) & 0xff : -1;
+            unit = next == 'u' ? 6 : 2;
+        }
+        else if (first < 0x80)
+        {
+            unit = 1;
+        }
+        else if ((first & 0xe0) == 0xc0)
+        {
+            unit = 2;
+        }
+        else if ((first & 0xf0) == 0xe0)
+        {
+            unit = 3;
+        }
+        else if ((first & 0xf8) == 0xf0)
+        {
+            unit = 4;
+        }
+        else
+        {
+            unit = 1;
+        }
+        return Math.min(unit, length);
+    }
+
+    // Output byte width of a source unit once escaped: the sum of each byte's escaped width, so a
+    // multibyte UTF-8 char passes through verbatim while an escape sequence's backslash and content are
+    // themselves escaped (JSON-in-JSON).
+    private static int escapedUnitWidth(
+        DirectBuffer source,
+        int index,
+        int unit)
+    {
+        int width = 0;
+        for (int i = 0; i < unit; i++)
+        {
+            width += escapedWidth(source.getByte(index + i) & 0xff);
+        }
+        return width;
     }
 
     private void putEscaped(

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -590,10 +590,8 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         }
     }
 
-    // Copies whole source units only: a unit is a whole UTF-8 character or a whole JSON escape sequence
-    // (a two-byte backslash escape or a six-byte backslash-u escape), never a partial multibyte char or
-    // split escape. Stops before a unit that does not fit the output bound; consumed() advances by the
-    // source bytes taken, always on a unit boundary.
+    // Copies whole source units (UTF-8 char or JSON escape sequence), stopping before one that overflows
+    // the output bound, so consumed() always advances on a unit boundary.
     private int writeRawSegment(
         DirectBuffer source,
         int index,
@@ -615,8 +613,8 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         return written;
     }
 
-    // Escapes whole source units only (see writeRawSegment): each unit's escaped output is emitted
-    // atomically, stopping before a unit whose escaped width would exceed the output bound.
+    // Escapes whole source units (see writeRawSegment), stopping before a unit whose escaped width
+    // would overflow the output bound.
     private int writeEscapedSegment(
         DirectBuffer source,
         int index,
@@ -640,10 +638,8 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         return written;
     }
 
-    // Byte length of the next source unit at index: a JSON escape sequence (backslash-X is 2 bytes,
-    // backslash-u-XXXX is 6 bytes) is one unit, a UTF-8 character is one unit of 1-4 bytes per its lead
-    // byte. A unit whose bytes are not all available within length is reported as the available remainder
-    // so it is held back, not split.
+    // Byte length of the next source unit: a backslash escape (2 or 6 bytes) or a UTF-8 char (1-4 bytes),
+    // capped at length so a unit not wholly available is held back rather than split.
     private static int unitLength(
         DirectBuffer source,
         int index,
@@ -679,9 +675,7 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         return Math.min(unit, length);
     }
 
-    // Output byte width of a source unit once escaped: the sum of each byte's escaped width, so a
-    // multibyte UTF-8 char passes through verbatim while an escape sequence's backslash and content are
-    // themselves escaped (JSON-in-JSON).
+    // Output byte width of a source unit once escaped: the sum of each byte's escaped width.
     private static int escapedUnitWidth(
         DirectBuffer source,
         int index,

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -59,6 +59,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     private long segmentStartOffset;
     private int segmentSliceOffset;
     private int segmentSliceLength;
+    private int segmentConsumed;
     private int segmentDepth;
     private boolean armNextValue;
 
@@ -148,6 +149,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         tokenizer.reset();
         segmentState = SegmentState.NONE;
         segmentDepth = 0;
+        segmentConsumed = 0;
         armNextValue = false;
         lastEvent = null;
         docState = DocState.NOT_STARTED;
@@ -278,6 +280,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
             {
                 segmentSliceOffset = bufferOffset(tokenizer.valueStreamStart());
                 segmentSliceLength = (int) (tokenizer.valueStreamEnd() - tokenizer.valueStreamStart());
+                segmentConsumed = 0;
             }
             if (armNextValue)
             {
@@ -317,6 +320,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
             {
                 segmentSliceOffset = sliceStart;
                 segmentSliceLength = ownedInput.offset() + ownedInput.length() - sliceStart;
+                segmentConsumed = 0;
                 segmentState = SegmentState.SCANNING;
                 event = JsonEvent.SEGMENT;
             }
@@ -338,6 +342,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
                     final int sliceEnd = bufferOffset(tokenizer.streamOffset());
                     segmentSliceOffset = sliceStart;
                     segmentSliceLength = sliceEnd - sliceStart;
+                    segmentConsumed = 0;
                     segmentState = SegmentState.NONE;
                     event = JsonEvent.SEGMENT;
                 }
@@ -360,6 +365,20 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         {
             armNextValue = true;
         }
+        else if (lastEvent == JsonEvent.KEY_NAME)
+        {
+            // a kept scalar leaf armed at its key: the upcoming value-string is streamed verbatim as raw
+            // segment fragments (no decoded retention) once parseValue enters it; the tokenizer clears
+            // the arm if the value turns out to be a container, number, or literal rather than a string
+            tokenizer.scalarSegment(true);
+        }
+    }
+
+    @Override
+    public void consumed(
+        int sourceBytes)
+    {
+        segmentConsumed += sourceBytes;
     }
 
     @Override
@@ -439,7 +458,9 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     @Override
     public DirectBuffer getSegment()
     {
-        segmentView.wrap(ownedInput.buffer(), segmentSliceOffset, segmentSliceLength);
+        // re-expose the unconsumed remainder of the current segment slice: a partial terminal write
+        // pushes back consumed() so the next pull/resume appends from where it stopped, append-only
+        segmentView.wrap(ownedInput.buffer(), segmentSliceOffset + segmentConsumed, segmentSliceLength - segmentConsumed);
         return segmentView;
     }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -367,9 +367,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         }
         else if (lastEvent == JsonEvent.KEY_NAME)
         {
-            // a kept scalar leaf armed at its key: the upcoming value-string is streamed verbatim as raw
-            // segment fragments (no decoded retention) once parseValue enters it; the tokenizer clears
-            // the arm if the value turns out to be a container, number, or literal rather than a string
+            // arm the upcoming value-string to stream verbatim; the tokenizer clears it for a non-string
             tokenizer.scalarSegment(true);
         }
     }
@@ -458,8 +456,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     @Override
     public DirectBuffer getSegment()
     {
-        // re-expose the unconsumed remainder of the current segment slice: a partial terminal write
-        // pushes back consumed() so the next pull/resume appends from where it stopped, append-only
+        // re-expose the unconsumed remainder of the segment slice after consumed() pushback, append-only
         segmentView.wrap(ownedInput.buffer(), segmentSliceOffset + segmentConsumed, segmentSliceLength - segmentConsumed);
         return segmentView;
     }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
@@ -111,9 +111,8 @@ public final class JsonProjectorImpl implements JsonTransform
         downstreamDemand = true;
     }
 
-    // Relays the terminal sink's consumed() pushback to the projector's own upstream so the parser
-    // advances by exactly the source bytes truly emitted, the same relay the projector does for
-    // segmentable(). The current upstream control is captured per feed/resume.
+    // Relays the sink's consumed() pushback to the projector's own upstream, the same way it relays
+    // segmentable(); the upstream control is captured per feed/resume.
     private final class DownstreamControl implements JsonController
     {
         @Override
@@ -243,9 +242,7 @@ public final class JsonProjectorImpl implements JsonTransform
         // A forwarded key reuses the char view already buffered above for path matching, so no key
         // ever materializes a String — neither the SKIP majority nor the KEEP keys carried downstream.
         pendingKey = d == Decision.SKIP ? null : key;
-        // arm the kept value for verbatim segment delivery: if it is a scalar leaf the upstream streams
-        // it as raw segment fragments; if it turns out to be a container the upstream re-arms at its start
-        // and the scalar arm is discarded. Best-effort, demand-gated, exactly like the container path.
+        // arm the kept value for verbatim segment delivery; best-effort, demand-gated
         boolean parentEmit = containers == 0 || frameEmit[containers - 1];
         if (parentEmit && d == Decision.KEEP_ALL && downstreamDemand)
         {

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
@@ -61,8 +61,9 @@ public final class JsonProjectorImpl implements JsonTransform
 
     private final KeySource keySource = new KeySource();
 
-    private final JsonController downstreamControl = this::onDownstreamSegmentable;
+    private final DownstreamControl downstreamControl = new DownstreamControl();
 
+    private JsonController upstreamControl;
     private int depth;
     private int containers;
     private Decision keyDecision;
@@ -110,6 +111,25 @@ public final class JsonProjectorImpl implements JsonTransform
         downstreamDemand = true;
     }
 
+    // Relays the terminal sink's consumed() pushback to the projector's own upstream so the parser
+    // advances by exactly the source bytes truly emitted, the same relay the projector does for
+    // segmentable(). The current upstream control is captured per feed/resume.
+    private final class DownstreamControl implements JsonController
+    {
+        @Override
+        public void segmentable()
+        {
+            onDownstreamSegmentable();
+        }
+
+        @Override
+        public void consumed(
+            int sourceBytes)
+        {
+            upstreamControl.consumed(sourceBytes);
+        }
+    }
+
     @Override
     public Status feed(
         JsonController control,
@@ -117,6 +137,7 @@ public final class JsonProjectorImpl implements JsonTransform
         JsonEvent event,
         JsonSink sink)
     {
+        upstreamControl = control;
         downstream = Status.ADVANCED;
         if (segMode == SegMode.AWAITING)
         {
@@ -190,7 +211,7 @@ public final class JsonProjectorImpl implements JsonTransform
             forward(sink, source, event);
             break;
         case KEY_NAME:
-            onKey(source);
+            onKey(control, source);
             break;
         case START_OBJECT:
         case START_ARRAY:
@@ -207,6 +228,7 @@ public final class JsonProjectorImpl implements JsonTransform
     }
 
     private void onKey(
+        JsonController control,
         JsonSource source)
     {
         StringBuilder key = segmentKeys[depth];
@@ -221,6 +243,14 @@ public final class JsonProjectorImpl implements JsonTransform
         // A forwarded key reuses the char view already buffered above for path matching, so no key
         // ever materializes a String — neither the SKIP majority nor the KEEP keys carried downstream.
         pendingKey = d == Decision.SKIP ? null : key;
+        // arm the kept value for verbatim segment delivery: if it is a scalar leaf the upstream streams
+        // it as raw segment fragments; if it turns out to be a container the upstream re-arms at its start
+        // and the scalar arm is discarded. Best-effort, demand-gated, exactly like the container path.
+        boolean parentEmit = containers == 0 || frameEmit[containers - 1];
+        if (parentEmit && d == Decision.KEEP_ALL && downstreamDemand)
+        {
+            control.segmentable();
+        }
     }
 
     private void forwardPendingKey(

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
@@ -1662,10 +1662,26 @@ public final class JsonSchemaImpl implements JsonSchema
 
     private final class Validator implements JsonTransform
     {
-        private final JsonController decline = () ->
+        // declines segmentable() (validation requires structured events) but relays consumed() to the
+        // upstream so a verbatim segment path further downstream still advances the parser correctly
+        private final class Decline implements JsonController
         {
-        };
+            @Override
+            public void segmentable()
+            {
+            }
 
+            @Override
+            public void consumed(
+                int sourceBytes)
+            {
+                upstreamControl.consumed(sourceBytes);
+            }
+        }
+
+        private final JsonController decline = new Decline();
+
+        private JsonController upstreamControl;
         private Eval eval;
 
         private Validator()
@@ -1680,6 +1696,7 @@ public final class JsonSchemaImpl implements JsonSchema
             JsonEvent event,
             JsonSink sink)
         {
+            upstreamControl = control;
             Status downstream = sink.feed(decline, source, event);
             Status status;
             if (event.segmented() || event == JsonEvent.START_DOCUMENT || event == JsonEvent.END_DOCUMENT)

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
@@ -1662,8 +1662,7 @@ public final class JsonSchemaImpl implements JsonSchema
 
     private final class Validator implements JsonTransform
     {
-        // declines segmentable() (validation requires structured events) but relays consumed() to the
-        // upstream so a verbatim segment path further downstream still advances the parser correctly
+        // declines segmentable() (validation needs structured events) but relays consumed() upstream
         private final class Decline implements JsonController
         {
             @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -168,10 +168,8 @@ public final class JsonSinkImpl implements JsonSink
         return deferred ? Status.ADVANCED : scalarStatus();
     }
 
-    // Append-only and stateless: writes the segment view whole, where the view is the remainder the
-    // upstream re-exposes after each consumed() pushback (no per-value write offset kept here). The
-    // generator copies as many whole source units as fit the output bound; the source bytes it took are
-    // pushed back via control.consumed(...) so the upstream advances and re-exposes the remainder.
+    // Append-only and stateless: writes the segment view whole and pushes back the source bytes the
+    // generator took via control.consumed(...) so the upstream re-exposes the remainder.
     private Status writeChunk(
         JsonController control,
         DirectBuffer segment,

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -37,7 +37,6 @@ public final class JsonSinkImpl implements JsonSink
     private final JsonGeneratorEx generator;
     private final Delivery delivery;
     private int depth;
-    private int segmentWritten;
     private boolean valueStarted;
     private boolean pendingSegment;
 
@@ -104,7 +103,7 @@ public final class JsonSinkImpl implements JsonSink
                     generator.writeRaw(segment, 0, 0);
                     valueStarted = true;
                 }
-                status = writeChunk(segment, source);
+                status = writeChunk(control, segment, source);
             }
             break;
         case VALUE_TRUE:
@@ -139,7 +138,7 @@ public final class JsonSinkImpl implements JsonSink
         JsonController control,
         JsonSource source)
     {
-        Status status = pendingSegment ? writeChunk(source.getSegment(), source) : Status.ADVANCED;
+        Status status = pendingSegment ? writeChunk(control, source.getSegment(), source) : Status.ADVANCED;
         return boundary(status);
     }
 
@@ -147,7 +146,6 @@ public final class JsonSinkImpl implements JsonSink
     public void reset()
     {
         depth = 0;
-        segmentWritten = 0;
         valueStarted = false;
         pendingSegment = false;
         generator.reset();
@@ -170,16 +168,21 @@ public final class JsonSinkImpl implements JsonSink
         return deferred ? Status.ADVANCED : scalarStatus();
     }
 
+    // Append-only and stateless: writes the segment view whole, where the view is the remainder the
+    // upstream re-exposes after each consumed() pushback (no per-value write offset kept here). The
+    // generator copies as many whole source units as fit the output bound; the source bytes it took are
+    // pushed back via control.consumed(...) so the upstream advances and re-exposes the remainder.
     private Status writeChunk(
+        JsonController control,
         DirectBuffer segment,
         JsonSource source)
     {
+        int available = segment.capacity();
         int before = generator.consumed();
-        int available = segment.capacity() - segmentWritten;
-        generator.writeSegment(segment, segmentWritten, available);
+        generator.writeSegment(segment, 0, available);
         int consumed = generator.consumed() - before;
         int outputDeferred = available - consumed;
-        segmentWritten += consumed;
+        control.consumed(consumed);
         Status status;
         if (outputDeferred > 0)
         {
@@ -188,7 +191,6 @@ public final class JsonSinkImpl implements JsonSink
         }
         else
         {
-            segmentWritten = 0;
             pendingSegment = false;
             if (source.deferredBytes())
             {

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -84,9 +84,8 @@ public final class JsonTokenizer
     // set while a segment scan is in progress: a value-string is then streamed across frames as raw
     // bytes (no rewind to require it whole-in-frame, no decoded retention) rather than buffered whole.
     private boolean segmenting;
-    // set while the current top-level value-string is being delivered verbatim as raw segment fragments
-    // (a kept scalar leaf armed by the projector): like segmenting it suppresses decoded retention, but
-    // unlike a container scan it lets the value-string itself fragment across windows at unit boundaries.
+    // set while a kept scalar leaf value-string is delivered verbatim as raw fragments: suppresses decoded
+    // retention and lets the value-string fragment across windows at unit boundaries
     private boolean scalarSegment;
     // set while a value-string that fills the input window is being delivered as a sequence of
     // fragments: each fragment carries the decoded chars scanned so far, deferredBytes() stays true
@@ -160,8 +159,7 @@ public final class JsonTokenizer
         this.segmenting = segmenting;
     }
 
-    // Arms the next top-level value-string to stream verbatim as raw segment fragments: decoded chars are
-    // not retained and the value-string fragments across windows at UTF-8/escape unit boundaries.
+    // Arms the next value-string to stream verbatim as raw fragments (no decoded retention).
     void scalarSegment(
         boolean scalarSegment)
     {
@@ -237,16 +235,12 @@ public final class JsonTokenizer
         if (midScalar)
         {
             final long valueBytes = streamOffset - valueStreamStart;
-            // a kept scalar leaf streamed verbatim fragments on any starve (whatever bytes scanned so
-            // far ship as a raw fragment); a retained-but-decoded value only fragments once its own bytes
-            // fill the window (smaller values reassemble whole next window)
+            // a kept scalar leaf fragments verbatim on any starve; a decoded value only once it fills the window
             final boolean fragment =
                 !terminalEof && (scalarSegment || fragmenting || valueBytes >= windowLength);
             if (fragment && resumeOp == ResumeOp.VALUE_STRING)
             {
-                // string: rewind to the last complete code-point/escape boundary, leaving the partial
-                // unit for the caller to carry; ship the chars decoded so far (verbatim leaf: ship the
-                // raw bytes scanned so far, nothing retained in scratch)
+                // rewind to the last complete code-point/escape boundary, leaving the partial unit for the caller
                 streamOffset = unitStartOffset;
                 resumeEscape = false;
                 resumeUnicodePending = 0;
@@ -676,8 +670,7 @@ public final class JsonTokenizer
         InputStream in,
         int c) throws IOException
     {
-        // a scalar-segment arm applies only to a value-string; clear it for any other value so it does
-        // not leak into a container's inner strings or a following value
+        // a scalar-segment arm applies only to a value-string; clear it for any other value
         if (c != '"')
         {
             scalarSegment = false;

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -84,6 +84,10 @@ public final class JsonTokenizer
     // set while a segment scan is in progress: a value-string is then streamed across frames as raw
     // bytes (no rewind to require it whole-in-frame, no decoded retention) rather than buffered whole.
     private boolean segmenting;
+    // set while the current top-level value-string is being delivered verbatim as raw segment fragments
+    // (a kept scalar leaf armed by the projector): like segmenting it suppresses decoded retention, but
+    // unlike a container scan it lets the value-string itself fragment across windows at unit boundaries.
+    private boolean scalarSegment;
     // set while a value-string that fills the input window is being delivered as a sequence of
     // fragments: each fragment carries the decoded chars scanned so far, deferredBytes() stays true
     // until the closing quote. A partial char/escape at a window boundary is left unconsumed (rewound
@@ -138,6 +142,7 @@ public final class JsonTokenizer
         streamOffset = 0;
         fragmentStart = 0;
         segmenting = false;
+        scalarSegment = false;
         fragmenting = false;
         starved = false;
         resumeOp = ResumeOp.NONE;
@@ -153,6 +158,14 @@ public final class JsonTokenizer
         boolean segmenting)
     {
         this.segmenting = segmenting;
+    }
+
+    // Arms the next top-level value-string to stream verbatim as raw segment fragments: decoded chars are
+    // not retained and the value-string fragments across windows at UTF-8/escape unit boundaries.
+    void scalarSegment(
+        boolean scalarSegment)
+    {
+        this.scalarSegment = scalarSegment;
     }
 
     // Set per input window: when true this window's EOF is the terminal delimiter (one-shot or final
@@ -224,17 +237,22 @@ public final class JsonTokenizer
         if (midScalar)
         {
             final long valueBytes = streamOffset - valueStreamStart;
-            final boolean fragment = !terminalEof && (fragmenting || valueBytes >= windowLength);
+            // a kept scalar leaf streamed verbatim fragments on any starve (whatever bytes scanned so
+            // far ship as a raw fragment); a retained-but-decoded value only fragments once its own bytes
+            // fill the window (smaller values reassemble whole next window)
+            final boolean fragment =
+                !terminalEof && (scalarSegment || fragmenting || valueBytes >= windowLength);
             if (fragment && resumeOp == ResumeOp.VALUE_STRING)
             {
                 // string: rewind to the last complete code-point/escape boundary, leaving the partial
-                // unit for the caller to carry; ship the chars decoded so far
+                // unit for the caller to carry; ship the chars decoded so far (verbatim leaf: ship the
+                // raw bytes scanned so far, nothing retained in scratch)
                 streamOffset = unitStartOffset;
                 resumeEscape = false;
                 resumeUnicodePending = 0;
                 resumeUnicodeValue = 0;
                 fragmenting = true;
-                if (scratch.length() > 0)
+                if (scalarSegment ? streamOffset > fragmentStart : scratch.length() > 0)
                 {
                     valueStreamStart = fragmentStart;
                     valueStreamEnd = streamOffset;
@@ -528,6 +546,7 @@ public final class JsonTokenizer
         pendingEvent = JsonParser.Event.VALUE_STRING;
         captureValue();
         fragmenting = false;
+        scalarSegment = false;
         resumeOp = ResumeOp.NONE;
         afterValueConsumed();
     }
@@ -657,6 +676,12 @@ public final class JsonTokenizer
         InputStream in,
         int c) throws IOException
     {
+        // a scalar-segment arm applies only to a value-string; clear it for any other value so it does
+        // not leak into a container's inner strings or a following value
+        if (c != '"')
+        {
+            scalarSegment = false;
+        }
         switch (c)
         {
         case '{':
@@ -986,7 +1011,7 @@ public final class JsonTokenizer
     // still retain (keys for path matching, numbers for grammar validation).
     private boolean streamingValue()
     {
-        return segmenting && resumeOp == ResumeOp.VALUE_STRING;
+        return (segmenting || scalarSegment) && resumeOp == ResumeOp.VALUE_STRING;
     }
 
     private int decodeUtf8(

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
@@ -240,6 +240,67 @@ class JsonProjectorSegmentTest
         return result.toString();
     }
 
+    @Test
+    void shouldStreamMultiLeafResourceLikeBinding()
+    {
+        String status = "z".repeat(300);
+        String json = "{\"id\":\"12345\",\"status\":\"" + status + "\",\"total\":42.5," +
+            "\"customer\":\"acme\",\"createdAt\":\"2026-01-01\"} ";
+
+        String escaped = driveMulti(json, 16, 7);
+        String whole = driveMulti(json, 4096, 4096);
+
+        assertEquals(whole, escaped);
+        assertEquals("{\"id\":\"12345\",\"status\":\"" + status + "\",\"total\":42.5}",
+            decodeJsonString(escaped));
+    }
+
+    private static String driveMulti(
+        String json,
+        int outBound,
+        int inStep)
+    {
+        MutableDirectBuffer out = new UnsafeBuffer(new byte[outBound]);
+        JsonGeneratorEx gen = JsonEx.createGenerator(Map.of(JsonGeneratorEx.GENERATE_ESCAPED, true));
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("/id", "/status", "/total")))
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.SEGMENTABLE)));
+
+        byte[] bytes = json.getBytes(UTF_8);
+        pipeline.reset();
+        gen.wrap(out, 0, outBound);
+
+        StringBuilder result = new StringBuilder();
+        int committed = 0;
+        int offset = 0;
+        Status status = Status.STARVED;
+        int guard = 0;
+        while (guard++ < 1_000_000)
+        {
+            if (status != Status.SUSPENDED)
+            {
+                offset = Math.min(offset + inStep, bytes.length);
+            }
+            boolean last = offset >= bytes.length;
+            status = pipeline.feed(new UnsafeBuffer(bytes), committed, offset - committed, last);
+            byte[] chunk = new byte[gen.length()];
+            out.getBytes(0, chunk);
+            result.append(new String(chunk, UTF_8));
+            committed = (int) pipeline.position();
+            if (status == Status.SUSPENDED)
+            {
+                gen.wrap(out, 0, outBound);
+            }
+            else if (status == Status.COMPLETED || status == Status.REJECTED)
+            {
+                break;
+            }
+        }
+
+        assertEquals(Status.COMPLETED, status);
+        return result.toString();
+    }
+
     // The project(/a) plain (non-escaped) rendering, whole-shot, for the JSON-in-JSON round-trip check.
     private static String plain(
         String json)

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
@@ -17,8 +17,11 @@ package io.aklivity.zilla.runtime.common.json;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.ByteArrayInputStream;
 import java.util.List;
 import java.util.Map;
+
+import jakarta.json.stream.JsonParser;
 
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -167,6 +170,108 @@ class JsonProjectorSegmentTest
 
         assertEquals(Status.COMPLETED, status);
         assertEquals("{\"a\":\"" + value + "\"}", output(gen));
+    }
+
+    @Test
+    void shouldStreamKeptScalarLeafSegmentedAcrossInputAndOutputBounds()
+    {
+        // a retained scalar leaf far larger than both the input window and the output bound, whose JSON
+        // string content carries escape sequences and a multibyte character: it streams verbatim through
+        // projector -> SEGMENTABLE sink -> escape-mode generator, fragmenting across input (STARVED) and
+        // output (SUSPENDED). The escaped chunked result must equal the escaped whole-shot result, and
+        // when read back as JSON string content must decode to the projected plain document (kept /a,
+        // dropped sibling /b excluded), with neither a multibyte character nor an escape sequence split.
+        String leafContent = ("A\\\"é\\\\B\\t" + "z".repeat(40)).repeat(4);
+        String json = "{\"a\":\"" + leafContent + "\",\"b\":\"" + "y".repeat(120) + "\"} ";
+
+        String escaped = drive(json, 16, 7);
+        String whole = drive(json, 4096, 4096);
+
+        assertEquals(whole, escaped);
+        assertEquals(plain(json), decodeJsonString(escaped));
+    }
+
+    // Drives the project(/a) -> SEGMENTABLE -> escape-mode pipeline with a bounded output (outBound) and a
+    // bounded input window (inStep), accumulating each drained output chunk; reconstructs the full escaped
+    // output across STARVED (input back-pressure) and SUSPENDED (output back-pressure).
+    private static String drive(
+        String json,
+        int outBound,
+        int inStep)
+    {
+        MutableDirectBuffer out = new UnsafeBuffer(new byte[outBound]);
+        JsonGeneratorEx gen = JsonEx.createGenerator(Map.of(JsonGeneratorEx.GENERATE_ESCAPED, true));
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("/a")))
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.SEGMENTABLE)));
+
+        byte[] bytes = json.getBytes(UTF_8);
+        pipeline.reset();
+        gen.wrap(out, 0, outBound);
+
+        StringBuilder result = new StringBuilder();
+        int committed = 0;
+        int offset = 0;
+        Status status = Status.STARVED;
+        int guard = 0;
+        while (guard++ < 1_000_000)
+        {
+            if (status != Status.SUSPENDED)
+            {
+                offset = Math.min(offset + inStep, bytes.length);
+            }
+            boolean last = offset >= bytes.length;
+            status = pipeline.feed(new UnsafeBuffer(bytes), committed, offset - committed, last);
+            byte[] chunk = new byte[gen.length()];
+            out.getBytes(0, chunk);
+            result.append(new String(chunk, UTF_8));
+            committed = (int) pipeline.position();
+            if (status == Status.SUSPENDED)
+            {
+                gen.wrap(out, 0, outBound);
+            }
+            else if (status == Status.COMPLETED || status == Status.REJECTED)
+            {
+                break;
+            }
+        }
+
+        assertEquals(Status.COMPLETED, status);
+        return result.toString();
+    }
+
+    // The project(/a) plain (non-escaped) rendering, whole-shot, for the JSON-in-JSON round-trip check.
+    private static String plain(
+        String json)
+    {
+        MutableDirectBuffer out = new UnsafeBuffer(new byte[4096]);
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(out, 0, out.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(List.of("/a")))
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.SEGMENTABLE)));
+        byte[] bytes = json.getBytes(UTF_8);
+        pipeline.reset();
+        Status status = pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length);
+        assertEquals(Status.COMPLETED, status);
+        byte[] rendered = new byte[gen.length()];
+        out.getBytes(0, rendered);
+        return new String(rendered, UTF_8);
+    }
+
+    private static String decodeJsonString(
+        String content)
+    {
+        String document = "{\"v\":\"" + content + "\"}";
+        JsonParser parser = JsonEx.createParser(new ByteArrayInputStream(document.getBytes(UTF_8)));
+        String result = null;
+        while (parser.hasNext())
+        {
+            if (parser.next() == JsonParser.Event.VALUE_STRING)
+            {
+                result = parser.getString();
+            }
+        }
+        return result;
     }
 
     private String output(


### PR DESCRIPTION
## Summary

Makes the verbatim segment path of `common-json` append-only and stateless in the pipeline, drivable purely by `position()`, so a retained scalar leaf far larger than both the input window and the output bound streams through `projector → SEGMENTABLE sink → escape-mode generator` with **no per-fragment allocation** and **no sink-side write offset**.

Previously the sink tracked a per-value `segmentWritten` offset to span suspend/resume, which forced the value to be held whole (a `getString()` allocation) and left the pipeline stateful. Now the terminal stage reports the source bytes a segment write actually took via a new `consumed(int)` callback; the parser advances `position()` by exactly that count and re-exposes the value remainder on resume, so each pull is append-only.

## Changes

- **`JsonController`**: add default `consumed(int)` so a terminal stage reports the source bytes a segment write actually took; mediating transforms relay it (the same way they relay `segmentable()`).
- **`JsonGeneratorImpl`**: `writeRawSegment`/`writeEscapedSegment` advance only on whole UTF-8 characters and whole JSON escape sequences, never splitting a multibyte char or escape across a `consumed()` boundary, so a fragmented value can be re-presented cleanly.
- **`JsonSinkImpl`**: drop the per-value `segmentWritten` offset; write `getSegment()` whole and push `consumed()` back so the upstream re-exposes the remainder.
- **`JsonParserImpl` / `JsonTokenizer`**: track per-segment `consumed` to re-expose the value remainder; arm a kept scalar leaf value-string (`scalarSegment`) to stream verbatim as raw fragments with no decoded retention.
- **`JsonProjectorImpl` / `JsonSchemaImpl` Validator**: relay `consumed()` to upstream (the validator still declines `segmentable()`).

## Tests

- `JsonProjectorSegmentTest#shouldStreamKeptScalarLeafSegmentedAcrossInputAndOutputBounds` — a retained scalar leaf larger than both bounds, with escapes and a multibyte char; asserts chunked escaped output equals whole-shot and round-trips as JSON-in-JSON.
- `JsonProjectorSegmentTest#shouldStreamMultiLeafResourceLikeBinding` — a binding-shaped multi-leaf resource (small kept scalar, large kept scalar, kept number, dropped siblings) projected through `SEGMENTABLE` into an escape-mode generator; asserts chunked == whole-shot and round-trips to the projected plain document.

Full `common-json` build green (checkstyle, license, coverage). Validated end-to-end: the `mcp_http · proxy` binding streams both legs through bounded 8K slots with all 26 integration tests passing at `ENGINE_BUFFER_SLOT_CAPACITY=8192`, including the 10k/100k large-payload scenarios.

https://claude.ai/code/session_01AEpU8rooKSEqf6EuU8ri1i

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEpU8rooKSEqf6EuU8ri1i)_