### PR TITLE
refactor(common-json): adapt JsonParserEx via Source/Control instead of casting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           docker load -i ~/docker-base-cache/base-images.tar || true
         fi
     - name: Build with Maven
-      run: ./mvnw -B -U -nsu -ntp -Ddocker.logStdout -Dfailsafe.skipAfterFailureCount=1 -Ddocker.verbose install jacoco:report-aggregate
+      run: ./mvnw -B -nsu -ntp -Ddocker.logStdout -Dfailsafe.skipAfterFailureCount=1 -Ddocker.verbose install jacoco:report-aggregate
       env:
         GITHUB_ACTOR: ${{ github.actor }}
         GITHUB_TOKEN: ${{ github.token }}

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonParserEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonParserEx.java
@@ -83,10 +83,34 @@ public interface JsonParserEx extends JsonParser
     boolean hasNextEvent();
 
     /**
-     * Advances and returns the next {@link JsonEvent} of the pipeline event stream — a superset of the
-     * standard {@code jakarta.json.stream.JsonParser.Event} adding document framing and segment delivery.
+     * How {@link #nextEvent(Mode)} delivers the value at the current boundary: {@code STRUCTURED} emits the
+     * typed event stream; {@code SEGMENTED} opts the value (and its descendants) in to verbatim delivery as a
+     * {@link JsonEvent#segmented()} run, read via {@link #getSegment()}. Best-effort and consulted only at a
+     * value boundary; for every other event it is ignored.
      */
-    JsonEvent nextEvent();
+    enum Mode
+    {
+        STRUCTURED,
+        SEGMENTED
+    }
+
+    /**
+     * Advances and returns the next {@link JsonEvent} in {@link Mode#STRUCTURED} mode.
+     */
+    default JsonEvent nextEvent()
+    {
+        return nextEvent(Mode.STRUCTURED);
+    }
+
+    /**
+     * Advances and returns the next {@link JsonEvent} of the pipeline event stream — a superset of the
+     * standard {@code jakarta.json.stream.JsonParser.Event} adding document framing and segment delivery. At a
+     * value boundary {@code mode} chooses structured events ({@link Mode#STRUCTURED}) or a verbatim segment run
+     * ({@link Mode#SEGMENTED}); elsewhere it is ignored. This is the mode-driven peer of a stage's
+     * {@link JsonController#segmentable()}, so the segment request need not narrow onto the parser surface.
+     */
+    JsonEvent nextEvent(
+        Mode mode);
 
     /**
      * A non-owning, on-stack {@link CharSequence} view of the current scalar token — a string value, a
@@ -97,4 +121,30 @@ public interface JsonParserEx extends JsonParser
      * so a caller holding a {@code JsonParserEx} reads scalars without narrowing to {@link JsonSource}.
      */
     CharSequence getStringView();
+
+    /**
+     * Valid only when the current event is {@link JsonEvent#segmented()}; non-owning view of the current
+     * contiguous slice, valid on-stack only. The {@link JsonSource#getSegment()} accessor promoted onto the
+     * parser surface so a pipeline exposes it to a stage without narrowing to {@link JsonSource}.
+     */
+    DirectBuffer getSegment();
+
+    /**
+     * Whether the current value has bytes still deferred to later events — {@code true} while more of this same
+     * value follows (the value is being streamed across input frames because it exceeds the input window),
+     * {@code false} when this event completes it. The {@link JsonSource#deferredBytes()} accessor promoted onto
+     * the parser surface.
+     */
+    boolean deferredBytes();
+
+    /**
+     * Reports {@code sourceBytes} source bytes consumed by a verbatim segment write so the parser advances its
+     * {@link #position()} and re-exposes the value remainder on resume — the output-side pushback that lets a
+     * terminal sink stream a length-delimited value without keeping its own offset. The default does nothing,
+     * for a parser whose values are never delivered in bounded pieces.
+     */
+    default void consumed(
+        int sourceBytes)
+    {
+    }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -37,13 +37,12 @@ import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
 import io.aklivity.zilla.runtime.common.json.DirectBufferInputStreamEx;
