### PR TITLE
common-json: converge scalar value delivery — canonical structured rendering, unified consumed() flow control, remove Delivery.DECODED

### DIFF
--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/transform/McpHttpRename.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/transform/McpHttpRename.java
@@ -103,6 +103,12 @@ public final class McpHttpRename implements JsonTransform
         }
 
         @Override
+        public CharSequence getStringView()
+        {
+            return key;
+        }
+
+        @Override
         public CharSequence getKey()
         {
             return key;
@@ -116,6 +122,18 @@ public final class McpHttpRename implements JsonTransform
 
         @Override
         public boolean isIntegralNumber()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getInt()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getLong()
         {
             throw new UnsupportedOperationException();
         }

--- a/runtime/common-json/README.md
+++ b/runtime/common-json/README.md
@@ -130,13 +130,16 @@ one frame — and spliced across chunks; a string that fits is still re-encoded 
 never longer than the raw token, so the fit check is safe). So a giant `{"data":"…"}` value streams in
 both `STRUCTURED` and `SEGMENTABLE` delivery.
 
-Resumption is a **per-stage cascade**, not an event replay: `JsonSink.resume(control, source)` and
-`JsonTransform.resume(control, source, sink)` continue any in-flight fragment before the next event is
-pulled, with the same `control` and `source` context as `feed`. `JsonTransform.resume(control, source,
-sink)` defaults to `sink.resume(control, source)`, so a stage that only forwards events ignores it
-entirely; a stage that itself emits a value across chunks (substituting or expanding output) overrides
-it to continue its own emission, draining the downstream first. This keeps the transform contract
-simple — no stage has to be suspend/resume aware unless it originates `SUSPENDED`.
+Resumption is a **per-stage cascade**, not an event replay: `JsonSink.resume(control, source, event)`
+and `JsonTransform.resume(control, source, event, sink)` continue any in-flight fragment before the next
+event is pulled, with the same `control` and `source` context as `feed` plus the value `event` that
+suspended (supplied by the pump, which owns the single resume cursor, so a stage keeps no per-value
+resume state). The sink holds none: it continues only while the source view still has an unwritten
+remainder (`getStringView().length()`/`getSegment().capacity()`) and otherwise just advances.
+`JsonTransform.resume` defaults to `sink.resume(control, source, event)`, so a stage that only forwards
+events ignores it entirely; a stage that itself emits a value across chunks (substituting or expanding
+output) overrides it to continue its own emission, draining the downstream first. This keeps the
+transform contract simple — no stage has to be suspend/resume aware unless it originates `SUSPENDED`.
 
 ### Writing JSON directly
 
@@ -145,7 +148,10 @@ and quoting automatically from an internal context stack, emitting in source ord
 insignificant whitespace. It implements `jakarta.json.stream.JsonGenerator` with covariant returns for
 fluent chaining, plus the streaming-to-buffer extensions: `writeNumber(literal)` emits a numeric
 lexeme verbatim, `writeRaw` splices a pre-encoded value (emitting its leading separator once), and
-`writeSegment` appends a bounded, consumption-driven fragment of that value with no separator.
+`writeSegment(source, index, length)` appends a bounded, consumption-driven fragment of that value with
+no separator. Its `writeSegment(source, index, length, completion)` overload owns the leading separator
+across fragments — emitted before the first fragment, the value ending on `Completion.COMPLETE` — so a
+fragmented value splices without the caller tracking whether the separator was already written.
 
 `createGenerator(Map.of(JsonGeneratorEx.GENERATE_ESCAPED, true))` opts the generator into **escape mode**: every
 byte it emits is escaped as JSON string *content* (structural bytes and UTF-8 continuation bytes pass

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEx.java
@@ -140,6 +140,22 @@ public interface JsonGeneratorEx extends JsonGenerator
         int index,
         int length);
 
+    /**
+     * Appends a value's verbatim bytes that may arrive in fragments, owning the value's leading structural
+     * separator so the caller holds no per-value state. The separator is emitted before the first fragment;
+     * each fragment appends bounded, consumption-driven content exactly as {@link #writeSegment(DirectBuffer,
+     * int, int)} (track via {@link #consumed()}); the value ends — readying the next value's separator — on
+     * {@link Completion#COMPLETE} once the final fragment is fully written. Pass {@link Completion#INCOMPLETE}
+     * while the source reports more deferred bytes, so a value delivered across fragments forms one spliced
+     * value. {@code writeSegment(source, index, length, COMPLETE)} for a value that fits one fragment is
+     * equivalent to {@link #writeRaw(DirectBuffer, int, int)}.
+     */
+    JsonGeneratorEx writeSegment(
+        DirectBuffer source,
+        int index,
+        int length,
+        Completion completion);
+
     @Override
     JsonGeneratorEx writeStartObject();
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSink.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSink.java
@@ -49,16 +49,18 @@ public interface JsonSink
         JsonEvent event);
 
     /**
-     * Continues any output left in flight by a prior {@link JsonPipeline.Status#SUSPENDED} — a value
-     * being written across chunks — before the next event is fed, reading the in-flight value from
-     * {@code source} and steering the immediate upstream with {@code control}. Returns {@link
-     * JsonPipeline.Status#SUSPENDED} if the bounded output filled again, or {@link
-     * JsonPipeline.Status#ADVANCED} when nothing remains pending. A stage with no in-flight output
-     * returns {@code ADVANCED}; the default is sufficient for stages that only forward events.
+     * Continues the value left in flight by a prior {@link JsonPipeline.Status#SUSPENDED} — a value being
+     * written across chunks — before the next event is fed. {@code event} is the value event that
+     * suspended (supplied by the pump, so the sink keeps no resume state); the sink re-reads the in-flight
+     * value's remainder from {@code source} and steers the immediate upstream with {@code control}. Returns
+     * {@link JsonPipeline.Status#SUSPENDED} if the bounded output filled again, or {@link
+     * JsonPipeline.Status#ADVANCED} when nothing remains pending. A stage with no in-flight output returns
+     * {@code ADVANCED}; the default is sufficient for stages that only forward events.
      */
     default JsonPipeline.Status resume(
         JsonController control,
-        JsonSource source)
+        JsonSource source,
+        JsonEvent event)
     {
         return JsonPipeline.Status.ADVANCED;
     }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSink.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSink.java
@@ -31,19 +31,16 @@ public interface JsonSink
     String DELIVERY = "io.aklivity.zilla.runtime.common.json.sink.delivery";
 
     /**
-     * Delivery mode a terminal sink requests. {@link #STRUCTURED} consumes structured events and
-     * renders output by splicing each value's verbatim token bytes (chunked across bounded output);
-     * {@link #SEGMENTABLE} opts in to verbatim segment delivery for kept values (best-effort,
-     * demand-gated) by calling {@link JsonController#segmentable()}; {@link #DECODED} renders each
-     * scalar from its decoded {@code getString()} via {@link JsonGeneratorEx#write(CharSequence,
-     * boolean)}, letting the generator own quoting/escaping so a value delivered as fragments forms a
-     * single string without the sink concatenating.
+     * Delivery mode a terminal sink requests. {@link #STRUCTURED} consumes structured events and renders
+     * each scalar canonically from its decoded value ({@link JsonSource#getStringView()}), the generator
+     * owning quoting/escaping so a value delivered as fragments forms one value without the sink
+     * concatenating; {@link #SEGMENTABLE} opts in to verbatim byte delivery for kept values (best-effort,
+     * demand-gated) by calling {@link JsonController#segmentable()}.
      */
     enum Delivery
     {
         STRUCTURED,
-        SEGMENTABLE,
-        DECODED
+        SEGMENTABLE
     }
 
     JsonPipeline.Status feed(

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSource.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSource.java
@@ -30,12 +30,31 @@ public interface JsonSource
 {
     String getString();
 
+    /**
+     * Non-owning, on-stack char view of the current scalar value (a number lexeme or a decoded string),
+     * valid only for the duration of the current event. The allocation-free counterpart to
+     * {@link #getString()} for stages that read or re-emit the value without retaining it.
+     */
+    CharSequence getStringView();
+
     // valid only on a key event; non-owning, on-stack char view of the current key
     CharSequence getKey();
 
     BigDecimal getBigDecimal();
 
     boolean isIntegralNumber();
+
+    /**
+     * The current number as an {@code int}. Valid only on an integral number that fits one window;
+     * a fragmented number throws (read it via {@link #getBigDecimal()} instead).
+     */
+    int getInt();
+
+    /**
+     * The current number as a {@code long}. Valid only on an integral number that fits one window;
+     * a fragmented number throws (read it via {@link #getBigDecimal()} instead).
+     */
+    long getLong();
 
     JsonLocation getLocation();
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonTransform.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonTransform.java
@@ -33,20 +33,21 @@ public interface JsonTransform
         JsonSink sink);
 
     /**
-     * Continues output left in flight by a prior {@link JsonPipeline.Status#SUSPENDED} before the next
-     * event is fed, with the same {@code control} and {@code source} context as {@link #feed}. The
-     * default forwards to {@code sink.resume(control, source)}, draining whatever is pending downstream —
-     * sufficient for a stage that only forwards events. A stage that itself emits a value across chunks
-     * (substituting or expanding output) overrides this to continue its own emission, draining the
-     * downstream first. Returns {@link JsonPipeline.Status#SUSPENDED} if the bounded output filled again,
-     * or {@link JsonPipeline.Status#ADVANCED} when nothing remains pending.
+     * Continues the value left in flight by a prior {@link JsonPipeline.Status#SUSPENDED} before the next
+     * event is fed, with the same {@code control} and {@code source} context as {@link #feed} and the
+     * {@code event} that suspended. The default forwards to {@code sink.resume(control, source, event)},
+     * draining whatever is pending downstream — sufficient for a stage that only forwards events. A stage
+     * that itself emits a value across chunks (substituting or expanding output) overrides this to continue
+     * its own emission, draining the downstream first. Returns {@link JsonPipeline.Status#SUSPENDED} if the
+     * bounded output filled again, or {@link JsonPipeline.Status#ADVANCED} when nothing remains pending.
      */
     default JsonPipeline.Status resume(
         JsonController control,
         JsonSource source,
+        JsonEvent event,
         JsonSink sink)
     {
-        return sink.resume(control, source);
+        return sink.resume(control, source, event);
     }
 
     default void reset()

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -461,6 +461,27 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     }
 
     @Override
