### PR TITLE
perf(common-yaml): stream generator output and reduce parse allocations

### DIFF
--- a/runtime/common-yaml/pom.xml
+++ b/runtime/common-yaml/pom.xml
@@ -38,6 +38,21 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.biboudis</groupId>
+      <artifactId>jmh-profilers</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -95,6 +110,22 @@
               </limits>
             </rule>
           </rules>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>io.gatling</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <artifactSet>
+            <includes>
+              <include>jakarta.json:jakarta.json-api</include>
+              <include>org.openjdk.jmh:jmh-core</include>
+              <include>net.sf.jopt-simple:jopt-simple</include>
+              <include>org.apache.commons:commons-math3</include>
+              <include>commons-cli:commons-cli</include>
+              <include>com.github.biboudis:jmh-profilers</include>
+            </includes>
+          </artifactSet>
         </configuration>
       </plugin>
     </plugins>

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlDocumentParser.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlDocumentParser.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class YamlDocumentParser
@@ -38,6 +39,10 @@ public final class YamlDocumentParser
     private final String source;
     private final YamlConfiguration config;
     private final List<String> comments;
+    private Matcher numberMatcher;
+    private Matcher hexIntegerMatcher;
+    private Matcher integerMatcher;
+    private Matcher floatMatcher;
     private int index;
 
     private YamlDocumentParser(
@@ -1196,6 +1201,42 @@ public final class YamlDocumentParser
         return value.isEmpty() ? value : value + "\n";
     }
 
+    private Matcher numberMatcher()
+    {
+        if (numberMatcher == null)
+        {
+            numberMatcher = NUMBER_PATTERN.matcher("");
+        }
+        return numberMatcher;
+    }
+
+    private Matcher hexIntegerMatcher()
+    {
+        if (hexIntegerMatcher == null)
+        {
+            hexIntegerMatcher = HEX_INTEGER_PATTERN.matcher("");
+        }
+        return hexIntegerMatcher;
+    }
+
+    private Matcher integerMatcher()
+    {
+        if (integerMatcher == null)
+        {
+            integerMatcher = INTEGER_PATTERN.matcher("");
+        }
+        return integerMatcher;
+    }
+
+    private Matcher floatMatcher()
+    {
+        if (floatMatcher == null)
+        {
+            floatMatcher = FLOAT_PATTERN.matcher("");
+        }
+        return floatMatcher;
+    }
+
     private YamlScalarNode parseScalar(
         String text,
         String tag,
@@ -1223,7 +1264,7 @@ public final class YamlDocumentParser
         case "true" -> YamlScalarNode.literal(YamlScalarType.TRUE, line.line, line.column, line.offset);
         case "false" -> YamlScalarNode.literal(YamlScalarType.FALSE, line.line, line.column, line.offset);
         case "null", "~" -> YamlScalarNode.literal(YamlScalarType.NULL, line.line, line.column, line.offset);
-        default -> HEX_INTEGER_PATTERN.matcher(text).matches() || NUMBER_PATTERN.matcher(text).matches() ?
+        default -> hexIntegerMatcher().reset(text).matches() || numberMatcher().reset(text).matches() ?
             YamlScalarNode.number(numberText(text), line.line, line.column, line.offset) :
             YamlScalarNode.string(text, line.line, line.column, line.offset);
         };
@@ -1336,7 +1377,7 @@ public final class YamlDocumentParser
         case "tag:yaml.org,2002:int" ->
         {
             String scalar = scalarText(value, text);
-            if (!HEX_INTEGER_PATTERN.matcher(scalar).matches() && !INTEGER_PATTERN.matcher(scalar).matches())
+            if (!hexIntegerMatcher().reset(scalar).matches() && !integerMatcher().reset(scalar).matches())
             {
                 throw error("Invalid tagged integer scalar", line);
             }
@@ -1346,7 +1387,7 @@ public final class YamlDocumentParser
         {
             String scalar = scalarText(value, text);
             rejectNonFinite(scalar, line);
-            if (!FLOAT_PATTERN.matcher(scalar).matches() && !INTEGER_PATTERN.matcher(scalar).matches())
+            if (!floatMatcher().reset(scalar).matches() && !integerMatcher().reset(scalar).matches())
             {
                 throw error("Invalid tagged float scalar", line);
             }

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlDocumentParser.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlDocumentParser.java
@@ -31,6 +31,7 @@ public final class YamlDocumentParser
     private static final Pattern INTEGER_PATTERN = Pattern.compile("-?(?:0|[1-9][0-9]*)");
     private static final Pattern FLOAT_PATTERN = Pattern.compile(
         "-?(?:0|[1-9][0-9]*)(?:\\.[0-9]+)?(?:[eE][+-]?[0-9]+)|-?(?:0|[1-9][0-9]*)\\.[0-9]+");
+    private static final Pattern FLOW_FOLD_PATTERN = Pattern.compile("[ \\t]*\\R[ \\t]*");
 
     private final List<Line> lines;
     private final Map<String, YamlNode> anchors;
@@ -2586,6 +2587,7 @@ public final class YamlDocumentParser
         private final Map<String, String> tagHandles;
         private final YamlConfiguration config;
         private int cursor;
+        private YamlDocumentParser delegate;
 
         private FlowParser(
             String text,
@@ -2599,6 +2601,24 @@ public final class YamlDocumentParser
             this.anchors = anchors;
             this.tagHandles = tagHandles;
             this.config = config;
+        }
+
+        private YamlDocumentParser delegate()
+        {
+            if (delegate == null)
+            {
+                delegate = new YamlDocumentParser(new Document(List.of(), new YamlLocation(1, 1, 0), "",
+                    DocumentScanner.defaultTagHandles(), config));
+            }
+            return delegate;
+        }
+
+        private YamlNode applyFlowTag(
+            YamlNode value,
+            String tag,
+            Line line)
+        {
+            return delegate().applyTag(value, tag, scalarText(value, ""), line);
         }
 
         private YamlNode parse()
@@ -2626,9 +2646,7 @@ public final class YamlDocumentParser
             }
 
             ValueSpec spec = parseFlowDecorators();
-            new YamlDocumentParser(new Document(List.of(), new YamlLocation(1, 1, 0), "",
-                DocumentScanner.defaultTagHandles(), config))
-                .validateSpec(spec, line);
+            delegate().validateSpec(spec, line);
             YamlNode value;
             if (spec.alias != null)
             {
@@ -2643,7 +2661,7 @@ public final class YamlDocumentParser
                 case '\'', '"' -> parseQuotedScalar();
                 default -> parseBareScalar();
                 };
-                value = applyFlowTag(value, spec.tag, line, config);
+                value = applyFlowTag(value, spec.tag, line);
                 if (spec.anchor != null)
                 {
                     if (!config.anchors())
@@ -2756,9 +2774,7 @@ public final class YamlDocumentParser
                     {
                         throw error("YAML merge keys are disabled", line);
                     }
-                    new YamlDocumentParser(new Document(List.of(), new YamlLocation(1, 1, text.length()), "",
-                        DocumentScanner.defaultTagHandles(), config))
-                        .merge(object, value, line);
+                    delegate().merge(object, value, line);
                 }
                 else
                 {
@@ -2957,9 +2973,7 @@ public final class YamlDocumentParser
 
             int mark = cursor;
             ValueSpec spec = parseFlowDecorators();
-            new YamlDocumentParser(new Document(List.of(), new YamlLocation(1, 1, 0), "",
-                DocumentScanner.defaultTagHandles(), config))
-                .validateSpec(spec, line);
+            delegate().validateSpec(spec, line);
             if (spec.alias != null)
             {
                 return new KeySpec(null, resolve(spec.alias));
@@ -2972,7 +2986,7 @@ public final class YamlDocumentParser
                 case '{', '[' -> parseValue();
                 default -> parseBareKeyScalar();
                 };
-                key = applyFlowTag(key, spec.tag, line, config);
+                key = applyFlowTag(key, spec.tag, line);
                 if (spec.anchor != null)
                 {
                     if (!config.anchors())
@@ -3021,15 +3035,30 @@ public final class YamlDocumentParser
             {
                 throw error("Document markers are not allowed in flow collection", line);
             }
-            return new YamlDocumentParser(new Document(List.of(), new YamlLocation(1, 1, text.length()), "",
-                DocumentScanner.defaultTagHandles(), config))
-                .parseScalar(value, null, line);
+            return delegate().parseScalar(value, null, line);
         }
 
         private static String foldFlowScalar(
             String value)
         {
-            return value.replaceAll("[ \\t]*\\R[ \\t]*", " ");
+            return hasLineBreak(value) ? FLOW_FOLD_PATTERN.matcher(value).replaceAll(" ") : value;
+        }
+
+        private static boolean hasLineBreak(
+            String value)
+        {
+            boolean found = false;
+            for (int i = 0; i < value.length(); i++)
+            {
+                char c = value.charAt(i);
+                if (c == '\n' || c == '\r' || c == '\f' || c == '\u000B' ||
+                    c == '\u0085' || c == '\u2028' || c == '\u2029')
+                {
+                    found = true;
+                    break;
+                }
+            }
+            return found;
         }
 
         private YamlScalarNode parseQuotedScalar()
@@ -3084,9 +3113,7 @@ public final class YamlDocumentParser
             {
                 throw error("Document markers are not allowed in flow collection", line);
             }
-            return new YamlDocumentParser(new Document(List.of(), new YamlLocation(1, 1, text.length()), "",
-                DocumentScanner.defaultTagHandles(), config))
-                .parseScalar(value, null, line);
+            return delegate().parseScalar(value, null, line);
         }
 
         private static boolean isFlowDocumentMarker(
@@ -3172,17 +3199,6 @@ public final class YamlDocumentParser
         {
             return text.charAt(index) == '#' && (index == 0 || Character.isWhitespace(text.charAt(index - 1)));
         }
-    }
-
-    private static YamlNode applyFlowTag(
-        YamlNode value,
-        String tag,
-        Line line,
-        YamlConfiguration config)
-    {
-        return new YamlDocumentParser(new Document(List.of(), new YamlLocation(1, 1, 0), "",
-            DocumentScanner.defaultTagHandles(), config))
-            .applyTag(value, tag, scalarText(value, ""), line);
     }
 
     private static final class Line

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlEmitter.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlEmitter.java
@@ -370,6 +370,12 @@ public final class YamlEmitter
     private static String formatKey(
         String value)
     {
+        return formatPlain(value);
+    }
+
+    public static String formatPlain(
+        String value)
+    {
         return plain(value) ? value : quote(value);
     }
 
@@ -575,7 +581,7 @@ public final class YamlEmitter
         {
         case "'" -> singleQuote(scalar.value);
         case "\"" -> quote(scalar.value);
-        default -> plain(scalar.value) ? scalar.value : quote(scalar.value);
+        default -> formatPlain(scalar.value);
         };
         };
         return formatPrefix(scalar) + value;

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlEmitter.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlEmitter.java
@@ -404,6 +404,45 @@ public final class YamlEmitter
         writer.write(buffer, at, buffer.length - at);
     }
 
