### PR TITLE
refactor(common-avro): make AvroSink stateless (resume event + consumed() pushback)

### DIFF
--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroController.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroController.java
@@ -26,4 +26,15 @@ package io.aklivity.zilla.runtime.common.avro;
 public interface AvroController
 {
     void segmentable();
+
+    /**
+     * Reports {@code sourceBytes} payload bytes consumed by a bounded value write, so the upstream advances
+     * its segment cursor and re-exposes the value's unconsumed remainder on resume — the output-side
+     * back-pressure pushback that lets a terminal sink stream a length-delimited value without keeping its
+     * own offset. The default does nothing for a non-mediating edge that forwards no value.
+     */
+    default void consumed(
+        int sourceBytes)
+    {
+    }
 }

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroParser.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroParser.java
@@ -121,9 +121,21 @@ public interface AvroParser
 
     /**
      * Non-owning, on-stack view of the current contiguous raw Avro bytes — valid on {@link AvroEvent#BYTES}
-     * and {@link AvroEvent#FIXED} value events (the chunk available now) and on segment events.
+     * and {@link AvroEvent#FIXED} value events (the chunk available now) and on segment events. After
+     * {@link #consumed(int)} pushback (a bounded-output suspend) it exposes only the unconsumed remainder.
      */
     DirectBuffer getSegment();
+
+    /**
+     * Advances the current value chunk's read cursor by {@code sourceBytes} already written downstream, so a
+     * subsequent {@link #getSegment()} after a bounded-output suspend exposes only the remainder — letting a
+     * terminal sink resume a length-delimited value without tracking its own offset. The default does
+     * nothing, for a parser whose values are never delivered in bounded pieces.
+     */
+    default void consumed(
+        int sourceBytes)
+    {
+    }
 
     /**
      * The bytes still to come in later events of the run the current event belongs to, {@code 0} on its

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroSink.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroSink.java
@@ -45,14 +45,16 @@ public interface AvroSink
 
     /**
      * Continues the value in flight when the previous {@link #feed} returned
-     * {@link AvroPipeline.Status#SUSPENDED}, after the caller has drained and re-wrapped the output. The
-     * default does nothing (a sink that never suspends never sees this); a sink that returns
-     * {@code SUSPENDED} overrides it to resume from where it paused, reading remaining bytes from
-     * {@code source}.
+     * {@link AvroPipeline.Status#SUSPENDED}, after the caller has drained and re-wrapped the output.
+     * {@code event} is the value event that suspended, supplied by the pump so the sink keeps no resume
+     * state of its own; the sink re-reads the in-flight value's remainder from {@code source}. The default
+     * does nothing (a sink that never suspends never sees this); a sink that returns {@code SUSPENDED}
+     * overrides it to resume from where it paused.
      */
     default AvroPipeline.Status resume(
         AvroController control,
-        AvroSource source)
+        AvroSource source,
+        AvroEvent event)
     {
         return AvroPipeline.Status.ADVANCED;
     }

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroTransform.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroTransform.java
@@ -40,9 +40,10 @@ public interface AvroTransform
     default AvroPipeline.Status resume(
         AvroController control,
         AvroSource source,
+        AvroEvent event,
         AvroSink sink)
     {
-        return sink.resume(control, source);
+        return sink.resume(control, source, event);
     }
 
     default void reset()

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroParserImpl.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroParserImpl.java
@@ -107,6 +107,7 @@ public final class AvroParserImpl implements AvroParser
 
     private int valueOffset;
     private int valueLength;
+    private int valueConsumed;
     private int valueRemaining;
     private int deferred;
     private boolean valueStreaming;
@@ -189,6 +190,7 @@ public final class AvroParserImpl implements AvroParser
         cursorType = null;
         done = false;
         valueRemaining = 0;
+        valueConsumed = 0;
         deferred = 0;
         valueStreaming = false;
         segmenting = false;
