### PR TITLE
refactor(common-protobuf): stateless wire sinks (pump-owned resume cursor + consumed() pushback)

### DIFF
--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufController.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufController.java
@@ -25,4 +25,14 @@ package io.aklivity.zilla.runtime.common.protobuf;
 public interface ProtobufController
 {
     void segmentable();
+
+    /**
+     * Reports {@code sourceBytes} source bytes consumed by a verbatim segment write so the upstream advances
+     * past them and re-exposes the value's remainder from {@link ProtobufSource#segment()} on resume — the
+     * pushback that lets a bounded sink stream a length-delimited value without tracking its own write cursor.
+     */
+    default void consumed(
+        int sourceBytes)
+    {
+    }
 }

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufGenerator.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufGenerator.java
@@ -61,6 +61,14 @@ public interface ProtobufGenerator
      */
     int remaining();
 
+    /**
+     * Cumulative count of source value bytes consumed by {@link #writeSegment} since the last {@link #wrap}.
+     * Because {@code writeSegment} is consumption-driven — it writes only as many of the offered bytes as fit
+     * the bound — a driver reads this around a call (as a delta) to learn how many bytes were taken and push
+     * the unconsumed remainder back to its upstream.
+     */
+    int consumed();
+
     ProtobufGenerator writeInt32(
         int field,
         int value);
@@ -143,12 +151,14 @@ public interface ProtobufGenerator
 
     /**
      * Writes part of a length-delimited {@code field} whose total body length is {@code length + deferred}.
-     * The first call (when no segment is open) emits the tag and the total length prefix, then writes the
-     * {@code length} bytes at {@code value[offset, offset+length)}; subsequent calls write further body
-     * bytes only, with {@code deferred} counting the bytes still to come after this call. So a value larger
-     * than the buffer is written across chunks — drain after a call that leaves {@code deferred > 0}, re-wrap
-     * (the open levels and segment persist), and continue. The total is known up front, so the length prefix
-     * is correct in the concatenated stream even though the body arrives in pieces.
+     * The first call (when no segment is open) emits the tag and the total length prefix; thereafter it
+     * appends body bytes from {@code value[offset, offset+length)}. It is <em>consumption-driven</em>: it
+     * writes only as many of the offered {@code length} bytes as fit the bound (and, on the first call, writes
+     * nothing if the header plus one byte would not fit), reporting how many it took via {@link #consumed()}.
+     * A driver reads {@code consumed()} as a delta to learn the amount written, pushes the remainder back to
+     * its upstream, drains, re-{@link #wrap(MutableDirectBuffer, int, int) wraps} (the open levels and segment
+     * persist), and continues. The total is known up front, so the length prefix is correct in the
+     * concatenated stream even though the body arrives in pieces.
      */
     ProtobufGenerator writeSegment(
         int field,

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufParser.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufParser.java
@@ -163,4 +163,15 @@ public interface ProtobufParser
      * {@code 0} on the last (or only) piece, and {@code 0} for every other event.
      */
     int deferredBytes();
+
+    /**
+     * Advances past {@code sourceBytes} of the current value's slice so {@link #segment()} re-exposes the
+     * unconsumed remainder — the pushback a bounded sink uses to stream a length-delimited value across
+     * output windows without tracking its own write cursor. The default is a no-op for cursors that need no
+     * pushback.
+     */
+    default void consumed(
+        int sourceBytes)
+    {
+    }
 }

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufSink.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufSink.java
@@ -34,13 +34,15 @@ public interface ProtobufSink
     /**
      * Continues the work left unfinished when a prior {@link #feed} returned
      * {@link ProtobufPipeline.Status#SUSPENDED} — the pipeline calls this on resume instead of replaying
-     * the event, so the events are not re-processed by the rest of the pipeline. The default has nothing
-     * pending and reports {@link ProtobufPipeline.Status#ADVANCED}; a bounded sink overrides it to resume
-     * writing the in-flight field, and {@code source} stays positioned on the suspended event.
+     * the event through the rest of the pipeline. {@code event} is the event that suspended (supplied by the
+     * pump, so the sink keeps no resume cursor of its own), with {@code source} still positioned to read it.
+     * The default has nothing pending and reports {@link ProtobufPipeline.Status#ADVANCED}; a bounded sink
+     * overrides it to resume writing the in-flight field.
      */
     default ProtobufPipeline.Status resume(
         ProtobufController control,
-        ProtobufSource source)
+        ProtobufSource source,
+        ProtobufEvent event)
     {
         return ProtobufPipeline.Status.ADVANCED;
     }

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufTransform.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufTransform.java
@@ -31,17 +31,19 @@ public interface ProtobufTransform
         ProtobufSink sink);
 
     /**
-     * Continues after a prior {@link #feed} returned {@link ProtobufPipeline.Status#SUSPENDED}. The default
-     * forwards to {@code sink.resume(control, source)}, so a stage that does not originate suspension needs
-     * no awareness of it; a stage that returns {@code SUSPENDED} on its own (e.g. to emit buffered events)
+     * Continues after a prior {@link #feed} returned {@link ProtobufPipeline.Status#SUSPENDED}, with the
+     * {@code event} that suspended supplied by the pump. The default forwards to
+     * {@code sink.resume(control, source, event)}, so a stage that does not originate suspension needs no
+     * awareness of it; a stage that returns {@code SUSPENDED} on its own (e.g. to emit buffered events)
      * overrides this to drive its own resumption before delegating downstream.
      */
     default ProtobufPipeline.Status resume(
         ProtobufController control,
         ProtobufSource source,
+        ProtobufEvent event,
         ProtobufSink sink)
     {
-        return sink.resume(control, source);
+        return sink.resume(control, source, event);
     }
 
     default void reset()

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufGeneratorImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufGeneratorImpl.java
@@ -52,6 +52,7 @@ public final class ProtobufGeneratorImpl implements ProtobufGenerator
     private int depth;
     private int limit;
     private int segmentRemaining;