+    public JsonGeneratorImpl writeSegment(
+        DirectBuffer source,
+        int index,
+        int length,
+        Completion completion)
+    {
+        if (pending != Pending.SEGMENT)
+        {
+            // emit the value's leading separator once, before its first fragment
+            preValue();
+            pending = Pending.SEGMENT;
+        }
+        int written = writeSegment.accept(source, index, length);
+        if (written == length && completion == Completion.COMPLETE)
+        {
+            pending = Pending.NONE;
+        }
+        return this;
+    }
+
+    @Override
     public void flush()
     {
     }
@@ -888,6 +909,7 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         NONE,
         AFTER_KEY,
         STRING,
-        NUMBER
+        NUMBER,
+        SEGMENT
     }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -204,8 +204,13 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
             putByte.accept('"');
             pending = Pending.STRING;
         }
-        writeStringBody(value);
-        if (completion == Completion.COMPLETE)
+        // emit only the code points whose escaped form fits the output bound (reserving room for the
+        // closing quote on the final fragment); report the source chars taken via consumed() so a chunking
+        // driver advances its cursor and resumes from the remainder, the char-domain analog of writeSegment
+        final int reserve = completion == Completion.COMPLETE ? 1 : 0;
+        final int written = writeStringBody(value, reserve);
+        consumed += written;
+        if (written == value.length() && completion == Completion.COMPLETE)
         {
             putByte.accept('"');
             pending = Pending.NONE;
@@ -503,48 +508,122 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         {
             int codePoint = Character.codePointAt(value, index);
             index += Character.charCount(codePoint);
-            switch (codePoint)
+            emitStringCodePoint(codePoint);
+        }
+    }
+
+    // Bounded counterpart used by write(CharSequence, Completion): emits whole code points while each one's
+    // escaped width fits the output bound (minus reserve, held back for a trailing close-quote), stopping
+    // on a code-point boundary so no UTF-8 char or escape is split; returns the count of source chars
+    // emitted so the caller can advance its cursor and resume from the remainder.
+    private int writeStringBody(
+        CharSequence value,
+        int reserve)
+    {
+        final int budget = limit - reserve;
+        int index = 0;
+        final int length = value.length();
+        while (index < length)
+        {
+            final int codePoint = Character.codePointAt(value, index);
+            if (budget - progress < codePointWidth(codePoint))
             {
-            case '"':
-                putByte.accept('\\');
-                putByte.accept('"');
-                break;
-            case '\\':
-                putByte.accept('\\');
-                putByte.accept('\\');
-                break;
-            case '\n':
-                putByte.accept('\\');
-                putByte.accept('n');
-                break;
-            case '\r':
-                putByte.accept('\\');
-                putByte.accept('r');
-                break;
-            case '\t':
-                putByte.accept('\\');
-                putByte.accept('t');
-                break;
-            case '\b':
-                putByte.accept('\\');
-                putByte.accept('b');
-                break;
-            case '\f':
-                putByte.accept('\\');
-                putByte.accept('f');
-                break;
-            default:
-                if (codePoint < 0x20)
-                {
-                    writeUnicodeEscape(codePoint);
-                }
-                else
-                {
-                    writeUtf8(codePoint);
-                }
                 break;
             }
+            index += Character.charCount(codePoint);
+            emitStringCodePoint(codePoint);
         }
+        return index;
+    }
+
+    private void emitStringCodePoint(
+        int codePoint)
+    {
+        switch (codePoint)
+        {
+        case '"':
+            putByte.accept('\\');
+            putByte.accept('"');
+            break;
+        case '\\':
+            putByte.accept('\\');
+            putByte.accept('\\');
+            break;
+        case '\n':
+            putByte.accept('\\');
+            putByte.accept('n');
+            break;
+        case '\r':
+            putByte.accept('\\');
+            putByte.accept('r');
+            break;
+        case '\t':
+            putByte.accept('\\');
+            putByte.accept('t');
+            break;
+        case '\b':
+            putByte.accept('\\');
+            putByte.accept('b');
+            break;
+        case '\f':
+            putByte.accept('\\');
+            putByte.accept('f');
+            break;
+        default:
+            if (codePoint < 0x20)
+            {
+                writeUnicodeEscape(codePoint);
+            }
+            else
+            {
+                writeUtf8(codePoint);
+            }
+            break;
+        }
+    }
+
+    // Output byte width of a code point once written as canonical JSON string content: a short escape
+    // (2 bytes), a control-char \\uXXXX escape (6), or its UTF-8 encoding (1-4). Mirrors emitStringCodePoint
+    // for the verbatim (non GENERATE_ESCAPED) generator, which is the only mode the decoded value path uses.
+    private static int codePointWidth(
+        int codePoint)
+    {
+        int width;
+        switch (codePoint)
+        {
+        case '"':
+        case '\\':
+        case '\n':
+        case '\r':
+        case '\t':
+        case '\b':
+        case '\f':
+            width = 2;
+            break;
+        default:
+            if (codePoint < 0x20)
+            {
+                width = 6;
+            }
+            else if (codePoint < 0x80)
+            {
+                width = 1;
+            }
+            else if (codePoint < 0x800)
+            {
+                width = 2;
+            }
+            else if (codePoint < 0x10000)
+            {
+                width = 3;
+            }
+            else
+            {
+                width = 4;
+            }
+            break;
+        }
+        return width;
     }
 
     private void writeUtf8(

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -231,14 +231,18 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     public JsonGeneratorImpl write(
         int value)
     {
-        return writeNumber(Integer.toString(value));
+        preValue();
+        progress += buffer.putIntAscii(progress, value);
+        return this;
     }
 
     @Override
     public JsonGeneratorImpl write(
         long value)
     {
-        return writeNumber(Long.toString(value));
+        preValue();
+        progress += buffer.putLongAscii(progress, value);
+        return this;
     }
 
     @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -426,8 +426,12 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
             preValue();
             pending = Pending.NUMBER;
         }
-        writeAscii(literal);
-        if (completion == Completion.COMPLETE)
+        // emit only the lexeme chars that fit the output bound and report them via consumed(), so a number
+        // longer than the bound suspends and resumes from the remainder — the analog of write(value, …) for
+        // a literal that carries no quoting or escaping
+        final int written = writeAsciiBounded(literal);
+        consumed += written;
+        if (written == literal.length() && completion == Completion.COMPLETE)
         {
             pending = Pending.NONE;
         }
@@ -671,6 +675,22 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         {
             putByte.accept(value.charAt(index));
         }
+    }
+
+    // Bounded counterpart for a fragmented/over-bound number lexeme: emits ASCII lexeme chars (each one
+    // output byte, no escaping) while the bound has room, returning the count emitted so the caller can
+    // advance its cursor and resume from the remainder.
+    private int writeAsciiBounded(
+        CharSequence value)
+    {
+        int index = 0;
+        final int length = value.length();
+        while (index < length && progress < limit)
+        {
+            putByte.accept(value.charAt(index));
+            index++;
+        }
+        return index;
     }
 
     // Copies whole source units (UTF-8 char or JSON escape sequence), stopping before one that overflows

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -426,7 +426,8 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         {
             throw new IllegalStateException("number spans multiple windows; use getBigDecimal()");
         }
-        return Integer.parseInt(tokenizer.stringValue());
+        final CharSequence lexeme = tokenizer.stringView();
+        return Integer.parseInt(lexeme, 0, lexeme.length(), 10);
     }
 
     @Override
@@ -436,7 +437,8 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         {
             throw new IllegalStateException("number spans multiple windows; use getBigDecimal()");
         }
-        return Long.parseLong(tokenizer.stringValue());
+        final CharSequence lexeme = tokenizer.stringView();
+        return Long.parseLong(lexeme, 0, lexeme.length(), 10);
     }
 
     @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -397,6 +397,12 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     }
 
     @Override
+    public CharSequence getStringView()
+    {
+        return tokenizer.stringView();
+    }
+
+    @Override
     public CharSequence getKey()
     {
         return tokenizer.stringView();

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -161,6 +161,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         armNextValue = false;
         stringViewOffset = 0;
         lastEvent = null;
+        currentEvent = null;
         docState = DocState.NOT_STARTED;
     }
 
@@ -232,7 +233,6 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         if (docState == DocState.NOT_STARTED)
         {
             docState = DocState.STARTED;
-            lastEvent = JsonEvent.START_DOCUMENT;
             event = JsonEvent.START_DOCUMENT;
         }
         else if (segmentState == SegmentState.NONE && !tokenizerHasNext() && tokenizer.done())
@@ -244,7 +244,31 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         {
             event = nextToken();
         }
+        // lastEvent is the canonical delivered event (the basis for the streaming-only accessor asserts);
+        // currentEvent is its jakarta projection (null for a segment or document framing), keeping the
+        // shared jakarta getters' asserts valid whether driven by the pipeline or the raw parser
+        lastEvent = event;
+        currentEvent = toEvent(event);
         return event;
+    }
+
+    private static Event toEvent(
+        JsonEvent event)
+    {
+        return switch (event)
+        {
+        case START_OBJECT -> Event.START_OBJECT;
+        case END_OBJECT -> Event.END_OBJECT;
+        case START_ARRAY -> Event.START_ARRAY;
+        case END_ARRAY -> Event.END_ARRAY;
+        case KEY_NAME -> Event.KEY_NAME;
+        case VALUE_STRING -> Event.VALUE_STRING;
+        case VALUE_NUMBER -> Event.VALUE_NUMBER;
+        case VALUE_TRUE -> Event.VALUE_TRUE;
+        case VALUE_FALSE -> Event.VALUE_FALSE;
+        case VALUE_NULL -> Event.VALUE_NULL;
+        default -> null;
+        };
     }
 
     @Override