@@ -874,6 +876,7 @@ public final class AvroParserImpl implements AvroParser
     {
         this.valueOffset = offset;
         this.valueLength = length;
+        this.valueConsumed = 0;
         this.string = null;
     }
 
@@ -883,12 +886,14 @@ public final class AvroParserImpl implements AvroParser
     {
         this.valueOffset = offset;
         this.valueLength = length;
+        this.valueConsumed = 0;
     }
 
     private void clearValue()
     {
         this.string = null;
         this.valueLength = 0;
+        this.valueConsumed = 0;
         this.deferred = 0;
     }
 
@@ -948,8 +953,15 @@ public final class AvroParserImpl implements AvroParser
     @Override
     public DirectBuffer getSegment()
     {
-        segmentView.wrap(buffer, valueOffset, valueLength);
+        segmentView.wrap(buffer, valueOffset + valueConsumed, valueLength - valueConsumed);
         return segmentView;
+    }
+
+    @Override
+    public void consumed(
+        int sourceBytes)
+    {
+        valueConsumed += sourceBytes;
     }
 
     @Override

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroPipelineImpl.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroPipelineImpl.java
@@ -50,6 +50,7 @@ final class AvroPipelineImpl implements AvroPipeline
     private final AvroSink root;
 
     private boolean suspended;