+    private int consumed;
     private boolean needsReopen;
     private boolean flushed;
 
@@ -90,6 +91,7 @@ public final class ProtobufGeneratorImpl implements ProtobufGenerator
             segmentRemaining = 0;
             needsReopen = false;
         }
+        consumed = 0;
         return this;
     }
 
@@ -97,6 +99,12 @@ public final class ProtobufGeneratorImpl implements ProtobufGenerator
     public int length()
     {
         return writer.length();
+    }
+
+    @Override
+    public int consumed()
+    {
+        return consumed;
     }
 
     @Override
@@ -317,14 +325,22 @@ public final class ProtobufGeneratorImpl implements ProtobufGenerator
     {
         if (segmentRemaining == 0)
         {
+            int total = length + deferred;
+            int header = varintSize((long) field << 3) + varintSize(total);
+            if (remaining() < header + 1)
+            {
+                // not even the tag, length prefix, and one body byte fit; take nothing so the caller drains
+                return this;
+            }
             reopen();
             writer.writeTag(field, ProtobufWireType.LEN);
-            int total = length + deferred;
             writer.writeVarint32(total);
             segmentRemaining = total;
         }
-        writer.writeRaw(value, offset, length);
-        segmentRemaining -= length;
+        int now = Math.min(length, remaining());
+        writer.writeRaw(value, offset, now);
+        segmentRemaining -= now;
+        consumed += now;
         if (segmentRemaining == 0)
         {
             completeSegment();

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufParserImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufParserImpl.java
@@ -81,6 +81,9 @@ public final class ProtobufParserImpl implements ProtobufParser, ProtobufSource
     private double doubleValue;
     private float floatValue;
     private final UnsafeBuffer segment = new UnsafeBuffer(new byte[0]);
+    private DirectBuffer segmentBuffer;
+    private int segmentOffset;
+    private int segmentLength;
     private int deferred;
     private int leafRemaining;
     private boolean leafString;
@@ -227,6 +230,16 @@ public final class ProtobufParserImpl implements ProtobufParser, ProtobufSource
     public int deferredBytes()
     {
         return deferred;
+    }
+
+    @Override
+    public void consumed(
+        int sourceBytes)
+    {
+        // advance the current value slice so segment() re-exposes the remainder on resume
+        segmentOffset += sourceBytes;
+        segmentLength -= sourceBytes;
+        segment.wrap(segmentBuffer, segmentOffset, segmentLength);
     }
 
     private ProtobufEvent value()
@@ -781,6 +794,9 @@ public final class ProtobufParserImpl implements ProtobufParser, ProtobufSource
         int offset,
         int length)
     {
+        segmentBuffer = buffer;
+        segmentOffset = offset;
+        segmentLength = length;
         segment.wrap(buffer, offset, length);
     }
 

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufPipelineImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufPipelineImpl.java
@@ -241,8 +241,8 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
     }
 
     // the head edge's controller: a stage's segmentable() request becomes a one-shot SEGMENTED mode that the