+    public static void writeScalar(
+        Writer writer,
+        String value) throws IOException
+    {
+        if (plain(value))
+        {
+            writer.write(value);
+        }
+        else
+        {
+            writer.write('"');
+            for (int i = 0; i < value.length(); i++)
+            {
+                char c = value.charAt(i);
+                char escape = switch (c)
+                {
+                case '"' -> '"';
+                case '\\' -> '\\';
+                case '\b' -> 'b';
+                case '\f' -> 'f';
+                case '\n' -> 'n';
+                case '\r' -> 'r';
+                case '\t' -> 't';
+                default -> '\0';
+                };
+                if (escape == '\0')
+                {
+                    writer.write(c);
+                }
+                else
+                {
+                    writer.write('\\');
+                    writer.write(escape);
+                }
+            }
+            writer.write('"');
+        }
+    }
+
     private static String formatNode(
         YamlNode node)
     {

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlEmitter.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlEmitter.java
@@ -16,13 +16,9 @@ package io.aklivity.zilla.runtime.common.yaml.internal;
 
 import java.io.IOException;
 import java.io.Writer;
-import java.util.regex.Pattern;
 
 public final class YamlEmitter
 {
-    private static final Pattern NUMBER_PATTERN = Pattern.compile(
-        "-?(?:0|[1-9][0-9]*)(?:\\.[0-9]+)?(?:[eE][+-]?[0-9]+)?");
-
     private YamlEmitter()
     {
     }
@@ -712,8 +708,58 @@ public final class YamlEmitter
     private static boolean looksLikeNumber(
         String value)
     {
-        char first = value.charAt(0);
-        return first >= '0' && first <= '9' && NUMBER_PATTERN.matcher(value).matches();
+        int length = value.length();
+        int at = integerPart(value);
+        boolean number = at > 0;
+        if (number && at < length && value.charAt(at) == '.')
+        {
+            int start = at + 1;
+            at = digits(value, start);
+            number = at > start;
+        }
+        if (number && at < length && (value.charAt(at) == 'e' || value.charAt(at) == 'E'))
+        {
+            int start = at + 1;
+            if (start < length && (value.charAt(start) == '+' || value.charAt(start) == '-'))
+            {
+                start++;
+            }
+            at = digits(value, start);
+            number = at > start;
+        }
+        return number && at == length;
+    }
+
+    private static int integerPart(
+        String value)
+    {
+        int at;
+        char first = value.isEmpty() ? '\0' : value.charAt(0);
+        if (first == '0')
+        {
+            at = 1;
+        }
+        else if (first >= '1' && first <= '9')
+        {
+            at = digits(value, 1);
+        }
+        else
+        {
+            at = 0;
+        }
+        return at;
+    }
+
+    private static int digits(
+        String value,
+        int start)
+    {
+        int at = start;
+        while (at < value.length() && value.charAt(at) >= '0' && value.charAt(at) <= '9')
+        {
+            at++;
+        }
+        return at;
     }
 
     private static String quote(

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlEmitter.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlEmitter.java
@@ -145,7 +145,7 @@ public final class YamlEmitter
         }
     }
 
-    private static void writeObjectValue(
+    static void writeObjectValue(
         YamlNode value,
         Writer writer,
         int indent,
@@ -201,61 +201,70 @@ public final class YamlEmitter
     {
         for (YamlNode value : array.values)
         {
-            writeLeadingComments(value, writer, indent, config);
-            if (value.alias != null)
-            {
-                writeIndent(writer, indent);
-                writer.write("- ");
-                writer.write(formatAlias(value));
-                writeLineComment(value, writer, config);
-                writer.write('\n');
-            }
-            else if (value instanceof YamlScalarNode scalar)
-            {
-                writeIndent(writer, indent);
-                writer.write("- ");
-                writeScalar(scalar, writer, indent, false, config);
-            }
-            else if (value instanceof YamlObjectNode object)
-            {
-                if (config.preserveComments() && object.lineComment != null)
-                {
-                    writeIndent(writer, indent);
-                    writer.write("-");
-                    writeLineComment(object, writer, config);
-                    writer.write('\n');
-                    writeNode(object, writer, indent + 1, config);
-                }
-                else
-                {
-                    writeArrayObject(object, writer, indent, config);
-                }
-            }
-            else if (isEmptyArray(value))
-            {
-                writeIndent(writer, indent);
-                writer.write("- ");
-                writer.write(formatPrefix(value));
-                writer.write("[]");
-                writeLineComment(value, writer, config);
-                writer.write('\n');
-            }
-            else if ("flow".equals(value.style))
-            {
-                writeIndent(writer, indent);
-                writer.write("- ");
-                writer.write(formatNode(value));
-                writeLineComment(value, writer, config);
-                writer.write('\n');
-            }
-            else
+            writeArrayElement(value, writer, indent, config);
+        }
+    }
+
+    static void writeArrayElement(
+        YamlNode value,
+        Writer writer,
+        int indent,
+        YamlConfiguration config) throws IOException
+    {
+        writeLeadingComments(value, writer, indent, config);
+        if (value.alias != null)
+        {
+            writeIndent(writer, indent);
+            writer.write("- ");
+            writer.write(formatAlias(value));
+            writeLineComment(value, writer, config);
+            writer.write('\n');
+        }
+        else if (value instanceof YamlScalarNode scalar)
+        {
+            writeIndent(writer, indent);
+            writer.write("- ");
+            writeScalar(scalar, writer, indent, false, config);
+        }
+        else if (value instanceof YamlObjectNode object)
+        {
+            if (config.preserveComments() && object.lineComment != null)
             {
                 writeIndent(writer, indent);
                 writer.write("-");
-                writeLineComment(value, writer, config);
+                writeLineComment(object, writer, config);
                 writer.write('\n');
-                writeNode(value, writer, indent + 1, config);
+                writeNode(object, writer, indent + 1, config);
             }
+            else
+            {
+                writeArrayObject(object, writer, indent, config);
+            }
+        }
+        else if (isEmptyArray(value))
+        {
+            writeIndent(writer, indent);
+            writer.write("- ");
+            writer.write(formatPrefix(value));
+            writer.write("[]");
+            writeLineComment(value, writer, config);
+            writer.write('\n');
+        }
+        else if ("flow".equals(value.style))
+        {
+            writeIndent(writer, indent);
+            writer.write("- ");
+            writer.write(formatNode(value));
+            writeLineComment(value, writer, config);
+            writer.write('\n');
+        }
+        else
+        {
+            writeIndent(writer, indent);
+            writer.write("-");
+            writeLineComment(value, writer, config);
+            writer.write('\n');
+            writeNode(value, writer, indent + 1, config);
         }
     }
 

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlEmitter.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlEmitter.java
@@ -384,6 +384,26 @@ public final class YamlEmitter
         return plain(value) ? value : quote(value);
     }
 
+    public static void writeInteger(
+        Writer writer,
+        long value,
+        char[] buffer) throws IOException
+    {
+        int at = buffer.length;
+        long magnitude = value > 0 ? -value : value;
+        do
+        {
+            buffer[--at] = (char) ('0' - (int) (magnitude % 10));
+            magnitude /= 10;
+        }
+        while (magnitude != 0);
+        if (value < 0)
+        {
+            buffer[--at] = '-';
+        }
+        writer.write(buffer, at, buffer.length - at);
+    }
+
     private static String formatNode(
         YamlNode node)
     {

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlEmitter.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlEmitter.java
@@ -16,14 +16,12 @@ package io.aklivity.zilla.runtime.common.yaml.internal;
 
 import java.io.IOException;
 import java.io.Writer;
-import java.util.Locale;
 import java.util.regex.Pattern;
 
 public final class YamlEmitter
 {
     private static final Pattern NUMBER_PATTERN = Pattern.compile(
         "-?(?:0|[1-9][0-9]*)(?:\\.[0-9]+)?(?:[eE][+-]?[0-9]+)?");
-    private static final Pattern PLAIN_PATTERN = Pattern.compile("[A-Za-z0-9_./@+-]+");
 
     private YamlEmitter()
     {
@@ -665,18 +663,42 @@ public final class YamlEmitter
     private static boolean plain(
         String value)
     {
-        String lower = value.toLowerCase(Locale.ROOT);
         return !value.isEmpty() &&
             !value.isBlank() &&
-            PLAIN_PATTERN.matcher(value).matches() &&
-            !NUMBER_PATTERN.matcher(value).matches() &&
-            !"true".equals(lower) &&
-            !"false".equals(lower) &&
-            !"null".equals(lower) &&
-            !"~".equals(lower) &&
+            isPlainChars(value) &&
             !value.startsWith("-") &&
             !value.startsWith("+") &&
-            !value.startsWith(".");
+            !value.startsWith(".") &&
+            !"true".equalsIgnoreCase(value) &&
+            !"false".equalsIgnoreCase(value) &&
+            !"null".equalsIgnoreCase(value) &&
+            !"~".equals(value) &&
+            !looksLikeNumber(value);
+    }
+
+    private static boolean isPlainChars(
+        String value)
+    {
+        boolean plain = true;
+        for (int i = 0; i < value.length(); i++)
+        {
+            char c = value.charAt(i);
+            boolean allowed = c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z' || c >= '0' && c <= '9' ||
+                c == '_' || c == '.' || c == '/' || c == '@' || c == '+' || c == '-';
+            if (!allowed)
+            {
+                plain = false;
+                break;
+            }
+        }
+        return plain;
+    }
+
+    private static boolean looksLikeNumber(
+        String value)
+    {
+        char first = value.charAt(0);
+        return first >= '0' && first <= '9' && NUMBER_PATTERN.matcher(value).matches();
     }
 
     private static String quote(

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlGeneratorImpl.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlGeneratorImpl.java
@@ -30,11 +30,14 @@ import io.aklivity.zilla.runtime.common.yaml.YamlValue;
 
 public final class YamlGeneratorImpl implements YamlGenerator
 {
+    private static final int ROOT = 0;
+    private static final int OBJECT_VALUE = 1;
+    private static final int ARRAY_ELEMENT = 2;
+
     private final Writer writer;
     private final YamlConfiguration config;
-    private final Deque<Context> stack;
-    private YamlNode rootNode;
-    private boolean written;
+    private final Deque<Scope> stack;
+    private boolean started;
     private boolean closed;
 
     public YamlGeneratorImpl(
@@ -61,8 +64,7 @@ public final class YamlGeneratorImpl implements YamlGenerator
     @Override
     public YamlGenerator writeStartObject()
     {
-        add(new YamlObjectNode(1, 1, 0));
-        stack.push(new Context(rootNode(), true));
+        beginContainer(false);
         return this;
     }
 
@@ -77,8 +79,7 @@ public final class YamlGeneratorImpl implements YamlGenerator
     @Override
     public YamlGenerator writeStartArray()
     {
-        add(new YamlArrayNode(1, 1, 0));
-        stack.push(new Context(rootNode(), false));
+        beginContainer(true);
         return this;
     }
 
@@ -95,12 +96,16 @@ public final class YamlGeneratorImpl implements YamlGenerator
         String name)
     {
         ensureOpen();
-        Context context = objectContext();
-        if (context.name != null)
+        if (stack.isEmpty() || stack.peek().array)
+        {
+            throw new IllegalStateException("Expected YAML object context");
+        }
+        Scope context = stack.peek();
+        if (context.pendingKey != null)
         {
             throw new IllegalStateException("YAML object key has already been written");
         }
-        context.name = name;
+        context.pendingKey = name;
         return this;
     }
 
@@ -108,7 +113,7 @@ public final class YamlGeneratorImpl implements YamlGenerator
     public YamlGenerator write(
         String value)
     {
-        add(YamlScalarNode.string(value, 1, 1, 0));
+        beginScalar(YamlEmitter.formatPlain(value));
         return this;
     }
 
@@ -125,7 +130,7 @@ public final class YamlGeneratorImpl implements YamlGenerator
     public YamlGenerator write(
         int value)
     {
-        add(YamlScalarNode.number(Integer.toString(value), 1, 1, 0));
+        beginScalar(Integer.toString(value));
         return this;
     }
 
@@ -142,7 +147,7 @@ public final class YamlGeneratorImpl implements YamlGenerator
     public YamlGenerator write(
         long value)
     {
-        add(YamlScalarNode.number(Long.toString(value), 1, 1, 0));
+        beginScalar(Long.toString(value));
         return this;
     }
 
@@ -163,7 +168,7 @@ public final class YamlGeneratorImpl implements YamlGenerator
         {
             throw new IllegalArgumentException("Non-finite YAML numbers are not valid JSON values");
         }
-        add(YamlScalarNode.number(Double.toString(value), 1, 1, 0));
+        beginScalar(Double.toString(value));
         return this;
     }
 
@@ -180,7 +185,7 @@ public final class YamlGeneratorImpl implements YamlGenerator
     public YamlGenerator write(
         boolean value)
     {
-        add(YamlScalarNode.literal(value ? YamlScalarType.TRUE : YamlScalarType.FALSE, 1, 1, 0));
+        beginScalar(value ? "true" : "false");
         return this;
     }
 
@@ -196,7 +201,7 @@ public final class YamlGeneratorImpl implements YamlGenerator
     @Override
     public YamlGenerator writeNull()
     {
-        add(YamlScalarNode.literal(YamlScalarType.NULL, 1, 1, 0));
+        beginScalar("null");
         return this;
     }
 
@@ -212,7 +217,7 @@ public final class YamlGeneratorImpl implements YamlGenerator
     public YamlGenerator write(
         YamlValue value)
     {
-        add(YamlValues.node(value));
+        placeNode(YamlValues.node(value));
         return this;
     }
 
@@ -233,19 +238,23 @@ public final class YamlGeneratorImpl implements YamlGenerator
         {
             throw new IllegalStateException("No YAML collection is open");
         }
-        Context context = stack.peek();
-        if (context.object && context.name != null)
+        Scope context = stack.peek();
+        if (!context.array && context.pendingKey != null)
         {
             throw new IllegalStateException("YAML object key has no value");
         }
         stack.pop();
+        if (!context.opened)
+        {
+            closeEmpty(context);
+        }
         return this;
     }
 
     @Override
     public void flush()
     {
-        writeDocument();
+        ensureOpen();
         try
         {
             writer.flush();
@@ -261,7 +270,10 @@ public final class YamlGeneratorImpl implements YamlGenerator
     {
         if (!closed)
         {
-            writeDocument();
+            if (!stack.isEmpty())
+            {
+                throw new IllegalStateException("YAML document has an open collection");
+            }
             try
             {
                 writer.close();
@@ -282,7 +294,7 @@ public final class YamlGeneratorImpl implements YamlGenerator
         {
             throw new IllegalStateException("YAML document has an open collection");
         }
-        if (written || rootNode != null)
+        if (started)
         {
             throw new IllegalStateException("YAML document has already been written");
         }
@@ -311,91 +323,238 @@ public final class YamlGeneratorImpl implements YamlGenerator
         {
             throw new IllegalStateException(ex.getMessage(), ex);
         }
-        written = true;
+        started = true;
     }
 
-    private void writeDocument()
+    private void beginScalar(
+        String text)
     {
         ensureOpen();
-        if (!stack.isEmpty())
+        if (stack.isEmpty())
         {
-            throw new IllegalStateException("YAML document has an open collection");
+            requireRootAvailable();
+            started = true;
+            emit(text);
+            emit("\n");
         }
-        if (!written && rootNode != null)
+        else
         {
+            Scope parent = stack.peek();
+            ensureOpened(parent);
+            if (parent.array)
+            {
+                parent.first = false;
+                indent(parent.childIndent);
+                emit("- ");
+                emit(text);
+                emit("\n");
+            }
+            else
+            {
+                String key = requireKey(parent);
+                if (parent.firstInline && parent.first)
+                {
+                    parent.firstInline = false;
+                }
+                else
+                {
+                    indent(parent.childIndent);
+                }
+                emit(YamlEmitter.formatPlain(key));
+                emit(": ");
+                emit(text);
+                emit("\n");
+                parent.first = false;
+            }
+        }
+    }
+
+    private void beginContainer(
+        boolean array)
+    {
+        ensureOpen();
+        Scope child;
+        if (stack.isEmpty())
+        {
+            requireRootAvailable();
+            started = true;
+            child = new Scope(ROOT, array, 0, null);
+        }
+        else
+        {
+            Scope parent = stack.peek();
+            ensureOpened(parent);
+            if (parent.array)
+            {
+                parent.first = false;
+                child = new Scope(ARRAY_ELEMENT, array, parent.childIndent, null);
+            }
+            else
+            {
+                String key = requireKey(parent);
+                parent.first = false;
+                child = new Scope(OBJECT_VALUE, array, parent.childIndent, key);
+            }
+        }
+        stack.push(child);
+    }
+
+    private void placeNode(
+        YamlNode node)
+    {
+        ensureOpen();
+        if (stack.isEmpty())
+        {
+            requireRootAvailable();
+            started = true;
             try
             {
-                YamlEmitter.write(rootNode, writer, config);
+                YamlEmitter.write(node, writer, config);
             }
             catch (IOException ex)
             {
                 throw new IllegalStateException(ex.getMessage(), ex);
             }
-            written = true;
-        }
-    }
-
-    private void add(
-        YamlNode node)
-    {
-        ensureOpen();
-        if (written)
-        {
-            throw new IllegalStateException("YAML document has already been written");
-        }
-
-        if (stack.isEmpty())
-        {
-            if (rootNode != null)
-            {
-                throw new IllegalStateException("Only one root YAML value is supported");
-            }
-            rootNode = node;
         }
         else
         {
-            Context context = stack.peek();
-            if (context.object)
+            Scope parent = stack.peek();
+            ensureOpened(parent);
+            try
             {
-                if (context.name == null)
+                if (parent.array)
                 {
-                    throw new IllegalStateException("Expected YAML object key");
+                    parent.first = false;
+                    YamlEmitter.writeArrayElement(node, writer, parent.childIndent, config);
                 }
-                ((YamlObjectNode) context.node).add(new YamlEntry(context.name, node, 1, 1, 0));
-                context.name = null;
+                else
+                {
+                    String key = requireKey(parent);
+                    if (parent.firstInline && parent.first)
+                    {
+                        parent.firstInline = false;
+                    }
+                    else
+                    {
+                        indent(parent.childIndent);
+                    }
+                    emit(YamlEmitter.formatPlain(key));
+                    emit(":");
+                    YamlEmitter.writeObjectValue(node, writer, parent.childIndent, config);
+                    parent.first = false;
+                }
             }
-            else
+            catch (IOException ex)
             {
-                ((YamlArrayNode) context.node).add(node);
+                throw new IllegalStateException(ex.getMessage(), ex);
             }
         }
     }
 
-    private YamlNode rootNode()
+    private void ensureOpened(
+        Scope scope)
     {
-        return stack.isEmpty() ? rootNode : childNode();
+        if (!scope.opened)
+        {
+            scope.opened = true;
+            switch (scope.introKind)
+            {
+            case ROOT -> scope.childIndent = 0;
+            case OBJECT_VALUE ->
+            {
+                indent(scope.introIndent);
+                emit(YamlEmitter.formatPlain(scope.introKey));
+                emit(":\n");
+                scope.childIndent = scope.introIndent + 1;
+            }
+            case ARRAY_ELEMENT ->
+            {
+                indent(scope.introIndent);
+                if (scope.array)
+                {
+                    emit("-\n");
+                }
+                else
+                {
+                    emit("- ");
+                    scope.firstInline = true;
+                }
+                scope.childIndent = scope.introIndent + 1;
+            }
+            default ->
+            {
+            }
+            }
+        }
     }
 
-    private YamlNode childNode()
+    private void closeEmpty(
+        Scope scope)
     {
-        Context parent = stack.peek();
-        if (parent.object)
+        String body = scope.array ? "[]" : "{}";
+        switch (scope.introKind)
         {
-            YamlObjectNode object = (YamlObjectNode) parent.node;
-            return object.entries.get(object.entries.size() - 1).value;
+        case ROOT -> emit(body);
+        case OBJECT_VALUE ->
+        {
+            indent(scope.introIndent);
+            emit(YamlEmitter.formatPlain(scope.introKey));
+            emit(": ");
+            emit(body);
         }
-
-        YamlArrayNode array = (YamlArrayNode) parent.node;
-        return array.values.get(array.values.size() - 1);
+        case ARRAY_ELEMENT ->
+        {
+            indent(scope.introIndent);
+            emit("- ");
+            emit(body);
+        }
+        default ->
+        {
+        }
+        }
+        emit("\n");
     }
 
-    private Context objectContext()
+    private String requireKey(
+        Scope object)
     {
-        if (stack.isEmpty() || !stack.peek().object)
+        if (object.pendingKey == null)
         {
-            throw new IllegalStateException("Expected YAML object context");
+            throw new IllegalStateException("Expected YAML object key");
         }
-        return stack.peek();
+        String key = object.pendingKey;
+        object.pendingKey = null;
+        return key;
+    }
+
+    private void requireRootAvailable()
+    {
+        if (started)
+        {
+            throw new IllegalStateException("Only one root YAML value is supported");
+        }
+    }
+
+    private void indent(
+        int depth)
+    {
+        for (int i = 0; i < depth; i++)
+        {
+            emit("  ");
+        }
+    }
+
+    private void emit(
+        String text)
+    {
+        try
+        {
+            writer.write(text);
+        }
+        catch (IOException ex)
+        {
+            throw new IllegalStateException(ex.getMessage(), ex);
+        }
     }
 
     private void ensureOpen()
@@ -406,18 +565,28 @@ public final class YamlGeneratorImpl implements YamlGenerator
         }
     }
 
-    private static final class Context
+    private static final class Scope
     {
-        final YamlNode node;
-        final boolean object;
-        String name;
+        private final int introKind;
+        private final boolean array;
+        private final int introIndent;
+        private final String introKey;
+        private int childIndent;
+        private boolean opened;
+        private boolean first = true;
+        private boolean firstInline;
+        private String pendingKey;
 
-        private Context(
-            YamlNode node,
-            boolean object)
+        private Scope(
+            int introKind,
+            boolean array,
+            int introIndent,
+            String introKey)
         {
-            this.node = node;
-            this.object = object;
+            this.introKind = introKind;
+            this.array = array;
+            this.introIndent = introIndent;
+            this.introKey = introKey;
         }
     }
 }

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlGeneratorImpl.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlGeneratorImpl.java
@@ -111,7 +111,7 @@ public final class YamlGeneratorImpl implements YamlGenerator
     public YamlGenerator write(
         String value)
     {
-        beginScalar(YamlEmitter.formatPlain(value));
+        beginScalarValue(value);
         return this;
     }
 
@@ -336,6 +336,14 @@ public final class YamlGeneratorImpl implements YamlGenerator
         emit("\n");
     }
 
+    private void beginScalarValue(
+        String value)
+    {
+        beginScalarPrefix();
+        emitScalar(value);
+        emit("\n");
+    }
+
     private void beginInteger(
         long value)
     {
@@ -379,7 +387,7 @@ public final class YamlGeneratorImpl implements YamlGenerator
                 {
                     indent(stack.childIndent());
                 }
-                emit(YamlEmitter.formatPlain(key));
+                emitScalar(key);
                 emit(": ");
                 stack.clearFirst();
             }
@@ -454,7 +462,7 @@ public final class YamlGeneratorImpl implements YamlGenerator
                     {
                         indent(childIndent);
                     }
-                    emit(YamlEmitter.formatPlain(key));
+                    emitScalar(key);
                     emit(":");
                     YamlEmitter.writeObjectValue(node, writer, childIndent, config);
                     stack.clearFirst();
@@ -477,7 +485,7 @@ public final class YamlGeneratorImpl implements YamlGenerator
             case OBJECT_VALUE ->
             {
                 indent(stack.introIndent());
-                emit(YamlEmitter.formatPlain(stack.introKey()));
+                emitScalar(stack.introKey());
                 emit(":\n");
             }
             case ARRAY_ELEMENT ->
@@ -512,7 +520,7 @@ public final class YamlGeneratorImpl implements YamlGenerator
         case OBJECT_VALUE ->
         {
             indent(introIndent);
-            emit(YamlEmitter.formatPlain(introKey));
+            emitScalar(introKey);
             emit(": ");
             emit(body);
         }
@@ -561,6 +569,19 @@ public final class YamlGeneratorImpl implements YamlGenerator
         try
         {
             writer.write(text);
+        }
+        catch (IOException ex)
+        {
+            throw new IllegalStateException(ex.getMessage(), ex);
+        }
+    }
+
+    private void emitScalar(
+        String value)
+    {
+        try
+        {
+            YamlEmitter.writeScalar(writer, value);
         }
         catch (IOException ex)
         {

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlGeneratorImpl.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlGeneratorImpl.java
@@ -34,6 +34,7 @@ public final class YamlGeneratorImpl implements YamlGenerator
     private final Writer writer;
     private final YamlConfiguration config;
     private final YamlGeneratorStack stack;
+    private final char[] numberBuffer;
     private boolean started;
     private boolean closed;
 
@@ -50,6 +51,7 @@ public final class YamlGeneratorImpl implements YamlGenerator
         this.writer = writer;
         this.config = config;
         this.stack = new YamlGeneratorStack();
+        this.numberBuffer = new char[20];
     }
 
     public YamlGeneratorImpl(
@@ -126,7 +128,7 @@ public final class YamlGeneratorImpl implements YamlGenerator
     public YamlGenerator write(
         int value)
     {
-        beginScalar(Integer.toString(value));
+        beginInteger(value);
         return this;
     }
 
@@ -143,7 +145,7 @@ public final class YamlGeneratorImpl implements YamlGenerator
     public YamlGenerator write(
         long value)
     {
-        beginScalar(Long.toString(value));
+        beginInteger(value);
         return this;
     }
 
@@ -329,13 +331,33 @@ public final class YamlGeneratorImpl implements YamlGenerator
     private void beginScalar(
         String text)
     {
+        beginScalarPrefix();
+        emit(text);
+        emit("\n");
+    }
+
+    private void beginInteger(
+        long value)
+    {
+        beginScalarPrefix();
+        try
+        {
+            YamlEmitter.writeInteger(writer, value, numberBuffer);
+        }
+        catch (IOException ex)
+        {
+            throw new IllegalStateException(ex.getMessage(), ex);
+        }
+        emit("\n");
+    }
+
+    private void beginScalarPrefix()
+    {
         ensureOpen();
         if (stack.isEmpty())
         {
             requireRootAvailable();
             started = true;
-            emit(text);
-            emit("\n");
         }
         else
         {
@@ -345,8 +367,6 @@ public final class YamlGeneratorImpl implements YamlGenerator
                 stack.clearFirst();
                 indent(stack.childIndent());
                 emit("- ");
-                emit(text);
-                emit("\n");
             }
             else
             {
@@ -361,8 +381,6 @@ public final class YamlGeneratorImpl implements YamlGenerator
                 }
                 emit(YamlEmitter.formatPlain(key));
                 emit(": ");
-                emit(text);
-                emit("\n");
                 stack.clearFirst();
             }
         }

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlGeneratorImpl.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlGeneratorImpl.java
@@ -14,14 +14,15 @@
  */
 package io.aklivity.zilla.runtime.common.yaml.internal;
 
+import static io.aklivity.zilla.runtime.common.yaml.internal.YamlGeneratorStack.ARRAY_ELEMENT;
+import static io.aklivity.zilla.runtime.common.yaml.internal.YamlGeneratorStack.OBJECT_VALUE;
+import static io.aklivity.zilla.runtime.common.yaml.internal.YamlGeneratorStack.ROOT;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.util.ArrayDeque;
-import java.util.Deque;
 
 import io.aklivity.zilla.runtime.common.yaml.YamlDocument;
 import io.aklivity.zilla.runtime.common.yaml.YamlGenerator;
@@ -30,13 +31,9 @@ import io.aklivity.zilla.runtime.common.yaml.YamlValue;
 
 public final class YamlGeneratorImpl implements YamlGenerator
 {
-    private static final int ROOT = 0;
-    private static final int OBJECT_VALUE = 1;
-    private static final int ARRAY_ELEMENT = 2;
-
     private final Writer writer;
     private final YamlConfiguration config;
-    private final Deque<Scope> stack;
+    private final YamlGeneratorStack stack;
     private boolean started;
     private boolean closed;
 
@@ -52,7 +49,7 @@ public final class YamlGeneratorImpl implements YamlGenerator
     {
         this.writer = writer;
         this.config = config;
-        this.stack = new ArrayDeque<>();
+        this.stack = new YamlGeneratorStack();
     }
 
     public YamlGeneratorImpl(
@@ -96,16 +93,15 @@ public final class YamlGeneratorImpl implements YamlGenerator
         String name)
     {
         ensureOpen();
-        if (stack.isEmpty() || stack.peek().array)
+        if (stack.isEmpty() || stack.array())
         {
             throw new IllegalStateException("Expected YAML object context");
         }
-        Scope context = stack.peek();
-        if (context.pendingKey != null)
+        if (stack.pendingKey() != null)
         {
             throw new IllegalStateException("YAML object key has already been written");
         }
-        context.pendingKey = name;
+        stack.pendingKey(name);
         return this;
     }
 
@@ -238,15 +234,19 @@ public final class YamlGeneratorImpl implements YamlGenerator
         {
             throw new IllegalStateException("No YAML collection is open");
         }
-        Scope context = stack.peek();
-        if (!context.array && context.pendingKey != null)
+        if (!stack.array() && stack.pendingKey() != null)
         {
             throw new IllegalStateException("YAML object key has no value");
         }
+        boolean opened = stack.opened();
+        int kind = stack.kind();
+        boolean array = stack.array();
+        int introIndent = stack.introIndent();
+        String introKey = stack.introKey();
         stack.pop();
-        if (!context.opened)
+        if (!opened)
         {
-            closeEmpty(context);
+            closeEmpty(kind, array, introIndent, introKey);
         }
         return this;
     }
@@ -339,32 +339,31 @@ public final class YamlGeneratorImpl implements YamlGenerator
         }
         else
         {
-            Scope parent = stack.peek();
-            ensureOpened(parent);
-            if (parent.array)
+            ensureOpened();
+            if (stack.array())
             {
-                parent.first = false;
-                indent(parent.childIndent);
+                stack.clearFirst();
+                indent(stack.childIndent());
                 emit("- ");
                 emit(text);
                 emit("\n");
             }
             else
             {
-                String key = requireKey(parent);
-                if (parent.firstInline && parent.first)
+                String key = requireKey();
+                if (stack.firstInline() && stack.first())
                 {
-                    parent.firstInline = false;
+                    stack.clearFirstInline();
                 }
                 else
                 {
-                    indent(parent.childIndent);
+                    indent(stack.childIndent());
                 }
                 emit(YamlEmitter.formatPlain(key));
                 emit(": ");
                 emit(text);
                 emit("\n");
-                parent.first = false;
+                stack.clearFirst();
             }
         }
     }
@@ -373,30 +372,29 @@ public final class YamlGeneratorImpl implements YamlGenerator
         boolean array)
     {
         ensureOpen();
-        Scope child;
         if (stack.isEmpty())
         {
             requireRootAvailable();
             started = true;
-            child = new Scope(ROOT, array, 0, null);
+            stack.push(ROOT, array, 0, null);
         }
         else
         {
-            Scope parent = stack.peek();
-            ensureOpened(parent);
-            if (parent.array)
+            ensureOpened();
+            if (stack.array())
             {
-                parent.first = false;
-                child = new Scope(ARRAY_ELEMENT, array, parent.childIndent, null);
+                int childIndent = stack.childIndent();
+                stack.clearFirst();
+                stack.push(ARRAY_ELEMENT, array, childIndent, null);
             }
             else
             {
-                String key = requireKey(parent);
-                parent.first = false;
-                child = new Scope(OBJECT_VALUE, array, parent.childIndent, key);
+                String key = requireKey();
+                int childIndent = stack.childIndent();
+                stack.clearFirst();
+                stack.push(OBJECT_VALUE, array, childIndent, key);
             }
         }
-        stack.push(child);
     }
 
     private void placeNode(
@@ -418,30 +416,30 @@ public final class YamlGeneratorImpl implements YamlGenerator
         }
         else
         {
-            Scope parent = stack.peek();
-            ensureOpened(parent);
+            ensureOpened();
             try
             {
-                if (parent.array)
+                if (stack.array())
                 {
-                    parent.first = false;
-                    YamlEmitter.writeArrayElement(node, writer, parent.childIndent, config);
+                    stack.clearFirst();
+                    YamlEmitter.writeArrayElement(node, writer, stack.childIndent(), config);
                 }
                 else
                 {
-                    String key = requireKey(parent);
-                    if (parent.firstInline && parent.first)
+                    String key = requireKey();
+                    int childIndent = stack.childIndent();
+                    if (stack.firstInline() && stack.first())
                     {
-                        parent.firstInline = false;
+                        stack.clearFirstInline();
                     }
                     else
                     {
-                        indent(parent.childIndent);
+                        indent(childIndent);
                     }
                     emit(YamlEmitter.formatPlain(key));
                     emit(":");
-                    YamlEmitter.writeObjectValue(node, writer, parent.childIndent, config);
-                    parent.first = false;
+                    YamlEmitter.writeObjectValue(node, writer, childIndent, config);
+                    stack.clearFirst();
                 }
             }
             catch (IOException ex)
@@ -451,35 +449,31 @@ public final class YamlGeneratorImpl implements YamlGenerator
         }
     }
 
-    private void ensureOpened(
-        Scope scope)
+    private void ensureOpened()
     {
-        if (!scope.opened)
+        if (!stack.opened())
         {
-            scope.opened = true;
-            switch (scope.introKind)
+            stack.markOpened();
+            switch (stack.kind())
             {
-            case ROOT -> scope.childIndent = 0;
             case OBJECT_VALUE ->
             {
-                indent(scope.introIndent);
-                emit(YamlEmitter.formatPlain(scope.introKey));
+                indent(stack.introIndent());
+                emit(YamlEmitter.formatPlain(stack.introKey()));
                 emit(":\n");
-                scope.childIndent = scope.introIndent + 1;
             }
             case ARRAY_ELEMENT ->
             {
-                indent(scope.introIndent);
-                if (scope.array)
+                indent(stack.introIndent());
+                if (stack.array())
                 {
                     emit("-\n");
                 }
                 else
                 {
                     emit("- ");
-                    scope.firstInline = true;
+                    stack.markFirstInline();
                 }
-                scope.childIndent = scope.introIndent + 1;
             }
             default ->
             {
@@ -489,41 +483,40 @@ public final class YamlGeneratorImpl implements YamlGenerator
     }
 
     private void closeEmpty(
-        Scope scope)
+        int kind,
+        boolean array,
+        int introIndent,
+        String introKey)
     {
-        String body = scope.array ? "[]" : "{}";
-        switch (scope.introKind)
+        String body = array ? "[]" : "{}";
+        switch (kind)
         {
-        case ROOT -> emit(body);
         case OBJECT_VALUE ->
         {
-            indent(scope.introIndent);
-            emit(YamlEmitter.formatPlain(scope.introKey));
+            indent(introIndent);
+            emit(YamlEmitter.formatPlain(introKey));
             emit(": ");
             emit(body);
         }
         case ARRAY_ELEMENT ->
         {
-            indent(scope.introIndent);
+            indent(introIndent);
             emit("- ");
             emit(body);
         }
-        default ->
-        {
-        }
+        default -> emit(body);
         }
         emit("\n");
     }
 
-    private String requireKey(
-        Scope object)
+    private String requireKey()
     {
-        if (object.pendingKey == null)
+        String key = stack.pendingKey();
+        if (key == null)
         {
             throw new IllegalStateException("Expected YAML object key");
         }
-        String key = object.pendingKey;
-        object.pendingKey = null;
+        stack.pendingKey(null);
         return key;
     }
 
@@ -562,31 +555,6 @@ public final class YamlGeneratorImpl implements YamlGenerator
         if (closed)
         {
             throw new IllegalStateException("YAML generator is closed");
-        }
-    }
-
-    private static final class Scope
-    {
-        private final int introKind;
-        private final boolean array;
-        private final int introIndent;
-        private final String introKey;
-        private int childIndent;
-        private boolean opened;
-        private boolean first = true;
-        private boolean firstInline;
-        private String pendingKey;
-
-        private Scope(
-            int introKind,
-            boolean array,
-            int introIndent,
-            String introKey)
-        {
-            this.introKind = introKind;
-            this.array = array;
-            this.introIndent = introIndent;
-            this.introKey = introKey;
         }
     }
 }

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlGeneratorStack.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/YamlGeneratorStack.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.yaml.internal;
+
+import java.util.Arrays;
+
+/**
+ * Allocation-free nesting stack for the streaming YAML generators. Each open object or array is one
+ * entry, encoded as a packed {@code int} frame plus an intro key and a pending key, so a generator
+ * holds two reusable arrays instead of one stack node object per nesting level.
+ */
+public final class YamlGeneratorStack
+{
+    public static final int ROOT = 0;
+    public static final int OBJECT_VALUE = 1;
+    public static final int ARRAY_ELEMENT = 2;
+
+    private static final int KIND_MASK = 0x3;
+    private static final int ARRAY = 1 << 2;
+    private static final int OPENED = 1 << 3;
+    private static final int FIRST = 1 << 4;
+    private static final int FIRST_INLINE = 1 << 5;
+    private static final int INTRO_INDENT_SHIFT = 6;
+
+    private int[] frames;
+    private String[] keys;
+    private int depth;
+
+    public YamlGeneratorStack()
+    {
+        this.frames = new int[8];
+        this.keys = new String[16];
+    }
+
+    public boolean isEmpty()
+    {
+        return depth == 0;
+    }
+
+    public void push(
+        int kind,
+        boolean array,
+        int introIndent,
+        String introKey)
+    {
+        if (depth == frames.length)
+        {
+            frames = Arrays.copyOf(frames, frames.length * 2);
+            keys = Arrays.copyOf(keys, keys.length * 2);
+        }
+        frames[depth] = kind | (array ? ARRAY : 0) | FIRST | (introIndent << INTRO_INDENT_SHIFT);
+        keys[depth * 2] = introKey;
+        keys[depth * 2 + 1] = null;
+        depth++;
+    }
+
+    public void pop()
+    {
+        depth--;
+    }
+
+    public int kind()
+    {
+        return frames[depth - 1] & KIND_MASK;
+    }
+
+    public boolean array()
+    {
+        return (frames[depth - 1] & ARRAY) != 0;
+    }
+
+    public boolean opened()
+    {
+        return (frames[depth - 1] & OPENED) != 0;
+    }
+
+    public boolean first()
+    {
+        return (frames[depth - 1] & FIRST) != 0;
+    }
+
+    public boolean firstInline()
+    {
+        return (frames[depth - 1] & FIRST_INLINE) != 0;
+    }
+
+    public int introIndent()
+    {
+        return frames[depth - 1] >>> INTRO_INDENT_SHIFT;
+    }
+
+    public int childIndent()
+    {
+        return kind() == ROOT ? 0 : introIndent() + 1;
+    }
+
+    public String introKey()
+    {
+        return keys[(depth - 1) * 2];
+    }
+
+    public String pendingKey()
+    {
+        return keys[(depth - 1) * 2 + 1];
+    }
+
+    public void markOpened()
+    {
+        frames[depth - 1] |= OPENED;
+    }
+
+    public void markFirstInline()
+    {
+        frames[depth - 1] |= FIRST_INLINE;
+    }
+
+    public void clearFirst()
+    {
+        frames[depth - 1] &= ~FIRST;
+    }
+
+    public void clearFirstInline()
+    {
+        frames[depth - 1] &= ~FIRST_INLINE;
+    }
+
+    public void pendingKey(
+        String name)
+    {
+        keys[(depth - 1) * 2 + 1] = name;
+    }
+}

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/json/YamlJsonEvent.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/json/YamlJsonEvent.java
@@ -24,7 +24,11 @@ final class YamlJsonEvent
     final JsonParser.Event event;
     final String value;
     final YamlNode node;
-    final YamlJsonLocation location;
+
+    private final int line;
+    private final int column;
+    private final long offset;
+    private YamlJsonLocation location;
 
     YamlJsonEvent(
         JsonParser.Event event,
@@ -47,7 +51,9 @@ final class YamlJsonEvent
         this.event = event;
         this.value = value;
         this.node = node;
-        this.location = new YamlJsonLocation(new YamlLocation(line, column, offset));
+        this.line = line;
+        this.column = column;
+        this.offset = offset;
     }
 
     YamlJsonEvent(
@@ -60,5 +66,17 @@ final class YamlJsonEvent
         this.value = value;
         this.node = node;
         this.location = location;
+        this.line = (int) location.getLineNumber();
+        this.column = (int) location.getColumnNumber();
+        this.offset = location.getStreamOffset();
+    }
+
+    YamlJsonLocation location()
+    {
+        if (location == null)
+        {
+            location = new YamlJsonLocation(new YamlLocation(line, column, offset));
+        }
+        return location;
     }
 }

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/json/YamlJsonEvent.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/json/YamlJsonEvent.java
@@ -21,26 +21,16 @@ import io.aklivity.zilla.runtime.common.yaml.internal.YamlNode;
 
 final class YamlJsonEvent
 {
-    final JsonParser.Event event;
-    final String value;
-    final YamlNode node;
+    JsonParser.Event event;
+    String value;
+    YamlNode node;
 
-    private final int line;
-    private final int column;
-    private final long offset;
+    private int line;
+    private int column;
+    private long offset;
     private YamlJsonLocation location;
 
-    YamlJsonEvent(
-        JsonParser.Event event,
-        String value,
-        int line,
-        int column,
-        long offset)
-    {
-        this(event, value, null, line, column, offset);
-    }
-
-    YamlJsonEvent(
+    YamlJsonEvent set(
         JsonParser.Event event,
         String value,
         YamlNode node,
@@ -54,9 +44,11 @@ final class YamlJsonEvent
         this.line = line;
         this.column = column;
         this.offset = offset;
+        this.location = null;
+        return this;
     }
 
-    YamlJsonEvent(
+    YamlJsonEvent set(
         JsonParser.Event event,
         String value,
         YamlNode node,
@@ -69,6 +61,7 @@ final class YamlJsonEvent
         this.line = (int) location.getLineNumber();
         this.column = (int) location.getColumnNumber();
         this.offset = location.getStreamOffset();
+        return this;
     }
 
     YamlJsonLocation location()

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/json/YamlJsonGenerator.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/json/YamlJsonGenerator.java
@@ -14,6 +14,9 @@
  */
 package io.aklivity.zilla.runtime.common.yaml.internal.json;
 
+import static io.aklivity.zilla.runtime.common.yaml.internal.YamlGeneratorStack.ARRAY_ELEMENT;
+import static io.aklivity.zilla.runtime.common.yaml.internal.YamlGeneratorStack.OBJECT_VALUE;
+import static io.aklivity.zilla.runtime.common.yaml.internal.YamlGeneratorStack.ROOT;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
@@ -22,8 +25,6 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.Map;
 
 import jakarta.json.JsonException;
@@ -33,15 +34,12 @@ import jakarta.json.JsonValue;
 import jakarta.json.stream.JsonGenerator;
 
 import io.aklivity.zilla.runtime.common.yaml.internal.YamlEmitter;
+import io.aklivity.zilla.runtime.common.yaml.internal.YamlGeneratorStack;
 
 public final class YamlJsonGenerator implements JsonGenerator
 {
-    private static final int ROOT = 0;
-    private static final int OBJECT_VALUE = 1;
-    private static final int ARRAY_ELEMENT = 2;
-
     private final Writer writer;
-    private final Deque<Scope> stack;
+    private final YamlGeneratorStack stack;
     private boolean rootDone;
     private boolean closed;
 
@@ -49,7 +47,7 @@ public final class YamlJsonGenerator implements JsonGenerator
         Writer writer)
     {
         this.writer = writer;
-        this.stack = new ArrayDeque<>();
+        this.stack = new YamlGeneratorStack();
     }
 
     public YamlJsonGenerator(
@@ -91,16 +89,15 @@ public final class YamlJsonGenerator implements JsonGenerator
         String name)
     {
         ensureOpen();
-        if (stack.isEmpty() || stack.peek().array)
+        if (stack.isEmpty() || stack.array())
         {
             throw new JsonException("Expected object context");
         }
-        Scope context = stack.peek();
-        if (context.pendingKey != null)
+        if (stack.pendingKey() != null)
         {
             throw new JsonException("Previous key has no value");
         }
-        context.pendingKey = name;
+        stack.pendingKey(name);
         return this;
     }
 
@@ -183,15 +180,19 @@ public final class YamlJsonGenerator implements JsonGenerator
         {
             throw new JsonException("No YAML structure to end");
         }
-        Scope context = stack.peek();
-        if (!context.array && context.pendingKey != null)
+        if (!stack.array() && stack.pendingKey() != null)
         {
             throw new JsonException("Object key has no value");
         }
+        boolean opened = stack.opened();
+        int kind = stack.kind();
+        boolean array = stack.array();
+        int introIndent = stack.introIndent();
+        String introKey = stack.introKey();
         stack.pop();
-        if (!context.opened)
+        if (!opened)
         {
-            closeEmpty(context);
+            closeEmpty(kind, array, introIndent, introKey);
         }
         if (stack.isEmpty())
         {
@@ -323,32 +324,31 @@ public final class YamlJsonGenerator implements JsonGenerator
         }
         else
         {
-            Scope parent = stack.peek();
-            ensureOpened(parent);
-            if (parent.array)
+            ensureOpened();
+            if (stack.array())
             {
-                parent.first = false;
-                indent(parent.childIndent);
+                stack.clearFirst();
+                indent(stack.childIndent());
                 emit("- ");
                 emit(text);
                 emit("\n");
             }
             else
             {
-                String key = requireKey(parent);
-                if (parent.firstInline && parent.first)
+                String key = requireKey();
+                if (stack.firstInline() && stack.first())
                 {
-                    parent.firstInline = false;
+                    stack.clearFirstInline();
                 }
                 else
                 {
-                    indent(parent.childIndent);
+                    indent(stack.childIndent());
                 }
                 emit(YamlEmitter.formatPlain(key));
                 emit(": ");
                 emit(text);
                 emit("\n");
-                parent.first = false;
+                stack.clearFirst();
             }
         }
     }
@@ -357,29 +357,28 @@ public final class YamlJsonGenerator implements JsonGenerator
         boolean array)
     {
         ensureOpen();
-        Scope child;
         if (stack.isEmpty())
         {
             requireRootAvailable();
-            child = new Scope(ROOT, array, 0, null);
+            stack.push(ROOT, array, 0, null);
         }
         else
         {
-            Scope parent = stack.peek();
-            ensureOpened(parent);
-            if (parent.array)
+            ensureOpened();
+            if (stack.array())
             {
-                parent.first = false;
-                child = new Scope(ARRAY_ELEMENT, array, parent.childIndent, null);
+                int childIndent = stack.childIndent();
+                stack.clearFirst();
+                stack.push(ARRAY_ELEMENT, array, childIndent, null);
             }
             else
             {
-                String key = requireKey(parent);
-                parent.first = false;
-                child = new Scope(OBJECT_VALUE, array, parent.childIndent, key);
+                String key = requireKey();
+                int childIndent = stack.childIndent();
+                stack.clearFirst();
+                stack.push(OBJECT_VALUE, array, childIndent, key);
             }
         }
-        stack.push(child);
     }
 
     private void writeValue(
@@ -414,35 +413,31 @@ public final class YamlJsonGenerator implements JsonGenerator
         }
     }
 