+    private AvroEvent suspendedEvent;
 
     AvroPipelineImpl(
         AvroParser parser,
@@ -83,11 +84,12 @@ final class AvroPipelineImpl implements AvroPipeline
         boolean last)
     {
         Status status = ADVANCED;
+        AvroEvent event = null;
         try
         {
             if (suspended)
             {
-                status = root.resume(control, source);
+                status = root.resume(control, source, suspendedEvent);
             }
             else
             {
@@ -95,7 +97,7 @@ final class AvroPipelineImpl implements AvroPipeline
             }
             while (status == ADVANCED)
             {
-                AvroEvent event = parser.nextEvent(control.mode());
+                event = parser.nextEvent(control.mode());
                 if (event == null)
                 {
                     break;
@@ -114,6 +116,12 @@ final class AvroPipelineImpl implements AvroPipeline
             status = REJECTED;
         }
         suspended = status == SUSPENDED;
+        // the pump remembers which event suspended (so the sink keeps no resume state); a re-suspend on
+        // resume leaves event null, keeping the prior suspendedEvent
+        if (suspended && event != null)
+        {
+            suspendedEvent = event;
+        }
         return status;
     }
 

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroPipelineImpl.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroPipelineImpl.java
@@ -58,7 +58,7 @@ final class AvroPipelineImpl implements AvroPipeline
     {
         this.parser = parser;
         this.source = new Source(parser);
-        this.control = new Control();
+        this.control = new Control(parser);
         this.root = root;
     }
 
@@ -211,15 +211,31 @@ final class AvroPipelineImpl implements AvroPipeline
     }
 
     // the head edge's controller: a stage's segmentable() request becomes a one-shot SEGMENTED mode that the
-    // pump passes to the parser on the next pull
+    // pump passes to the parser on the next pull; consumed() pushback advances the parser's value cursor so
+    // the terminal sink resumes a bounded value without keeping its own offset
     private static final class Control implements AvroController
     {
+        private final AvroParser parser;
+
         private boolean segmented;
+
+        private Control(
+            AvroParser parser)
+        {
+            this.parser = parser;
+        }
 
         @Override
         public void segmentable()
         {
             segmented = true;
+        }
+
+        @Override
+        public void consumed(
+            int sourceBytes)
+        {
+            parser.consumed(sourceBytes);
         }
 
         private AvroParser.Mode mode()

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroSinkImpl.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroSinkImpl.java
@@ -46,8 +46,6 @@ public final class AvroSinkImpl implements AvroSink
     private final AvroGenerator generator;
     private final Delivery delivery;
     private int depth;
-    private int valueOffset;
-    private boolean valueStarted;
 
     public AvroSinkImpl(
         AvroGenerator generator)
@@ -187,7 +185,7 @@ public final class AvroSinkImpl implements AvroSink
         case STRING:
         case BYTES:
         case FIXED:
-            status = writeValue(source);
+            status = writeValue(control, source);
             break;
         case SEGMENT:
             status = atomic();
@@ -220,39 +218,34 @@ public final class AvroSinkImpl implements AvroSink
     public void reset()
     {
         depth = 0;
-        valueOffset = 0;
-        valueStarted = false;
     }
 
+    // Streams a length-delimited value (string/bytes/fixed) into the bounded generator without sink state:
+    // the segment is the value's unconsumed remainder (the parser advances it on consumed()), so a resume
+    // re-reads it from the source and continues. The generator writes the length prefix once and copies
+    // only what fits the bound; consumed() pushes the written payload back so the parser re-exposes the rest.
     private Status writeValue(
+        AvroController control,
         AvroSource source)
     {
-        Status status;
-        if (!valueStarted && generator.length() > 0 && generator.remaining() < HEADROOM)
-        {
-            status = SUSPENDED;
-        }
-        else
+        Status status = atomic();
+        if (status == ADVANCED)
         {
             DirectBuffer segment = source.getSegment();
-            int total = segment.capacity();
+            int available = segment.capacity();
             int deferred = source.deferredBytes();
-            valueOffset += generator.writeSegment(segment, valueOffset, total - valueOffset, deferred);
-            valueStarted = true;
-            if (valueOffset < total)
+            int written = generator.writeSegment(segment, 0, available, deferred);
+            if (written > 0)
+            {
+                control.consumed(written);
+            }
+            if (written < available)
             {
                 status = SUSPENDED;
             }
-            else if (deferred > 0)
-            {
-                valueOffset = 0;
-                status = ADVANCED;
-            }
-            else
+            else if (deferred == 0)
             {
                 generator.flush();
-                valueOffset = 0;
-                valueStarted = false;
                 status = scalar();
             }
         }

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroSinkImpl.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroSinkImpl.java
@@ -48,7 +48,6 @@ public final class AvroSinkImpl implements AvroSink
     private int depth;
     private int valueOffset;
     private boolean valueStarted;
-    private AvroEvent pending;
 
     public AvroSinkImpl(
         AvroGenerator generator)
@@ -205,16 +204,16 @@ public final class AvroSinkImpl implements AvroSink
         default:
             break;
         }
-        pending = status == SUSPENDED ? event : null;
         return status;
     }
 
     @Override
     public Status resume(
         AvroController control,
-        AvroSource source)
+        AvroSource source,
+        AvroEvent event)
     {
-        return feed(control, source, pending);
+        return feed(control, source, event);
     }
 
     @Override
@@ -223,7 +222,6 @@ public final class AvroSinkImpl implements AvroSink
         depth = 0;
         valueOffset = 0;
         valueStarted = false;
-        pending = null;
     }
 
     private Status writeValue(

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroStreamImpl.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroStreamImpl.java
@@ -84,9 +84,10 @@ public final class AvroStreamImpl implements AvroStream
         @Override
         public Status resume(
             AvroController control,
-            AvroSource source)
+            AvroSource source,
+            AvroEvent event)
         {
-            return transform.resume(control, source, downstream);
+            return transform.resume(control, source, event, downstream);
         }
 
         @Override

--- a/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/AvroGeneratorTest.java
+++ b/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/AvroGeneratorTest.java
@@ -15,6 +15,7 @@
 package io.aklivity.zilla.runtime.common.avro;
 
 import static io.aklivity.zilla.runtime.common.avro.AvroValues.NO_CONTROL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.agrona.DirectBuffer;
