### PR TITLE
ci: cache and authenticate Docker Hub image pulls to survive rate limits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,11 +161,25 @@ jobs:
         run: |
           docker load -i ~/docker-cache/docker.tar
 
-      - name: Cache Docker images
+      - name: Restore cached example images
         if: ${{ hashFiles(format('examples/{0}/compose.yaml', matrix.dir)) != '' }}
-        uses: ScribeMD/docker-cache@0.5.0
+        uses: actions/cache/restore@v5
         with:
-          key: docker-${{ runner.os }}-${{ matrix.dir }}-${{ hashFiles(format('examples/{0}/compose.yaml', matrix.dir)) }}
+          path: ~/docker-examples-cache/images.tar
+          key: docker-examples-${{ runner.os }}-${{ matrix.dir }}-${{ github.run_id }}
+          restore-keys: |
+            docker-examples-${{ runner.os }}-${{ matrix.dir }}-
+
+      - name: Load cached example images
+        run: |
+          if [ -f ~/docker-examples-cache/images.tar ]; then
+            docker load -i ~/docker-examples-cache/images.tar || true
+          fi
+
+      - name: Pull example images
+        if: ${{ hashFiles(format('examples/{0}/compose.yaml', matrix.dir)) != '' }}
+        working-directory: examples/${{ matrix.dir }}
+        run: docker compose pull --ignore-pull-failures || true
 
       - name: Start Zilla and wait for it to be healthy
         working-directory: examples/${{ matrix.dir }}
@@ -176,6 +190,22 @@ jobs:
         run: |
           set -o pipefail
           ./.github/test.sh | tee $GITHUB_STEP_SUMMARY
+
+      - name: Save example images
+        if: ${{ always() && hashFiles(format('examples/{0}/compose.yaml', matrix.dir)) != '' }}
+        run: |
+          mkdir -p ~/docker-examples-cache
+          imgs=$(docker images --format '{{.Repository}}:{{.Tag}}' \
+            | grep -Ev '<none>|ghcr.io/aklivity/zilla')
+          if [ -n "$imgs" ]; then
+            docker save -o ~/docker-examples-cache/images.tar $imgs
+          fi
+      - name: Save example image cache
+        if: ${{ always() && hashFiles(format('examples/{0}/compose.yaml', matrix.dir)) != '' }}
+        uses: actions/cache/save@v5
+        with:
+          path: ~/docker-examples-cache/images.tar
+          key: docker-examples-${{ runner.os }}-${{ matrix.dir }}-${{ github.run_id }}
 
       - name: Collect docker logs on failure
         if: failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,11 +42,40 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Restore base image cache
+      uses: actions/cache/restore@v5
+      with:
+        path: ~/docker-base-cache/base-images.tar
+        key: docker-base-${{ runner.os }}-${{ github.run_id }}
+        restore-keys: |
+          docker-base-${{ runner.os }}-
+    - name: Load cached base images
+      run: |
+        if [ -f ~/docker-base-cache/base-images.tar ]; then
+          docker load -i ~/docker-base-cache/base-images.tar || true
+        fi
     - name: Build with Maven
       run: ./mvnw -B -U -nsu -ntp -Ddocker.logStdout -Dfailsafe.skipAfterFailureCount=1 -Ddocker.verbose install jacoco:report-aggregate
       env:
         GITHUB_ACTOR: ${{ github.actor }}
         GITHUB_TOKEN: ${{ github.token }}
+
+    - name: Save base images
+      if: always()
+      run: |
+        mkdir -p ~/docker-base-cache
+        imgs=$(docker images --format '{{.Repository}}:{{.Tag}}' \
+          | grep -Ev '<none>|ghcr.io/aklivity/zilla' \
+          | grep -E '^(eclipse-temurin|ubuntu|alpine):')
+        if [ -n "$imgs" ]; then
+          docker save -o ~/docker-base-cache/base-images.tar $imgs
+        fi
+    - name: Save base image cache
+      if: always()
+      uses: actions/cache/save@v5
+      with:
+        path: ~/docker-base-cache/base-images.tar
+        key: docker-base-${{ runner.os }}-${{ github.run_id }}
 
     - name: Save Docker image
       if: success()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,25 +161,11 @@ jobs:
         run: |
           docker load -i ~/docker-cache/docker.tar
 