-    // pump passes to the parser on the next pull
-    private static final class Control implements ProtobufController
+    // pump passes to the parser on the next pull, and a sink's consumed() pushback advances the parser's slice
+    private final class Control implements ProtobufController
     {
         private boolean segmented;
 
@@ -250,6 +250,13 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
         public void segmentable()
         {
             segmented = true;
+        }
+
+        @Override
+        public void consumed(
+            int sourceBytes)
+        {
+            parser.consumed(sourceBytes);
         }
 
         private ProtobufParser.Mode mode()

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufPipelineImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufPipelineImpl.java
@@ -46,6 +46,8 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
 
     private boolean suspended;
     private boolean starved;
+    // the event in flight across an output suspend, handed to head.resume() so no sink stores it
+    private ProtobufEvent resumeEvent;
 
     public ProtobufPipelineImpl(
         ProtobufParser parser,
@@ -72,6 +74,7 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
         head.reset();
         suspended = false;
         starved = false;
+        resumeEvent = null;
     }
 
     @Override
@@ -93,7 +96,7 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
             if (suspended)
             {
                 // output back-pressure: continue the suspended work on the same window without replaying it
-                status = head.resume(control, source);
+                status = head.resume(control, source, resumeEvent);
             }
             else if (starved)
             {
@@ -114,6 +117,11 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
                 else
                 {
                     status = head.feed(control, source, event);
+                    if (status == Status.SUSPENDED)
+                    {
+                        // the pump owns the resume cursor: remember the in-flight event for the next entry
+                        resumeEvent = event;
+                    }
                 }
             }
             suspended = status == Status.SUSPENDED;
@@ -151,9 +159,10 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
         @Override
         public Status resume(
             ProtobufController control,
-            ProtobufSource source)
+            ProtobufSource source,
+            ProtobufEvent event)
         {
-            return transform.resume(control, source, downstream);
+            return transform.resume(control, source, event, downstream);
         }
 
         @Override

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufTypedSinkImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufTypedSinkImpl.java
@@ -58,7 +58,6 @@ public final class ProtobufTypedSinkImpl implements ProtobufSink
     private ProtobufField pending;
     private int valueWritten;
     private int valueTotal;
-    private ProtobufEvent suspended;
 
     public ProtobufTypedSinkImpl(
         ProtobufGenerator generator,
@@ -78,22 +77,18 @@ public final class ProtobufTypedSinkImpl implements ProtobufSink
         ProtobufSource source,
         ProtobufEvent event)
     {
-        ProtobufPipeline.Status status = dispatch(source, event);
-        if (status == ProtobufPipeline.Status.SUSPENDED)
-        {
-            suspended = event;
-        }
-        return status;
+        return dispatch(source, event);
     }
 
     @Override
     public ProtobufPipeline.Status resume(
         ProtobufController control,
-        ProtobufSource source)
+        ProtobufSource source,
+        ProtobufEvent event)
     {
         // re-run the event that did not fit; the field/value position is held in pending and valueWritten,
         // so this continues a fragmented value or retries a whole field against the freshly drained buffer
-        return dispatch(source, suspended);
+        return dispatch(source, event);
     }
 
     @Override
@@ -103,7 +98,6 @@ public final class ProtobufTypedSinkImpl implements ProtobufSink
         pending = null;
         valueWritten = 0;
         valueTotal = 0;
-        suspended = null;
     }
 
     private ProtobufPipeline.Status dispatch(

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufTypedSinkImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufTypedSinkImpl.java
@@ -56,8 +56,6 @@ public final class ProtobufTypedSinkImpl implements ProtobufSink
 
     private int depth;
     private ProtobufField pending;
-    private int valueWritten;
-    private int valueTotal;
 
     public ProtobufTypedSinkImpl(
         ProtobufGenerator generator,
@@ -77,7 +75,7 @@ public final class ProtobufTypedSinkImpl implements ProtobufSink
         ProtobufSource source,
         ProtobufEvent event)
     {
-        return dispatch(source, event);
+        return dispatch(control, source, event);
     }
 
     @Override
@@ -86,9 +84,9 @@ public final class ProtobufTypedSinkImpl implements ProtobufSink
         ProtobufSource source,
         ProtobufEvent event)
     {
-        // re-run the event that did not fit; the field/value position is held in pending and valueWritten,
-        // so this continues a fragmented value or retries a whole field against the freshly drained buffer
-        return dispatch(source, event);
+        // re-run the event that did not fit; pending holds the field and the source re-exposes the value's
+        // unconsumed remainder, so this continues a fragmented value or retries a whole field on a fresh buffer
+        return dispatch(control, source, event);
     }
 
     @Override
@@ -96,11 +94,10 @@ public final class ProtobufTypedSinkImpl implements ProtobufSink
     {
         depth = -1;
         pending = null;
-        valueWritten = 0;
-        valueTotal = 0;
     }
 
     private ProtobufPipeline.Status dispatch(
+        ProtobufController control,
         ProtobufSource source,
         ProtobufEvent event)
     {
@@ -117,7 +114,7 @@ public final class ProtobufTypedSinkImpl implements ProtobufSink
             pending = mapField(source.field());
             break;
         case VALUE:
-            status = onValue(source);
+            status = onValue(control, source);
             break;
         case END_MESSAGE:
             status = onEndMessage();
@@ -184,96 +181,53 @@ public final class ProtobufTypedSinkImpl implements ProtobufSink
     }
 
     private ProtobufPipeline.Status onValue(
+        ProtobufController control,
         ProtobufSource source)
     {
         ProtobufPipeline.Status status = ProtobufPipeline.Status.ADVANCED;
         if (scope(depth).active && pending != null)
         {
             status = pending.type().wireType() == ProtobufWireType.LEN
-                ? onValueLength(pending, source)
+                ? onValueLength(control, pending, source)
                 : onValueScalar(pending, source);
         }
         return status;
     }
 