-    private void ensureOpened(
-        Scope scope)
+    private void ensureOpened()
     {
-        if (!scope.opened)
+        if (!stack.opened())
         {
-            scope.opened = true;
-            switch (scope.introKind)
+            stack.markOpened();
+            switch (stack.kind())
             {
-            case ROOT -> scope.childIndent = 0;
             case OBJECT_VALUE ->
             {
-                indent(scope.introIndent);
-                emit(YamlEmitter.formatPlain(scope.introKey));
+                indent(stack.introIndent());
+                emit(YamlEmitter.formatPlain(stack.introKey()));
                 emit(":\n");
-                scope.childIndent = scope.introIndent + 1;
             }
             case ARRAY_ELEMENT ->
             {
-                indent(scope.introIndent);
-                if (scope.array)
+                indent(stack.introIndent());
+                if (stack.array())
                 {
                     emit("-\n");
                 }
                 else
                 {
                     emit("- ");
-                    scope.firstInline = true;
+                    stack.markFirstInline();
                 }
-                scope.childIndent = scope.introIndent + 1;
             }
             default ->
             {
@@ -452,41 +447,40 @@ public final class YamlJsonGenerator implements JsonGenerator
     }
 
     private void closeEmpty(
-        Scope scope)
+        int kind,
+        boolean array,
+        int introIndent,
+        String introKey)
     {
-        String body = scope.array ? "[]" : "{}";
-        switch (scope.introKind)
+        String body = array ? "[]" : "{}";
+        switch (kind)
         {
-        case ROOT -> emit(body);
         case OBJECT_VALUE ->
         {
-            indent(scope.introIndent);
-            emit(YamlEmitter.formatPlain(scope.introKey));
+            indent(introIndent);
+            emit(YamlEmitter.formatPlain(introKey));
             emit(": ");
             emit(body);
         }
         case ARRAY_ELEMENT ->
         {
-            indent(scope.introIndent);
+            indent(introIndent);
             emit("- ");
             emit(body);
         }
-        default ->
-        {
-        }
+        default -> emit(body);
         }
         emit("\n");
     }
 
-    private String requireKey(
-        Scope object)
+    private String requireKey()
     {
-        if (object.pendingKey == null)
+        String key = stack.pendingKey();
+        if (key == null)
         {
             throw new JsonException("Expected an object key");
         }
-        String key = object.pendingKey;
-        object.pendingKey = null;
+        stack.pendingKey(null);
         return key;
     }
 
@@ -525,31 +519,6 @@ public final class YamlJsonGenerator implements JsonGenerator
         if (closed)
         {
             throw new JsonException("YAML generator is closed");
-        }
-    }
-
-    private static final class Scope
-    {
-        private final int introKind;
-        private final boolean array;
-        private final int introIndent;
-        private final String introKey;
-        private int childIndent;
-        private boolean opened;
-        private boolean first = true;
-        private boolean firstInline;
-        private String pendingKey;
-
-        private Scope(
-            int introKind,
-            boolean array,
-            int introIndent,
-            String introKey)
-        {
-            this.introKind = introKind;
-            this.array = array;
-            this.introIndent = introIndent;
-            this.introKey = introKey;
         }
     }
 }

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/json/YamlJsonGenerator.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/json/YamlJsonGenerator.java
@@ -26,28 +26,23 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Map;
 
