### PR TITLE
refactor(common-json): consolidate scalar and key reads on getStringView

### DIFF
--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonParserEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonParserEx.java
@@ -87,4 +87,14 @@ public interface JsonParserEx extends JsonParser
      * standard {@code jakarta.json.stream.JsonParser.Event} adding document framing and segment delivery.
      */
     JsonEvent nextEvent();
+
+    /**
+     * A non-owning, on-stack {@link CharSequence} view of the current scalar token — a string value, a
+     * number lexeme, or an object key — valid until the parser advances. The zero-copy peer of
+     * {@link #getString()}: a streaming caller reads or matches the value (or key) without materializing a
+     * {@code String}. The backing buffer is reused across events, so copy out anything needed beyond the
+     * current event. This promotes the {@link JsonSource#getStringView()} accessor onto the parser surface
+     * so a caller holding a {@code JsonParserEx} reads scalars without narrowing to {@link JsonSource}.
+     */
+    CharSequence getStringView();
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSource.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonSource.java
@@ -31,14 +31,12 @@ public interface JsonSource
     String getString();
 
     /**
-     * Non-owning, on-stack char view of the current scalar value (a number lexeme or a decoded string),
-     * valid only for the duration of the current event. The allocation-free counterpart to
-     * {@link #getString()} for stages that read or re-emit the value without retaining it.
+     * Non-owning, on-stack char view of the current scalar token — a decoded string value, a number
+     * lexeme, or an object key — valid only for the duration of the current event. The allocation-free
+     * counterpart to {@link #getString()} for stages that read or re-emit the value (or key) without
+     * retaining it.
      */
     CharSequence getStringView();
-
-    // valid only on a key event; non-owning, on-stack char view of the current key
-    CharSequence getKey();
 
     BigDecimal getBigDecimal();
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -450,9 +450,11 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     @Override
     public CharSequence getStringView()
     {
-        assert lastEvent == JsonEvent.VALUE_STRING || lastEvent == JsonEvent.VALUE_NUMBER;
+        assert lastEvent == JsonEvent.VALUE_STRING || lastEvent == JsonEvent.VALUE_NUMBER ||
+            lastEvent == JsonEvent.KEY_NAME;
         // while rendering a structured scalar, expose the unconsumed char remainder so a resumed write
-        // continues from where the bounded output left off; otherwise the full decoded view
+        // continues from where the bounded output left off; otherwise (a key, or a fresh value) the full
+        // decoded view
         return charScalar()
             ? stringViewRO.wrap(tokenizer.stringView(), stringViewOffset)
             : tokenizer.stringView();
@@ -464,13 +466,6 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     private boolean charScalar()
     {
         return lastEvent == JsonEvent.VALUE_NUMBER || lastEvent == JsonEvent.VALUE_STRING;
-    }
-
-    @Override
-    public CharSequence getKey()
-    {
-        assert lastEvent == JsonEvent.KEY_NAME;
-        return tokenizer.stringView();
     }
 
     @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
@@ -232,7 +232,7 @@ public final class JsonProjectorImpl implements JsonTransform
     {
         StringBuilder key = segmentKeys[depth];
         key.setLength(0);
-        key.append(source.getKey());
+        key.append(source.getStringView());
         segmentIsKey[depth] = true;
         indexes[depth] = -1;
         depth++;
@@ -590,12 +590,6 @@ public final class JsonProjectorImpl implements JsonTransform
 
         @Override
         public CharSequence getStringView()
-        {
-            return key;
-        }
-
-        @Override
-        public CharSequence getKey()
         {
             return key;
         }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
@@ -1006,12 +1006,6 @@ public final class JsonSchemaImpl implements JsonSchema
         }
 
         @Override
-        public CharSequence getKey()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
         public DirectBuffer getSegment()
         {
             throw new UnsupportedOperationException();
@@ -1498,12 +1492,6 @@ public final class JsonSchemaImpl implements JsonSchema
 
         @Override
         public JsonLocation getLocation()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public CharSequence getKey()
         {
             throw new UnsupportedOperationException();
         }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -62,7 +62,7 @@ public final class JsonSinkImpl implements JsonSink
         switch (event)
         {
         case KEY_NAME:
-            generator.writeKey(source.getKey());
+            generator.writeKey(source.getStringView());
             break;
         case START_OBJECT:
             generator.writeStartObject();

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonParserTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonParserTest.java
@@ -47,6 +47,22 @@ import org.junit.jupiter.api.Test;
 class JsonParserTest
 {
     @Test
+    void shouldViewKeyAndValueThroughStringView()
+    {
+        JsonParserEx parser = JsonEx.createParser();
+        byte[] bytes = "{\"alpha\":-12345}".getBytes(UTF_8);
+        parser.wrap(new UnsafeBuffer(bytes), 0, bytes.length);
+
+        assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
+        assertEquals(JsonEvent.START_OBJECT, parser.nextEvent());
+        assertEquals(JsonEvent.KEY_NAME, parser.nextEvent());
+        assertEquals("alpha", parser.getStringView().toString());
+        assertEquals(JsonEvent.VALUE_NUMBER, parser.nextEvent());
+        assertEquals("-12345", parser.getStringView().toString());
+        assertEquals(JsonEvent.END_OBJECT, parser.nextEvent());
+    }
+
+    @Test
     void shouldParseFlatObject()
     {
         JsonParser parser = parserFor("{\"jsonrpc\":\"2.0\",\"id\":42,\"method\":\"tools/list\"}");


### PR DESCRIPTION
## Summary

`getKey()` and `getStringView()` both returned the tokenizer's current char view (`tokenizer.stringView()`); the only difference was the asserted event. Since `getKey()` is **not** part of the jakarta `JsonParser` contract, this folds it into `getStringView()`, leaving one zero-copy scalar accessor for string values, number lexemes, and object keys.

## Changes

- **`getStringView()` now also accepts `KEY_NAME`.** A key takes the non-`charScalar()` branch and returns the full `tokenizer.stringView()` — identical to what `getKey()` returned. `SEGMENT` remains rejected (the scalar-on-segment contract test is unaffected).
- **Removed `JsonSource.getKey()`** and its four implementations (`JsonParserImpl`, `ParserSource`, `TokenCursor`, `KeySource`). The two call sites — `JsonSinkImpl` (`writeKey`) and `JsonProjectorImpl` (key path capture) — now read `getStringView()`.
- **Promoted `getStringView()` onto `JsonParserEx`**, so a caller holding the parser reads scalars and keys without narrowing to `JsonSource`.

## Why

A single zero-copy accessor across the streaming read surface is simpler than two near-identical ones, and keeps the `*Ex` extension surface focused. `getString()` (jakarta) already accepts `KEY_NAME`, so `getStringView()` now mirrors it allocation-free.

## Validation

`./mvnw install -pl runtime/common-json` — 4781 tests pass, checkstyle and license clean, JaCoCo coverage gate met. Added `JsonParserTest.shouldViewKeyAndValueThroughStringView` covering `getStringView()` on a key (and value) via `JsonParserEx`.

https://claude.ai/code/session_01HoyRbFKGExxejhKGacFfFH

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoyRbFKGExxejhKGacFfFH)_