### PR TITLE
fix(binding-mcp-http): align JSON key reads with getStringView()

### DIFF
--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/transform/McpHttpArguments.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/transform/McpHttpArguments.java
@@ -97,7 +97,7 @@ public final class McpHttpArguments implements JsonTransform
             depth++;
             break;
         case KEY_NAME:
-            argsArmed = depth == 1 && "arguments".contentEquals(source.getKey());
+            argsArmed = depth == 1 && "arguments".contentEquals(source.getStringView());
             break;
         case END_OBJECT:
         case END_ARRAY:
@@ -133,7 +133,7 @@ public final class McpHttpArguments implements JsonTransform
             }
             break;
         case KEY_NAME:
-            captureKey = forwardDepth == 1 ? source.getKey().toString() : null;
+            captureKey = forwardDepth == 1 ? source.getStringView().toString() : null;
             status = forward(sink, source, event);
             break;
         case VALUE_STRING:

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/transform/McpHttpRename.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/transform/McpHttpRename.java
@@ -73,7 +73,7 @@ public final class McpHttpRename implements JsonTransform
             status = sink.feed(control, source, event);
             break;
         case KEY_NAME:
-            final String renamed = depth == 1 ? renames.get(source.getKey().toString()) : null;
+            final String renamed = depth == 1 ? renames.get(source.getStringView().toString()) : null;
             status = renamed != null
                 ? sink.feed(control, keySource.with(renamed), event)
                 : sink.feed(control, source, event);
@@ -104,12 +104,6 @@ public final class McpHttpRename implements JsonTransform
 
         @Override
         public CharSequence getStringView()
-        {
-            return key;
-        }
-
-        @Override
-        public CharSequence getKey()
         {
             return key;
         }


### PR DESCRIPTION
## Summary

`common-json` #1892 removed `JsonSource.getKey()`, consolidating scalar and key reads onto `getStringView()`. The `binding-mcp-http` JSON transforms still called `getKey()`, so the module no longer compiles on `develop`. This aligns them:

- `McpHttpArguments` / `McpHttpRename` read the current object key via `source.getStringView()` (now valid for `KEY_NAME`).
- `McpHttpRename.KeySource` drops its `@Override getKey()` (the removed interface method); `getStringView()` already returns the renamed key.

## Test plan

`./mvnw clean install -pl runtime/binding-mcp-http -am -DskipITs` — `binding-mcp-http` compiles and its unit tests pass.

(Note: an unrelated `filesystem-http` JaCoCo coverage gate currently fails in a full `-am` build on `develop` — separate from this change.)

https://claude.ai/code/session_01KDCFMo1s8mqfAW1LRAoAPA

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDCFMo1s8mqfAW1LRAoAPA)_