+    // A length-delimited value streams through the consumption-driven generator: it takes only what fits, the
+    // sink pushes the unconsumed remainder back to the source via control.consumed(), and on resume the source
+    // re-exposes that remainder — so the sink tracks no write cursor of its own. A whole value that fits is one
+    // writeSegment call producing a single canonical record (its prefix is the minimal length varint).
     private ProtobufPipeline.Status onValueLength(
+        ProtobufController control,
         ProtobufField field,
         ProtobufSource source)
     {
-        int number = field.number();
         DirectBuffer segment = source.segment();
-        int length = segment.capacity();
+        int available = segment.capacity();
         int deferred = source.deferredBytes();
-        int remaining = generator.remaining();
+        int before = generator.consumed();
+        generator.writeSegment(field.number(), segment, 0, available, deferred);
+        int written = generator.consumed() - before;
+        control.consumed(written);
         ProtobufPipeline.Status status;
-        if (valueWritten == 0 && deferred == 0 && tagSize(number) + varintSize(length) + length <= remaining)
+        if (written < available)
         {
-            // whole value present and it fits — write it in one piece
-            generator.writeBytes(number, segment, 0, length);
-            status = ProtobufPipeline.Status.ADVANCED;
-        }
-        else if (valueWritten == 0 && deferred == 0 && generator.length() > 0)
-        {
-            // break at this field boundary; on a fresh buffer the whole value may fit
-            generator.flush();
-            status = ProtobufPipeline.Status.SUSPENDED;
-        }
-        else
-        {
-            // a value chunked on input (deferred > 0) or too large for one buffer streams via writeSegment
-            status = writeChunk(number, length, deferred, source, remaining);
-        }
-        return status;
-    }
-
-    private ProtobufPipeline.Status writeChunk(
-        int number,
-        int length,
-        int deferred,
-        ProtobufSource source,
-        int remaining)
-    {
-        if (valueWritten == 0)
-        {
-            // the first chunk carries the whole value's length: length now plus all that is still deferred
-            valueTotal = length + deferred;
-        }
-        int chunkRemaining = valueTotal - deferred - valueWritten;
-        int segmentOffset = length - chunkRemaining;
-        int header = valueWritten == 0 ? tagSize(number) + varintSize(valueTotal) : 0;
-        ProtobufPipeline.Status status;
-        if (valueWritten == 0 && header + 1 > remaining && generator.length() > 0)
-        {
-            // can't even start the value here; a fresh buffer may hold the header
-            generator.flush();
-            status = ProtobufPipeline.Status.SUSPENDED;
-        }
-        else if (valueWritten == 0 && header + 1 > remaining)
-        {
-            throw new ProtobufException("value header exceeds output limit");
-        }
-        else
-        {
-            int now = Math.min(remaining - header, chunkRemaining);
-            generator.writeSegment(number, source.segment(), segmentOffset, now, valueTotal - valueWritten - now);
-            valueWritten += now;
-            if (now < chunkRemaining)
+            if (generator.length() > 0)
             {
-                // output filled mid-chunk; suspend and replay this same value event
+                // output filled before this chunk drained; drain and replay against a fresh buffer
                 generator.flush();
                 status = ProtobufPipeline.Status.SUSPENDED;
             }
-            else if (deferred > 0)
-            {
-                // chunk fully written, more input chunks of this value still to come
-                status = ProtobufPipeline.Status.ADVANCED;
-            }
             else
             {
-                valueWritten = 0;
-                valueTotal = 0;
-                status = ProtobufPipeline.Status.ADVANCED;
+                throw new ProtobufException("value header exceeds output limit");
             }
+        }
+        else
+        {
+            // this chunk fully written: ADVANCED whether the value completed (deferred == 0) or more input follows
+            status = ProtobufPipeline.Status.ADVANCED;
         }
         return status;
     }

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufUntypedSinkImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufUntypedSinkImpl.java
@@ -40,8 +40,6 @@ public final class ProtobufUntypedSinkImpl implements ProtobufSink
     private final ProtobufGenerator generator;
 
     private int depth;
-    private int valueWritten;
-    private int valueTotal;
 
     public ProtobufUntypedSinkImpl(
         ProtobufGenerator generator)
@@ -55,7 +53,7 @@ public final class ProtobufUntypedSinkImpl implements ProtobufSink
         ProtobufSource source,
         ProtobufEvent event)
     {
-        return dispatch(source, event);
+        return dispatch(control, source, event);
     }
 
     @Override
@@ -64,18 +62,17 @@ public final class ProtobufUntypedSinkImpl implements ProtobufSink
         ProtobufSource source,
         ProtobufEvent event)
     {
-        return dispatch(source, event);
+        return dispatch(control, source, event);
     }
 
     @Override
     public void reset()
     {
         depth = 0;
-        valueWritten = 0;
-        valueTotal = 0;
     }
 
     private ProtobufPipeline.Status dispatch(
+        ProtobufController control,
         ProtobufSource source,
         ProtobufEvent event)
     {
@@ -93,7 +90,7 @@ public final class ProtobufUntypedSinkImpl implements ProtobufSink
             }
             break;
         case VALUE:
-            status = onValue(source);
+            status = onValue(control, source);
             break;
         default:
             break;