@@ -296,10 +320,12 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
             }
             else if (lastEvent == JsonEvent.VALUE_STRING)
             {
-                // verbatim string token (with quotes): the sink splices the raw bytes
+                // verbatim string token (with quotes): delivered as a segment so the raw bytes are spliced
+                // through the byte path; getSegment() is then valid only on this segmented event
                 segmentSliceOffset = bufferOffset(tokenizer.valueStreamStart());
                 segmentSliceLength = (int) (tokenizer.valueStreamEnd() - tokenizer.valueStreamStart());
                 segmentConsumed = 0;
+                lastEvent = JsonEvent.SEGMENT;
             }
             if (armNextValue)
             {
@@ -417,12 +443,14 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     @Override
     public String getString()
     {
+        assert currentEvent == Event.KEY_NAME || currentEvent == Event.VALUE_STRING || currentEvent == Event.VALUE_NUMBER;
         return tokenizer.stringValue();
     }
 
     @Override
     public CharSequence getStringView()
     {
+        assert lastEvent == JsonEvent.VALUE_STRING || lastEvent == JsonEvent.VALUE_NUMBER;
         // while rendering a structured scalar, expose the unconsumed char remainder so a resumed write
         // continues from where the bounded output left off; otherwise the full decoded view
         return charScalar()
@@ -431,24 +459,24 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     }
 
     // True while the current scalar is delivered decoded (rendered canonically by the sink from its char
-    // view) rather than verbatim: a number lexeme, or a value-string the tokenizer did not stream verbatim.
-    // Derived from the current event and the tokenizer's verbatim mark, not stored, so there is no per-value
-    // flag to reset; it stays valid while the parser is parked mid-output on resume.
+    // view): a number lexeme or a canonical string. A verbatim value-string is delivered as a SEGMENT, so
+    // any VALUE_STRING here is canonical; derived from the delivered event, valid while parked on resume.
     private boolean charScalar()
     {
-        return lastEvent == JsonEvent.VALUE_NUMBER ||
-            lastEvent == JsonEvent.VALUE_STRING && !tokenizer.stringVerbatim();
+        return lastEvent == JsonEvent.VALUE_NUMBER || lastEvent == JsonEvent.VALUE_STRING;
     }
 
     @Override
     public CharSequence getKey()
     {
+        assert lastEvent == JsonEvent.KEY_NAME;
         return tokenizer.stringView();
     }
 
     @Override
     public boolean isIntegralNumber()
     {
+        assert currentEvent == Event.VALUE_NUMBER;
         final CharSequence v = numberLexeme();
         if (v == null)
         {
@@ -466,6 +494,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     @Override
     public int getInt()
     {
+        assert currentEvent == Event.VALUE_NUMBER;
         if (tokenizer.numberFragmented())
         {
             throw new IllegalStateException("number spans multiple windows; use getBigDecimal()");
@@ -477,6 +506,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     @Override
     public long getLong()
     {
+        assert currentEvent == Event.VALUE_NUMBER;
         if (tokenizer.numberFragmented())
         {
             throw new IllegalStateException("number spans multiple windows; use getBigDecimal()");
@@ -488,6 +518,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     @Override
     public BigDecimal getBigDecimal()
     {
+        assert currentEvent == Event.VALUE_NUMBER;
         return new BigDecimal(numberLexeme().toString());
     }
 
@@ -507,6 +538,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     @Override
     public DirectBuffer getSegment()
     {
+        assert lastEvent != null && lastEvent.segmented();
         // re-expose the unconsumed remainder of the segment slice after consumed() pushback, append-only
         segmentView.wrap(ownedInput.buffer(), segmentSliceOffset + segmentConsumed, segmentSliceLength - segmentConsumed);
         return segmentView;

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -287,15 +287,16 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
             break;
         default:
             lastEvent = JsonEvent.of(next());
-            if (lastEvent == JsonEvent.VALUE_STRING && !tokenizer.stringVerbatim())
+            if (lastEvent == JsonEvent.VALUE_NUMBER ||
+                lastEvent == JsonEvent.VALUE_STRING && !tokenizer.stringVerbatim())
             {
-                // canonical string: the sink renders it from the decoded char view, so reset the char
-                // cursor; the raw segment slice is not used for this value
+                // structured scalar (number lexeme or canonical string): the sink renders it from the
+                // decoded char view, so reset the char cursor; the raw segment slice is not used
                 stringViewOffset = 0;
             }
-            else if (lastEvent == JsonEvent.VALUE_STRING || lastEvent == JsonEvent.VALUE_NUMBER)
+            else if (lastEvent == JsonEvent.VALUE_STRING)
             {
-                // verbatim string token (with quotes) or number lexeme: the sink splices the raw bytes
+                // verbatim string token (with quotes): the sink splices the raw bytes
                 segmentSliceOffset = bufferOffset(tokenizer.valueStreamStart());
                 segmentSliceLength = (int) (tokenizer.valueStreamEnd() - tokenizer.valueStreamStart());
                 segmentConsumed = 0;
@@ -396,8 +397,8 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     public void consumed(
         int sourceUnits)
     {
-        // a canonical string advances its char cursor; a verbatim segment or number its raw byte cursor
-        if (decodedString())
+        // a decoded scalar advances its char cursor; a verbatim string or raw segment its byte cursor
+        if (charScalar())
         {
             stringViewOffset += sourceUnits;
         }
@@ -422,19 +423,21 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     @Override
     public CharSequence getStringView()
     {
-        // while rendering a canonical string, expose the unconsumed char remainder so a resumed write
+        // while rendering a structured scalar, expose the unconsumed char remainder so a resumed write
         // continues from where the bounded output left off; otherwise the full decoded view
-        return decodedString()
+        return charScalar()
             ? stringViewRO.wrap(tokenizer.stringView(), stringViewOffset)
             : tokenizer.stringView();
     }
 
-    // True while the current value-string is delivered decoded (rendered canonically by the sink) rather
-    // than verbatim. Derived from the current event and the tokenizer's verbatim mark, not stored, so
-    // there is no per-value flag to reset; it stays valid while the parser is parked mid-output on resume.
-    private boolean decodedString()
+    // True while the current scalar is delivered decoded (rendered canonically by the sink from its char
+    // view) rather than verbatim: a number lexeme, or a value-string the tokenizer did not stream verbatim.
+    // Derived from the current event and the tokenizer's verbatim mark, not stored, so there is no per-value
+    // flag to reset; it stays valid while the parser is parked mid-output on resume.
+    private boolean charScalar()
     {
-        return lastEvent == JsonEvent.VALUE_STRING && !tokenizer.stringVerbatim();
+        return lastEvent == JsonEvent.VALUE_NUMBER ||
+            lastEvent == JsonEvent.VALUE_STRING && !tokenizer.stringVerbatim();
     }
 
     @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -62,6 +62,11 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     private int segmentConsumed;
     private int segmentDepth;
     private boolean armNextValue;
+    // running char cursor into the decoded chars of the current canonical value-string: getStringView()
+    // exposes the unconsumed remainder from here and consumed() advances it, so a resumed bounded write
+    // continues where the output bound left off
+    private int stringViewOffset;
+    private final StringView stringViewRO = new StringView();
 
     private enum SegmentState
     {
@@ -154,6 +159,7 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         segmentDepth = 0;
         segmentConsumed = 0;
         armNextValue = false;
+        stringViewOffset = 0;
         lastEvent = null;
         docState = DocState.NOT_STARTED;
     }
@@ -281,8 +287,15 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
             break;
         default:
             lastEvent = JsonEvent.of(next());
-            if (lastEvent == JsonEvent.VALUE_STRING || lastEvent == JsonEvent.VALUE_NUMBER)
+            if (lastEvent == JsonEvent.VALUE_STRING && !tokenizer.stringVerbatim())
             {
+                // canonical string: the sink renders it from the decoded char view, so reset the char
+                // cursor; the raw segment slice is not used for this value
+                stringViewOffset = 0;
+            }
+            else if (lastEvent == JsonEvent.VALUE_STRING || lastEvent == JsonEvent.VALUE_NUMBER)
+            {
+                // verbatim string token (with quotes) or number lexeme: the sink splices the raw bytes
                 segmentSliceOffset = bufferOffset(tokenizer.valueStreamStart());
                 segmentSliceLength = (int) (tokenizer.valueStreamEnd() - tokenizer.valueStreamStart());
                 segmentConsumed = 0;
@@ -369,6 +382,8 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         else if (lastEvent == JsonEvent.START_DOCUMENT)
         {
             armNextValue = true;
+            // a bare top-level string then streams verbatim too; cleared by the tokenizer for any non-string
+            tokenizer.scalarSegment(true);
         }
         else if (lastEvent == JsonEvent.KEY_NAME)
         {
@@ -379,9 +394,17 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
 
     @Override
     public void consumed(
-        int sourceBytes)
+        int sourceUnits)
     {
-        segmentConsumed += sourceBytes;
+        // a canonical string advances its char cursor; a verbatim segment or number its raw byte cursor
+        if (decodedString())
+        {
+            stringViewOffset += sourceUnits;
+        }
+        else
+        {
+            segmentConsumed += sourceUnits;
+        }
     }
 
     @Override
@@ -399,7 +422,19 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     @Override
     public CharSequence getStringView()
     {
-        return tokenizer.stringView();
+        // while rendering a canonical string, expose the unconsumed char remainder so a resumed write
+        // continues from where the bounded output left off; otherwise the full decoded view
+        return decodedString()
+            ? stringViewRO.wrap(tokenizer.stringView(), stringViewOffset)
+            : tokenizer.stringView();
+    }
+
+    // True while the current value-string is delivered decoded (rendered canonically by the sink) rather
+    // than verbatim. Derived from the current event and the tokenizer's verbatim mark, not stored, so
+    // there is no per-value flag to reset; it stays valid while the parser is parked mid-output on resume.
+    private boolean decodedString()
+    {
+        return lastEvent == JsonEvent.VALUE_STRING && !tokenizer.stringVerbatim();
     }
 
     @Override
@@ -668,4 +703,47 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         }
     }
 
+    // Reusable, allocation-free char view onto the decoded string remainder: wraps the tokenizer's decoded
+    // chars at a running offset so a bounded write can resume from where it left off without copying.
+    private static final class StringView implements CharSequence
+    {
+        private CharSequence base;
+        private int offset;
+
+        private StringView wrap(
+            CharSequence base,
+            int offset)
+        {
+            this.base = base;
+            this.offset = offset;
+            return this;
+        }
+
+        @Override
+        public int length()
+        {
+            return base.length() - offset;
+        }
+
+        @Override
+        public char charAt(
+            int index)
+        {
+            return base.charAt(offset + index);
+        }
+
+        @Override
+        public CharSequence subSequence(
+            int start,
+            int end)
+        {
+            return base.subSequence(offset + start, offset + end);
+        }
+
+        @Override
+        public String toString()
+        {
+            return base.subSequence(offset, base.length()).toString();
+        }
+    }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
@@ -19,6 +19,7 @@ import jakarta.json.stream.JsonParsingException;
 import org.agrona.DirectBuffer;
 
 import io.aklivity.zilla.runtime.common.json.JsonController;
+import io.aklivity.zilla.runtime.common.json.JsonEvent;
 import io.aklivity.zilla.runtime.common.json.JsonParserEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonSink;
@@ -38,6 +39,8 @@ public final class JsonPipelineImpl implements JsonPipeline
     private final JsonSink root;
 
     private boolean suspended;
+    // the value event in flight across a suspend, handed to root.resume() so no stage stores it
+    private JsonEvent resumeEvent;
 
     public JsonPipelineImpl(
         JsonParserEx parser,
@@ -56,6 +59,7 @@ public final class JsonPipelineImpl implements JsonPipeline
         parser.reset();
         root.reset();
         suspended = false;
+        resumeEvent = null;
     }
 
     @Override
@@ -76,7 +80,7 @@ public final class JsonPipelineImpl implements JsonPipeline
         {
             if (suspended)
             {
-                status = root.resume(control, source);
+                status = root.resume(control, source, resumeEvent);
             }
             else
             {
@@ -84,7 +88,13 @@ public final class JsonPipelineImpl implements JsonPipeline
             }
             while (status == Status.ADVANCED && parser.hasNextEvent())
             {
-                status = root.feed(control, source, parser.nextEvent());
+                final JsonEvent event = parser.nextEvent();
+                status = root.feed(control, source, event);
+                if (status == Status.SUSPENDED)
+                {
+                    // the pump owns the resume cursor: remember the in-flight event for the next entry
+                    resumeEvent = event;
+                }
             }
             if (status == Status.ADVANCED)
             {

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
@@ -589,6 +589,12 @@ public final class JsonProjectorImpl implements JsonTransform
         }
 
         @Override
+        public CharSequence getStringView()
+        {
+            return key;
+        }
+
+        @Override
         public CharSequence getKey()
         {
             return key;
@@ -602,6 +608,18 @@ public final class JsonProjectorImpl implements JsonTransform
 
         @Override
         public boolean isIntegralNumber()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getInt()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getLong()
         {
             throw new UnsupportedOperationException();
         }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
@@ -970,6 +970,12 @@ public final class JsonSchemaImpl implements JsonSchema
         }
 
         @Override
+        public CharSequence getStringView()
+        {
+            return parser.getString();
+        }
+
+        @Override
         public BigDecimal getBigDecimal()
         {
             return parser.getBigDecimal();
@@ -979,6 +985,18 @@ public final class JsonSchemaImpl implements JsonSchema
         public boolean isIntegralNumber()
         {
             return parser.isIntegralNumber();
+        }
+
+        @Override
+        public int getInt()
+        {
+            return parser.getInt();
+        }
+
+        @Override
+        public long getLong()
+        {
+            return parser.getLong();
         }
 
         @Override
@@ -1449,6 +1467,12 @@ public final class JsonSchemaImpl implements JsonSchema
         }
 
         @Override
+        public CharSequence getStringView()
+        {
+            return token.text;
+        }
+
+        @Override
         public boolean isIntegralNumber()
         {
             return !token.text.contains(".") && !token.text.contains("e") && !token.text.contains("E");
@@ -1458,6 +1482,18 @@ public final class JsonSchemaImpl implements JsonSchema
         public BigDecimal getBigDecimal()
         {
             return new BigDecimal(token.text);
+        }
+
+        @Override
+        public int getInt()
+        {
+            return Integer.parseInt(token.text);
+        }
+
+        @Override
+        public long getLong()
+        {
+            return Long.parseLong(token.text);
         }
 
         @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -38,8 +38,10 @@ public final class JsonSinkImpl implements JsonSink
     private final Delivery delivery;
     private int depth;
     private boolean valueStarted;
-    private boolean pendingSegment;
-    private boolean pendingDecoded;
+    // the value event currently mid-write across a bounded-output suspend, or null when nothing is in
+    // flight; resume() re-runs that value's write, and the delivery mode resolves a decoded string from a
+    // verbatim one. A boundary() suspend at an event boundary leaves this null, so resume just advances.
+    private JsonEvent pending;
 
     public JsonSinkImpl(
         JsonGeneratorEx generator)
@@ -62,7 +64,6 @@ public final class JsonSinkImpl implements JsonSink
         JsonEvent event)
     {
         Status status = Status.ADVANCED;
-        DirectBuffer segment;
         switch (event)
         {
         case KEY_NAME:
@@ -88,25 +89,7 @@ public final class JsonSinkImpl implements JsonSink
         case VALUE_STRING:
         case VALUE_NUMBER:
         case SEGMENT:
-            if (event == JsonEvent.VALUE_STRING && delivery != Delivery.SEGMENTABLE)
-            {
-                // structured (canonical) string: render from the decoded char view, the generator owning
-                // quoting/escaping and joining fragments (deferredBytes) into one string. The bounded write
-                // emits only what fits and reports consumed chars, the same flow control as the byte path.
-                status = writeDecodedString(control, source);
-            }
-            else
-            {
-                // verbatim string token, number lexeme, or segment: splice the raw bytes, fragmenting across
-                // chunks; the value's leading separator is emitted once, before its first content byte
-                segment = source.getSegment();
-                if (!valueStarted)
-                {
-                    generator.writeRaw(segment, 0, 0);
-                    valueStarted = true;
-                }
-                status = writeChunk(control, segment, source);
-            }
+            status = writeValue(control, source, event);
             break;
         case VALUE_TRUE:
             generator.write(true);
@@ -140,19 +123,7 @@ public final class JsonSinkImpl implements JsonSink
         JsonController control,
         JsonSource source)
     {
-        Status status;
-        if (pendingDecoded)
-        {
-            status = writeDecodedString(control, source);
-        }
-        else if (pendingSegment)
-        {
-            status = writeChunk(control, source.getSegment(), source);
-        }
-        else
-        {
-            status = Status.ADVANCED;
-        }
+        Status status = pending != null ? writeValue(control, source, pending) : Status.ADVANCED;
         return boundary(status);
     }
 
@@ -161,9 +132,36 @@ public final class JsonSinkImpl implements JsonSink
     {
         depth = 0;
         valueStarted = false;
-        pendingSegment = false;
-        pendingDecoded = false;
+        pending = null;
         generator.reset();
+    }
+
+    // Writes one scalar/segment value, fed fresh or resumed: a structured (non-SEGMENTABLE) string renders
+    // canonically from its decoded char view; a verbatim string, number lexeme, or segment splices raw
+    // bytes. Records the event as pending while the bounded output leaves it mid-write so resume re-runs it.
+    private Status writeValue(
+        JsonController control,
+        JsonSource source,
+        JsonEvent event)
+    {
+        Status status;
+        if (event == JsonEvent.VALUE_STRING && delivery != Delivery.SEGMENTABLE)
+        {
+            status = writeDecodedString(control, source);
+        }
+        else
+        {
+            final DirectBuffer segment = source.getSegment();
+            if (!valueStarted)
+            {
+                // emit the value's leading separator once, before its first content byte
+                generator.writeRaw(segment, 0, 0);
+                valueStarted = true;
+            }
+            status = writeChunk(control, segment, source);
+        }
+        pending = status == Status.SUSPENDED ? event : null;
+        return status;
     }
 
     // Renders a structured string canonically from its decoded char view: the generator owns the quotes and
@@ -184,19 +182,17 @@ public final class JsonSinkImpl implements JsonSink
         Status status;
         if (available - consumed > 0)
         {
-            pendingDecoded = true;
             status = Status.SUSPENDED;
         }
         else
         {
-            pendingDecoded = false;
             status = deferred ? Status.ADVANCED : scalarStatus();
         }
         return status;
     }
 
-    // Append-only and stateless: writes the segment view whole and pushes back the source bytes the
-    // generator took via control.consumed(...) so the upstream re-exposes the remainder.
+    // Writes the segment view whole and pushes back the source bytes the generator took via
+    // control.consumed(...) so the upstream re-exposes the remainder.
     private Status writeChunk(
         JsonController control,
         DirectBuffer segment,
@@ -211,21 +207,16 @@ public final class JsonSinkImpl implements JsonSink
         Status status;
         if (outputDeferred > 0)
         {
-            pendingSegment = true;
             status = Status.SUSPENDED;
+        }
+        else if (source.deferredBytes())
+        {
+            status = Status.ADVANCED;
         }
         else
         {
-            pendingSegment = false;
-            if (source.deferredBytes())
-            {
-                status = Status.ADVANCED;
-            }
-            else
-            {
-                valueStarted = false;
-                status = scalarStatus();
-            }
+            valueStarted = false;
+            status = scalarStatus();
         }
         return status;
     }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -87,11 +87,13 @@ public final class JsonSinkImpl implements JsonSink
         case VALUE_STRING:
         case VALUE_NUMBER:
         case SEGMENT:
-            if (delivery == Delivery.DECODED && event != JsonEvent.SEGMENT)
+            if (delivery == Delivery.DECODED && event == JsonEvent.VALUE_STRING)
             {
-                // render from the decoded value; the generator owns quoting/escaping and joins
-                // fragments (deferredBytes) into one string, so the sink does no concatenation
-                status = writeDecoded(source, event);
+                // render the string from its decoded value; the generator owns quoting/escaping and
+                // joins fragments (deferredBytes) into one string, so the sink does no concatenation.
+                // A number's decoded form equals its raw lexeme, so it splices verbatim via the segment
+                // path below — the same bounded consumed() flow control as every other value.
+                status = writeDecoded(source);
             }
             else
             {
@@ -152,19 +154,11 @@ public final class JsonSinkImpl implements JsonSink
     }
 
     private Status writeDecoded(
-        JsonSource source,
-        JsonEvent event)
+        JsonSource source)
     {
         final boolean deferred = source.deferredBytes();
         final Completion completion = deferred ? Completion.INCOMPLETE : Completion.COMPLETE;
-        if (event == JsonEvent.VALUE_NUMBER)
-        {
-            generator.writeNumber(source.getStringView(), completion);
-        }
-        else
-        {
-            generator.write(source.getStringView(), completion);
-        }
+        generator.write(source.getStringView(), completion);
         return deferred ? Status.ADVANCED : scalarStatus();
     }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -37,7 +37,6 @@ public final class JsonSinkImpl implements JsonSink
     private final JsonGeneratorEx generator;
     private final Delivery delivery;
     private int depth;
-    private boolean valueStarted;
 
     public JsonSinkImpl(
         JsonGeneratorEx generator)
@@ -130,7 +129,6 @@ public final class JsonSinkImpl implements JsonSink
     public void reset()
     {
         depth = 0;
-        valueStarted = false;
         generator.reset();
     }
 
@@ -174,14 +172,7 @@ public final class JsonSinkImpl implements JsonSink
         }
         else
         {
-            final DirectBuffer segment = source.getSegment();
-            if (!valueStarted)
-            {
-                // emit the value's leading separator once, before its first content byte
-                generator.writeRaw(segment, 0, 0);
-                valueStarted = true;
-            }
-            status = writeChunk(control, segment, source);
+            status = writeChunk(control, source.getSegment(), source);
         }
         return status;
     }
@@ -222,16 +213,19 @@ public final class JsonSinkImpl implements JsonSink
         return status;
     }
 
-    // Writes the segment view whole and pushes back the source bytes the generator took via
+    // Splices the segment view, the generator owning the value's leading separator (emitted once on the
+    // first fragment) so the sink keeps no state; pushes back the source bytes the generator took via
     // control.consumed(...) so the upstream re-exposes the remainder.
     private Status writeChunk(
         JsonController control,
         DirectBuffer segment,
         JsonSource source)
     {
+        boolean deferred = source.deferredBytes();
+        Completion completion = deferred ? Completion.INCOMPLETE : Completion.COMPLETE;
         int available = segment.capacity();
         int before = generator.consumed();
-        generator.writeSegment(segment, 0, available);
+        generator.writeSegment(segment, 0, available, completion);
         int consumed = generator.consumed() - before;
         int outputDeferred = available - consumed;
         control.consumed(consumed);
@@ -240,13 +234,12 @@ public final class JsonSinkImpl implements JsonSink
         {
             status = Status.SUSPENDED;
         }
-        else if (source.deferredBytes())
+        else if (deferred)
         {
             status = Status.ADVANCED;
         }
         else
         {
-            valueStarted = false;
             status = scalarStatus();
         }
         return status;

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -145,9 +145,10 @@ public final class JsonSinkImpl implements JsonSink
         JsonEvent event)
     {
         Status status;
-        if (event == JsonEvent.VALUE_NUMBER ||
-            event == JsonEvent.VALUE_STRING && delivery != Delivery.SEGMENTABLE)
+        if (event == JsonEvent.VALUE_NUMBER || event == JsonEvent.VALUE_STRING)
         {
+            // a structured scalar renders canonically from its char view; a verbatim value arrives as a
+            // SEGMENT, so getSegment() is reached only for segmented events
             status = writeScalar(control, source, event);
         }
         else

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -159,11 +159,11 @@ public final class JsonSinkImpl implements JsonSink
         final Completion completion = deferred ? Completion.INCOMPLETE : Completion.COMPLETE;
         if (event == JsonEvent.VALUE_NUMBER)
         {
-            generator.writeNumber(source.getString(), completion);
+            generator.writeNumber(source.getStringView(), completion);
         }
         else
         {
-            generator.write(source.getString(), completion);
+            generator.write(source.getStringView(), completion);
         }
         return deferred ? Status.ADVANCED : scalarStatus();
     }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -39,6 +39,7 @@ public final class JsonSinkImpl implements JsonSink
     private int depth;
     private boolean valueStarted;
     private boolean pendingSegment;
+    private boolean pendingDecoded;
 
     public JsonSinkImpl(
         JsonGeneratorEx generator)
@@ -87,18 +88,17 @@ public final class JsonSinkImpl implements JsonSink
         case VALUE_STRING:
         case VALUE_NUMBER:
         case SEGMENT:
-            if (delivery == Delivery.DECODED && event == JsonEvent.VALUE_STRING)
+            if (event == JsonEvent.VALUE_STRING && delivery != Delivery.SEGMENTABLE)
             {
-                // render the string from its decoded value; the generator owns quoting/escaping and
-                // joins fragments (deferredBytes) into one string, so the sink does no concatenation.
-                // A number's decoded form equals its raw lexeme, so it splices verbatim via the segment
-                // path below — the same bounded consumed() flow control as every other value.
-                status = writeDecoded(source);
+                // structured (canonical) string: render from the decoded char view, the generator owning
+                // quoting/escaping and joining fragments (deferredBytes) into one string. The bounded write
+                // emits only what fits and reports consumed chars, the same flow control as the byte path.
+                status = writeDecodedString(control, source);
             }
             else
             {
-                // splice the kept leaf's raw token bytes verbatim, fragmenting across chunks; the value's
-                // leading separator is emitted once, before its first content byte
+                // verbatim string token, number lexeme, or segment: splice the raw bytes, fragmenting across
+                // chunks; the value's leading separator is emitted once, before its first content byte
                 segment = source.getSegment();
                 if (!valueStarted)
                 {
@@ -140,7 +140,19 @@ public final class JsonSinkImpl implements JsonSink
         JsonController control,
         JsonSource source)
     {
-        Status status = pendingSegment ? writeChunk(control, source.getSegment(), source) : Status.ADVANCED;
+        Status status;
+        if (pendingDecoded)
+        {
+            status = writeDecodedString(control, source);
+        }
+        else if (pendingSegment)
+        {
+            status = writeChunk(control, source.getSegment(), source);
+        }
+        else
+        {
+            status = Status.ADVANCED;
+        }
         return boundary(status);
     }
 
@@ -150,16 +162,37 @@ public final class JsonSinkImpl implements JsonSink
         depth = 0;
         valueStarted = false;
         pendingSegment = false;
+        pendingDecoded = false;
         generator.reset();
     }
 
-    private Status writeDecoded(
+    // Renders a structured string canonically from its decoded char view: the generator owns the quotes and
+    // escaping and writes only what fits the bound, reporting consumed source chars so the parser advances
+    // its char cursor and re-exposes the remainder on resume — the char-domain analog of writeChunk.
+    private Status writeDecodedString(
+        JsonController control,
         JsonSource source)
     {
         final boolean deferred = source.deferredBytes();
         final Completion completion = deferred ? Completion.INCOMPLETE : Completion.COMPLETE;
-        generator.write(source.getStringView(), completion);
-        return deferred ? Status.ADVANCED : scalarStatus();
+        final CharSequence view = source.getStringView();
+        final int available = view.length();
+        final int before = generator.consumed();
+        generator.write(view, completion);
+        final int consumed = generator.consumed() - before;
+        control.consumed(consumed);
+        Status status;
+        if (available - consumed > 0)
+        {
+            pendingDecoded = true;
+            status = Status.SUSPENDED;
+        }
+        else
+        {
+            pendingDecoded = false;
+            status = deferred ? Status.ADVANCED : scalarStatus();
+        }
+        return status;
     }
 
     // Append-only and stateless: writes the segment view whole and pushes back the source bytes the

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -38,10 +38,6 @@ public final class JsonSinkImpl implements JsonSink
     private final Delivery delivery;
     private int depth;
     private boolean valueStarted;
-    // the value event currently mid-write across a bounded-output suspend, or null when nothing is in
-    // flight; resume() re-runs that value's write, and the delivery mode resolves a decoded string from a
-    // verbatim one. A boundary() suspend at an event boundary leaves this null, so resume just advances.
-    private JsonEvent pending;
 
     public JsonSinkImpl(
         JsonGeneratorEx generator)
@@ -121,9 +117,12 @@ public final class JsonSinkImpl implements JsonSink
     @Override
     public Status resume(
         JsonController control,
-        JsonSource source)
+        JsonSource source,
+        JsonEvent event)
     {
-        Status status = pending != null ? writeValue(control, source, pending) : Status.ADVANCED;
+        // the pump supplies the event that suspended; continue only while its value still has an unwritten
+        // remainder (a boundary drain after a completed value, or a structural event, leaves none)
+        Status status = inFlight(source, event) ? writeValue(control, source, event) : Status.ADVANCED;
         return boundary(status);
     }
 
@@ -132,13 +131,35 @@ public final class JsonSinkImpl implements JsonSink
     {
         depth = 0;
         valueStarted = false;
-        pending = null;
         generator.reset();
+    }
+
+    // Whether the suspended event still has value bytes/chars left to write, read from the source cursor —
+    // the sink keeps no pending state of its own.
+    private boolean inFlight(
+        JsonSource source,
+        JsonEvent event)
+    {
+        boolean result;
+        switch (event)
+        {
+        case VALUE_STRING:
+        case VALUE_NUMBER:
+            result = source.getStringView().length() > 0;
+            break;
+        case SEGMENT:
+            result = source.getSegment().capacity() > 0;
+            break;
+        default:
+            result = false;
+            break;
+        }
+        return result;
     }
 
     // Writes one scalar/segment value, fed fresh or resumed: a structured (non-SEGMENTABLE) string renders
     // canonically from its decoded char view; a verbatim string, number lexeme, or segment splices raw
-    // bytes. Records the event as pending while the bounded output leaves it mid-write so resume re-runs it.
+    // bytes.
     private Status writeValue(
         JsonController control,
         JsonSource source,
@@ -162,7 +183,6 @@ public final class JsonSinkImpl implements JsonSink
             }
             status = writeChunk(control, segment, source);
         }
-        pending = status == Status.SUSPENDED ? event : null;
         return status;
     }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -145,9 +145,10 @@ public final class JsonSinkImpl implements JsonSink
         JsonEvent event)
     {
         Status status;
-        if (event == JsonEvent.VALUE_STRING && delivery != Delivery.SEGMENTABLE)
+        if (event == JsonEvent.VALUE_NUMBER ||
+            event == JsonEvent.VALUE_STRING && delivery != Delivery.SEGMENTABLE)
         {
-            status = writeDecodedString(control, source);
+            status = writeScalar(control, source, event);
         }
         else
         {
@@ -164,19 +165,28 @@ public final class JsonSinkImpl implements JsonSink
         return status;
     }
 
-    // Renders a structured string canonically from its decoded char view: the generator owns the quotes and
-    // escaping and writes only what fits the bound, reporting consumed source chars so the parser advances
-    // its char cursor and re-exposes the remainder on resume — the char-domain analog of writeChunk.
-    private Status writeDecodedString(
+    // Renders a structured scalar canonically from its decoded char view: the generator owns quoting and
+    // escaping (a string) or emits the lexeme (a number), writing only what fits the bound and reporting
+    // consumed source chars so the parser advances its char cursor and re-exposes the remainder on resume —
+    // the char-domain analog of writeChunk.
+    private Status writeScalar(
         JsonController control,
-        JsonSource source)
+        JsonSource source,
+        JsonEvent event)
     {
         final boolean deferred = source.deferredBytes();
         final Completion completion = deferred ? Completion.INCOMPLETE : Completion.COMPLETE;
         final CharSequence view = source.getStringView();
         final int available = view.length();
         final int before = generator.consumed();
-        generator.write(view, completion);
+        if (event == JsonEvent.VALUE_NUMBER)
+        {
+            generator.writeNumber(view, completion);
+        }
+        else
+        {
+            generator.write(view, completion);
+        }
         final int consumed = generator.consumed() - before;
         control.consumed(consumed);
         Status status;

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonStreamImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonStreamImpl.java
@@ -90,9 +90,10 @@ public final class JsonStreamImpl implements JsonStream
         @Override
         public Status resume(
             JsonController control,
-            JsonSource source)
+            JsonSource source,
+            JsonEvent event)
         {
-            return transform.resume(control, source, downstream);
+            return transform.resume(control, source, event, downstream);
         }
 
         @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -97,6 +97,11 @@ public final class JsonTokenizer
     // getLong() then throw (the value would overflow) and getBigDecimal() reads the accumulated lexeme.
     private boolean numberFragmented;
 
+    // set at each VALUE_STRING delivery: true when the value-string was streamed verbatim as raw bytes
+    // (a segment scan or an armed scalar leaf), so the caller splices its raw token bytes; false when it
+    // was decoded into scratch, so the caller renders it canonically from the decoded chars.
+    private boolean stringVerbatim;
+
     // set when a read hits the end of the current input window mid-token: the scan unwinds logically
     // (no exception) and advance() routes to onScalarStarved; reset at the top of each advance()
     private boolean starved;
@@ -133,6 +138,7 @@ public final class JsonTokenizer
         scratch.setLength(0);
         numberLexeme.setLength(0);
         numberFragmented = false;
+        stringVerbatim = false;
         pathDepth = 0;
         state = ParseState.DOC_START;
         pendingEvent = null;
@@ -250,6 +256,7 @@ public final class JsonTokenizer
                 {
                     valueStreamStart = fragmentStart;
                     valueStreamEnd = streamOffset;
+                    stringVerbatim = scalarSegment || segmenting;
                     pendingEvent = JsonParser.Event.VALUE_STRING;
                     // capture lazily: a verbatim/segmented consumer reads only getSegment() and never
                     // materializes the decoded chars, so leave them in scratch (cleared when the next
@@ -363,6 +370,13 @@ public final class JsonTokenizer
     public boolean numberFragmented()
     {
         return numberFragmented;
+    }
+
+    // True when the just-delivered value-string was streamed verbatim as raw bytes rather than decoded
+    // into scratch; the parser then splices its raw token bytes instead of rendering canonically.
+    public boolean stringVerbatim()
+    {
+        return stringVerbatim;
     }
 
     public CharSequence numberLexeme()
@@ -537,6 +551,7 @@ public final class JsonTokenizer
     {
         valueStreamStart = fragmentStart;
         valueStreamEnd = streamOffset;
+        stringVerbatim = scalarSegment || segmenting;
         pendingEvent = JsonParser.Event.VALUE_STRING;
         captureValue();
         fragmenting = false;

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorExTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorExTest.java
@@ -110,6 +110,30 @@ class JsonGeneratorExTest
     }
 
     @Test
+    void shouldWriteSignedIntBoundaries()
+    {
+        assertEquals("[0,-1,2147483647,-2147483648]", generate(g -> g
+            .writeStartArray()
+            .write(0)
+            .write(-1)
+            .write(Integer.MAX_VALUE)
+            .write(Integer.MIN_VALUE)
+            .writeEnd()));
+    }
+
+    @Test
+    void shouldWriteSignedLongBoundaries()
+    {
+        assertEquals("[0,-1,9223372036854775807,-9223372036854775808]", generate(g -> g
+            .writeStartArray()
+            .write(0L)
+            .write(-1L)
+            .write(Long.MAX_VALUE)
+            .write(Long.MIN_VALUE)
+            .writeEnd()));
+    }
+
+    @Test
     void shouldRejectNonFiniteDouble()
     {
         assertThrows(NumberFormatException.class, () -> generate(g -> g.write(Double.NaN)));

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonParserTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonParserTest.java
@@ -259,6 +259,50 @@ class JsonParserTest
     }
 
     @Test
+    void shouldGetIntBoundariesWithoutMaterializingString()
+    {
+        JsonParser parser = parserFor("[0,-1,2147483647,-2147483648]");
+
+        assertEquals(START_ARRAY, parser.next());
+        assertEquals(VALUE_NUMBER, parser.next());
+        assertEquals(0, parser.getInt());
+        assertEquals(VALUE_NUMBER, parser.next());
+        assertEquals(-1, parser.getInt());
+        assertEquals(VALUE_NUMBER, parser.next());
+        assertEquals(Integer.MAX_VALUE, parser.getInt());
+        assertEquals(VALUE_NUMBER, parser.next());
+        assertEquals(Integer.MIN_VALUE, parser.getInt());
+        assertEquals(END_ARRAY, parser.next());
+    }
+
+    @Test
+    void shouldGetLongBoundariesWithoutMaterializingString()
+    {
+        JsonParser parser = parserFor("[0,-1,9223372036854775807,-9223372036854775808]");
+
+        assertEquals(START_ARRAY, parser.next());
+        assertEquals(VALUE_NUMBER, parser.next());
+        assertEquals(0L, parser.getLong());
+        assertEquals(VALUE_NUMBER, parser.next());
+        assertEquals(-1L, parser.getLong());
+        assertEquals(VALUE_NUMBER, parser.next());
+        assertEquals(Long.MAX_VALUE, parser.getLong());
+        assertEquals(VALUE_NUMBER, parser.next());
+        assertEquals(Long.MIN_VALUE, parser.getLong());
+        assertEquals(END_ARRAY, parser.next());
+    }
+
+    @Test
+    void shouldRejectGetIntOnNonIntegralNumber()
+    {
+        JsonParser parser = parserFor("[3.14]");
+
+        assertEquals(START_ARRAY, parser.next());
+        assertEquals(VALUE_NUMBER, parser.next());
+        assertThrows(NumberFormatException.class, parser::getInt);
+    }
+
+    @Test
     void shouldDecodeTwoByteUtf8()
     {
         byte[] bytes = {'"', (byte) 0xC3, (byte) 0xA9, '"'};

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonParserTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonParserTest.java
@@ -709,12 +709,14 @@ class JsonParserTest
     }
 
     @Test
-    void shouldThrowIsIntegralOnNonNumberEvent()
+    void shouldRejectIsIntegralOnNonNumberEvent()
     {
         JsonParser parser = parserFor("true");
         parser.next();
 
-        assertThrows(IllegalStateException.class, parser::isIntegralNumber);
+        // isIntegralNumber() is valid only on a VALUE_NUMBER event; misuse trips the contract assert
+        // (assertions enabled under test), falling back to IllegalStateException when assertions are off
+        assertThrows(AssertionError.class, parser::isIntegralNumber);
     }
 
     @Test

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
@@ -143,10 +143,11 @@ class JsonProjectorSegmentTest
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(JsonEx.projector(List.of("/a")))
-            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.DECODED)));
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
 
         // a retained scalar leaf far larger than the input window: it fragments across windows and the
-        // DECODED sink rejoins the fragments; the dropped sibling /b also fragments and must not be emitted
+        // structured sink rejoins the fragments canonically; the dropped sibling /b also fragments and
+        // must not be emitted
         String value = "x".repeat(40);
         String json = "{\"a\":\"" + value + "\",\"b\":\"" + "y".repeat(40) + "\"} ";
         byte[] bytes = json.getBytes(UTF_8);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
@@ -62,19 +62,19 @@ class JsonProjectorSegmentTest
     }
 
     @Test
-    void shouldPreserveLeafStringEscapesVerbatimWhenStructured()
+    void shouldCanonicalizeLeafStringEscapesWhenStructured()
     {
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(JsonEx.projector(List.of("")))
             .into(JsonEx.createSink(gen));
 
-        // structured delivery normalizes structure (whitespace) but preserves each leaf value's bytes,
-        // so the original A escape survives rather than collapsing to A
+        // structured delivery renders each leaf string from its decoded value, so escaping is canonical:
+        // the redundant A collapses to A. Byte-verbatim preservation is the segmented path's job.
         Status status = run(pipeline, "{ \"a\" : \"x\\u0041y\" } ");
 
         assertEquals(Status.COMPLETED, status);
-        assertEquals("{\"a\":\"x\\u0041y\"}", output(gen));
+        assertEquals("{\"a\":\"xAy\"}", output(gen));
     }
 
     @Test

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSinkSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSinkSegmentTest.java
@@ -161,6 +161,6 @@ class JsonSinkSegmentTest
         // reset is a no-op and resume reports nothing pending
         JsonSink sink = (control, source, event) -> Status.ADVANCED;
         sink.reset();
-        assertEquals(Status.ADVANCED, sink.resume(null, null));
+        assertEquals(Status.ADVANCED, sink.resume(null, null, null));
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSourceContractTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSourceContractTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+class JsonSourceContractTest
+{
+    // getSegment() is valid only in reaction to a segmented event; reading it off a structured value
+    // event trips the parser's assert (assertions are enabled under the test runner).
+    @Test
+    void shouldRejectSegmentAccessOnStructuredValue()
+    {
+        JsonTransform probe = (control, source, event, sink) ->
+        {
+            if (event == JsonEvent.VALUE_NUMBER)
+            {
+                assertThrows(AssertionError.class, source::getSegment);
+            }
+            return sink.feed(control, source, event);
+        };
+        run(probe, "[42]", JsonSink.Delivery.STRUCTURED);
+    }
+
+    // the scalar value getters are valid only in reaction to a structured value event; reading one off a
+    // segmented event trips the assert
+    @Test
+    void shouldRejectScalarAccessOnSegment()
+    {
+        JsonTransform probe = (control, source, event, sink) ->
+        {
+            if (event == JsonEvent.SEGMENT)
+            {
+                assertThrows(AssertionError.class, source::getStringView);
+                assertThrows(AssertionError.class, source::getInt);
+            }
+            return sink.feed(control, source, event);
+        };
+        // the sink opts into segment delivery, so the whole document arrives as SEGMENT events
+        run(probe, "{\"a\":1}", JsonSink.Delivery.SEGMENTABLE);
+    }
+
+    private static void run(
+        JsonTransform probe,
+        String json,
+        JsonSink.Delivery delivery)
+    {
+        JsonGeneratorEx generator = JsonEx.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[256]);
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(probe)
+            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, delivery)));
+        generator.wrap(output, 0, output.capacity());
+        pipeline.reset();
+
+        byte[] bytes = (json + " ").getBytes(UTF_8);
+        pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length);
+    }
+}

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSourceTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSourceTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
+
+class JsonSourceTest
+{
+    @Test
+    void shouldReadPrimitivesAndViewThroughSource()
+    {
+        List<String> views = new ArrayList<>();
+        List<Integer> ints = new ArrayList<>();
+        List<Long> longs = new ArrayList<>();
+
+        // a stage reads the new JsonSource accessors off the value it is handed, then forwards
+        // the event to the terminal sink so the pipeline still completes the document
+        JsonTransform capture = (control, source, event, sink) ->
+        {
+            if (event == JsonEvent.VALUE_NUMBER && !source.deferredBytes())
+            {
+                views.add(source.getStringView().toString());
+                ints.add(source.getInt());
+                longs.add(source.getLong());
+            }
+            else if (event == JsonEvent.VALUE_STRING && !source.deferredBytes())
+            {
+                views.add(source.getStringView().toString());
+            }
+            return sink.feed(control, source, event);
+        };
+
+        JsonGeneratorEx gen = JsonEx.createGenerator();
+        MutableDirectBuffer buffer = new UnsafeBuffer(new byte[256]);
+        gen.wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(capture)
+            .into(JsonEx.createSink(gen));
+
+        byte[] bytes = "[42,-7,\"hi\"]".getBytes(UTF_8);
+        pipeline.reset();
+        Status status = pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length);
+
+        assertEquals(Status.COMPLETED, status);
+        assertEquals(List.of(42, -7), ints);
+        assertEquals(List.of(42L, -7L), longs);
+        assertEquals(List.of("42", "-7", "hi"), views);
+
+        byte[] out = new byte[gen.length()];
+        buffer.getBytes(0, out);
+        assertEquals("[42,-7,\"hi\"]", new String(out, UTF_8));
+    }
+}

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/bench/JsonPipelineBM.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/bench/JsonPipelineBM.java
@@ -88,7 +88,6 @@ public class JsonPipelineBM
     private final JsonGeneratorEx generator = JsonEx.createGenerator();
     private final JsonSink structuredSink = JsonEx.createSink(generator);
     private final JsonSink segmentableSink = JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, Delivery.SEGMENTABLE));