@@ -24,7 +25,7 @@ import org.junit.jupiter.api.Test;
 public class AvroGeneratorTest
 {
     private final UnsafeBuffer out = new UnsafeBuffer(new byte[64]);
-    private final AvroSource zero = new ZeroSource();
+    private final AvroSource zero = new ZeroSource(new byte[0]);
 
     private AvroSink sink(
         String schemaText)
@@ -56,9 +57,24 @@ public class AvroGeneratorTest
         assertThrows(AvroValidationException.class, () -> sink.feed(NO_CONTROL, zero, AvroEvent.INT));
     }
 
+    @Test
+    public void shouldStreamBytesValueReportingConsumed()
+    {
+        AvroSink sink = sink("\"bytes\"");
+        AvroSource bytes = new ZeroSource(new byte[] { 0x01, 0x02, 0x03 });
+        // writeValue streams the segment and reports control.consumed(...) — here the no-op default
+        assertEquals(AvroPipeline.Status.COMPLETED, sink.feed(NO_CONTROL, bytes, AvroEvent.BYTES));
+    }
+
     private static final class ZeroSource implements AvroSource
     {
-        private final UnsafeBuffer empty = new UnsafeBuffer(new byte[0]);
+        private final UnsafeBuffer empty;
+
+        private ZeroSource(
+            byte[] segment)
+        {
+            this.empty = new UnsafeBuffer(segment);
+        }
         private final AvroLocation location = new AvroLocation()
         {
             @Override


### PR DESCRIPTION
## Summary

Makes the terminal `AvroSink` stateless, mirroring the design `common-json`'s `JsonSink` landed in #1888 — so the two streaming libraries share one model: the pump supplies the resume event, and value-write progress lives in the generator/parser via a `consumed()` pushback, not in the sink.

Two commits:

### 1. Drop resume state — pump supplies the event
- `AvroSink.resume(AvroController, AvroSource, **AvroEvent**)` — the pipeline re-supplies the event that suspended, so the sink keeps no `pending` field.
- `AvroTransform.resume` and `AvroStreamImpl.BoundSink` thread the event; `AvroPipelineImpl` remembers the suspending event (a re-suspend keeps the prior one).
- `AvroSinkImpl` drops `pending`.

### 2. Drop value-offset state — `consumed()` pushback
- New `AvroController.consumed(int)` and `AvroParser.consumed(int)` — the output-side back-pressure peer of `JsonController.consumed` / the JSON parser's segment cursor.
- `AvroParserImpl` tracks `valueConsumed`; `getSegment()` exposes only the unconsumed remainder after a bounded-output suspend (`getString()`/`decode()` still see the whole value). `AvroPipelineImpl`'s controller forwards `consumed()` to the parser.
- `AvroSinkImpl.writeValue` streams a length-delimited value by re-reading the source remainder and reporting `consumed()`, dropping `valueOffset`/`valueStarted`. It suspends on the existing **stateless** `atomic()` gate (`length()>0 && remaining()<HEADROOM`), which already guards the length-prefix write — so no generator change was needed.

Net: `AvroSinkImpl` keeps only structural `depth` (exactly as `JsonSinkImpl` does).

## Validation
`./mvnw verify -pl runtime/common-avro` — all 82 tests pass (structured + segmented transcode, fragmented values, malformed rejects), 0 checkstyle, JaCoCo coverage met. `AvroPipelineBM` structured/segmented transcode stay ~0 B/op (0.002–0.007), confirming no allocation regression. Added an `AvroGeneratorTest` case covering the `consumed()` pushback on a hand-fed value sink.

## Note for the AvroJson bridge
A parser that delivers length-delimited values in bounded pieces must override `AvroParser.consumed(int)` (the interface default is a no-op). `AvroParserImpl` does. The bridge's JSON-driven `AvroParser` (PR #1884) delivers whole values (`deferredBytes()==0`) so the no-op default is correct there; when #1884 merges this, no change is required, but it's worth a glance.

https://claude.ai/code/session_01HoyRbFKGExxejhKGacFfFH

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoyRbFKGExxejhKGacFfFH)_