### PR TITLE
feat(common-protobuf): compile ProtobufSchema from .proto source text

### DIFF
--- a/runtime/common-protobuf/pom.xml
+++ b/runtime/common-protobuf/pom.xml
@@ -38,6 +38,11 @@
       <artifactId>common-json</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.antlr</groupId>
+      <artifactId>antlr4-runtime</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
@@ -92,6 +97,10 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
       </plugin>
       <plugin>
+        <groupId>org.antlr</groupId>
+        <artifactId>antlr4-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
@@ -122,6 +131,9 @@
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <configuration>
+          <excludes>
+            <exclude>io/aklivity/zilla/runtime/common/protobuf/internal/parser/**/*.class</exclude>
+          </excludes>
           <rules>
             <rule>
               <element>BUNDLE</element>

--- a/runtime/common-protobuf/src/main/antlr4/io/aklivity/zilla/runtime/common/protobuf/internal/parser/Protobuf2.g4
+++ b/runtime/common-protobuf/src/main/antlr4/io/aklivity/zilla/runtime/common/protobuf/internal/parser/Protobuf2.g4
@@ -1,0 +1,416 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+grammar Protobuf2;
+
+proto
+  : syntax
+    (
+        importStatement
+      | packageStatement
+      | optionStatement
+      | topLevelDef
+      | emptyStatement_
+    )* EOF
+  ;
+
+// Syntax
+
+syntax
+  : SYNTAX EQ (PROTO2_LIT_SINGLE | PROTO2_LIT_DOUBLE) SEMI
+  ;
+
+// Import Statement
+
+importStatement
+  : IMPORT ( WEAK | PUBLIC )? strLit SEMI
+  ;
+
+// Package
+
+packageStatement
+  : PACKAGE fullIdent SEMI
+  ;
+
+// Option
+
+optionStatement
+  : OPTION optionName EQ constant SEMI
+  ;
+
+optionName
+  : fullIdent
+  | LP fullIdent RP ( DOT fullIdent )?
+  ;
+
+// Normal Field - Proto2 includes required, optional, repeated
+fieldLabel
+  : REQUIRED | OPTIONAL | REPEATED
+  ;
+
+field
+  : fieldLabel type_ fieldName EQ fieldNumber ( LB fieldOptions RB )? SEMI
+  ;
+
+fieldOptions
+  : fieldOption ( COMMA  fieldOption )*
+  ;
+
+fieldOption
+  : optionName EQ constant
+  ;
+
+fieldNumber
+  : intLit
+  ;
+
+// Group field (deprecated but still supported in proto2)
+group
+  : fieldLabel GROUP groupName EQ fieldNumber LC ( field | emptyStatement_ )* RC
+  ;
+
+// Oneof and oneof field
+
+oneof
+  : ONEOF oneofName LC ( optionStatement | oneofField | emptyStatement_ )* RC
+  ;
+
+oneofField
+  : type_ fieldName EQ fieldNumber ( LB fieldOptions RB )? SEMI
+  ;
+
+// Map field
+
+mapField
+  : MAP LT keyType COMMA type_ GT mapName
+        EQ fieldNumber ( LB fieldOptions RB )? SEMI
+  ;
+keyType
+  : INT32
+  | INT64
+  | UINT32
+  | UINT64
+  | SINT32
+  | SINT64
+  | FIXED32
+  | FIXED64
+  | SFIXED32
+  | SFIXED64
+  | BOOL
+  | STRING
+  ;
+
+// field types
+
+type_
+  : DOUBLE
+  | FLOAT
+  | INT32
+  | INT64
+  | UINT32
+  | UINT64
+  | SINT32
+  | SINT64
+  | FIXED32
+  | FIXED64
+  | SFIXED32
+  | SFIXED64
+  | BOOL
+  | STRING
+  | BYTES
+  | messageType
+  | enumType
+  ;
+
+// Reserved
+
+reserved
+  : RESERVED ( ranges | reservedFieldNames ) SEMI
+  ;
+
+ranges
+  : range_ ( COMMA range_ )*
+  ;
+
+range_
+  : intLit ( TO ( intLit | MAX ) )?
+  ;
+
+reservedFieldNames
+  : strLit ( COMMA strLit )*
+  ;
+
+// Extensions (proto2 specific)
+
+extensions
+  : EXTENSIONS ranges SEMI
+  ;
+
+// Extend definition
+
+extendDef
+    :   EXTEND messageType LC ( field
+                                 | group
+                                 | emptyStatement_
+                                 )* RC
+    ;
+
+// Top Level definitions
+
+topLevelDef
+  : messageDef
+  | enumDef
+  | extendDef
+  | serviceDef
+  ;
+
+// enum
+
+enumDef
+  : ENUM enumName enumBody
+  ;
+
+enumBody
+  : LC enumElement* RC
+  ;
+
+enumElement
+  : optionStatement
+  | enumField
+  | emptyStatement_
+  ;
+
+enumField
+  : ident EQ ( MINUS )? intLit enumValueOptions?SEMI
+  ;
+
+enumValueOptions
+  : LB enumValueOption ( COMMA  enumValueOption )* RB
+  ;
+
+enumValueOption
+  : optionName EQ constant
+  ;
+
+// message
+
+messageDef
+  : MESSAGE messageName messageBody
+  ;
+
+messageBody
+  : LC messageElement* RC
+  ;
+
+messageElement
+  : field
+  | group
+  | enumDef
+  | messageDef
+  | extendDef
+  | extensions
+  | optionStatement
+  | oneof
+  | mapField
+  | reserved
+  | emptyStatement_
+  ;
+
+// service
+
+serviceDef
+  : SERVICE serviceName LC serviceElement* RC
+  ;
+
+serviceElement
+  : optionStatement
+  | rpc
+  | emptyStatement_
+  ;
+
+rpc
+  : RPC rpcName LP ( clientStreaming=STREAM )? messageType RP
+        RETURNS LP ( serverStreaming=STREAM )? messageType RP
+        (LC ( optionStatement | emptyStatement_ )* RC | SEMI)
+  ;
+
+// lexical
+
+constant
+  : fullIdent
+  | (MINUS | PLUS )? intLit
+  | ( MINUS | PLUS )? floatLit
+  | strLit
+  | boolLit
+  | blockLit
+  ;
+
+// not specified in specification but used in tests
+blockLit
+  : LC ( ident COLON constant )* RC
+  ;
+
+emptyStatement_: SEMI;
+
+// Lexical elements
+
+ident: IDENTIFIER | keywords;
+fullIdent: ident ( DOT ident )*;
+groupName: ident;
+messageName: ident;
+enumName: ident;
+fieldName: ident;
+oneofName: ident;
+mapName: ident;
+serviceName: ident;
+rpcName: ident;
+messageType: ( DOT )? ( ident DOT )* messageName;
+enumType: ( DOT )? ( ident DOT )* enumName;
+
+intLit: INT_LIT;
+strLit: STR_LIT | PROTO2_LIT_SINGLE | PROTO2_LIT_DOBULE;
+boolLit: BOOL_LIT;
+floatLit: FLOAT_LIT;
+
+// keywords
+SYNTAX: 'syntax';
+IMPORT: 'import';
+WEAK: 'weak';
+PUBLIC: 'public';
+PACKAGE: 'package';
+OPTION: 'option';
+REQUIRED: 'required';
+OPTIONAL: 'optional';
+REPEATED: 'repeated';
+ONEOF: 'oneof';
+MAP: 'map';
+GROUP: 'group';
+EXTENSIONS: 'extensions';
+INT32: 'int32';
+INT64: 'int64';
+UINT32: 'uint32';
+UINT64: 'uint64';
+SINT32: 'sint32';
+SINT64: 'sint64';
+FIXED32: 'fixed32';
+FIXED64: 'fixed64';
+SFIXED32: 'sfixed32';
+SFIXED64: 'sfixed64';
+BOOL: 'bool';
+STRING: 'string';
+DOUBLE: 'double';
+FLOAT: 'float';
+BYTES: 'bytes';
+RESERVED: 'reserved';
+TO: 'to';
+MAX: 'max';
+ENUM: 'enum';
+MESSAGE: 'message';
+SERVICE: 'service';
+EXTEND: 'extend';
+RPC: 'rpc';
+STREAM: 'stream';
+RETURNS: 'returns';
+
+PROTO2_LIT_SINGLE: '"proto2"';
+PROTO2_LIT_DOBULE: '\'proto2\'';
+
+// symbols
+
+SEMI: ';';
+EQ: '=';
+LP: '(';
+RP: ')';
+LB: '[';
+RB: ']';
+LC: '{';
+RC: '}';
+LT: '<';
+GT: '>';
+DOT: '.';
+COMMA: ',';
+COLON: ':';
+PLUS: '+';
+MINUS: '-';
+
+STR_LIT: ( '\'' ( CHAR_VALUE )*? '\'' ) |  ( '"' ( CHAR_VALUE )*? '"' );
+fragment CHAR_VALUE: HEX_ESCAPE | OCT_ESCAPE | CHAR_ESCAPE | ~[\u0000\n\\];
+fragment HEX_ESCAPE: '\\' ( 'x' | 'X' ) HEX_DIGIT HEX_DIGIT;
+fragment OCT_ESCAPE: '\\' OCTAL_DIGIT OCTAL_DIGIT OCTAL_DIGIT;
+fragment CHAR_ESCAPE: '\\' ( 'a' | 'b' | 'f' | 'n' | 'r' | 't' | 'v' | '\\' | '\'' | '"' );
+
+BOOL_LIT: 'true' | 'false';
+
+FLOAT_LIT : ( DECIMALS DOT DECIMALS? EXPONENT? | DECIMALS EXPONENT | DOT DECIMALS EXPONENT? ) | 'inf' | 'nan';
+fragment EXPONENT  : ( 'e' | 'E' ) (PLUS | MINUS)? DECIMALS;
+fragment DECIMALS  : DECIMAL_DIGIT+;
+
+INT_LIT     : DECIMAL_LIT | OCTAL_LIT | HEX_LIT;
+fragment DECIMAL_LIT : ( [1-9] ) DECIMAL_DIGIT*;
+fragment OCTAL_LIT   : '0' OCTAL_DIGIT*;
+fragment HEX_LIT     : '0' ( 'x' | 'X' ) HEX_DIGIT+ ;
+
+IDENTIFIER: LETTER ( LETTER | DECIMAL_DIGIT )*;
+
+fragment LETTER: [A-Za-z_];
+fragment DECIMAL_DIGIT: [0-9];
+fragment OCTAL_DIGIT: [0-7];
+fragment HEX_DIGIT: [0-9A-Fa-f];
+
+// comments
+WS  :   [ \t\r\n\u000C]+ -> skip;
+LINE_COMMENT: '//' ~[\r\n]* -> channel(HIDDEN);
+COMMENT: '/*' .*? '*/' -> channel(HIDDEN);
+
+keywords
+  : SYNTAX
+  | IMPORT
+  | WEAK
+  | PUBLIC
+  | PACKAGE
+  | OPTION
+  | REQUIRED
+  | OPTIONAL
+  | REPEATED
+  | ONEOF
+  | MAP
+  | GROUP
+  | EXTENSIONS
+  | INT32
+  | INT64
+  | UINT32
+  | UINT64
+  | SINT32
+  | SINT64
+  | FIXED32
+  | FIXED64
+  | SFIXED32
+  | SFIXED64
+  | BOOL
+  | STRING
+  | DOUBLE
+  | FLOAT
+  | BYTES
+  | RESERVED
+  | TO
+  | MAX
+  | ENUM
+  | MESSAGE
+  | SERVICE
+  | EXTEND
+  | RPC
+  | STREAM
+  | RETURNS
+  | BOOL_LIT
+  ;

--- a/runtime/common-protobuf/src/main/antlr4/io/aklivity/zilla/runtime/common/protobuf/internal/parser/Protobuf3.g4
+++ b/runtime/common-protobuf/src/main/antlr4/io/aklivity/zilla/runtime/common/protobuf/internal/parser/Protobuf3.g4
@@ -1,0 +1,400 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+grammar Protobuf3;
+
+proto
+  : syntax
+    (
+        importStatement
+      | packageStatement
+      | optionStatement
+      | topLevelDef
+      | emptyStatement_
+    )* EOF
+  ;
+
+// Syntax
+
+syntax
+  : SYNTAX EQ (PROTO3_LIT_SINGLE | PROTO3_LIT_DOUBLE) SEMI
+  ;
+
+// Import Statement
+
+importStatement
+  : IMPORT ( WEAK | PUBLIC )? strLit SEMI
+  ;
+
+// Package
+
+packageStatement
+  : PACKAGE fullIdent SEMI
+  ;
+
+// Option
+
+optionStatement
+  : OPTION optionName EQ constant SEMI
+  ;
+
+optionName
+  : fullIdent
+  | LP fullIdent RP ( DOT fullIdent )?
+  ;
+
+// Normal Field
+fieldLabel
+  : OPTIONAL | REPEATED
+  ;
+
+field
+  : fieldLabel? type_ fieldName EQ fieldNumber ( LB fieldOptions RB )? SEMI
+  ;
+
+fieldOptions
+  : fieldOption ( COMMA  fieldOption )*
+  ;
+
+fieldOption
+  : optionName EQ constant
+  ;
+
+fieldNumber
+  : intLit
+  ;
+
+// Oneof and oneof field
+
+oneof
+  : ONEOF oneofName LC ( optionStatement | oneofField | emptyStatement_ )* RC
+  ;
+
+oneofField
+  : type_ fieldName EQ fieldNumber ( LB fieldOptions RB )? SEMI
+  ;
+
+// Map field
+
+mapField
+  : MAP LT keyType COMMA type_ GT mapName
+        EQ fieldNumber ( LB fieldOptions RB )? SEMI
+  ;
+keyType
+  : INT32
+  | INT64
+  | UINT32
+  | UINT64
+  | SINT32
+  | SINT64
+  | FIXED32
+  | FIXED64
+  | SFIXED32
+  | SFIXED64
+  | BOOL
+  | STRING
+  ;
+
+// field types
+
+type_
+  : DOUBLE
+  | FLOAT
+  | INT32
+  | INT64
+  | UINT32
+  | UINT64
+  | SINT32
+  | SINT64
+  | FIXED32
+  | FIXED64
+  | SFIXED32
+  | SFIXED64
+  | BOOL
+  | STRING
+  | BYTES
+  | messageType
+  | enumType
+  ;
+
+// Reserved
+
+reserved
+  : RESERVED ( ranges | reservedFieldNames ) SEMI
+  ;
+
+ranges
+  : range_ ( COMMA range_ )*
+  ;
+
+range_
+  : intLit ( TO ( intLit | MAX ) )?
+  ;
+
+reservedFieldNames
+  : strLit ( COMMA strLit )*
+  ;
+
+// Top Level definitions
+
+topLevelDef
+  : messageDef
+  | enumDef
+  | extendDef
+  | serviceDef
+  ;
+
+// enum
+
+enumDef
+  : ENUM enumName enumBody
+  ;
+
+enumBody
+  : LC enumElement* RC
+  ;
+
+enumElement
+  : optionStatement
+  | enumField
+  | emptyStatement_
+  ;
+
+enumField
+  : ident EQ ( MINUS )? intLit enumValueOptions?SEMI
+  ;
+
+enumValueOptions
+  : LB enumValueOption ( COMMA  enumValueOption )* RB
+  ;
+
+enumValueOption
+  : optionName EQ constant
+  ;
+
+// message
+
+messageDef
+  : MESSAGE messageName messageBody
+  ;
+
+messageBody
+  : LC messageElement* RC
+  ;
+
+messageElement
+  : field
+  | enumDef
+  | messageDef
+  | extendDef
+  | optionStatement
+  | oneof
+  | mapField
+  | reserved
+  | emptyStatement_
+  ;
+
+// Extend definition
+//
+// NB: not defined in the spec but supported by protoc and covered by protobuf3 tests
+//     see e.g. php/tests/proto/test_import_descriptor_proto.proto
+//     of https://github.com/protocolbuffers/protobuf
+// it also was discussed here: https://github.com/protocolbuffers/protobuf/issues/4610
+
+extendDef
+    :   EXTEND messageType LC ( field
+                                 | emptyStatement_
+                                 )* RC
+    ;
+
+// service
+
+serviceDef
+  : SERVICE serviceName LC serviceElement* RC
+  ;
+
+serviceElement
+  : optionStatement
+  | rpc
+  | emptyStatement_
+  ;
+
+rpc
+  : RPC rpcName LP ( clientStreaming=STREAM )? messageType RP
+        RETURNS LP ( serverStreaming=STREAM )? messageType RP
+        (LC ( optionStatement | emptyStatement_ )* RC | SEMI)
+  ;
+
+// lexical
+
+constant
+  : fullIdent
+  | (MINUS | PLUS )? intLit
+  | ( MINUS | PLUS )? floatLit
+  | strLit
+  | boolLit
+  | blockLit
+  ;
+
+// not specified in specification but used in tests
+blockLit
+  : LC ( ident COLON constant )* RC
+  ;
+
+emptyStatement_: SEMI;
+
+// Lexical elements
+
+ident: IDENTIFIER | keywords;
+fullIdent: ident ( DOT ident )*;
+messageName: ident;
+enumName: ident;
+fieldName: ident;
+oneofName: ident;
+mapName: ident;
+serviceName: ident;
+rpcName: ident;
+messageType: ( DOT )? ( ident DOT )* messageName;
+enumType: ( DOT )? ( ident DOT )* enumName;
+
+intLit: INT_LIT;
+strLit: STR_LIT | PROTO3_LIT_SINGLE | PROTO3_LIT_DOBULE;
+boolLit: BOOL_LIT;
+floatLit: FLOAT_LIT;
+
+// keywords
+SYNTAX: 'syntax';
+IMPORT: 'import';
+WEAK: 'weak';
+PUBLIC: 'public';
+PACKAGE: 'package';
+OPTION: 'option';
+OPTIONAL: 'optional';
+REPEATED: 'repeated';
+ONEOF: 'oneof';
+MAP: 'map';
+INT32: 'int32';
+INT64: 'int64';
+UINT32: 'uint32';
+UINT64: 'uint64';
+SINT32: 'sint32';
+SINT64: 'sint64';
+FIXED32: 'fixed32';
+FIXED64: 'fixed64';
+SFIXED32: 'sfixed32';
+SFIXED64: 'sfixed64';
+BOOL: 'bool';
+STRING: 'string';
+DOUBLE: 'double';
+FLOAT: 'float';
+BYTES: 'bytes';
+RESERVED: 'reserved';
+TO: 'to';
+MAX: 'max';
+ENUM: 'enum';
+MESSAGE: 'message';
+SERVICE: 'service';
+EXTEND: 'extend';
+RPC: 'rpc';
+STREAM: 'stream';
+RETURNS: 'returns';
+
+PROTO3_LIT_SINGLE: '"proto3"';
+PROTO3_LIT_DOBULE: '\'proto3\'';
+
+// symbols
+
+SEMI: ';';
+EQ: '=';
+LP: '(';
+RP: ')';
+LB: '[';
+RB: ']';
+LC: '{';
+RC: '}';
+LT: '<';
+GT: '>';
+DOT: '.';
+COMMA: ',';
+COLON: ':';
+PLUS: '+';
+MINUS: '-';
+
+STR_LIT: ( '\'' ( CHAR_VALUE )*? '\'' ) |  ( '"' ( CHAR_VALUE )*? '"' );
+fragment CHAR_VALUE: HEX_ESCAPE | OCT_ESCAPE | CHAR_ESCAPE | ~[\u0000\n\\];
+fragment HEX_ESCAPE: '\\' ( 'x' | 'X' ) HEX_DIGIT HEX_DIGIT;
+fragment OCT_ESCAPE: '\\' OCTAL_DIGIT OCTAL_DIGIT OCTAL_DIGIT;
+fragment CHAR_ESCAPE: '\\' ( 'a' | 'b' | 'f' | 'n' | 'r' | 't' | 'v' | '\\' | '\'' | '"' );
+
+BOOL_LIT: 'true' | 'false';
+
+FLOAT_LIT : ( DECIMALS DOT DECIMALS? EXPONENT? | DECIMALS EXPONENT | DOT DECIMALS EXPONENT? ) | 'inf' | 'nan';
+fragment EXPONENT  : ( 'e' | 'E' ) (PLUS | MINUS)? DECIMALS;
+fragment DECIMALS  : DECIMAL_DIGIT+;
+
+INT_LIT     : DECIMAL_LIT | OCTAL_LIT | HEX_LIT;
+fragment DECIMAL_LIT : ( [1-9] ) DECIMAL_DIGIT*;
+fragment OCTAL_LIT   : '0' OCTAL_DIGIT*;
+fragment HEX_LIT     : '0' ( 'x' | 'X' ) HEX_DIGIT+ ;
+
+IDENTIFIER: LETTER ( LETTER | DECIMAL_DIGIT )*;
+
+fragment LETTER: [A-Za-z_];
+fragment DECIMAL_DIGIT: [0-9];
+fragment OCTAL_DIGIT: [0-7];
+fragment HEX_DIGIT: [0-9A-Fa-f];
+
+// comments
+WS  :   [ \t\r\n\u000C]+ -> skip;
+LINE_COMMENT: '//' ~[\r\n]* -> channel(HIDDEN);
+COMMENT: '/*' .*? '*/' -> channel(HIDDEN);
+
+keywords
+  : SYNTAX
+  | IMPORT
+  | WEAK
+  | PUBLIC
+  | PACKAGE
+  | OPTION
+  | OPTIONAL
+  | REPEATED
+  | ONEOF
+  | MAP
+  | INT32
+  | INT64
+  | UINT32
+  | UINT64
+  | SINT32
+  | SINT64
+  | FIXED32
+  | FIXED64
+  | SFIXED32
+  | SFIXED64
+  | BOOL
+  | STRING
+  | DOUBLE
+  | FLOAT
+  | BYTES
+  | RESERVED
+  | TO
+  | MAX
+  | ENUM
+  | MESSAGE
+  | SERVICE
+  | EXTEND
+  | RPC
+  | STREAM
+  | RETURNS
+  | BOOL_LIT
+  ;

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/Protobuf.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/Protobuf.java
@@ -19,6 +19,7 @@ import org.agrona.DirectBuffer;
 import io.aklivity.zilla.runtime.common.protobuf.internal.ProtobufGeneratorImpl;
 import io.aklivity.zilla.runtime.common.protobuf.internal.ProtobufParserImpl;
 import io.aklivity.zilla.runtime.common.protobuf.internal.ProtobufSchemaCompiler;
+import io.aklivity.zilla.runtime.common.protobuf.internal.ProtobufSourceCompiler;
 import io.aklivity.zilla.runtime.common.protobuf.internal.ProtobufStreamImpl;
 
 /**
@@ -51,6 +52,19 @@ public final class Protobuf
         int length)
     {
         return new ProtobufSchemaCompiler().compile(fileDescriptorSet, offset, length);
+    }
+
+    /**
+     * Compiles {@code .proto} source text (a single proto2 or proto3 file, detected from its
+     * {@code syntax} statement) into a {@link ProtobufSchema}, parsed with this library's own ANTLR
+     * grammars so there is no {@code protobuf-java} dependency. Composite field type references are
+     * resolved by the proto scoping rules and {@code map} fields are expanded to the synthetic
+     * {@code map_entry} message, matching {@code protoc}.
+     */
+    public static ProtobufSchema schema(
+        CharSequence source)
+    {
+        return new ProtobufSourceCompiler().compile(source);
     }
 
     /**

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufSourceCompiler.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufSourceCompiler.java
@@ -1,0 +1,697 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.protobuf.internal;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.antlr.v4.runtime.BailErrorStrategy;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufEnum;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufException;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufField;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufMessage;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufSchema;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufType;
+import io.aklivity.zilla.runtime.common.protobuf.internal.parser.Protobuf2BaseListener;
+import io.aklivity.zilla.runtime.common.protobuf.internal.parser.Protobuf2Lexer;
+import io.aklivity.zilla.runtime.common.protobuf.internal.parser.Protobuf2Parser;
+import io.aklivity.zilla.runtime.common.protobuf.internal.parser.Protobuf3BaseListener;
+import io.aklivity.zilla.runtime.common.protobuf.internal.parser.Protobuf3Lexer;
+import io.aklivity.zilla.runtime.common.protobuf.internal.parser.Protobuf3Parser;
+
+/**
+ * Compiles {@code .proto} source text into a {@link ProtobufSchema}, decoded with this library's own
+ * ANTLR grammars so there is no {@code protobuf-java} dependency. A single file is parsed (proto2 or
+ * proto3, detected from its {@code syntax} statement); composite field type references are resolved
+ * by the proto scoping rules (innermost enclosing scope outward) to the dotless full names this model
+ * keys on, and {@code map} fields are expanded into the synthetic {@code map_entry} message and a
+ * repeated reference to it, matching {@code protoc}.
+ */
+public final class ProtobufSourceCompiler
+{
+    private static final Pattern SYNTAX_PATTERN = Pattern.compile(
+        "^\\s*syntax\\s*=\\s*[\"'](proto2|proto3)[\"']\\s*;",
+        Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
+
+    private static final Map<String, ProtobufType> SCALARS = Map.ofEntries(
+        Map.entry("double", ProtobufType.DOUBLE),
+        Map.entry("float", ProtobufType.FLOAT),
+        Map.entry("int32", ProtobufType.INT32),
+        Map.entry("int64", ProtobufType.INT64),
+        Map.entry("uint32", ProtobufType.UINT32),
+        Map.entry("uint64", ProtobufType.UINT64),
+        Map.entry("sint32", ProtobufType.SINT32),
+        Map.entry("sint64", ProtobufType.SINT64),
+        Map.entry("fixed32", ProtobufType.FIXED32),
+        Map.entry("fixed64", ProtobufType.FIXED64),
+        Map.entry("sfixed32", ProtobufType.SFIXED32),
+        Map.entry("sfixed64", ProtobufType.SFIXED64),
+        Map.entry("bool", ProtobufType.BOOL),
+        Map.entry("string", ProtobufType.STRING),
+        Map.entry("bytes", ProtobufType.BYTES));
+
+    public ProtobufSchema compile(
+        CharSequence source)
+    {
+        String text = source != null ? source.toString() : null;
+        if (text == null || text.isEmpty())
+        {
+            throw new ProtobufException("empty protobuf schema");
+        }
+
+        Matcher matcher = SYNTAX_PATTERN.matcher(text);
+        boolean proto3 = !matcher.find() || "proto3".equalsIgnoreCase(matcher.group(1));
+
+        CharStream input = CharStreams.fromString(text);
+        Draft draft = new Draft(proto3);
+        if (proto3)
+        {
+            Protobuf3Lexer lexer = new Protobuf3Lexer(input);
+            Protobuf3Parser parser = new Protobuf3Parser(new CommonTokenStream(lexer));
+            parser.setErrorHandler(new BailErrorStrategy());
+            new ParseTreeWalker().walk(new Proto3Listener(draft), parser.proto());
+        }
+        else
+        {
+            Protobuf2Lexer lexer = new Protobuf2Lexer(input);
+            Protobuf2Parser parser = new Protobuf2Parser(new CommonTokenStream(lexer));
+            parser.setErrorHandler(new BailErrorStrategy());
+            new ParseTreeWalker().walk(new Proto2Listener(draft), parser.proto());
+        }
+
+        return link(draft);
+    }
+
+    private ProtobufSchema link(
+        Draft draft)
+    {
+        Set<String> names = new LinkedHashSet<>();
+        for (DraftMessage message : draft.messages)
+        {
+            names.add(message.fullName);
+        }
+        for (DraftEnum enumeration : draft.enums)
+        {
+            names.add(enumeration.fullName);
+        }
+
+        ProtobufSchema.Builder schema = ProtobufSchema.builder();
+        for (DraftEnum enumeration : draft.enums)
+        {
+            ProtobufEnum.Builder builder = ProtobufEnum.builder(enumeration.fullName);
+            for (int i = 0; i < enumeration.valueNames.size(); i++)
+            {
+                builder.value(enumeration.valueNames.get(i), enumeration.valueNumbers.get(i));
+            }
+            schema.enumeration(builder.build());
+        }
+        for (DraftMessage message : draft.messages)
+        {
+            ProtobufMessage.Builder builder = ProtobufMessage.builder(message.fullName).mapEntry(message.mapEntry);
+            for (DraftField field : message.fields)
+            {
+                builder.field(linkField(field, draft.proto3, names));
+            }
+            schema.message(builder.build());
+        }
+        return schema.build();
+    }
+
+    private ProtobufField linkField(
+        DraftField field,
+        boolean proto3,
+        Set<String> names)
+    {
+        ProtobufType type = SCALARS.get(field.typeToken);
+        String typeName = null;
+        if (type == null)
+        {
+            String resolved = resolveTypeName(field.typeToken, field.scope, names);
+            if (resolved == null)
+            {
+                throw new ProtobufException("unresolved type " + field.typeToken);
+            }
+            typeName = resolved;
+            type = field.enumNames.contains(resolved) ? ProtobufType.ENUM : ProtobufType.MESSAGE;
+        }
+
+        ProtobufField.Builder builder = ProtobufField.builder()
+            .number(field.number)
+            .name(field.name)
+            .type(type)
+            .repeated(field.repeated)
+            .required(field.required)
+            .proto3Optional(field.proto3Optional);
+        if (typeName != null)
+        {
+            builder.typeName(typeName);
+        }
+        if (field.jsonName != null)
+        {
+            builder.jsonName(field.jsonName);
+        }
+        if (field.oneofName != null)
+        {
+            builder.oneof(field.oneofName);
+        }
+        boolean packed = field.packed != null
+            ? field.packed
+            : proto3 && field.repeated && type.packable();
+        builder.packed(packed);
+
+        return builder.build();
+    }
+
+    private static String resolveTypeName(
+        String token,
+        String scope,
+        Set<String> names)
+    {
+        String result = null;
+        if (token.startsWith("."))
+        {
+            result = token.substring(1);
+        }
+        else
+        {
+            String prefix = scope;
+            boolean done = false;
+            while (!done)
+            {
+                String candidate = prefix.isEmpty() ? token : prefix + "." + token;
+                if (names.contains(candidate))
+                {
+                    result = candidate;
+                    done = true;
+                }
+                else if (prefix.isEmpty())
+                {
+                    done = true;
+                }
+                else
+                {
+                    int dot = prefix.lastIndexOf('.');
+                    prefix = dot < 0 ? "" : prefix.substring(0, dot);
+                }
+            }
+        }
+        return result;
+    }
+
+    private static String capitalize(
+        String name)
+    {
+        return name.isEmpty() ? name : Character.toUpperCase(name.charAt(0)) + name.substring(1);
+    }
+
+    private static String stripQuotes(
+        String value)
+    {
+        String result = value;
+        if (value.length() >= 2 &&
+            (value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"' ||
+                value.charAt(0) == '\'' && value.charAt(value.length() - 1) == '\''))
+        {
+            result = value.substring(1, value.length() - 1);
+        }
+        return result;
+    }
+
+    private static final class Draft
+    {
+        private final boolean proto3;
+        private final List<DraftMessage> messages;
+        private final List<DraftEnum> enums;
+        private final Set<String> enumNames;
+        private String packageName;
+
+        private Draft(
+            boolean proto3)
+        {
+            this.proto3 = proto3;
+            this.messages = new ArrayList<>();
+            this.enums = new ArrayList<>();
+            this.enumNames = new LinkedHashSet<>();
+            this.packageName = "";
+        }
+    }
+
+    private static final class DraftMessage
+    {
+        private final String fullName;
+        private final boolean mapEntry;
+        private final List<DraftField> fields;
+
+        private DraftMessage(
+            String fullName,
+            boolean mapEntry)
+        {
+            this.fullName = fullName;
+            this.mapEntry = mapEntry;
+            this.fields = new ArrayList<>();
+        }
+    }
+
+    private static final class DraftEnum
+    {
+        private final String fullName;
+        private final List<String> valueNames;
+        private final List<Integer> valueNumbers;
+
+        private DraftEnum(
+            String fullName)
+        {
+            this.fullName = fullName;
+            this.valueNames = new ArrayList<>();
+            this.valueNumbers = new ArrayList<>();
+        }
+    }
+
+    private static final class DraftField
+    {
+        private int number;
+        private String name;
+        private String typeToken;
+        private String scope;
+        private boolean repeated;
+        private boolean required;
+        private boolean proto3Optional;
+        private Boolean packed;
+        private String jsonName;
+        private String oneofName;
+        private Set<String> enumNames;
+    }
+
+    private static final class Assembler
+    {
+        private final Draft draft;
+        private final Deque<String> scope;
+        private final Deque<DraftMessage> messages;
+        private String oneof;
+
+        private Assembler(
+            Draft draft)
+        {
+            this.draft = draft;
+            this.scope = new ArrayDeque<>();
+            this.messages = new ArrayDeque<>();
+        }
+
+        private void setPackage(
+            String packageName)
+        {
+            draft.packageName = packageName;
+        }
+
+        private String qualify(
+            String name)
+        {
+            String base = currentScope();
+            return base.isEmpty() ? name : base + "." + name;
+        }
+
+        private String currentScope()
+        {
+            StringBuilder builder = new StringBuilder(draft.packageName);
+            for (String name : scope)
+            {
+                if (builder.length() > 0)
+                {
+                    builder.append('.');
+                }
+                builder.append(name);
+            }
+            return builder.toString();
+        }
+
+        private void enterMessage(
+            String name)
+        {
+            DraftMessage message = new DraftMessage(qualify(name), false);
+            draft.messages.add(message);
+            messages.push(message);
+            scope.push(name);
+        }
+
+        private void exitMessage()
+        {
+            messages.pop();
+            scope.pop();
+        }
+
+        private void addEnum(
+            String name,
+            List<String> valueNames,
+            List<Integer> valueNumbers)
+        {
+            String fullName = qualify(name);
+            draft.enumNames.add(fullName);
+            DraftEnum enumeration = new DraftEnum(fullName);
+            enumeration.valueNames.addAll(valueNames);
+            enumeration.valueNumbers.addAll(valueNumbers);
+            draft.enums.add(enumeration);
+        }
+
+        private void addField(
+            DraftField field)
+        {
+            field.scope = currentScope();
+            field.enumNames = draft.enumNames;
+            messages.peek().fields.add(field);
+        }
+
+        private void addMap(
+            String mapName,
+            int number,
+            String keyType,
+            String valueType)
+        {
+            String entryName = capitalize(mapName) + "Entry";
+            String enclosing = currentScope();
+            DraftMessage entry = new DraftMessage(enclosing.isEmpty() ? entryName : enclosing + "." + entryName, true);
+            DraftField key = new DraftField();
+            key.number = 1;
+            key.name = "key";
+            key.typeToken = keyType;
+            key.scope = entry.fullName;
+            key.enumNames = draft.enumNames;
+            DraftField value = new DraftField();
+            value.number = 2;
+            value.name = "value";
+            value.typeToken = valueType;
+            value.scope = enclosing;
+            value.enumNames = draft.enumNames;
+            entry.fields.add(key);
+            entry.fields.add(value);
+            draft.messages.add(entry);
+
+            DraftField field = new DraftField();
+            field.number = number;
+            field.name = mapName;
+            field.typeToken = entryName;
+            field.repeated = true;
+            addField(field);
+        }
+
+        private boolean inMessage()
+        {
+            return !messages.isEmpty();
+        }
+    }
+
+    private static final class Proto3Listener extends Protobuf3BaseListener
+    {
+        private final Assembler helper;
+
+        private Proto3Listener(
+            Draft draft)
+        {
+            this.helper = new Assembler(draft);
+        }
+
+        @Override
+        public void enterPackageStatement(
+            Protobuf3Parser.PackageStatementContext ctx)
+        {
+            helper.setPackage(ctx.fullIdent().getText());
+        }
+
+        @Override
+        public void enterMessageDef(
+            Protobuf3Parser.MessageDefContext ctx)
+        {
+            helper.enterMessage(ctx.messageName().getText());
+        }
+
+        @Override
+        public void exitMessageDef(
+            Protobuf3Parser.MessageDefContext ctx)
+        {
+            helper.exitMessage();
+        }
+
+        @Override
+        public void enterField(
+            Protobuf3Parser.FieldContext ctx)
+        {
+            if (helper.inMessage())
+            {
+                String label = ctx.fieldLabel() != null ? ctx.fieldLabel().getText() : null;
+                DraftField field = new DraftField();
+                field.name = ctx.fieldName().getText();
+                field.number = Integer.parseInt(ctx.fieldNumber().getText());
+                field.typeToken = ctx.type_().getText();
+                field.repeated = "repeated".equals(label);
+                field.proto3Optional = "optional".equals(label);
+                applyOptions(field, ctx.fieldOptions());
+                helper.addField(field);
+            }
+        }
+
+        @Override
+        public void enterOneof(
+            Protobuf3Parser.OneofContext ctx)
+        {
+            helper.oneof = ctx.oneofName().getText();
+        }
+
+        @Override
+        public void exitOneof(
+            Protobuf3Parser.OneofContext ctx)
+        {
+            helper.oneof = null;
+        }
+
+        @Override
+        public void enterOneofField(
+            Protobuf3Parser.OneofFieldContext ctx)
+        {
+            if (helper.inMessage())
+            {
+                DraftField field = new DraftField();
+                field.name = ctx.fieldName().getText();
+                field.number = Integer.parseInt(ctx.fieldNumber().getText());
+                field.typeToken = ctx.type_().getText();
+                field.oneofName = helper.oneof;
+                applyOptions(field, ctx.fieldOptions());
+                helper.addField(field);
+            }
+        }
+
+        @Override
+        public void enterMapField(
+            Protobuf3Parser.MapFieldContext ctx)
+        {
+            if (helper.inMessage())
+            {
+                helper.addMap(ctx.mapName().getText(), Integer.parseInt(ctx.fieldNumber().getText()),
+                    ctx.keyType().getText(), ctx.type_().getText());
+            }
+        }
+
+        @Override
+        public void enterEnumDef(
+            Protobuf3Parser.EnumDefContext ctx)
+        {
+            List<String> valueNames = new ArrayList<>();
+            List<Integer> valueNumbers = new ArrayList<>();
+            for (Protobuf3Parser.EnumElementContext element : ctx.enumBody().enumElement())
+            {
+                if (element.enumField() != null)
+                {
+                    Protobuf3Parser.EnumFieldContext value = element.enumField();
+                    int number = Integer.parseInt(value.intLit().getText());
+                    if (value.MINUS() != null)
+                    {
+                        number = -number;
+                    }
+                    valueNames.add(value.ident().getText());
+                    valueNumbers.add(number);
+                }
+            }
+            helper.addEnum(ctx.enumName().getText(), valueNames, valueNumbers);
+        }
+
+        private void applyOptions(
+            DraftField field,
+            Protobuf3Parser.FieldOptionsContext ctx)
+        {
+            if (ctx != null)
+            {
+                for (Protobuf3Parser.FieldOptionContext option : ctx.fieldOption())
+                {
+                    String name = option.optionName().getText();
+                    String value = option.constant().getText();
+                    if ("packed".equals(name))
+                    {
+                        field.packed = Boolean.parseBoolean(value);
+                    }
+                    else if ("json_name".equals(name))
+                    {
+                        field.jsonName = stripQuotes(value);
+                    }
+                }
+            }
+        }
+    }
+
+    private static final class Proto2Listener extends Protobuf2BaseListener
+    {
+        private final Assembler helper;
+
+        private Proto2Listener(
+            Draft draft)
+        {
+            this.helper = new Assembler(draft);
+        }
+
+        @Override
+        public void enterPackageStatement(
+            Protobuf2Parser.PackageStatementContext ctx)
+        {
+            helper.setPackage(ctx.fullIdent().getText());
+        }
+
+        @Override
+        public void enterMessageDef(
+            Protobuf2Parser.MessageDefContext ctx)
+        {
+            helper.enterMessage(ctx.messageName().getText());
+        }
+
+        @Override
+        public void exitMessageDef(
+            Protobuf2Parser.MessageDefContext ctx)
+        {
+            helper.exitMessage();
+        }
+
+        @Override
+        public void enterField(
+            Protobuf2Parser.FieldContext ctx)
+        {
+            if (helper.inMessage())
+            {
+                String label = ctx.fieldLabel() != null ? ctx.fieldLabel().getText() : null;
+                DraftField field = new DraftField();
+                field.name = ctx.fieldName().getText();
+                field.number = Integer.parseInt(ctx.fieldNumber().getText());
+                field.typeToken = ctx.type_().getText();
+                field.repeated = "repeated".equals(label);
+                field.required = "required".equals(label);
+                applyOptions(field, ctx.fieldOptions());
+                helper.addField(field);
+            }
+        }
+
+        @Override
+        public void enterOneof(
+            Protobuf2Parser.OneofContext ctx)
+        {
+            helper.oneof = ctx.oneofName().getText();
+        }
+
+        @Override
+        public void exitOneof(
+            Protobuf2Parser.OneofContext ctx)
+        {
+            helper.oneof = null;
+        }
+
+        @Override
+        public void enterOneofField(
+            Protobuf2Parser.OneofFieldContext ctx)
+        {
+            if (helper.inMessage())
+            {
+                DraftField field = new DraftField();
+                field.name = ctx.fieldName().getText();
+                field.number = Integer.parseInt(ctx.fieldNumber().getText());
+                field.typeToken = ctx.type_().getText();
+                field.oneofName = helper.oneof;
+                applyOptions(field, ctx.fieldOptions());
+                helper.addField(field);
+            }
+        }
+
+        @Override
+        public void enterMapField(
+            Protobuf2Parser.MapFieldContext ctx)
+        {
+            if (helper.inMessage())
+            {
+                helper.addMap(ctx.mapName().getText(), Integer.parseInt(ctx.fieldNumber().getText()),
+                    ctx.keyType().getText(), ctx.type_().getText());
+            }
+        }
+
+        @Override
+        public void enterEnumDef(
+            Protobuf2Parser.EnumDefContext ctx)
+        {
+            List<String> valueNames = new ArrayList<>();
+            List<Integer> valueNumbers = new ArrayList<>();
+            for (Protobuf2Parser.EnumElementContext element : ctx.enumBody().enumElement())
+            {
+                if (element.enumField() != null)
+                {
+                    Protobuf2Parser.EnumFieldContext value = element.enumField();
+                    int number = Integer.parseInt(value.intLit().getText());
+                    if (value.MINUS() != null)
+                    {
+                        number = -number;
+                    }
+                    valueNames.add(value.ident().getText());
+                    valueNumbers.add(number);
+                }
+            }
+            helper.addEnum(ctx.enumName().getText(), valueNames, valueNumbers);
+        }
+
+        private void applyOptions(
+            DraftField field,
+            Protobuf2Parser.FieldOptionsContext ctx)
+        {
+            if (ctx != null)
+            {
+                for (Protobuf2Parser.FieldOptionContext option : ctx.fieldOption())
+                {
+                    String name = option.optionName().getText();
+                    String value = option.constant().getText();
+                    if ("packed".equals(name))
+                    {
+                        field.packed = Boolean.parseBoolean(value);
+                    }
+                    else if ("json_name".equals(name))
+                    {
+                        field.jsonName = stripQuotes(value);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/runtime/common-protobuf/src/main/moditect/module-info.java
+++ b/runtime/common-protobuf/src/main/moditect/module-info.java
@@ -16,6 +16,7 @@ module io.aklivity.zilla.runtime.common.protobuf
 {
     requires transitive org.agrona;
     requires transitive io.aklivity.zilla.runtime.common.json;
+    requires org.antlr.antlr4.runtime;
 
     exports io.aklivity.zilla.runtime.common.protobuf;
     exports io.aklivity.zilla.runtime.common.protobuf.json;

--- a/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufSourceCompilerTest.java
+++ b/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufSourceCompilerTest.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.protobuf;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.function.Consumer;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+import io.aklivity.zilla.runtime.common.json.JsonEx;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline.Status;
+import io.aklivity.zilla.runtime.common.protobuf.json.ProtobufJson;
+
+public class ProtobufSourceCompilerTest
+{
+    private static final String PROTO3 =
+        "syntax = \"proto3\";\n" +
+        "package test;\n" +
+        "enum Color { RED = 0; GREEN = 1; BLUE = 2; }\n" +
+        "message Nested { string name = 1; }\n" +
+        "message Person {\n" +
+        "  string name = 1;\n" +
+        "  Nested home = 2;\n" +
+        "  repeated int32 nums = 3;\n" +
+        "  repeated string tags = 4;\n" +
+        "  map<string, string> props = 5;\n" +
+        "  map<string, int32> scores = 6;\n" +
+        "  repeated Nested labels = 7;\n" +
+        "  Color color = 8;\n" +
+        "  optional string note = 9;\n" +
+        "}\n";
+
+    private static final String PROTO2 =
+        "syntax = \"proto2\";\n" +
+        "package test;\n" +
+        "enum Status { ACTIVE = 0; INACTIVE = 1; }\n" +
+        "message Account {\n" +
+        "  required string name = 1;\n" +
+        "  optional int32 id = 2;\n" +
+        "  repeated int32 nums = 3;\n" +
+        "  optional Status status = 4;\n" +
+        "  map<string, int32> scores = 5;\n" +
+        "  oneof kind {\n" +
+        "    string s = 6;\n" +
+        "    int32 i = 7;\n" +
+        "  }\n" +
+        "}\n";
+
+    @Test
+    public void shouldCompileProto3AndResolveNames()
+    {
+        ProtobufSchema schema = Protobuf.schema(PROTO3);
+
+        assertNotNull(schema.message("test.Person"));
+        assertNotNull(schema.message("test.Nested"));
+        assertNotNull(schema.enumeration("test.Color"));
+        assertEquals("test.Nested", schema.message("test.Person").field(2).typeName());
+        assertEquals("home", schema.message("test.Person").field(2).jsonName());
+        assertTrue(schema.message("test.Person").field(3).repeated());
+        assertEquals("test.Color", schema.message("test.Person").field(8).typeName());
+        assertEquals(ProtobufType.ENUM, schema.message("test.Person").field(8).type());
+    }
+
+    @Test
+    public void shouldExpandProto3MapAsEntryMessage()
+    {
+        ProtobufSchema schema = Protobuf.schema(PROTO3);
+
+        assertNotNull(schema.message("test.Person.PropsEntry"));
+        assertTrue(schema.message("test.Person.PropsEntry").mapEntry());
+        assertEquals("test.Person.PropsEntry", schema.message("test.Person").field(5).typeName());
+        assertTrue(schema.message("test.Person").field(5).repeated());
+        assertEquals(ProtobufType.STRING, schema.message("test.Person.PropsEntry").field(2).type());
+        assertEquals(ProtobufType.INT32, schema.message("test.Person.ScoresEntry").field(2).type());
+    }
+
+    @Test
+    public void shouldMarkProto3Optional()
+    {
+        ProtobufSchema schema = Protobuf.schema(PROTO3);
+
+        assertTrue(schema.message("test.Person").field(9).proto3Optional());
+    }
+
+    @Test
+    public void shouldPackProto3RepeatedScalarByDefault()
+    {
+        ProtobufSchema schema = Protobuf.schema(PROTO3);
+
+        assertTrue(schema.message("test.Person").field(3).packed());
+    }
+
+    @Test
+    public void shouldRoundTripProto3NestedRepeatedAndMaps()
+    {
+        ProtobufSchema schema = Protobuf.schema(PROTO3);
+        String json = "{" +
+            "\"name\":\"neo\"," +
+            "\"home\":{\"name\":\"Zion\"}," +
+            "\"nums\":[1,2,3]," +
+            "\"tags\":[\"a\",\"b\"]," +
+            "\"props\":{\"k\":\"v\"}," +
+            "\"scores\":{\"s\":7}" +
+            "}";
+
+        assertEquals(json, roundTrip(schema, "test.Person", json));
+    }
+
+    @Test
+    public void shouldRenderProto3EnumAsName()
+    {
+        ProtobufSchema schema = Protobuf.schema(PROTO3);
+
+        assertEquals("{\"color\":\"GREEN\"}", roundTrip(schema, "test.Person", "{\"color\":\"GREEN\"}"));
+    }
+
+    @Test
+    public void shouldCompileProto2OneofAndMap()
+    {
+        ProtobufSchema schema = Protobuf.schema(PROTO2);
+
+        assertEquals("kind", schema.message("test.Account").field(6).oneofName());
+        assertEquals("kind", schema.message("test.Account").field(7).oneofName());
+        assertTrue(schema.message("test.Account.ScoresEntry").mapEntry());
+        assertEquals("test.Status", schema.message("test.Account").field(4).typeName());
+    }
+
+    @Test
+    public void shouldNotPackProto2RepeatedScalarByDefault()
+    {
+        ProtobufSchema schema = Protobuf.schema(PROTO2);
+
+        assertFalse(schema.message("test.Account").field(3).packed());
+    }
+
+    @Test
+    public void shouldValidateProto2RequiredField()
+    {
+        ProtobufSchema schema = Protobuf.schema(PROTO2);
+
+        byte[] valid = wire(g -> g.writeString(1, "neo"));
+        byte[] missing = wire(g -> g.writeInt32(2, 7));
+
+        assertTrue(schema.validate("test.Account", new UnsafeBuffer(valid), 0, valid.length));
+        assertFalse(schema.validate("test.Account", new UnsafeBuffer(missing), 0, missing.length));
+    }
+
+    @Test
+    public void shouldHonorExplicitPackedAndJsonNameOptions()
+    {
+        ProtobufSchema schema = Protobuf.schema(
+            "syntax = \"proto3\";\n" +
+            "message M {\n" +
+            "  repeated int32 nums = 1 [packed = false];\n" +
+            "  string user_id = 2 [json_name = \"uid\"];\n" +
+            "}\n");
+
+        assertFalse(schema.message("M").field(1).packed());
+        assertEquals("uid", schema.message("M").field(2).jsonName());
+    }
+
+    @Test
+    public void shouldDeriveJsonNameForSnakeCaseField()
+    {
+        ProtobufSchema schema = Protobuf.schema(
+            "syntax = \"proto3\";\n" +
+            "message M { string user_id = 1; }\n");
+
+        assertEquals("userId", schema.message("M").field(1).jsonName());
+    }
+
+    @Test
+    public void shouldCompileWithoutPackage()
+    {
+        ProtobufSchema schema = Protobuf.schema(
+            "syntax = \"proto3\";\n" +
+            "message Outer { message Inner { string v = 1; } Inner inner = 1; }\n");
+
+        assertNotNull(schema.message("Outer.Inner"));
+        assertEquals("Outer.Inner", schema.message("Outer").field(1).typeName());
+    }
+
+    @Test
+    public void shouldRejectEmptySource()
+    {
+        assertThrows(ProtobufException.class, () -> Protobuf.schema(""));
+        assertThrows(ProtobufException.class, () -> Protobuf.schema((CharSequence) null));
+    }
+
+    @Test
+    public void shouldRejectUnresolvedType()
+    {
+        assertThrows(ProtobufException.class, () -> Protobuf.schema(
+            "syntax = \"proto3\";\n" +
+            "message M { Missing other = 1; }\n"));
+    }
+
+    private static String roundTrip(
+        ProtobufSchema schema,
+        String messageName,
+        String json)
+    {
+        return toJson(schema, messageName, toProtobuf(schema, messageName, json));
+    }
+
+    private static String toJson(
+        ProtobufSchema schema,
+        String messageName,
+        byte[] wire)
+    {
+        MutableDirectBuffer out = new UnsafeBuffer(new byte[8192]);
+        ProtobufGenerator generator = ProtobufJson.generator(JsonEx.createGenerator(), schema, messageName);
+        generator.wrap(out, 0, out.capacity());
+        ProtobufPipeline pipeline = Protobuf.stream(Protobuf.parser(schema, messageName))
+            .into(ProtobufSink.of(generator, schema, messageName));
+        pipeline.reset();
+
+        assertEquals(Status.COMPLETED, pipeline.feed(new UnsafeBuffer(wire), 0, wire.length));
+        generator.flush();
+
+        byte[] bytes = new byte[generator.length()];
+        out.getBytes(0, bytes);
+        return new String(bytes, UTF_8);
+    }
+
+    private static byte[] toProtobuf(
+        ProtobufSchema schema,
+        String messageName,
+        String json)
+    {
+        MutableDirectBuffer out = new UnsafeBuffer(new byte[8192]);
+        ProtobufGenerator generator = Protobuf.generator().wrap(out, 0, out.capacity());
+        ProtobufPipeline pipeline = Protobuf.stream(ProtobufJson.parser(JsonEx.createParser(), schema, messageName))
+            .into(ProtobufSink.of(generator, schema, messageName));
+        pipeline.reset();
+
+        byte[] in = json.getBytes(UTF_8);
+        assertEquals(Status.COMPLETED, pipeline.feed(new UnsafeBuffer(in), 0, in.length));
+
+        byte[] bytes = new byte[generator.length()];
+        out.getBytes(0, bytes);
+        return bytes;
+    }
+
+    private static byte[] wire(
+        Consumer<ProtobufGenerator> body)
+    {
+        MutableDirectBuffer buffer = new UnsafeBuffer(new byte[8192]);
+        ProtobufGenerator generator = Protobuf.generator().wrap(buffer, 0, buffer.capacity());
+        body.accept(generator);
+        byte[] bytes = new byte[generator.length()];
+        buffer.getBytes(0, bytes);
+        return bytes;
+    }
+}


### PR DESCRIPTION
## Motivation

Foundation for re-platforming the `model-protobuf` converter (#1857) onto `common-protobuf`. The schema catalog hands the converter `.proto` **source text**, but `common-protobuf` today only compiles a `ProtobufSchema` from a binary `FileDescriptorSet` (`ProtobufSchemaCompiler`) or its programmatic builder — there is no `.proto` source parser. This PR closes that gap so the converter can resolve catalog schemas without re-introducing `protobuf-java`.

This is intentionally a standalone PR; the `model-protobuf` re-platform (the converter layer of #1857) lands separately and depends on this.

## Changes

- New `Protobuf.schema(CharSequence source)` public entry point.
- New internal `ProtobufSourceCompiler` that parses a single proto2 or proto3 file (syntax auto-detected) with the library's own ANTLR grammars — **no `protobuf-java` dependency**:
  - composite field type references resolved by the proto scoping rules (innermost enclosing scope outward) to the dotless full names the model keys on;
  - `map<k,v>` expanded to the synthetic `<Name>Entry` `map_entry` message + a repeated reference, matching `protoc`;
  - `oneof`, proto3 `optional`, enums, nested messages, explicit `[packed=...]` / `[json_name=...]` options, and proto2-vs-proto3 packed defaults handled.
- Grammars (`Protobuf2.g4`, `Protobuf3.g4`) added under `src/main/antlr4`; ANTLR runtime dependency + plugin wired in; generated parser package excluded from JaCoCo; `requires org.antlr.antlr4.runtime` added to the module descriptor.

## Tests

`ProtobufSourceCompilerTest` covers proto2 + proto3: name/type resolution, map-entry expansion, proto3 optional, packed defaults (proto2 unpacked vs proto3 packed), oneof, enum-by-name rendering, explicit packed/json_name options, no-package nesting, proto2 `required` validation, and JSON round-trips (nested/repeated/maps) driven through the existing `ProtobufJson` pipeline. Error paths (empty/null source, unresolved type) assert `ProtobufException`.

`./mvnw clean install -pl runtime/common-protobuf -DskipITs` passes (unit tests, checkstyle, license, JaCoCo, moditect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfzS5MmFH2NQBefvoB3o7d

---
_Generated by [Claude Code](https://claude.ai/code/session_01MfzS5MmFH2NQBefvoB3o7d)_