-import jakarta.json.JsonArray;
 import jakarta.json.JsonException;
 import jakarta.json.JsonNumber;
-import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
 import jakarta.json.stream.JsonGenerator;
 
-import io.aklivity.zilla.runtime.common.yaml.internal.YamlArrayNode;
 import io.aklivity.zilla.runtime.common.yaml.internal.YamlEmitter;
-import io.aklivity.zilla.runtime.common.yaml.internal.YamlEntry;
-import io.aklivity.zilla.runtime.common.yaml.internal.YamlNode;
-import io.aklivity.zilla.runtime.common.yaml.internal.YamlObjectNode;
-import io.aklivity.zilla.runtime.common.yaml.internal.YamlScalarNode;
-import io.aklivity.zilla.runtime.common.yaml.internal.YamlScalarType;
 
 public final class YamlJsonGenerator implements JsonGenerator
 {
+    private static final int ROOT = 0;
+    private static final int OBJECT_VALUE = 1;
+    private static final int ARRAY_ELEMENT = 2;
+
     private final Writer writer;
-    private final Deque<Context> stack;
-    private YamlNode root;
-    private boolean written;
+    private final Deque<Scope> stack;
+    private boolean rootDone;
     private boolean closed;
 
     public YamlJsonGenerator(
@@ -66,9 +61,7 @@ public final class YamlJsonGenerator implements JsonGenerator
     @Override
     public JsonGenerator writeStartObject()
     {
-        YamlObjectNode object = new YamlObjectNode(1, 1, 0);
-        addValue(object);
-        stack.push(Context.object(object));
+        beginContainer(false);
         return this;
     }
 
@@ -80,25 +73,9 @@ public final class YamlJsonGenerator implements JsonGenerator
     }
 
     @Override
-    public JsonGenerator writeKey(
-        String name)
-    {
-        ensureOpen();
-        Context context = requireObject();
-        if (context.pendingKey != null)
-        {
-            throw new JsonException("Previous key has no value");
-        }
-        context.pendingKey = name;
-        return this;
-    }
-
-    @Override
     public JsonGenerator writeStartArray()
     {
-        YamlArrayNode array = new YamlArrayNode(1, 1, 0);
-        addValue(array);
-        stack.push(Context.array(array));
+        beginContainer(true);
         return this;
     }
 
@@ -107,6 +84,24 @@ public final class YamlJsonGenerator implements JsonGenerator
         String name)
     {
         return writeKey(name).writeStartArray();
+    }
+
+    @Override
+    public JsonGenerator writeKey(
+        String name)
+    {
+        ensureOpen();
+        if (stack.isEmpty() || stack.peek().array)
+        {
+            throw new JsonException("Expected object context");
+        }
+        Scope context = stack.peek();
+        if (context.pendingKey != null)
+        {
+            throw new JsonException("Previous key has no value");
+        }
+        context.pendingKey = name;
+        return this;
     }
 
     @Override