-import io.aklivity.zilla.runtime.common.json.JsonController;
 import io.aklivity.zilla.runtime.common.json.JsonEvent;
 import io.aklivity.zilla.runtime.common.json.JsonParserEx;
-import io.aklivity.zilla.runtime.common.json.JsonSource;
+import io.aklivity.zilla.runtime.common.json.JsonParserEx.Mode;
 import io.aklivity.zilla.runtime.common.json.internal.json.JsonValues;
 
-public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonController
+public final class JsonParserImpl implements JsonParserEx
 {
     private final InputStream in;
     private final DirectBufferInputStreamEx ownedInput;
@@ -227,10 +226,39 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
     }
 
     @Override
-    public JsonEvent nextEvent()
+    public JsonEvent nextEvent(
+        Mode mode)
     {
+        if (mode == Mode.SEGMENTED)
+        {
+            // arm the just-delivered boundary to stream verbatim before pulling its events (the mode-driven
+            // peer of a stage's JsonController.segmentable(); keyed off the previously delivered event)
+            if (lastEvent == JsonEvent.START_OBJECT || lastEvent == JsonEvent.START_ARRAY)
+            {
+                segmentStartOffset = tokenizer.streamOffset() - 1;
+                segmentState = SegmentState.PENDING_START;
+                segmentDepth = 1;
+                tokenizer.segmenting(true);
+            }
+            else if (lastEvent == JsonEvent.START_DOCUMENT)
+            {
+                armNextValue = true;
+                // a bare top-level string then streams verbatim too; cleared by the tokenizer for a non-string
+                tokenizer.scalarSegment(true);
+            }
+            else if (lastEvent == JsonEvent.KEY_NAME)
+            {
+                // arm the upcoming value-string to stream verbatim; the tokenizer clears it for a non-string
+                tokenizer.scalarSegment(true);
+            }
+        }
         JsonEvent event;
-        if (docState == DocState.NOT_STARTED)
+        if (!hasNextEvent())
+        {
+            // window consumed mid-document, or the document already ended: no event this pull
+            event = null;
+        }
+        else if (docState == DocState.NOT_STARTED)
         {
             docState = DocState.STARTED;
             event = JsonEvent.START_DOCUMENT;
@@ -244,11 +272,14 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
         {
             event = nextToken();
         }
-        // lastEvent is the canonical delivered event (the basis for the streaming-only accessor asserts);
-        // currentEvent is its jakarta projection (null for a segment or document framing), keeping the
-        // shared jakarta getters' asserts valid whether driven by the pipeline or the raw parser
-        lastEvent = event;
-        currentEvent = toEvent(event);
+        if (event != null)
+        {
+            // lastEvent is the canonical delivered event (the basis for the streaming-only accessor asserts);
+            // currentEvent is its jakarta projection (null for a segment or document framing), keeping the
+            // shared jakarta getters' asserts valid whether driven by the pipeline or the raw parser
+            lastEvent = event;
+            currentEvent = toEvent(event);
+        }
         return event;
     }
 
@@ -394,29 +425,6 @@ public final class JsonParserImpl implements JsonParserEx, JsonSource, JsonContr
             }
         }
         return event;
-    }
-
-    @Override
-    public void segmentable()
-    {
-        if (lastEvent == JsonEvent.START_OBJECT || lastEvent == JsonEvent.START_ARRAY)
-        {
-            segmentStartOffset = tokenizer.streamOffset() - 1;
-            segmentState = SegmentState.PENDING_START;
-            segmentDepth = 1;
-            tokenizer.segmenting(true);
-        }
-        else if (lastEvent == JsonEvent.START_DOCUMENT)
-        {
-            armNextValue = true;
-            // a bare top-level string then streams verbatim too; cleared by the tokenizer for any non-string
-            tokenizer.scalarSegment(true);
-        }
-        else if (lastEvent == JsonEvent.KEY_NAME)
-        {
-            // arm the upcoming value-string to stream verbatim; the tokenizer clears it for a non-string
-            tokenizer.scalarSegment(true);
-        }
     }
 
     @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
