### PR TITLE
Parameterize ZpmInstallTest with dynamic version properties

### DIFF
--- a/manager/pom.xml
+++ b/manager/pom.xml
@@ -101,6 +101,12 @@
   </dependencies>
 
   <build>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
     <plugins>
       <plugin>
         <groupId>org.jasig.maven</groupId>
@@ -112,6 +118,7 @@
         <configuration>
           <excludes>
             <exclude>src/main/java/org/apache/ivy/**</exclude>
+            <exclude>src/test/resources/**/*.json</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/manager/src/test/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstallTest.java
+++ b/manager/src/test/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstallTest.java
@@ -20,6 +20,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.io.FileMatchers.anExistingFile;
 
 import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
 
 import org.junit.Test;
 
@@ -30,12 +34,22 @@ import io.aklivity.zilla.manager.internal.ZpmCli;
 public class ZpmInstallTest
 {
     @Test
-    public void shouldInstallEngine()
+    public void shouldInstallEngine() throws Exception
     {
+        Properties versions = new Properties();
+        try (InputStream resource = getClass().getResourceAsStream("/conf/install/version.properties"))
+        {
+            versions.load(resource);
+        }
+        String version = versions.getProperty("project.version");
+        String agronaVersion = versions.getProperty("agrona.version");
+
+        Path configDir = Paths.get(getClass().getResource("/conf/install/zpm.json").toURI()).getParent();
+
         String[] args =
         {
             "install",
-            "--config-directory", "src/conf/install",
+            "--config-directory", configDir.toString(),
             "--lock-directory", "target/test-locks/install",
             "--output-directory", "target/zpm",
             "--launcher-directory", "target",
@@ -48,11 +62,15 @@ public class ZpmInstallTest
         install.run();
 
         assertThat(install, instanceOf(ZpmInstall.class));
-        assertThat(new File("src/conf/install/zpm.json"), anExistingFile());
+        assertThat(configDir.resolve("zpm.json").toFile(), anExistingFile());
         assertThat(new File("target/test-locks/install/zpm-lock.json"), anExistingFile());
-        assertThat(new File("target/zpm/cache/io/aklivity/zilla/engine/0.9.5/engine-0.9.5.jar"), anExistingFile());
-        assertThat(new File("target/zpm/cache/io/aklivity/zilla/binding-tcp/0.9.5/binding-tcp-0.9.5.jar"), anExistingFile());
-        assertThat(new File("target/zpm/cache/io/aklivity/zilla/binding-tls/0.9.5/binding-tls-0.9.5.jar"), anExistingFile());
-        assertThat(new File("target/zpm/cache/org/agrona/agrona/1.6.0/agrona-1.6.0.jar"), anExistingFile());
+        assertThat(new File(String.format("target/zpm/cache/io/aklivity/zilla/engine/%1$s/engine-%1$s.jar", version)),
+            anExistingFile());
+        assertThat(new File(String.format("target/zpm/cache/io/aklivity/zilla/binding-tcp/%1$s/binding-tcp-%1$s.jar", version)),
+            anExistingFile());
+        assertThat(new File(String.format("target/zpm/cache/io/aklivity/zilla/binding-tls/%1$s/binding-tls-%1$s.jar", version)),
+            anExistingFile());
+        assertThat(new File(String.format("target/zpm/cache/org/agrona/agrona/%1$s/agrona-%1$s.jar", agronaVersion)),
+            anExistingFile());
     }
 }

--- a/manager/src/test/resources/conf/install/version.properties
+++ b/manager/src/test/resources/conf/install/version.properties
@@ -1,0 +1,18 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+project.version=${project.version}
+agrona.version=${agrona.version}

--- a/manager/src/test/resources/conf/install/zpm.json
+++ b/manager/src/test/resources/conf/install/zpm.json
@@ -7,7 +7,7 @@
 
   "imports":
   [
-    "io.aklivity.zilla:runtime:0.9.5"
+    "io.aklivity.zilla:runtime:${project.version}"
   ],
 
   "dependencies":

--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,13 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <configuration>
+            <propertiesEncoding>${project.build.sourceEncoding}</propertiesEncoding>
+          </configuration>
+        </plugin>
+        <plugin>
           <groupId>org.jasig.maven</groupId>
           <artifactId>maven-notice-plugin</artifactId>
           <version>1.1.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
+          <version>3.4.0</version>
           <configuration>
             <propertiesEncoding>${project.build.sourceEncoding}</propertiesEncoding>
           </configuration>


### PR DESCRIPTION
## Description

This change makes the `ZpmInstallTest` test more maintainable by parameterizing hardcoded version numbers. Instead of embedding specific versions (0.9.5 for Zilla components, 1.6.0 for Agrona) directly in test assertions, the test now reads versions from a properties file that is filtered during the Maven build process.

### Changes Made

1. **Test refactoring** (`ZpmInstallTest.java`):
   - Load project and dependency versions from `version.properties` resource file
   - Replace hardcoded version strings with dynamic variables in file path assertions
   - Use `Path` API for more robust resource location handling
   - Updated method signature to throw `Exception` for resource loading

2. **New properties file** (`version.properties`):
   - Created test resource file with Maven property placeholders
   - Properties are filtered during build to inject actual versions from `pom.xml`

3. **Maven configuration**:
   - Enabled resource filtering for test resources in `manager/pom.xml`
   - Added `maven-resources-plugin` configuration in root `pom.xml` to ensure proper encoding
   - Excluded JSON files from license header checks to avoid conflicts with filtered content

4. **Configuration update** (`zpm.json`):
   - Updated hardcoded runtime version to use Maven property placeholder

### Benefits

- Test assertions now automatically use the versions defined in `pom.xml`, eliminating manual synchronization
- Reduces maintenance burden when versions are updated
- Makes the test more resilient to version changes across the project

## Test Plan

The existing `ZpmInstallTest.shouldInstallEngine()` test validates the changes. The test now dynamically verifies that installed artifacts match the configured project versions rather than hardcoded values.

https://claude.ai/code/session_01MYw48RN2u5mT7boyncBHBc