@@ -188,12 +183,20 @@ public final class YamlJsonGenerator implements JsonGenerator
         {
             throw new JsonException("No YAML structure to end");
         }
-        Context context = stack.peek();
-        if (context.pendingKey != null)
+        Scope context = stack.peek();
+        if (!context.array && context.pendingKey != null)
         {
             throw new JsonException("Object key has no value");
         }
         stack.pop();
+        if (!context.opened)
+        {
+            closeEmpty(context);
+        }
+        if (stack.isEmpty())
+        {
+            rootDone = true;
+        }
         return this;
     }
 
@@ -201,7 +204,7 @@ public final class YamlJsonGenerator implements JsonGenerator
     public JsonGenerator write(
         JsonValue value)
     {
-        addValue(fromJsonValue(value));
+        writeValue(value);
         return this;
     }
 
@@ -209,7 +212,7 @@ public final class YamlJsonGenerator implements JsonGenerator
     public JsonGenerator write(
         String value)
     {
-        addValue(YamlScalarNode.string(value, 1, 1, 0));
+        beginScalar(YamlEmitter.formatPlain(value));
         return this;
     }
 
@@ -217,7 +220,7 @@ public final class YamlJsonGenerator implements JsonGenerator
     public JsonGenerator write(
         BigDecimal value)
     {
-        addValue(YamlScalarNode.number(value.toString(), 1, 1, 0));
+        beginScalar(value.toString());
         return this;
     }
 
@@ -225,7 +228,7 @@ public final class YamlJsonGenerator implements JsonGenerator
     public JsonGenerator write(
         BigInteger value)
     {
-        addValue(YamlScalarNode.number(value.toString(), 1, 1, 0));
+        beginScalar(value.toString());
         return this;
     }
 
@@ -233,7 +236,7 @@ public final class YamlJsonGenerator implements JsonGenerator
     public JsonGenerator write(
         int value)
     {
-        addValue(YamlScalarNode.number(Integer.toString(value), 1, 1, 0));
+        beginScalar(Integer.toString(value));
         return this;
     }
 
@@ -241,7 +244,7 @@ public final class YamlJsonGenerator implements JsonGenerator
     public JsonGenerator write(
         long value)
     {
-        addValue(YamlScalarNode.number(Long.toString(value), 1, 1, 0));
+        beginScalar(Long.toString(value));
         return this;
     }
 
@@ -253,7 +256,7 @@ public final class YamlJsonGenerator implements JsonGenerator
         {
             throw new JsonException("Non-finite double values are not valid JSON values");
         }
-        addValue(YamlScalarNode.number(Double.toString(value), 1, 1, 0));
+        beginScalar(Double.toString(value));
         return this;
     }
 
@@ -261,14 +264,14 @@ public final class YamlJsonGenerator implements JsonGenerator
     public JsonGenerator write(
         boolean value)
     {
-        addValue(YamlScalarNode.literal(value ? YamlScalarType.TRUE : YamlScalarType.FALSE, 1, 1, 0));
+        beginScalar(value ? "true" : "false");
         return this;
     }
 
     @Override
     public JsonGenerator writeNull()
     {
-        addValue(YamlScalarNode.literal(YamlScalarType.NULL, 1, 1, 0));
+        beginScalar("null");
         return this;
     }
 