@@ -14,6 +14,9 @@
  */
 package io.aklivity.zilla.runtime.common.json.internal;
 
+import java.math.BigDecimal;
+
+import jakarta.json.stream.JsonLocation;
 import jakarta.json.stream.JsonParsingException;
 
 import org.agrona.DirectBuffer;
@@ -21,6 +24,7 @@ import org.agrona.DirectBuffer;
 import io.aklivity.zilla.runtime.common.json.JsonController;
 import io.aklivity.zilla.runtime.common.json.JsonEvent;
 import io.aklivity.zilla.runtime.common.json.JsonParserEx;
+import io.aklivity.zilla.runtime.common.json.JsonParserEx.Mode;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonSink;
 import io.aklivity.zilla.runtime.common.json.JsonSource;
@@ -28,14 +32,14 @@ import io.aklivity.zilla.runtime.common.json.JsonSource;
 /**
  * Backs {@link JsonPipeline}: holds the bound root {@link JsonSink} and the {@link JsonParserEx}
  * driver. {@link #feed(DirectBuffer, int, int)} re-targets the parser at the frame buffer then pumps
- * each parsed event through the root sink, passing the parser itself as the immutable
- * {@code JsonSource} view and the {@link JsonController}.
+ * each parsed event through the root sink, passing a {@link Source} view that adapts the parser to the
+ * immutable {@code JsonSource} surface and a {@link Control} that adapts it to the {@link JsonController}.
  */
 public final class JsonPipelineImpl implements JsonPipeline
 {
     private final JsonParserEx parser;
-    private final JsonSource source;
-    private final JsonController control;
+    private final Source source;
+    private final Control control;
     private final JsonSink root;
 
     private boolean suspended;
@@ -47,9 +51,9 @@ public final class JsonPipelineImpl implements JsonPipeline
         JsonSink root)
     {
         this.parser = parser;
-        // the parser is also the per-event source view and the upstream controller a stage steers
-        this.source = (JsonSource) parser;
-        this.control = (JsonController) parser;
+        // the source view and the upstream controller a stage steers are adapters over the parser surface
+        this.source = new Source(parser);
+        this.control = new Control(parser);
         this.root = root;
     }
 
@@ -86,9 +90,16 @@ public final class JsonPipelineImpl implements JsonPipeline
             {
                 parser.wrap(buffer, offset, length, last);
             }
-            while (status == Status.ADVANCED && parser.hasNextEvent())
+            while (status == Status.ADVANCED)
             {
-                final JsonEvent event = parser.nextEvent();
+                // pull with the requested mode before any tokenizer advance, so a segmentable() request lands
+                // on the just-delivered boundary; a null event means the window is consumed (no hasNextEvent()
+                // gate here, which would advance the tokenizer past the boundary before the mode is applied)
+                final JsonEvent event = parser.nextEvent(control.mode());
+                if (event == null)
+                {
+                    break;
+                }
                 status = root.feed(control, source, event);
                 if (status == Status.SUSPENDED)
                 {
@@ -109,5 +120,107 @@ public final class JsonPipelineImpl implements JsonPipeline
         }
         suspended = status == Status.SUSPENDED;
         return status;
+    }
+
+    // Adapts the parser to the non-advancing JsonSource view a stage reads off the current event.
+    private static final class Source implements JsonSource
+    {
+        private final JsonParserEx parser;
+
+        private Source(
+            JsonParserEx parser)
+        {
+            this.parser = parser;
+        }
+
+        @Override
+        public String getString()
+        {
+            return parser.getString();
+        }
+
+        @Override
+        public CharSequence getStringView()
+        {
+            return parser.getStringView();
+        }
+
+        @Override
+        public BigDecimal getBigDecimal()
+        {
+            return parser.getBigDecimal();
+        }
+
+        @Override
+        public boolean isIntegralNumber()
+        {
+            return parser.isIntegralNumber();
+        }
+
+        @Override
+        public int getInt()
+        {
+            return parser.getInt();
+        }
+
+        @Override
+        public long getLong()
+        {
+            return parser.getLong();
+        }
+
+        @Override
+        public JsonLocation getLocation()
+        {
+            return parser.getLocation();
+        }
+
+        @Override
+        public DirectBuffer getSegment()
+        {
+            return parser.getSegment();
+        }
+
+        @Override
+        public boolean deferredBytes()
+        {
+            return parser.deferredBytes();
+        }
+    }
+
+    // Adapts the parser to the JsonController a stage uses to steer its immediate upstream: a segmentable()
+    // request becomes a one-shot SEGMENTED mode the pump threads into the parser's next pull, so the segment
+    // request need not narrow onto the parser surface; consumed() pushback forwards to the parser's cursor.
+    private static final class Control implements JsonController
+    {
+        private final JsonParserEx parser;
+
+        private boolean segmented;
+
+        private Control(
+            JsonParserEx parser)
+        {
+            this.parser = parser;
+        }
+
+        @Override
+        public void segmentable()
+        {
+            segmented = true;
+        }
+
+        @Override
+        public void consumed(
+            int sourceBytes)
+        {
+            parser.consumed(sourceBytes);
+        }
+
+        private Mode mode()
+        {
+            Mode mode = segmented ? Mode.SEGMENTED : Mode.STRUCTURED;
+            segmented = false;
+            return mode;
+        }
     }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