@@ -102,12 +99,38 @@ public final class ProtobufUntypedSinkImpl implements ProtobufSink
     }
 
     private ProtobufPipeline.Status onValue(
+        ProtobufController control,
         ProtobufSource source)
     {
         ProtobufPipeline.Status status;
         if (source.wireType() == ProtobufWireType.LEN)
         {
-            status = writeChunk(source);
+            // a length-delimited value streams through the consumption-driven generator; the sink pushes the
+            // unconsumed remainder back via control.consumed() and the source re-exposes it on resume, so the
+            // sink keeps no write cursor
+            DirectBuffer segment = source.segment();
+            int available = segment.capacity();
+            int deferred = source.deferredBytes();
+            int before = generator.consumed();
+            generator.writeSegment(source.fieldNumber(), segment, 0, available, deferred);
+            int written = generator.consumed() - before;
+            control.consumed(written);
+            if (written < available)
+            {
+                if (generator.length() > 0)
+                {
+                    generator.flush();
+                    status = ProtobufPipeline.Status.SUSPENDED;
+                }
+                else
+                {
+                    throw new ProtobufException("value header exceeds output limit");
+                }
+            }
+            else
+            {
+                status = ProtobufPipeline.Status.ADVANCED;
+            }
         }
         else
         {
@@ -116,74 +139,5 @@ public final class ProtobufUntypedSinkImpl implements ProtobufSink
             status = ProtobufPipeline.Status.ADVANCED;
         }
         return status;
-    }
-
-    private ProtobufPipeline.Status writeChunk(
-        ProtobufSource source)
-    {
-        int number = source.fieldNumber();
-        DirectBuffer segment = source.segment();
-        int length = segment.capacity();
-        int deferred = source.deferredBytes();
-        int remaining = generator.remaining();
-        if (valueWritten == 0)
-        {
-            // the first chunk carries the whole value's length: length now plus all that is still deferred
-            valueTotal = length + deferred;
-        }
-        int chunkRemaining = valueTotal - deferred - valueWritten;
-        int segmentOffset = length - chunkRemaining;
-        int header = valueWritten == 0 ? tagSize(number) + varintSize(valueTotal) : 0;
-        ProtobufPipeline.Status status;
-        if (valueWritten == 0 && header + 1 > remaining && generator.length() > 0)
-        {
-            generator.flush();
-            status = ProtobufPipeline.Status.SUSPENDED;
-        }
-        else if (valueWritten == 0 && header + 1 > remaining)
-        {
-            throw new ProtobufException("value header exceeds output limit");
-        }
-        else
-        {
-            int now = Math.min(remaining - header, chunkRemaining);
-            generator.writeSegment(number, segment, segmentOffset, now, valueTotal - valueWritten - now);
-            valueWritten += now;
-            if (now < chunkRemaining)
-            {
-                generator.flush();
-                status = ProtobufPipeline.Status.SUSPENDED;
-            }
-            else if (deferred > 0)
-            {
-                status = ProtobufPipeline.Status.ADVANCED;
-            }
-            else
-            {
-                valueWritten = 0;
-                valueTotal = 0;
-                status = ProtobufPipeline.Status.ADVANCED;
-            }
-        }
-        return status;
-    }
-
-    private static int tagSize(
-        int number)
-    {
-        return varintSize((long) number << 3);
-    }
-
-    private static int varintSize(
-        long value)
-    {
-        long remaining = value & 0xffffffffL;
-        int size = 1;
-        while (remaining >= 0x80L)
-        {
-            remaining >>>= 7;
-            size++;
-        }
-        return size;
     }
 }

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufUntypedSinkImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufUntypedSinkImpl.java
@@ -42,7 +42,6 @@ public final class ProtobufUntypedSinkImpl implements ProtobufSink
     private int depth;
     private int valueWritten;
     private int valueTotal;
-    private ProtobufEvent suspended;
 
     public ProtobufUntypedSinkImpl(
         ProtobufGenerator generator)