@@ -277,7 +280,10 @@ public final class YamlJsonGenerator implements JsonGenerator
     {
         if (!closed)
         {
-            writeDocument();
+            if (!stack.isEmpty())
+            {
+                throw new JsonException("YAML document is incomplete");
+            }
             try
             {
                 writer.close();
@@ -293,7 +299,7 @@ public final class YamlJsonGenerator implements JsonGenerator
     @Override
     public void flush()
     {
-        writeDocument();
+        ensureOpen();
         try
         {
             writer.flush();
@@ -304,68 +310,213 @@ public final class YamlJsonGenerator implements JsonGenerator
         }
     }
 
-    private void addValue(
-        YamlNode value)
+    private void beginScalar(
+        String text)
     {
         ensureOpen();
-        if (written)
-        {
-            throw new JsonException("YAML document has already been written");
-        }
         if (stack.isEmpty())
         {
-            if (root != null)
-            {
-                throw new JsonException("Only one root YAML value is supported");
-            }
-            root = value;
+            requireRootAvailable();
+            emit(text);
+            emit("\n");
+            rootDone = true;
         }
         else
         {
-            Context context = stack.peek();
-            if (context.object != null)
+            Scope parent = stack.peek();
+            ensureOpened(parent);
+            if (parent.array)
             {
-                if (context.pendingKey == null)
-                {
-                    throw new JsonException("Expected an object key");
-                }
-                context.object.add(new YamlEntry(context.pendingKey, value, 1, 1, 0));
-                context.pendingKey = null;
+                parent.first = false;
+                indent(parent.childIndent);
+                emit("- ");
+                emit(text);
+                emit("\n");
             }
             else
             {
-                context.array.add(value);
+                String key = requireKey(parent);
+                if (parent.firstInline && parent.first)
+                {
+                    parent.firstInline = false;
+                }
+                else
+                {
+                    indent(parent.childIndent);
+                }
+                emit(YamlEmitter.formatPlain(key));
+                emit(": ");
+                emit(text);
+                emit("\n");
+                parent.first = false;
             }
         }
     }
 
-    private Context requireObject()
-    {
-        if (stack.isEmpty() || stack.peek().object == null)
-        {
-            throw new JsonException("Expected object context");
-        }
-        return stack.peek();
-    }
-
-    private void writeDocument()
+    private void beginContainer(
+        boolean array)
     {
         ensureOpen();
-        if (!stack.isEmpty())
+        Scope child;
+        if (stack.isEmpty())
         {
-            throw new JsonException("YAML document is incomplete");
+            requireRootAvailable();
+            child = new Scope(ROOT, array, 0, null);
         }
-        if (!written && root != null)
+        else
         {
-            try
+            Scope parent = stack.peek();
+            ensureOpened(parent);
+            if (parent.array)
             {
-                YamlEmitter.write(root, writer);
+                parent.first = false;
+                child = new Scope(ARRAY_ELEMENT, array, parent.childIndent, null);
             }
-            catch (IOException ex)
+            else
             {
-                throw new JsonException(ex.getMessage(), ex);
+                String key = requireKey(parent);
+                parent.first = false;
+                child = new Scope(OBJECT_VALUE, array, parent.childIndent, key);
             }
-            written = true;
+        }
+        stack.push(child);
+    }
+
+    private void writeValue(
+        JsonValue value)
+    {
+        switch (value.getValueType())
+        {
+        case OBJECT ->
+        {
+            beginContainer(false);
+            for (Map.Entry<String, JsonValue> entry : value.asJsonObject().entrySet())
+            {
+                writeKey(entry.getKey());
+                writeValue(entry.getValue());
+            }
+            writeEnd();
+        }
+        case ARRAY ->
+        {
+            beginContainer(true);
+            for (JsonValue element : value.asJsonArray())
+            {
+                writeValue(element);
+            }
+            writeEnd();
+        }
+        case STRING -> beginScalar(YamlEmitter.formatPlain(((JsonString) value).getString()));
+        case NUMBER -> beginScalar(((JsonNumber) value).toString());
+        case TRUE -> beginScalar("true");
+        case FALSE -> beginScalar("false");
+        case NULL -> beginScalar("null");
+        }
+    }
+
+    private void ensureOpened(
+        Scope scope)
+    {
+        if (!scope.opened)
+        {
+            scope.opened = true;
+            switch (scope.introKind)
+            {
+            case ROOT -> scope.childIndent = 0;
+            case OBJECT_VALUE ->
+            {
+                indent(scope.introIndent);
+                emit(YamlEmitter.formatPlain(scope.introKey));
+                emit(":\n");
+                scope.childIndent = scope.introIndent + 1;
+            }
+            case ARRAY_ELEMENT ->
+            {
+                indent(scope.introIndent);
+                if (scope.array)
+                {
+                    emit("-\n");
+                }
+                else
+                {
+                    emit("- ");
+                    scope.firstInline = true;
+                }
+                scope.childIndent = scope.introIndent + 1;
+            }
+            default ->
+            {
+            }
+            }
+        }
+    }
+
+    private void closeEmpty(
+        Scope scope)
+    {
+        String body = scope.array ? "[]" : "{}";
+        switch (scope.introKind)
+        {
+        case ROOT -> emit(body);
+        case OBJECT_VALUE ->
+        {
+            indent(scope.introIndent);
+            emit(YamlEmitter.formatPlain(scope.introKey));
+            emit(": ");
+            emit(body);
+        }
+        case ARRAY_ELEMENT ->
+        {
+            indent(scope.introIndent);
+            emit("- ");
+            emit(body);
+        }
+        default ->
+        {
+        }
+        }
+        emit("\n");
+    }
+
+    private String requireKey(
+        Scope object)
+    {
+        if (object.pendingKey == null)
+        {
+            throw new JsonException("Expected an object key");
+        }
+        String key = object.pendingKey;
+        object.pendingKey = null;
+        return key;
+    }
+
+    private void requireRootAvailable()
+    {
+        if (rootDone)
+        {
+            throw new JsonException("Only one root YAML value is supported");
+        }
+    }
+
+    private void indent(
+        int depth)
+    {
+        for (int i = 0; i < depth; i++)
+        {
+            emit("  ");
+        }
+    }
+
+    private void emit(
+        String text)
+    {
+        try
+        {
+            writer.write(text);
+        }
+        catch (IOException ex)
+        {
+            throw new JsonException(ex.getMessage(), ex);
         }
     }
 
@@ -377,67 +528,28 @@ public final class YamlJsonGenerator implements JsonGenerator
         }
     }
 
-    private static YamlNode fromJsonValue(
-        JsonValue value)
+    private static final class Scope
     {
-        return switch (value.getValueType())
-        {
-        case OBJECT -> fromJsonObject(value.asJsonObject());
-        case ARRAY -> fromJsonArray(value.asJsonArray());
-        case STRING -> YamlScalarNode.string(((JsonString) value).getString(), 1, 1, 0);
-        case NUMBER -> YamlScalarNode.number(((JsonNumber) value).toString(), 1, 1, 0);
-        case TRUE -> YamlScalarNode.literal(YamlScalarType.TRUE, 1, 1, 0);
-        case FALSE -> YamlScalarNode.literal(YamlScalarType.FALSE, 1, 1, 0);
-        case NULL -> YamlScalarNode.literal(YamlScalarType.NULL, 1, 1, 0);
-        };
-    }
+        private final int introKind;
+        private final boolean array;
+        private final int introIndent;
+        private final String introKey;
+        private int childIndent;
+        private boolean opened;
+        private boolean first = true;
+        private boolean firstInline;
+        private String pendingKey;
 
-    private static YamlObjectNode fromJsonObject(
-        JsonObject value)
-    {
-        YamlObjectNode object = new YamlObjectNode(1, 1, 0);
-        for (Map.Entry<String, JsonValue> entry : value.entrySet())
+        private Scope(
+            int introKind,
+            boolean array,
+            int introIndent,
+            String introKey)
         {
-            object.add(new YamlEntry(entry.getKey(), fromJsonValue(entry.getValue()), 1, 1, 0));
-        }
-        return object;
-    }
-
-    private static YamlArrayNode fromJsonArray(
-        JsonArray value)
-    {
-        YamlArrayNode array = new YamlArrayNode(1, 1, 0);
-        for (JsonValue element : value)
-        {
-            array.add(fromJsonValue(element));
-        }
-        return array;
-    }
-
-    private static final class Context
-    {
-        final YamlObjectNode object;
-        final YamlArrayNode array;
-        String pendingKey;
-
-        private Context(
-            YamlObjectNode object,
-            YamlArrayNode array)
-        {
-            this.object = object;
+            this.introKind = introKind;
             this.array = array;
-        }
-
-        static Context object(
-            YamlObjectNode object)
-        {
-            return new Context(object, null);
-        }
-
-        static Context array(
-            YamlArrayNode array)
-        {
-            return new Context(null, array);
+            this.introIndent = introIndent;
+            this.introKey = introKey;
         }
     }
 }

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/json/YamlJsonGenerator.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/json/YamlJsonGenerator.java
@@ -215,7 +215,7 @@ public final class YamlJsonGenerator implements JsonGenerator
     public JsonGenerator write(
         String value)
     {
-        beginScalar(YamlEmitter.formatPlain(value));
+        beginScalarValue(value);
         return this;
     }
 
@@ -321,6 +321,14 @@ public final class YamlJsonGenerator implements JsonGenerator
         emit("\n");
     }
 
+    private void beginScalarValue(
+        String value)
+    {
+        beginScalarPrefix();
+        emitScalar(value);
+        emit("\n");
+    }
+
     private void beginInteger(
         long value)
     {
@@ -364,7 +372,7 @@ public final class YamlJsonGenerator implements JsonGenerator
                 {
                     indent(stack.childIndent());
                 }
-                emit(YamlEmitter.formatPlain(key));
+                emitScalar(key);
                 emit(": ");
                 stack.clearFirst();
             }
@@ -423,7 +431,7 @@ public final class YamlJsonGenerator implements JsonGenerator
             }
             writeEnd();
         }
-        case STRING -> beginScalar(YamlEmitter.formatPlain(((JsonString) value).getString()));
+        case STRING -> beginScalarValue(((JsonString) value).getString());
         case NUMBER -> beginScalar(((JsonNumber) value).toString());
         case TRUE -> beginScalar("true");
         case FALSE -> beginScalar("false");
@@ -441,7 +449,7 @@ public final class YamlJsonGenerator implements JsonGenerator
             case OBJECT_VALUE ->
             {
                 indent(stack.introIndent());
-                emit(YamlEmitter.formatPlain(stack.introKey()));
+                emitScalar(stack.introKey());
                 emit(":\n");
             }
             case ARRAY_ELEMENT ->
@@ -476,7 +484,7 @@ public final class YamlJsonGenerator implements JsonGenerator
         case OBJECT_VALUE ->
         {
             indent(introIndent);
-            emit(YamlEmitter.formatPlain(introKey));
+            emitScalar(introKey);
             emit(": ");
             emit(body);
         }