@@ -52,6 +52,7 @@ import org.agrona.DirectBuffer;
 import io.aklivity.zilla.runtime.common.json.JsonController;
 import io.aklivity.zilla.runtime.common.json.JsonEvent;
 import io.aklivity.zilla.runtime.common.json.JsonParserEx;
+import io.aklivity.zilla.runtime.common.json.JsonParserEx.Mode;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
 import io.aklivity.zilla.runtime.common.json.JsonRefResolver;
 import io.aklivity.zilla.runtime.common.json.JsonSchema;
@@ -2102,15 +2103,28 @@ public final class JsonSchemaImpl implements JsonSchema
         }
 
         @Override
-        public JsonEvent nextEvent()
+        public JsonEvent nextEvent(
+            Mode mode)
         {
-            return delegateEx.nextEvent();
+            return delegateEx.nextEvent(mode);
         }
 
         @Override
         public CharSequence getStringView()
         {
             return delegateEx != null ? delegateEx.getStringView() : delegate.getString();
+        }
+
+        @Override
+        public DirectBuffer getSegment()
+        {
+            return delegateEx.getSegment();
+        }
+
+        @Override
+        public boolean deferredBytes()
+        {
+            return delegateEx.deferredBytes();
         }
 
         private void report(

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserDocumentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserDocumentTest.java
@@ -22,6 +22,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
 import io.aklivity.zilla.runtime.common.json.JsonEvent;
+import io.aklivity.zilla.runtime.common.json.JsonParserEx.Mode;
 
 public class JsonParserDocumentTest
 {
@@ -60,8 +61,7 @@ public class JsonParserDocumentTest
 
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.START_OBJECT, parser.nextEvent());
-        parser.segmentable();
-        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent(Mode.SEGMENTED));
         assertEquals(JsonEvent.END_DOCUMENT, parser.nextEvent());
         assertFalse(parser.hasNextEvent());
     }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserSegmentHardeningTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserSegmentHardeningTest.java
@@ -24,6 +24,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
 import io.aklivity.zilla.runtime.common.json.JsonEvent;
+import io.aklivity.zilla.runtime.common.json.JsonParserEx.Mode;
 
 public class JsonParserSegmentHardeningTest
 {
@@ -35,8 +36,7 @@ public class JsonParserSegmentHardeningTest
         wrap(parser, "{\"a\":1,");
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.START_OBJECT, parser.nextEvent());
-        parser.segmentable();
-        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent(Mode.SEGMENTED));
         final String first = segment(parser);
         assertEquals("{\"a\":1,", first);
         assertTrue(parser.deferredBytes());
@@ -67,8 +67,7 @@ public class JsonParserSegmentHardeningTest
 
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.START_OBJECT, parser.nextEvent());
-        parser.segmentable();
-        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent(Mode.SEGMENTED));
         assertEquals("{}", segment(parser));
         assertFalse(parser.deferredBytes());
         assertEquals(JsonEvent.END_DOCUMENT, parser.nextEvent());