-      - name: Restore cached example images
+      - name: Cache Docker images
         if: ${{ hashFiles(format('examples/{0}/compose.yaml', matrix.dir)) != '' }}
-        uses: actions/cache/restore@v5
+        uses: ScribeMD/docker-cache@0.5.0
         with:
-          path: ~/docker-examples-cache/images.tar
-          key: docker-examples-${{ runner.os }}-${{ matrix.dir }}-${{ github.run_id }}
-          restore-keys: |
-            docker-examples-${{ runner.os }}-${{ matrix.dir }}-
-
-      - name: Load cached example images
-        run: |
-          if [ -f ~/docker-examples-cache/images.tar ]; then
-            docker load -i ~/docker-examples-cache/images.tar || true
-          fi
-
-      - name: Pull example images
-        if: ${{ hashFiles(format('examples/{0}/compose.yaml', matrix.dir)) != '' }}
-        working-directory: examples/${{ matrix.dir }}
-        run: docker compose pull --ignore-pull-failures || true
+          key: docker-${{ runner.os }}-${{ matrix.dir }}-${{ hashFiles(format('examples/{0}/compose.yaml', matrix.dir)) }}
 
       - name: Start Zilla and wait for it to be healthy
         working-directory: examples/${{ matrix.dir }}
@@ -190,22 +176,6 @@ jobs:
         run: |
           set -o pipefail
           ./.github/test.sh | tee $GITHUB_STEP_SUMMARY
-
-      - name: Save example images
-        if: ${{ always() && hashFiles(format('examples/{0}/compose.yaml', matrix.dir)) != '' }}
-        run: |
-          mkdir -p ~/docker-examples-cache
-          imgs=$(docker images --format '{{.Repository}}:{{.Tag}}' \
-            | grep -Ev '<none>|ghcr.io/aklivity/zilla')
-          if [ -n "$imgs" ]; then
-            docker save -o ~/docker-examples-cache/images.tar $imgs
-          fi
-      - name: Save example image cache
-        if: ${{ always() && hashFiles(format('examples/{0}/compose.yaml', matrix.dir)) != '' }}
-        uses: actions/cache/save@v5
-        with:
-          path: ~/docker-examples-cache/images.tar
-          key: docker-examples-${{ runner.os }}-${{ matrix.dir }}-${{ github.run_id }}
 
       - name: Collect docker logs on failure
         if: failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
         mkdir -p ~/docker-base-cache
         imgs=$(docker images --format '{{.Repository}}:{{.Tag}}' \
           | grep -Ev '<none>|ghcr.io/aklivity/zilla' \
-          | grep -E '^(eclipse-temurin|ubuntu|alpine):')
+          | grep -E '^(eclipse-temurin|ubuntu|alpine|kreinerattila/tshark):')
         if [ -n "$imgs" ]; then
           docker save -o ~/docker-base-cache/base-images.tar $imgs
         fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -76,6 +76,12 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
 
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
     - name: Autobuild
       uses: github/codeql-action/autobuild@v4
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,26 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Login to Docker Hub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Restore base image cache
+      uses: actions/cache/restore@v5
+      with:
+        path: ~/docker-base-cache/base-images.tar
+        key: docker-base-${{ runner.os }}-${{ github.run_id }}
+        restore-keys: |
+          docker-base-${{ runner.os }}-
+
+    - name: Load cached base images
+      run: |
+        if [ -f ~/docker-base-cache/base-images.tar ]; then
+          docker load -i ~/docker-base-cache/base-images.tar || true
+        fi
+
     - name: Determine docker tag
       id: tag
       run: |
@@ -169,6 +189,23 @@ jobs:
       env:
         GITHUB_ACTOR: ${{ github.actor }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Save base images
+      if: always()
+      run: |
+        mkdir -p ~/docker-base-cache
+        imgs=$(docker images --format '{{.Repository}}:{{.Tag}}' \
+          | grep -Ev '<none>|ghcr.io/aklivity/zilla' \
+          | grep -E '^(eclipse-temurin|ubuntu|alpine):')
+        if [ -n "$imgs" ]; then
+          docker save -o ~/docker-base-cache/base-images.tar $imgs
+        fi
+    - name: Save base image cache
+      if: always()
+      uses: actions/cache/save@v5
+      with:
+        path: ~/docker-base-cache/base-images.tar
+        key: docker-base-${{ runner.os }}-${{ github.run_id }}
 
     - name: Setup buildx to publish multi-arch images
       run: docker buildx create --driver docker-container --name release --use

--- a/cloud/helm-chart/pom.xml
+++ b/cloud/helm-chart/pom.xml
@@ -57,6 +57,7 @@
           <chartDirectory>src/main/helm</chartDirectory>
           <chartVersion>${project.version}</chartVersion>
           <appVersion>${project.version}</appVersion>
+          <helmVersion>${helm.version}</helmVersion>
           <skipUpload>true</skipUpload>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <mockito.version>5.23.0</mockito.version>
     <k3po.version>3.4.3</k3po.version>
     <jmh.version>1.37</jmh.version>
+    <helm.version>3.16.4</helm.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
## Description

PR builds were failing when Docker Hub returned `toomanyrequests` (pull rate
limit) while pulling base images (e.g. `eclipse-temurin`, `ubuntu`) and
Testcontainers/example images. This authenticates the anonymous pull paths and
caches the pulled images so they are not re-pulled on every run, priming the
cache incrementally so a build that fails partway on a rate-limit rejection
still persists what it already pulled.

### `build` job — base image cache (`build.yml`)

- **Restore + load before the build**, **save with `if: always()` after** — so
  `docker build` reuses local base images and images pulled before a later
  rate-limit rejection are still cached.
- **Incremental priming key**: `docker-base-<os>-<run_id>` with a
  `docker-base-<os>-` `restore-keys` prefix, so the cache accumulates across
  runs until fully cached.
- Save filter covers `eclipse-temurin` / `ubuntu` / `alpine` and the
  `kreinerattila/tshark` image that `command-dump`'s `KafkaDescribeConfigsNetworkIT`
  pulls via Testcontainers; the locally built `ghcr.io/aklivity/zilla` image and
  `<none>` images are excluded.

### `codeql.yml` — authenticate pulls

- CodeQL autobuild builds the `docker-image` module; added a
  `docker/login-action` step so its base-image pulls authenticate.

### `release.yml` — authenticate pulls + cache base images

- Added a `docker/login-action` (docker.io) before the Maven deploy — buildx's
  container driver reads the host `~/.docker/config.json`, so this authenticates
  its multi-arch pulls too — plus the same restore/save base-image cache as the
  build job (shared `docker-base-<os>-` key scheme).

### `helm-chart` — pin helm version (`pom.xml`, `cloud/helm-chart/pom.xml`)

- `helm-maven-plugin:init` auto-detected helm's latest release via the GitHub
  API when `helmVersion` was unset; unauthenticated CI requests 403 under the
  shared-IP rate limit. Pin `helmVersion` (via a `helm.version` property) so
  init skips the API lookup and pulls the binary directly from the
  `get.helm.sh` CDN.

### Testing job (examples) — unchanged

- The example-image cache continues to use `ScribeMD/docker-cache` keyed by
  `hashFiles(compose.yaml)`. (An earlier attempt to switch it to a run_id-keyed
  `actions/cache` was reverted: the content-hash key is stable across branches,
  so PRs reuse the cache primed by develop and skip the pull, whereas the
  run_id key was a guaranteed cold miss that made all parallel example jobs pull
  at once and exhaust the Docker Hub quota.)

https://claude.ai/code/session_01WNApFoCmD6wD5Wqibrtc4B