@@ -525,6 +533,19 @@ public final class YamlJsonGenerator implements JsonGenerator
         try
         {
             writer.write(text);
+        }
+        catch (IOException ex)
+        {
+            throw new JsonException(ex.getMessage(), ex);
+        }
+    }
+
+    private void emitScalar(
+        String value)
+    {
+        try
+        {
+            YamlEmitter.writeScalar(writer, value);
         }
         catch (IOException ex)
         {

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/json/YamlJsonGenerator.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/json/YamlJsonGenerator.java
@@ -40,6 +40,7 @@ public final class YamlJsonGenerator implements JsonGenerator
 {
     private final Writer writer;
     private final YamlGeneratorStack stack;
+    private final char[] numberBuffer;
     private boolean rootDone;
     private boolean closed;
 
@@ -48,6 +49,7 @@ public final class YamlJsonGenerator implements JsonGenerator
     {
         this.writer = writer;
         this.stack = new YamlGeneratorStack();
+        this.numberBuffer = new char[20];
     }
 
     public YamlJsonGenerator(
@@ -237,7 +239,7 @@ public final class YamlJsonGenerator implements JsonGenerator
     public JsonGenerator write(
         int value)
     {
-        beginScalar(Integer.toString(value));
+        beginInteger(value);
         return this;
     }
 
@@ -245,7 +247,7 @@ public final class YamlJsonGenerator implements JsonGenerator
     public JsonGenerator write(
         long value)
     {
-        beginScalar(Long.toString(value));
+        beginInteger(value);
         return this;
     }
 
@@ -314,12 +316,32 @@ public final class YamlJsonGenerator implements JsonGenerator
     private void beginScalar(
         String text)
     {
+        beginScalarPrefix();
+        emit(text);
+        emit("\n");
+    }
+
+    private void beginInteger(
+        long value)
+    {
+        beginScalarPrefix();
+        try
+        {
+            YamlEmitter.writeInteger(writer, value, numberBuffer);
+        }
+        catch (IOException ex)
+        {
+            throw new JsonException(ex.getMessage(), ex);
+        }
+        emit("\n");
+    }
+
+    private void beginScalarPrefix()
+    {
         ensureOpen();
         if (stack.isEmpty())
         {
             requireRootAvailable();
-            emit(text);
-            emit("\n");
             rootDone = true;
         }
         else
@@ -330,8 +352,6 @@ public final class YamlJsonGenerator implements JsonGenerator
                 stack.clearFirst();
                 indent(stack.childIndent());
                 emit("- ");
-                emit(text);
-                emit("\n");
             }
             else
             {
@@ -346,8 +366,6 @@ public final class YamlJsonGenerator implements JsonGenerator
                 }
                 emit(YamlEmitter.formatPlain(key));
                 emit(": ");
-                emit(text);
-                emit("\n");
                 stack.clearFirst();
             }
         }

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/json/YamlJsonParser.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/json/YamlJsonParser.java
@@ -55,6 +55,8 @@ public final class YamlJsonParser implements JsonParser
     private final String text;
     private final Map<String, ?> config;
     private final boolean uniqueKeys;
+    private final YamlJsonEvent eventA = new YamlJsonEvent();
+    private final YamlJsonEvent eventB = new YamlJsonEvent();
     private YamlJsonLocation end;
     private long documentOffset;
     private YamlJsonEvent current;
@@ -527,7 +529,7 @@ public final class YamlJsonParser implements JsonParser
         int column,
         long offset)
     {
-        return new YamlJsonEvent(event, value, node, line, column, documentOffset + offset);
+        return freeEvent().set(event, value, node, line, column, documentOffset + offset);
     }
 
     private YamlJsonEvent eventAtEnd(
@@ -535,7 +537,12 @@ public final class YamlJsonParser implements JsonParser
         String value,
         YamlNode node)
     {
-        return new YamlJsonEvent(event, value, node, end);
+        return freeEvent().set(event, value, node, end);
+    }
+
+    private YamlJsonEvent freeEvent()
+    {
+        return current == eventA ? eventB : eventA;
     }
 
     private static YamlJsonLocation location(

--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/json/YamlJsonParser.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/json/YamlJsonParser.java
@@ -49,6 +49,8 @@ import io.aklivity.zilla.runtime.common.yaml.internal.YamlScalarNode;
 
 public final class YamlJsonParser implements JsonParser
 {
+    private static final Map<String, ?> JSON_AS_YAML_DEFAULTS = Map.of(YamlConfig.FEATURE_NON_SCALAR_KEYS, false);
+
     private final Deque<Frame> stack;
     private final String text;
     private final Map<String, ?> config;
@@ -128,13 +130,18 @@ public final class YamlJsonParser implements JsonParser
     private static Map<String, ?> jsonAsYamlConfig(
         Map<String, ?> config)
     {
-        Map<String, Object> effective = new HashMap<>();
-        if (config != null)
+        Map<String, ?> effective;
+        if (config == null || config.isEmpty())
         {
-            effective.putAll(config);
+            effective = JSON_AS_YAML_DEFAULTS;
         }
-        effective.put(YamlConfig.FEATURE_NON_SCALAR_KEYS, false);
-        return Map.copyOf(effective);
+        else
+        {
+            Map<String, Object> merged = new HashMap<>(config);
+            merged.put(YamlConfig.FEATURE_NON_SCALAR_KEYS, false);
+            effective = Map.copyOf(merged);
+        }
+        return effective;
     }
 
     @Override
@@ -216,7 +223,7 @@ public final class YamlJsonParser implements JsonParser
     @Override
     public JsonLocation getLocation()
     {
-        return exhausted ? end : current != null ? current.location : end;
+        return exhausted ? end : current != null ? current.location() : end;
     }
 
     @Override
@@ -238,11 +245,20 @@ public final class YamlJsonParser implements JsonParser
     @Override
     public JsonValue getValue()
     {
-        if (current == null || current.node == null)
+        JsonValue value;
+        if (current != null && current.node != null)
+        {
+            value = toJsonValue(current.node);
+        }
+        else if (current != null && current.event == Event.KEY_NAME && current.value != null)
+        {
+            value = YamlJsonValues.string(current.value);
+        }
+        else
         {
             throw new IllegalStateException("No value is available for current event");
         }
-        return toJsonValue(current.node);
+        return value;
     }
 
     @Override
@@ -341,9 +357,7 @@ public final class YamlJsonParser implements JsonParser
                     YamlEntry entry = object.entries.get(frame.index);
                     String name = jsonKeyName(entry);
                     frame.value = true;
-                    return event(Event.KEY_NAME, name,
-                        YamlScalarNode.string(name, entry.line, entry.column, entry.offset),
-                        entry.line, entry.column, entry.offset);
+                    return event(Event.KEY_NAME, name, null, entry.line, entry.column, entry.offset);
                 }
 
                 boolean root = stack.size() == 1;

--- a/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/YamlJsonGeneratorTest.java
+++ b/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/YamlJsonGeneratorTest.java
@@ -144,6 +144,20 @@ class YamlJsonGeneratorTest
     }
 
     @Test
+    void shouldQuoteAndEscapeSpecialCharacters()
+    {
+        StringWriter out = new StringWriter();
+
+        YamlJson.createGenerator(out)
+            .writeStartObject()
+                .write("v", "a\"b\\c\nd\te\bf\fg\rh")
+            .writeEnd()
+            .close();
+
+        assertEquals("v: \"a\\\"b\\\\c\\nd\\te\\bf\\fg\\rh\"\n", out.toString());
+    }
+
+    @Test
     void shouldGenerateIntegerScalarEdges()
     {
         StringWriter out = new StringWriter();

--- a/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/YamlJsonGeneratorTest.java
+++ b/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/YamlJsonGeneratorTest.java
@@ -114,6 +114,66 @@ class YamlJsonGeneratorTest
     }
 
     @Test
+    void shouldQuoteNumericStringsAndLeaveAmbiguousStringsPlain()
+    {
+        StringWriter out = new StringWriter();
+
+        YamlJson.createGenerator(out)
+            .writeStartObject()
+                .write("zero", "0")
+                .write("integer", "42")
+                .write("exponent", "1e10")
+                .write("signedExponent", "1.5e-3")
+                .write("leadingZero", "007")
+                .write("address", "0.0.0.0")
+                .write("version", "1.2.3")
+                .write("word", "server")
+            .writeEnd()
+            .close();
+
+        assertEquals("""
+            zero: "0"
+            integer: "42"
+            exponent: "1e10"
+            signedExponent: "1.5e-3"
+            leadingZero: 007
+            address: 0.0.0.0
+            version: 1.2.3
+            word: server
+            """, out.toString());
+    }
+
+    @Test
+    void shouldGenerateObjectsNestedBeyondInitialStackCapacity()
+    {
+        int depth = 12;
+
+        StringWriter out = new StringWriter();
+        JsonGenerator generator = YamlJson.createGenerator(out);
+
+        generator.writeStartObject();
+        for (int level = 0; level < depth; level++)
+        {
+            generator.writeStartObject("k" + level);
+        }
+        generator.write("leaf", "v");
+        for (int level = 0; level <= depth; level++)
+        {
+            generator.writeEnd();
+        }
+        generator.close();
+
+        StringBuilder expected = new StringBuilder();
+        for (int level = 0; level < depth; level++)
+        {
+            expected.append("  ".repeat(level)).append('k').append(level).append(":\n");
+        }
+        expected.append("  ".repeat(depth)).append("leaf: v\n");
+
+        assertEquals(expected.toString(), out.toString());
+    }
+
+    @Test
     void shouldGenerateFromJsonValues()
     {
         StringWriter out = new StringWriter();

--- a/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/YamlJsonGeneratorTest.java
+++ b/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/YamlJsonGeneratorTest.java
@@ -144,6 +144,30 @@ class YamlJsonGeneratorTest
     }
 
     @Test
+    void shouldGenerateIntegerScalarEdges()
+    {
+        StringWriter out = new StringWriter();
+
+        YamlJson.createGenerator(out)
+            .writeStartObject()
+                .write("zero", 0)
+                .write("negative", -7114)
+                .write("intMin", Integer.MIN_VALUE)
+                .write("longMin", Long.MIN_VALUE)
+                .write("longMax", Long.MAX_VALUE)
+            .writeEnd()
+            .close();
+
+        assertEquals("""
+            zero: 0
+            negative: -7114
+            intMin: -2147483648
+            longMin: -9223372036854775808
+            longMax: 9223372036854775807
+            """, out.toString());
+    }
+
+    @Test
     void shouldGenerateObjectsNestedBeyondInitialStackCapacity()
     {
         int depth = 12;

--- a/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/YamlJsonParserTest.java
+++ b/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/YamlJsonParserTest.java
@@ -52,6 +52,38 @@ import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 class YamlJsonParserTest
 {
     @Test
+    void shouldKeepCurrentEventStableAcrossLookahead()
+    {
+        JsonParser parser = parserFor("""
+            first: alpha
+            second: beta
+            """);
+
+        assertEquals(START_OBJECT, parser.next());
+
+        assertEquals(KEY_NAME, parser.next());
+        assertEquals("first", parser.getString());
+        // peek ahead before consuming the current value; current must remain valid
+        parser.hasNext();
+        assertEquals("first", parser.getString());
+
+        assertEquals(VALUE_STRING, parser.next());
+        parser.hasNext();
+        assertEquals("alpha", parser.getString());
+
+        assertEquals(KEY_NAME, parser.next());
+        parser.hasNext();
+        assertEquals("second", parser.getString());
+
+        assertEquals(VALUE_STRING, parser.next());
+        parser.hasNext();
+        assertEquals("beta", parser.getString());
+
+        assertEquals(END_OBJECT, parser.next());
+        assertFalse(parser.hasNext());
+    }
+
+    @Test
     void shouldParseBlockMappingsAndIndentlessSequences()
     {
         JsonParser parser = parserFor("""

--- a/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/bench/BlackholeWriter.java
+++ b/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/bench/BlackholeWriter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.yaml.bench;
+
+import java.io.Writer;
+
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * A {@link Writer} sink for the generate benchmarks that adds no allocation of its own and cannot be
+ * eliminated by the JIT. Every write is forwarded to a JMH {@link Blackhole} rather than buffered, so
+ * {@code gc.alloc.rate.norm} reflects the generator's own allocation instead of an output buffer growing.
+ * The {@code String}-accepting overrides are provided deliberately: the default {@link Writer#write(String)}
+ * copies into a freshly allocated {@code char[]}, which would reintroduce the very overhead being avoided.
+ */
+final class BlackholeWriter extends Writer
+{
+    private final Blackhole blackhole;
+
+    BlackholeWriter(
+        Blackhole blackhole)
+    {
+        this.blackhole = blackhole;
+    }
+
+    @Override
+    public void write(
+        int c)
+    {
+        blackhole.consume(c);
+    }
+
+    @Override
+    public void write(
+        String str)
+    {
+        blackhole.consume(str);
+    }
+
+    @Override
+    public void write(
+        String str,
+        int off,
+        int len)
+    {
+        blackhole.consume(str);
+        blackhole.consume(off);
+        blackhole.consume(len);
+    }
+
+    @Override
+    public void write(
+        char[] cbuf,
+        int off,
+        int len)
+    {
+        blackhole.consume(cbuf);
+        blackhole.consume(off);
+        blackhole.consume(len);
+    }
+
+    @Override
+    public void flush()
+    {
+    }
+
+    @Override
+    public void close()
+    {
+    }
+}

--- a/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/bench/YamlBM.java
+++ b/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/bench/YamlBM.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.yaml.bench;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import io.aklivity.zilla.runtime.common.yaml.Yaml;
+import io.aklivity.zilla.runtime.common.yaml.YamlEvent;
+import io.aklivity.zilla.runtime.common.yaml.YamlParser;
+import io.aklivity.zilla.runtime.common.yaml.YamlValue;
+
+/**
+ * Exercises the native {@code Yaml} facade over inputs representative of Zilla config: block mappings with
+ * indentless sequences (the common case), flow collections with comments, and anchors with merge keys. Each
+ * input is driven through both the streaming event parser ({@code Yaml.createParser}) and the source-preserving
+ * tree reader ({@code Yaml.createReader().readValue()}) so event throughput can be compared against tree
+ * materialization, and (under {@code -prof gc}) allocation per document can be read directly. A streaming
+ * generate benchmark provides the inverse: emitting a config-shaped document through the builder API.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@Fork(3)
+@Warmup(iterations = 10, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = SECONDS)
+@OutputTimeUnit(SECONDS)
+public class YamlBM
+{
+    private static final String BLOCK_CONFIG = """
+        name: example
+        bindings:
+          tcp0:
+            type: tcp
+            kind: server
+            options:
+              host: 0.0.0.0
+              port: 7114
+            routes:
+            - exit: http0
+              when:
+              - port: 7114
+          http0:
+            type: http
+            kind: server
+            routes:
+            - exit: echo0
+              when:
+              - headers:
+                  ":path": /
+        """;
+
+    private static final String FLOW = """
+        name: test # trailing comment
+        values: [1, true, false, null, "a # value", {path: "/a#b"}]
+        matrix: [[1, 2], [3, 4], [5, 6]]
+        """;
+
+    private static final String ANCHORS_MERGE = """
+        defaults: &defaults
+          type: test
+          enabled: true
+        base: &base
+          host: localhost
+          port: 7114
+        tls: &tls
+          port: 443
+          secure: true
+        route:
+          <<: [*base, *tls]
+          host: example.com
+        binding:
+          <<: *defaults
+          enabled: false
+        """;
+
+    @Benchmark
+    public int parseBlockConfig()
+    {
+        return parse(BLOCK_CONFIG);
+    }
+
+    @Benchmark
+    public int parseFlow()
+    {
+        return parse(FLOW);
+    }
+
+    @Benchmark
+    public int parseAnchorsMerge()
+    {
+        return parse(ANCHORS_MERGE);
+    }
+
+    @Benchmark
+    public int readValueBlockConfig()
+    {
+        return readValue(BLOCK_CONFIG);
+    }
+
+    @Benchmark
+    public int readValueAnchorsMerge()
+    {
+        return readValue(ANCHORS_MERGE);
+    }
+
+    @Benchmark
+    public int generateBlockConfig()
+    {
+        StringWriter out = new StringWriter();
+        Yaml.createGenerator(out)
+            .writeStartObject()
+                .write("name", "example")
+                .writeStartObject("bindings")
+                    .writeStartObject("tcp0")
+                        .write("type", "tcp")
+                        .write("kind", "server")
+                        .writeStartObject("options")
+                            .write("host", "0.0.0.0")
+                            .write("port", 7114)
+                        .writeEnd()
+                        .writeStartArray("routes")
+                            .writeStartObject()
+                                .write("exit", "http0")
+                                .writeStartArray("when")
+                                    .writeStartObject()
+                                        .write("port", 7114)
+                                    .writeEnd()
+                                .writeEnd()
+                            .writeEnd()
+                        .writeEnd()
+                    .writeEnd()
+                .writeEnd()
+            .writeEnd()
+            .close();
+        return out.getBuffer().length();
+    }
+
+    private int parse(
+        String text)
+    {
+        YamlParser parser = Yaml.createParser(new StringReader(text));
+        int hash = 0;
+        while (parser.hasNext())
+        {
+            YamlEvent event = parser.next();
+            String value = event.getString();
+            if (value != null)
+            {
+                hash += value.hashCode();
+            }
+        }
+        return hash;
+    }
+
+    private int readValue(
+        String text)
+    {
+        YamlValue value = Yaml.createReader(new StringReader(text)).readValue();
+        return System.identityHashCode(value);
+    }
+
+    public static void main(
+        String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+            .include(YamlBM.class.getSimpleName())
+            .addProfiler("gc")
+            .forks(1)
+            .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/bench/YamlBM.java
+++ b/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/bench/YamlBM.java
@@ -35,6 +35,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import io.aklivity.zilla.runtime.common.yaml.Yaml;
 import io.aklivity.zilla.runtime.common.yaml.YamlEvent;
+import io.aklivity.zilla.runtime.common.yaml.YamlGenerator;
 import io.aklivity.zilla.runtime.common.yaml.YamlParser;
 import io.aklivity.zilla.runtime.common.yaml.YamlValue;
 
@@ -101,6 +102,11 @@ public class YamlBM
           enabled: false
         """;
 
+    private static final String QUOTED_VALUE = "value: with #special \"chars\" and \\backslash";
+
+    private static final String[] SCALAR_ITEMS = scalarItems();
+    private static final String[] OBJECT_KEYS = objectKeys();
+
     @Benchmark
     public int parseBlockConfig()
     {
@@ -160,6 +166,63 @@ public class YamlBM
                 .writeEnd()
             .writeEnd()
             .close();
+    }
+
+    @Benchmark
+    public void generateScalarArray(
+        Blackhole blackhole)
+    {
+        YamlGenerator generator = Yaml.createGenerator(new BlackholeWriter(blackhole));
+        generator.writeStartObject()
+            .writeStartArray("values");
+        for (int index = 0; index < 64; index++)
+        {
+            if ((index & 1) == 0)
+            {
+                generator.write(SCALAR_ITEMS[index >> 1]);
+            }
+            else
+            {
+                generator.write(index);
+            }
+        }
+        generator.writeEnd()
+            .writeEnd()
+            .close();
+    }
+
+    @Benchmark
+    public void generateQuotedScalars(
+        Blackhole blackhole)
+    {
+        YamlGenerator generator = Yaml.createGenerator(new BlackholeWriter(blackhole));
+        generator.writeStartObject();
+        for (int index = 0; index < OBJECT_KEYS.length; index++)
+        {
+            generator.write(OBJECT_KEYS[index], QUOTED_VALUE);
+        }
+        generator.writeEnd()
+            .close();
+    }
+
+    private static String[] scalarItems()
+    {
+        String[] items = new String[32];
+        for (int index = 0; index < items.length; index++)
+        {
+            items[index] = "item" + (index << 1);
+        }
+        return items;
+    }
+
+    private static String[] objectKeys()
+    {
+        String[] keys = new String[32];
+        for (int index = 0; index < keys.length; index++)
+        {
+            keys[index] = "key" + index;
+        }
+        return keys;
     }
 
     private int parse(

--- a/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/bench/YamlBM.java
+++ b/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/bench/YamlBM.java
@@ -17,7 +17,6 @@ package io.aklivity.zilla.runtime.common.yaml.bench;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.io.StringReader;
-import java.io.StringWriter;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -28,6 +27,7 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
@@ -132,10 +132,10 @@ public class YamlBM
     }
 
     @Benchmark
-    public int generateBlockConfig()
+    public void generateBlockConfig(
+        Blackhole blackhole)
     {
-        StringWriter out = new StringWriter();
-        Yaml.createGenerator(out)
+        Yaml.createGenerator(new BlackholeWriter(blackhole))
             .writeStartObject()
                 .write("name", "example")
                 .writeStartObject("bindings")
@@ -160,7 +160,6 @@ public class YamlBM
                 .writeEnd()
             .writeEnd()
             .close();
-        return out.getBuffer().length();
     }
 
     private int parse(

--- a/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/bench/YamlJsonBM.java
+++ b/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/bench/YamlJsonBM.java
@@ -18,6 +18,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.io.StringReader;
 
+import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -84,6 +85,11 @@ public class YamlJsonBM
           host: example.com
         """;
 
+    private static final String QUOTED_VALUE = "value: with #special \"chars\" and \\backslash";
+
+    private static final String[] SCALAR_ITEMS = scalarItems();
+    private static final String[] OBJECT_KEYS = objectKeys();
+
     @Benchmark
     public int parseBlockConfig()
     {
@@ -131,6 +137,63 @@ public class YamlJsonBM
                 .writeEnd()
             .writeEnd()
             .close();
+    }
+
+    @Benchmark
+    public void generateScalarArray(
+        Blackhole blackhole)
+    {
+        JsonGenerator generator = YamlJson.createGenerator(new BlackholeWriter(blackhole));
+        generator.writeStartObject()
+            .writeStartArray("values");
+        for (int index = 0; index < 64; index++)
+        {
+            if ((index & 1) == 0)
+            {
+                generator.write(SCALAR_ITEMS[index >> 1]);
+            }
+            else
+            {
+                generator.write(index);
+            }
+        }
+        generator.writeEnd()
+            .writeEnd()
+            .close();
+    }
+
+    @Benchmark
+    public void generateQuotedScalars(
+        Blackhole blackhole)
+    {
+        JsonGenerator generator = YamlJson.createGenerator(new BlackholeWriter(blackhole));
+        generator.writeStartObject();
+        for (int index = 0; index < OBJECT_KEYS.length; index++)
+        {
+            generator.write(OBJECT_KEYS[index], QUOTED_VALUE);
+        }
+        generator.writeEnd()
+            .close();
+    }
+
+    private static String[] scalarItems()
+    {
+        String[] items = new String[32];
+        for (int index = 0; index < items.length; index++)
+        {
+            items[index] = "item" + (index << 1);
+        }
+        return items;
+    }
+
+    private static String[] objectKeys()
+    {
+        String[] keys = new String[32];
+        for (int index = 0; index < keys.length; index++)
+        {
+            keys[index] = "key" + index;
+        }
+        return keys;
     }
 
     private int parse(

--- a/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/bench/YamlJsonBM.java
+++ b/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/bench/YamlJsonBM.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.yaml.bench;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import jakarta.json.stream.JsonParser;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
+
+/**
+ * Exercises the {@code YamlJson} adapter that bridges YAML source to the {@code jakarta.json} streaming API:
+ * {@code YamlJsonParser} projects YAML (block mappings, JSON-syntax documents, anchors and merge keys) into
+ * {@code JsonParser} events, while {@code YamlJsonGenerator} renders YAML from {@code JsonGenerator} calls.
+ * The parse benchmarks materialize key and scalar text via {@code getString()} so the projection cost — not
+ * just event dispatch — is measured; with {@code -prof gc} the allocation per document is reported directly.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@Fork(3)
+@Warmup(iterations = 10, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = SECONDS)
+@OutputTimeUnit(SECONDS)
+public class YamlJsonBM
+{
+    private static final String BLOCK_CONFIG = """
+        name: example
+        bindings:
+          tcp0:
+            type: tcp
+            kind: server
+            options:
+              host: 0.0.0.0
+              port: 7114
+            routes:
+            - exit: http0
+              when:
+              - port: 7114
+        """;
+
+    private static final String JSON_DOCUMENT = """
+        {"name":"test","enabled":true,"items":[{"id":1,"name":"a"},{"id":2,"name":"b"}],
+         "nested":{"x":1,"y":2},"missing":null}
+        """;
+
+    private static final String ANCHORS_MERGE = """
+        base: &base
+          host: localhost
+          port: 7114
+        tls: &tls
+          port: 443
+          secure: true
+        route:
+          <<: [*base, *tls]
+          host: example.com
+        """;
+
+    @Benchmark
+    public int parseBlockConfig()
+    {
+        return parse(BLOCK_CONFIG);
+    }
+
+    @Benchmark
+    public int parseJsonDocument()
+    {
+        return parse(JSON_DOCUMENT);
+    }
+
+    @Benchmark
+    public int parseAnchorsMerge()
+    {
+        return parse(ANCHORS_MERGE);
+    }
+
+    @Benchmark
+    public int generateBlockConfig()
+    {
+        StringWriter out = new StringWriter();
+        YamlJson.createGenerator(out)
+            .writeStartObject()
+                .write("name", "example")
+                .writeStartObject("bindings")
+                    .writeStartObject("tcp0")
+                        .write("type", "tcp")
+                        .write("kind", "server")
+                        .writeStartObject("options")
+                            .write("host", "0.0.0.0")
+                            .write("port", 7114)
+                        .writeEnd()
+                        .writeStartArray("routes")
+                            .writeStartObject()
+                                .write("exit", "http0")
+                                .writeStartArray("when")
+                                    .writeStartObject()
+                                        .write("port", 7114)
+                                    .writeEnd()
+                                .writeEnd()
+                            .writeEnd()
+                        .writeEnd()
+                    .writeEnd()
+                .writeEnd()
+            .writeEnd()
+            .close();
+        return out.getBuffer().length();
+    }
+
+    private int parse(
+        String text)
+    {
+        JsonParser parser = YamlJson.createParser(new StringReader(text));
+        int hash = 0;
+        while (parser.hasNext())
+        {
+            JsonParser.Event event = parser.next();
+            switch (event)
+            {
+            case KEY_NAME, VALUE_STRING, VALUE_NUMBER -> hash += parser.getString().hashCode();
+            default -> hash += event.ordinal();
+            }
+        }
+        return hash;
+    }
+
+    public static void main(
+        String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+            .include(YamlJsonBM.class.getSimpleName())
+            .addProfiler("gc")
+            .forks(1)
+            .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/bench/YamlJsonBM.java
+++ b/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/bench/YamlJsonBM.java
@@ -17,7 +17,6 @@ package io.aklivity.zilla.runtime.common.yaml.bench;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.io.StringReader;
-import java.io.StringWriter;
 
 import jakarta.json.stream.JsonParser;
 
@@ -30,6 +29,7 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
@@ -103,10 +103,10 @@ public class YamlJsonBM
     }
 
     @Benchmark
-    public int generateBlockConfig()
+    public void generateBlockConfig(
+        Blackhole blackhole)
     {
-        StringWriter out = new StringWriter();
-        YamlJson.createGenerator(out)
+        YamlJson.createGenerator(new BlackholeWriter(blackhole))
             .writeStartObject()
                 .write("name", "example")
                 .writeStartObject("bindings")
@@ -131,7 +131,6 @@ public class YamlJsonBM
                 .writeEnd()
             .writeEnd()
             .close();
-        return out.getBuffer().length();
     }
 
     private int parse(


### PR DESCRIPTION
## Description

This PR refactors the YAML generator implementations (`YamlJsonGenerator` and `YamlGeneratorImpl`) to emit YAML directly to a writer using a streaming approach, rather than building an intermediate tree structure in memory, and drives the generate path to near-zero per-document allocation.

### Core Changes

1. **New `YamlGeneratorStack` class**: Replaces per-level context objects with an allocation-free nesting stack that encodes state as packed `int` frames plus string arrays for keys. This eliminates object allocation overhead during generation.

2. **Direct streaming emission**: Both generators now write YAML directly to the output writer as values are added, rather than constructing `YamlNode` trees and emitting them later. This reduces memory usage and improves performance for large documents.

3. **Allocation-free scalar rendering**:
   - **Integers** (`write(int)` / `write(long)`) are rendered into a reusable per-generator `char[]` buffer (filled back-to-front, written in one call) instead of via `Integer.toString` / `Long.toString`. Digits accumulate in non-positive space so `MIN_VALUE` is handled without negation overflow.
   - **Quoted scalars** (keys and string values that require quoting) stream the opening quote, per-character escapes, and closing quote straight to the `Writer` via `YamlEmitter.writeScalar`, instead of building a `StringBuilder` and returning a new `String`.
   - **Numeric-scalar detection** in the emitter replaced the per-scalar regex `Matcher` with an allocation-free character scan.

4. **Simplified state management**: Removed `Context` inner classes and `YamlNode` tree building logic. State is tracked via `YamlGeneratorStack` with methods like `opened()`, `first()`, `array()`, `pendingKey()`.

### Supporting Changes

- **`YamlEmitter`**: extracted `writeArrayElement()` / `writeObjectValue()` for reuse; added `formatPlain()`, `writeInteger()`, and `writeScalar()`; cached regex matchers in `YamlDocumentParser` to reduce parse-path allocation.
- **`YamlJsonParser`**: static `JSON_AS_YAML_DEFAULTS` map to avoid per-parser allocation; reuse a two-slot `YamlJsonEvent` pool across the one-event lookahead so events no longer allocate per `next()`.
- **`YamlJsonEvent`**: mutable reusable holder; caches its location lazily.

### Testing & Benchmarking

Added JMH benchmarks (`YamlBM`, `YamlJsonBM`, `BlackholeWriter`) covering event parsing, tree materialization via `readValue()`, and generation across multiple shapes (block config, scalar arrays, quoted/escaped scalars). The generate benchmarks use a `BlackholeWriter` sink (forwards every write to a JMH `Blackhole`) so `gc.alloc.rate.norm` reflects the generator's own allocation rather than a growing output buffer, and dead-code elimination cannot fire. Benchmark inputs are precomputed so the measured method allocates nothing of its own.

Added unit tests for the paths the refactor introduced: numeric-scalar quoting edges, escape sequences, integer edges (`0`, negative, `Integer`/`Long.MIN_VALUE`, `MAX_VALUE`), nesting beyond the scope stack's initial capacity, and current-event stability across parser lookahead.

#### Results

Measured with `-prof gc`, `@Fork(3)`, 10×1s warmup, 5×1s measurement (15 data points per benchmark). **Before** = pre-optimization baseline (`f31d17a2`), measured with the same `BlackholeWriter` sink so both sides exclude the output buffer.

| Benchmark | Alloc before (B/op) | Alloc after (B/op) | Δ alloc | Thrpt before (op/s) | Thrpt after (op/s) | Δ thrpt |
|---|--:|--:|--:|--:|--:|--:|
| `YamlJsonBM.generateBlockConfig` | 7,760 | **264** | **−96.6%** | 244,757 | 1,432,446 | **+485%** |
| `YamlJsonBM.generateScalarArray` | 18,088 | **264** | **−98.5%** | 131,848 | 796,555 | **+504%** |
| `YamlJsonBM.generateQuotedScalars` | 26,984 | **104** | **−99.6%** | 58,745 | 426,602 | **+626%** |
| `YamlBM.generateBlockConfig` | 7,776 | **280** | **−96.4%** | 244,096 | 1,458,161 | **+497%** |
| `YamlBM.generateScalarArray` | 18,104 | **280** | **−98.5%** | 130,780 | 811,926 | **+521%** |
| `YamlBM.generateQuotedScalars` | 27,056 | **104** | **−99.6%** | 59,104 | 485,528 | **+721%** |
| `YamlJsonBM.parseJsonDocument` | 37,160 | 17,024 | −54.2% | 99,792 | 206,697 | +107% |
| `YamlBM.parseFlow` | 45,443 | 18,304 | −59.7% | 73,082 | 121,092 | +66% |
| `YamlJsonBM.parseBlockConfig` | 23,264 | 17,960 | −22.8% | 108,009 | 158,101 | +46% |
| `YamlJsonBM.parseAnchorsMerge` | 23,240 | 19,144 | −17.6% | 124,399 | 174,893 | +41% |
| `YamlBM.readValueBlockConfig` | 25,816 | 22,936 | −11.2% | 82,295 | 85,194 | +4% |
| `YamlBM.parseBlockConfig` | 30,304 | 27,440 | −9.5% | 71,976 | 73,541 | +2% |
| `YamlBM.readValueAnchorsMerge` | 25,080 | 23,845 | −4.9% | 100,857 | 103,648 | +3% |
| `YamlBM.parseAnchorsMerge` | 28,328 | 27,328 | −3.5% | 91,183 | 92,088 | +1% |

Generation is now allocation-bound only by the fresh per-document generator instance (~104–280 B/op); integer and quoted-scalar writing allocate nothing. Parse improvements come from eliminating per-scalar parser/regex churn and per-event allocation. The residual parse allocation is the input read plus the document model the parser projects events from — architectural, and a cold (config-load) path; the streaming/buffer-backed parser direction that would address it (and unlock `getStringView()`) is tracked in #1905.

### Benefits

- **Lower memory footprint**: no intermediate tree structures; direct streaming to output
- **Better performance**: ~5–8× generate throughput, large reductions in GC pressure
- **Simpler code**: fewer abstraction layers and context objects
- **Measurable**: benchmarks provide concrete before/after data and guard against regressions

https://claude.ai/code/session_01RE6huar5XQ4GpK9RVRcQXr