@@ -82,8 +81,7 @@ public class JsonParserSegmentHardeningTest
 
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.START_ARRAY, parser.nextEvent());
-        parser.segmentable();
-        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent(Mode.SEGMENTED));
         assertEquals("[]", segment(parser));
         assertFalse(parser.deferredBytes());
         assertEquals(JsonEvent.END_DOCUMENT, parser.nextEvent());
@@ -97,8 +95,7 @@ public class JsonParserSegmentHardeningTest
         wrap(parser, "{\"a\":1} ");
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.START_OBJECT, parser.nextEvent());
-        parser.segmentable();
-        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent(Mode.SEGMENTED));
         assertEquals("{\"a\":1}", segment(parser));
         assertFalse(parser.deferredBytes());
         assertEquals(JsonEvent.END_DOCUMENT, parser.nextEvent());
@@ -124,8 +121,7 @@ public class JsonParserSegmentHardeningTest
         wrap(parser, "{\"a\":1,");
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.START_OBJECT, parser.nextEvent());
-        parser.segmentable();
-        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent(Mode.SEGMENTED));
         assertEquals("{\"a\":1,", segment(parser));
         assertTrue(parser.deferredBytes());
         assertFalse(parser.hasNextEvent());

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserSegmentTest.java
@@ -24,6 +24,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
 import io.aklivity.zilla.runtime.common.json.JsonEvent;
+import io.aklivity.zilla.runtime.common.json.JsonParserEx.Mode;
 
 public class JsonParserSegmentTest
 {
@@ -35,8 +36,7 @@ public class JsonParserSegmentTest
 
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.START_OBJECT, parser.nextEvent());
-        parser.segmentable();
-        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent(Mode.SEGMENTED));
         assertEquals("{\"a\":1}", segment(parser));
         assertFalse(parser.deferredBytes());
     }
@@ -49,8 +49,7 @@ public class JsonParserSegmentTest
 
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.START_OBJECT, parser.nextEvent());
-        parser.segmentable();
-        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent(Mode.SEGMENTED));
         assertEquals("{\"a\":\"}{\"}", segment(parser));
         assertFalse(parser.deferredBytes());
     }
@@ -63,8 +62,7 @@ public class JsonParserSegmentTest
 
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.START_ARRAY, parser.nextEvent());
-        parser.segmentable();
-        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent(Mode.SEGMENTED));
         assertEquals("[1,2,3]", segment(parser));
         assertFalse(parser.deferredBytes());
     }
@@ -80,8 +78,7 @@ public class JsonParserSegmentTest
         assertEquals(JsonEvent.KEY_NAME, parser.nextEvent());
         assertEquals("a", parser.getString());
         assertEquals(JsonEvent.START_OBJECT, parser.nextEvent());
-        parser.segmentable();
-        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent(Mode.SEGMENTED));
         assertEquals("{\"x\":1}", segment(parser));
         assertFalse(parser.deferredBytes());
         assertEquals(JsonEvent.KEY_NAME, parser.nextEvent());
@@ -99,8 +96,7 @@ public class JsonParserSegmentTest
         wrap(parser, "{\"a\":1,");
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.START_OBJECT, parser.nextEvent());
-        parser.segmentable();
-        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent(Mode.SEGMENTED));
         final String first = segment(parser);
         assertEquals("{\"a\":1,", first);
         assertTrue(parser.deferredBytes());
@@ -123,8 +119,9 @@ public class JsonParserSegmentTest
 
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
         assertEquals(JsonEvent.VALUE_NUMBER, parser.nextEvent());
-        parser.segmentable();
         assertEquals("42", parser.getString());
+        // requesting SEGMENTED with a scalar as the last delivered event is ignored
+        assertEquals(JsonEvent.END_DOCUMENT, parser.nextEvent(Mode.SEGMENTED));
     }
 
     @Test