-    private final JsonSink decodedSink = JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, Delivery.DECODED));
 
     private JsonPipeline scalarLeavesPipeline;
     private JsonPipeline keptContainerStructuredPipeline;
@@ -99,8 +98,7 @@ public class JsonPipelineBM
     private JsonPipeline mostlySkippedSegmentedPipeline;
     private JsonPipeline fragmentStringStructuredPipeline;
     private JsonPipeline fragmentStringSegmentedPipeline;
-    private JsonPipeline fragmentStringDecodedPipeline;
-    private JsonPipeline fragmentNumberDecodedPipeline;
+    private JsonPipeline fragmentNumberStructuredPipeline;
 
     private UnsafeBuffer flatBuffer;
     private UnsafeBuffer nestedBuffer;
@@ -140,8 +138,7 @@ public class JsonPipelineBM
         // no transform: an over-window value fragments and is rendered straight to the sink
         fragmentStringStructuredPipeline = JsonEx.stream(JsonEx.createParser()).into(structuredSink);
         fragmentStringSegmentedPipeline = JsonEx.stream(JsonEx.createParser()).into(segmentableSink);
-        fragmentStringDecodedPipeline = JsonEx.stream(JsonEx.createParser()).into(decodedSink);
-        fragmentNumberDecodedPipeline = JsonEx.stream(JsonEx.createParser()).into(decodedSink);
+        fragmentNumberStructuredPipeline = JsonEx.stream(JsonEx.createParser()).into(structuredSink);
 
         byte[] flatBytes = FLAT_OBJECT.getBytes(UTF_8);
         byte[] nestedBytes = NESTED_OBJECT.getBytes(UTF_8);
@@ -220,15 +217,9 @@ public class JsonPipelineBM
     }
 
     @Benchmark
-    public int fragmentStringDecoded()
+    public int fragmentNumberStructured()
     {
-        return runWindowed(fragmentStringDecodedPipeline, largeStringBuffer, largeStringLength, FRAGMENT_WINDOW);
-    }
-
-    @Benchmark
-    public int fragmentNumberDecoded()
-    {
-        return runWindowed(fragmentNumberDecodedPipeline, largeNumberBuffer, largeNumberLength, FRAGMENT_WINDOW);
+        return runWindowed(fragmentNumberStructuredPipeline, largeNumberBuffer, largeNumberLength, FRAGMENT_WINDOW);
     }
 
     private int run(

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -94,6 +94,20 @@ class JsonPipelineChunkingTest
     }
 
     @Test
+    void shouldChunkDecodedNumberValueThroughBoundedOutput()
+    {
+        JsonGeneratorEx generator = JsonEx.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.DECODED)));
+
+        // a single decoded number lexeme longer than the output bound must suspend/resume mid-value,
+        // propagating consumed bytes back to the parser rather than overrunning the generator's limit
+        String json = "{\"n\":" + "1".repeat(100) + "}";
+        assertEquals(json, chunked(pipeline, generator, output, json));
+    }
+
+    @Test
     void shouldStreamStringValueAcrossInputFrames()
     {
         JsonGeneratorEx generator = JsonEx.createGenerator();

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -94,12 +94,12 @@ class JsonPipelineChunkingTest
     }
 
     @Test