@@ -56,20 +55,16 @@ public final class ProtobufUntypedSinkImpl implements ProtobufSink
         ProtobufSource source,
         ProtobufEvent event)
     {
-        ProtobufPipeline.Status status = dispatch(source, event);
-        if (status == ProtobufPipeline.Status.SUSPENDED)
-        {
-            suspended = event;
-        }
-        return status;
+        return dispatch(source, event);
     }
 
     @Override
     public ProtobufPipeline.Status resume(
         ProtobufController control,
-        ProtobufSource source)
+        ProtobufSource source,
+        ProtobufEvent event)
     {
-        return dispatch(source, suspended);
+        return dispatch(source, event);
     }
 
     @Override
@@ -78,7 +73,6 @@ public final class ProtobufUntypedSinkImpl implements ProtobufSink
         depth = 0;
         valueWritten = 0;
         valueTotal = 0;
-        suspended = null;
     }
 
     private ProtobufPipeline.Status dispatch(

--- a/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufControllerTest.java
+++ b/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufControllerTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.protobuf;
+
+import org.junit.jupiter.api.Test;
+
+public class ProtobufControllerTest
+{
+    @Test
+    public void shouldIgnoreConsumedByDefault()
+    {
+        // a controller that opts out of segment delivery inherits the no-op consumed() pushback
+        ProtobufController control = () -> {};
+        control.consumed(5);
+    }
+}


### PR DESCRIPTION
## Summary

Makes the `common-protobuf` wire sinks stateless for back-pressure, mirroring the `common-json` `JsonSink` convergence (#1888) and `consumed()` flow (#1882/#1888). Two stacked changes:

### 1. Pump owns the resume cursor
Thread the suspended event through `resume()` so the pipeline pump — not the sink — holds the replay cursor.
- `ProtobufSink.resume(control, source, event)` and `ProtobufTransform.resume(control, source, event, sink)` gain the `event` param (the transform default forwards `sink.resume(control, source, event)`).
- `ProtobufPipelineImpl` remembers the in-flight event when `feed` returns `SUSPENDED` and hands it back on resume; `StageSink` forwards it.
- `ProtobufTypedSinkImpl`/`ProtobufUntypedSinkImpl` drop their `suspended` field.

### 2. `consumed()` segment pushback
Make `writeSegment` consumption-driven so the sink no longer tracks a per-value write cursor.
- `ProtobufController.consumed(int)`: a sink reports source bytes taken by a verbatim segment write; the pump forwards it to the parser.
- `ProtobufParser`/`ProtobufParserImpl`: `consumed()` advances the current value slice so `segment()` re-exposes the unconsumed remainder on resume.
- `ProtobufGenerator.writeSegment` writes only as many of the offered bytes as fit (header once) and reports `ProtobufGenerator.consumed()`.
- `ProtobufTypedSinkImpl`/`ProtobufUntypedSinkImpl` drop `valueWritten`/`valueTotal` and always stream a length-delimited value through `writeSegment` + `control.consumed()`.

## Result

The wire sinks now hold only message-nesting context (`depth`/`scope`) — no resume cursor, no per-value write cursor (the same shape `JsonSink` reached). A whole length-delimited value that fits is a single `writeSegment` call producing the **identical canonical single record** (its prefix is the same minimal length varint), so non-streaming output is byte-for-byte unchanged.

## Compatibility

`ProtobufSink.resume`, `ProtobufTransform.resume`, `ProtobufController`, `ProtobufParser.consumed`, and `ProtobufGenerator.{consumed,writeSegment}` are public surface. `consumed()` is a default no-op on the controller/parser; `writeSegment` already required callers to respect the bound, so clamping is strictly safer.

## Test plan

`./mvnw clean install -pl runtime/common-protobuf` — BUILD SUCCESS, coverage gate met. The suspend/resume + chunking + canonical + conformance suites (`ProtobufPipelineTest`, `ProtobufChunkingTest`, `ProtobufCanonicalizerTest`, `ProtobufBinaryConformanceTest`, `ProtobufGeneratorTest`) cover the `writeSegment` contract change; `ProtobufControllerTest` exercises the no-op default.

https://claude.ai/code/session_01KDCFMo1s8mqfAW1LRAoAPA

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDCFMo1s8mqfAW1LRAoAPA)_