@@ -134,8 +131,7 @@ public class JsonParserSegmentTest
         wrap(parser, "{ \"a\" : 1 } ");
 
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
-        parser.segmentable();
-        assertEquals(JsonEvent.SEGMENT, parser.nextEvent());
+        assertEquals(JsonEvent.SEGMENT, parser.nextEvent(Mode.SEGMENTED));
         assertEquals("{ \"a\" : 1 }", segment(parser));
         assertFalse(parser.deferredBytes());
         assertEquals(JsonEvent.END_DOCUMENT, parser.nextEvent());
@@ -148,8 +144,7 @@ public class JsonParserSegmentTest
         wrap(parser, "42 ");
 
         assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
-        parser.segmentable();
-        assertEquals(JsonEvent.VALUE_NUMBER, parser.nextEvent());
+        assertEquals(JsonEvent.VALUE_NUMBER, parser.nextEvent(Mode.SEGMENTED));
         assertEquals("42", parser.getString());
         assertEquals(JsonEvent.END_DOCUMENT, parser.nextEvent());
     }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -24,8 +24,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.json.stream.JsonParser;
-
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
@@ -336,12 +334,11 @@ class JsonPipelineChunkingTest
         {
             if (event == JsonEvent.VALUE_NUMBER && !source.deferredBytes())
             {
-                final JsonParser number = (JsonParser) source;
-                wholes.add(number.getBigDecimal());
+                wholes.add(source.getBigDecimal());
                 boolean rejected = false;
                 try
                 {
-                    number.getInt();
+                    source.getInt();
                 }
                 catch (IllegalStateException ex)
                 {


### PR DESCRIPTION
## Summary

Eliminates the `(JsonSource)` / `(JsonController)` casts of the parser in `JsonPipelineImpl`, replacing them with `Source` and `Control` inner adapters that delegate through the `JsonParserEx` interface — mirroring `AvroPipelineImpl`.

## Changes

- **`JsonParserEx`** — promotes `getSegment()`, `deferredBytes()`, and `consumed()` (default no-op) onto the interface, as `AvroParser` does. Adds a `Mode { STRUCTURED, SEGMENTED }` enum and `nextEvent(Mode)`, with `nextEvent()` as a default delegating to `STRUCTURED`. `segmentable()` is intentionally **not** on the interface.
- **`JsonPipelineImpl`** — `Source implements JsonSource` and `Control implements JsonController` delegate to the parser. `Control.segmentable()` records a one-shot flag; the pump threads `control.mode()` into `parser.nextEvent(...)`.
- **`JsonParserImpl`** — now `implements JsonParserEx` only (drops `JsonSource, JsonController`). The `segmentable()` method is removed; its arming logic is inlined into `nextEvent(Mode.SEGMENTED)`, matching `AvroParserImpl`.
- **`JsonSchemaImpl.ValidatingParser`** — updated to the new `JsonParserEx` surface (`nextEvent(Mode)`, `getSegment`, `deferredBytes`).

### Pump fix

JSON's pump previously called `parser.hasNextEvent()` in the loop condition, which advanced the tokenizer **past** the value boundary before the deferred `SEGMENTED` mode could arm — corrupting segment start offsets (e.g. `{ "a" : 1 }` → `" : 1 }`). The pump now mirrors Avro: pull with the requested mode first, `break` on a `null` event, so arming precedes the advance.

## Tests

Parser-level tests drive segmentation via `nextEvent(Mode.SEGMENTED)` instead of `parser.segmentable()`; the chunking probe reads `source.getBigDecimal()` / `getInt()` directly rather than casting `source` to `JsonParser`.

**4787 tests pass, 0 checkstyle violations.**

---

## Unrelated: CI build flag cleanup

Also drops `-U` from the `Build with Maven` step in `.github/workflows/build.yml`. The command carried both `-U` (force snapshot/metadata update) and `-nsu` (no snapshot updates), which are contradictory; `-U` forced a re-fetch of every group's `maven-metadata.xml` each build, adding remote chatter. Keeps `-nsu -ntp`.

Note: for `pull_request` events GitHub uses the workflow definition from the **base** branch, so this flag change takes effect once merged to `develop`, not on this PR's own build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfJwE4PAk8wzfKVgLw4RXs