-    void shouldChunkDecodedNumberValueThroughBoundedOutput()
+    void shouldChunkStructuredNumberValueThroughBoundedOutput()
     {
         JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
-            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.DECODED)));
+            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
 
         // a single decoded number lexeme longer than the output bound must suspend/resume mid-value,
         // propagating consumed bytes back to the parser rather than overrunning the generator's limit
@@ -108,12 +108,12 @@ class JsonPipelineChunkingTest
     }
 
     @Test
-    void shouldChunkDecodedControlHeavyStringThroughBoundedOutput()
+    void shouldChunkStructuredControlHeavyStringThroughBoundedOutput()
     {
         JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
-            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.DECODED)));
+            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
 
         // a control-char-heavy string rendered canonically (short escapes) far exceeds the output bound:
         // the bounded write must suspend mid-string without splitting an escape, then resume byte-correct
@@ -122,12 +122,12 @@ class JsonPipelineChunkingTest
     }
 
     @Test
-    void shouldChunkDecodedMultibyteStringThroughBoundedOutput()
+    void shouldChunkStructuredMultibyteStringThroughBoundedOutput()
     {
         JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
-            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.DECODED)));
+            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
 
         // multibyte UTF-8 content far larger than the output bound: a suspend must fall on a code-point
         // boundary so no multibyte character is split across chunks
@@ -136,14 +136,14 @@ class JsonPipelineChunkingTest
     }
 
     @Test
-    void shouldChunkDecodedStringAcrossInputAndOutputBounds()
+    void shouldChunkStructuredStringAcrossInputAndOutputBounds()
     {
         // a decoded string larger than both the input window and the output bound, carrying escapes and a
         // multibyte char: with the input window wider than the output bound a single fragment overruns the
         // bound, so it starves on input and suspends mid-fragment on output, reconstructing canonically
         String content = ("\\né\\t" + "x".repeat(6)).repeat(8);
         String json = "{\"data\":\"" + content + "\"}";
-        assertEquals(json, chunkedWindowed(JsonSink.Delivery.DECODED, json, 40, 24));
+        assertEquals(json, chunkedWindowed(JsonSink.Delivery.STRUCTURED, json, 40, 24));
     }
 
     @Test
@@ -271,19 +271,10 @@ class JsonPipelineChunkingTest
     }
 
     @Test
-    void shouldReconstructWindowFragmentedStringValueDecoded()
+    void shouldReconstructWindowFragmentedStringValueStructured()
     {
-        // small feed windows fragment the over-window value; the DECODED sink re-renders each fragment
-        // via generator.write(getString(), Completion) with no concatenation
-        String json = "{\"data\":\"" + "x".repeat(40) + "\"}";
-        assertEquals(json, feedWindowed(json, JsonSink.Delivery.DECODED, 8));
-    }
-
-    @Test
-    void shouldReconstructWindowFragmentedStringValueVerbatim()
-    {
-        // same fragmented value, verbatim path: each fragment's getSegment() raw bytes splice back to
-        // the whole token
+        // small feed windows fragment the over-window value; the structured sink re-renders each fragment
+        // canonically from getStringView() with no concatenation
         String json = "{\"data\":\"" + "x".repeat(40) + "\"}";
         assertEquals(json, feedWindowed(json, JsonSink.Delivery.STRUCTURED, 8));
     }
@@ -297,7 +288,7 @@ class JsonPipelineChunkingTest
         JsonGeneratorEx generator = JsonEx.createGenerator();
         MutableDirectBuffer output = new UnsafeBuffer(new byte[512]);
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
-            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.DECODED)));
+            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
         generator.wrap(output, 0, output.capacity());
         pipeline.reset();
 
@@ -323,14 +314,7 @@ class JsonPipelineChunkingTest
     }
 
     @Test
-    void shouldReconstructWindowFragmentedNumberValueDecoded()
-    {
-        String json = "{\"n\":" + "1".repeat(40) + "}";
-        assertEquals(json, feedWindowed(json, JsonSink.Delivery.DECODED, 8));
-    }
-
-    @Test
-    void shouldReconstructWindowFragmentedNumberValueVerbatim()
+    void shouldReconstructWindowFragmentedNumberValueStructured()
     {
         String json = "{\"n\":" + "1".repeat(40) + "}";
         assertEquals(json, feedWindowed(json, JsonSink.Delivery.STRUCTURED, 8));
@@ -369,7 +353,7 @@ class JsonPipelineChunkingTest
         };
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(probe)
-            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.DECODED)));
+            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
         generator.wrap(output, 0, output.capacity());
         pipeline.reset();
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -108,6 +108,45 @@ class JsonPipelineChunkingTest
     }
 
     @Test
+    void shouldChunkDecodedControlHeavyStringThroughBoundedOutput()
+    {
+        JsonGeneratorEx generator = JsonEx.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.DECODED)));
+
+        // a control-char-heavy string rendered canonically (short escapes) far exceeds the output bound:
+        // the bounded write must suspend mid-string without splitting an escape, then resume byte-correct
+        String json = "{\"data\":\"" + "\\n\\t\\r\\b\\f".repeat(12) + "\"}";
+        assertEquals(json, chunked(pipeline, generator, output, json));
+    }
+
+    @Test
+    void shouldChunkDecodedMultibyteStringThroughBoundedOutput()
+    {
+        JsonGeneratorEx generator = JsonEx.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.DECODED)));
+
+        // multibyte UTF-8 content far larger than the output bound: a suspend must fall on a code-point
+        // boundary so no multibyte character is split across chunks
+        String json = "{\"data\":\"" + "é中".repeat(20) + "\"}";
+        assertEquals(json, chunked(pipeline, generator, output, json));
+    }
+
+    @Test
+    void shouldChunkDecodedStringAcrossInputAndOutputBounds()
+    {
+        // a decoded string larger than both the input window and the output bound, carrying escapes and a
+        // multibyte char: with the input window wider than the output bound a single fragment overruns the
+        // bound, so it starves on input and suspends mid-fragment on output, reconstructing canonically
+        String content = ("\\né\\t" + "x".repeat(6)).repeat(8);
+        String json = "{\"data\":\"" + content + "\"}";
+        assertEquals(json, chunkedWindowed(JsonSink.Delivery.DECODED, json, 40, 24));
+    }
+
+    @Test
     void shouldStreamStringValueAcrossInputFrames()
     {
         JsonGeneratorEx generator = JsonEx.createGenerator();
@@ -391,6 +430,63 @@ class JsonPipelineChunkingTest
         byte[] out = new byte[generator.length()];
         output.getBytes(0, out);
         return new String(out, UTF_8);
+    }
+
+    // Drives a value through both bounds at once: fixed-size input windows (carrying the unconsumed tail
+    // across STARVED) and a bounded output (draining + re-targeting across SUSPENDED), concatenating every
+    // drained chunk into one document. Asserts both axes engage at least once.
+    private static String chunkedWindowed(
+        JsonSink.Delivery delivery,
+        String json,
+        int inWindow,
+        int outBound)
+    {
+        JsonGeneratorEx generator = JsonEx.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[256]);
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, delivery)));
+
+        byte[] msg = (json + " ").getBytes(UTF_8);
+        StringBuilder result = new StringBuilder();
+        pipeline.reset();
+        generator.wrap(output, 0, outBound);
+        int committed = 0;
+        int offset = 0;
+        int suspends = 0;
+        int starves = 0;
+        int guard = 0;
+        Status status = Status.STARVED;
+        while (guard++ < 100_000)
+        {
+            if (status == Status.STARVED)
+            {
+                offset = Math.min(offset + inWindow, msg.length);
+            }
+            boolean last = offset >= msg.length;
+            status = pipeline.feed(new UnsafeBuffer(msg), committed, offset - committed, last);
+            byte[] chunk = new byte[generator.length()];
+            output.getBytes(0, chunk);
+            result.append(new String(chunk, UTF_8));
+            if (status == Status.SUSPENDED)
+            {
+                suspends++;
+            }
+            else if (status == Status.STARVED)
+            {
+                assertFalse(last, "last window must not starve");
+                starves++;
+                committed = (int) pipeline.position();
+            }
+            else
+            {
+                break;
+            }
+            generator.wrap(output, 0, outBound);
+        }
+        assertEquals(Status.COMPLETED, status);
+        assertTrue(suspends >= 1, "expected at least one SUSPENDED chunk boundary");
+        assertTrue(starves >= 1, "expected at least one STARVED input boundary");
+        return result.toString();
     }
 
     // Drives a value through the pipeline with the generator bounded at BOUND, draining and re-targeting


### PR DESCRIPTION
Fixes #1887

## Summary

Converges the `JsonStream` scalar-value delivery model so a single, bounded `consumed()` flow-control mechanism drives the parser for every value, folds `Delivery.DECODED` into `STRUCTURED`, and tightens the accessor contract so each `JsonSource` accessor is valid only in reaction to its event class. The delivery semantics are now clean and orthogonal:

- **STRUCTURED** = logical/canonical value — each scalar is rendered from its decoded char view (`getStringView()`); strings are canonically escaped, numbers emit their lexeme.
- **SEGMENTABLE** = verbatim bytes — kept values (whole subtrees *and* scalar leaves) are delivered as `SEGMENT` events and spliced from `getSegment()`.

This began as allocation-free `common-json` cleanups (allocation-free `write(int/long)`, `getInt`/`getLong`/`getStringView` without materializing a `String`) and grew into the contract convergence those surfaced.

## What changed

### Bounded, consumed-reporting scalar writers (generator)
`write(CharSequence, Completion)` and `writeNumber(CharSequence, Completion)` are now **bounded**: each emits only what fits the output bound, stops on a clean code-point boundary (never splitting a UTF-8 char or `\uXXXX`), reserves room for a string's closing quote, and reports the **source chars consumed** — the char-domain analog of the byte-based `writeSegment`. A `writeSegment(DirectBuffer, int, int, Completion)` overload owns a verbatim value's leading separator across fragments (emitted once on the first fragment, value ending on `COMPLETE`), mirroring the scalar writers.

### Char cursor + canonical rendering (parser/sink)
- `getStringView()` exposes the unconsumed decoded-char remainder via a reused, allocation-free view; `consumed()` advances a char cursor for a decoded scalar and the raw byte cursor for a segment.
- The sink renders structured strings **and numbers** canonically from the char view, suspending/resuming on the output bound; segments splice raw bytes.
- **The sink is fully stateless** apart from the intrinsic `depth` (top-level completion): `resume(JsonController, JsonSource, JsonEvent)` takes the in-flight event from the pump and continues only while the source still has an unwritten remainder (`getStringView().length()`/`getSegment().capacity()`); a boundary drain after a completed value is a no-op. `JsonPipelineImpl` owns the single resume cursor (the suspended event); the generator owns the segment leading-separator. `feed`/`resume` share one `writeValue` path.

### Tightened, enforced contract
- `getSegment()` is valid only on a **segmented** event; the scalar value getters (`getStringView`/`getInt`/`getLong`/`getBigDecimal`/`isIntegralNumber`/`getString`/`getKey`) only on their **structured** event. Enforced by `assert`s in `JsonParserImpl`, so the contract holds whether driven by the streaming pipeline or the raw `jakarta` parser.
- `lastEvent` is the canonical delivered event (set uniformly in `nextEvent`); `currentEvent` is derived from it as the `jakarta` projection (`null` for a segment or document framing). Shared `jakarta` getters assert `currentEvent`; streaming-only `getStringView`/`getKey`/`getSegment` assert `lastEvent`.
- A **verbatim scalar leaf** under SEGMENTABLE is now delivered as a `SEGMENT` event (not `VALUE_STRING`), so `getSegment()` is genuinely segmented-only and the sink routes values purely by event — no stage forwarding a `VALUE_NUMBER`/canonical `VALUE_STRING` implicitly signs up to support a downstream `getSegment()`.
- `JsonSink.resume`/`JsonTransform.resume` gain a `JsonEvent` parameter so the pump supplies the in-flight event and the stages keep no per-value resume state; the forwarding transforms (projector, validator) are otherwise unchanged.

### Removed `Delivery.DECODED`
With strings and numbers both rendered canonically from the char view, `DECODED` is identical to `STRUCTURED`; removed, all usages folded in. The four `McpHttpProxyFactory` STRUCTURED pipelines are unchanged (canonical, per the issue audit — none depend on byte-exact escaping; the verbatim response path already uses `SEGMENTABLE` + `GENERATE_ESCAPED`).

## Semantic change (accepted in #1887)

Structured string values are now **canonically escaped** (e.g. `\uA` → `A`, `a\/b` → `a/b`); **numbers stay byte-exact** (rendered from the lexeme). Byte-verbatim preservation remains available via the segmented/`SEGMENTABLE` path.

## Tests (test-first)

- Bounded-output chunking (added failing first, against the overrun): control-char-heavy, multibyte-UTF-8, and across-both-bounds decoded values — each suspends mid-value and reconstructs byte-correct.
- Contract enforcement: `getSegment()` after a structured event and a scalar getter after a `SEGMENT` both trip the assert.
- Deduped the now-equivalent decoded/verbatim STRUCTURED tests and the JMH fragment benchmarks; one projector test moved from verbatim to canonical; the `isIntegralNumber` misuse test moved to the assert.

## Verification

- `./mvnw clean install -pl runtime/common-json` — green (tests + checkstyle + jacoco 0.90).
- Full reactor `clean install -DskipITs -Djacoco.skip=true` (minus docker/helm, which need a daemon) — `BUILD SUCCESS`; the MCP pipelines compile and their unit tests pass.
- JMH `JsonPipelineBM` (`-prof gc`): every scenario stays effectively zero-allocation (≤ ~0.04 B/op, `gc.count ≈ 0`), including the segmented paths through the new `writeSegment(…, Completion)` overload.

## Not pursued

Full `resume()` removal (parser re-delivers a partial value through `feed()`, eliminating the method entirely) remains rejected: it requires every transform's `feed()` to be idempotent under event re-delivery (the projector's path/index bookkeeping is not), adding complexity for no behavioral payoff. The stages are already stateless via the `JsonEvent`-carrying `resume()`.

https://claude.ai/code/session_0111mS4B2sLNGVSq9NZEH1YT