### PR TITLE
feat(common-protobuf): strict reject-unknown-fields option + pipeline rejection reason

### DIFF
--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufPipeline.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufPipeline.java
@@ -76,6 +76,16 @@ public interface ProtobufPipeline
     void reset();
 
     /**
+     * A short, human-readable reason for the most recent {@link Status#REJECTED} — e.g. an unknown
+     * field, an unknown enum value, or truncated input — or {@code null} when the last feed did not
+     * reject. Cleared by {@link #reset()}.
+     */
+    default String reason()
+    {
+        return null;
+    }
+
+    /**
      * The number of input bytes committed since the message began — always at a whole-unit boundary. On
      * {@link Status#STARVED} everything at or after this position is the unconsumed tail: the caller
      * retains it (typically in its own reassembly slot) and re-presents it, contiguous with the next

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufPipelineImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufPipelineImpl.java
@@ -46,6 +46,7 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
 
     private boolean suspended;
     private boolean starved;
+    private String reason;
     // the event in flight across an output suspend, handed to head.resume() so no sink stores it
     private ProtobufEvent resumeEvent;
 
@@ -74,6 +75,7 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
         head.reset();
         suspended = false;
         starved = false;
+        reason = null;
         resumeEvent = null;
     }
 
@@ -81,6 +83,12 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
     public long position()
     {
         return parser.position();
+    }
+
+    @Override
+    public String reason()
+    {
+        return reason;
     }
 
     @Override
@@ -130,6 +138,7 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
         catch (ProtobufException ex)
         {
             status = Status.REJECTED;
+            reason = ex.getMessage();
         }
         return status;
     }

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/json/ProtobufJson.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/json/ProtobufJson.java
@@ -85,12 +85,35 @@ public final class ProtobufJson
      * encodes it. Streams windowed JSON input, returning {@code null} from {@code nextEvent} on a partial
      * window and continuing via {@code resume}.
      */
+    /**
+     * Generator/parser config key (a {@link Boolean}): when {@code true}, the parser rejects unknown JSON
+     * fields (the message reaches {@link io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline.Status#REJECTED}
+     * with a reason) instead of silently ignoring them. Absent or {@code false} keeps the default of ignoring
+     * unknown fields. Reject mirrors the proto3 JSON mapping's default for a strict parser.
+     */
+    public static final String REJECT_UNKNOWN_FIELDS =
+        "io.aklivity.zilla.runtime.common.protobuf.json.reject.unknown.fields";
+
     public static ProtobufParser parser(
         JsonParserEx parser,
         ProtobufSchema schema,
         String messageName)
     {
         return new ProtobufJsonParserImpl(parser, schema, messageName);
+    }
+
+    /**
+     * As {@link #parser(JsonParserEx, ProtobufSchema, String)}, configured via {@code config} — see
+     * {@link #REJECT_UNKNOWN_FIELDS}.
+     */
+    public static ProtobufParser parser(
+        JsonParserEx parser,
+        ProtobufSchema schema,
+        String messageName,
+        Map<String, ?> config)
+    {
+        boolean rejectUnknownFields = Boolean.TRUE.equals(config.get(REJECT_UNKNOWN_FIELDS));
+        return new ProtobufJsonParserImpl(parser, schema, messageName, rejectUnknownFields);
     }
 
     /**

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/json/internal/ProtobufJsonParserImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/json/internal/ProtobufJsonParserImpl.java
@@ -67,6 +67,7 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
     private final JsonParserEx parser;
     private final ProtobufSchema schema;
     private final String messageName;
+    private final boolean rejectUnknownFields;
     private final UnsafeBuffer estimateView;
     private final ExpandableArrayBuffer valueBuffer;
     private final UnsafeBuffer valueView;
@@ -101,9 +102,19 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
         ProtobufSchema schema,
         String messageName)
     {
+        this(parser, schema, messageName, false);
+    }
+
+    public ProtobufJsonParserImpl(
+        JsonParserEx parser,
+        ProtobufSchema schema,
+        String messageName,
+        boolean rejectUnknownFields)
+    {
         this.parser = parser;
         this.schema = schema;
         this.messageName = messageName;
+        this.rejectUnknownFields = rejectUnknownFields;
         this.estimateView = new UnsafeBuffer(new byte[ESTIMATE]);
         this.valueBuffer = new ExpandableArrayBuffer();
         this.valueView = new UnsafeBuffer();
@@ -345,6 +356,10 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
                 ProtobufField field = frame.message.field(parser.getStringView());
                 if (field == null)
                 {
+                    if (rejectUnknownFields)
+                    {
+                        throw new ProtobufException("unknown field " + parser.getStringView());
+                    }
                     beginSkip();
                 }
                 else

--- a/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/json/ProtobufJsonStrictTest.java
+++ b/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/json/ProtobufJsonStrictTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.protobuf.json;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+import io.aklivity.zilla.runtime.common.json.JsonEx;
+import io.aklivity.zilla.runtime.common.protobuf.Protobuf;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufGenerator;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufParser;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline.Status;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufSchema;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufSink;
+
+public class ProtobufJsonStrictTest
+{
+    private static final String SCHEMA =
+        "syntax = \"proto3\";\n" +
+        "message Person { string name = 1; int32 id = 2; }\n";
+
+    @Test
+    public void shouldRejectUnknownFieldWhenConfigured()
+    {
+        ProtobufSchema schema = Protobuf.schema(SCHEMA);
+        ProtobufGenerator generator = Protobuf.generator().wrap(new UnsafeBuffer(new byte[256]), 0, 256);
+        ProtobufParser parser = ProtobufJson.parser(JsonEx.createParser(), schema, "Person",
+            Map.of(ProtobufJson.REJECT_UNKNOWN_FIELDS, Boolean.TRUE));
+        ProtobufPipeline pipeline = Protobuf.stream(parser).into(ProtobufSink.of(generator, schema, "Person"));
+        pipeline.reset();
+
+        byte[] in = "{\"name\":\"neo\",\"nope\":1}".getBytes(UTF_8);
+        assertEquals(Status.REJECTED, pipeline.feed(new UnsafeBuffer(in), 0, in.length));
+        assertTrue(pipeline.reason().contains("nope"), pipeline.reason());
+    }
+
+    @Test
+    public void shouldIgnoreUnknownFieldByDefault()
+    {
+        ProtobufSchema schema = Protobuf.schema(SCHEMA);
+        ProtobufGenerator generator = Protobuf.generator().wrap(new UnsafeBuffer(new byte[256]), 0, 256);
+        ProtobufParser parser = ProtobufJson.parser(JsonEx.createParser(), schema, "Person");
+        ProtobufPipeline pipeline = Protobuf.stream(parser).into(ProtobufSink.of(generator, schema, "Person"));
+        pipeline.reset();
+
+        byte[] in = "{\"name\":\"neo\",\"nope\":1}".getBytes(UTF_8);
+        assertEquals(Status.COMPLETED, pipeline.feed(new UnsafeBuffer(in), 0, in.length));
+        assertNull(pipeline.reason());
+    }
+
+    @Test
+    public void shouldReportNoReasonOnSuccess()
+    {
+        ProtobufSchema schema = Protobuf.schema(SCHEMA);
+        ProtobufGenerator generator = Protobuf.generator().wrap(new UnsafeBuffer(new byte[256]), 0, 256);
+        ProtobufParser parser = ProtobufJson.parser(JsonEx.createParser(), schema, "Person",
+            Map.of(ProtobufJson.REJECT_UNKNOWN_FIELDS, Boolean.TRUE));
+        ProtobufPipeline pipeline = Protobuf.stream(parser).into(ProtobufSink.of(generator, schema, "Person"));
+        pipeline.reset();
+
+        byte[] in = "{\"name\":\"neo\"}".getBytes(UTF_8);
+        assertEquals(Status.COMPLETED, pipeline.feed(new UnsafeBuffer(in), 0, in.length));
+        assertNull(pipeline.reason());
+    }
+
+    @Test
+    public void shouldClearReasonOnReset()
+    {
+        ProtobufSchema schema = Protobuf.schema(SCHEMA);
+        ProtobufGenerator generator = Protobuf.generator();
+        ProtobufParser parser = ProtobufJson.parser(JsonEx.createParser(), schema, "Person",
+            Map.of(ProtobufJson.REJECT_UNKNOWN_FIELDS, Boolean.TRUE));
+        ProtobufPipeline pipeline = Protobuf.stream(parser).into(ProtobufSink.of(generator, schema, "Person"));
+
+        MutableDirectBuffer out = new UnsafeBuffer(new byte[256]);
+        generator.wrap(out, 0, out.capacity());
+        pipeline.reset();
+        byte[] bad = "{\"nope\":1}".getBytes(UTF_8);
+        assertEquals(Status.REJECTED, pipeline.feed(new UnsafeBuffer(bad), 0, bad.length));
+
+        generator.wrap(out, 0, out.capacity());
+        pipeline.reset();
+        assertNull(pipeline.reason());
+        byte[] good = "{\"name\":\"neo\"}".getBytes(UTF_8);
+        assertEquals(Status.COMPLETED, pipeline.feed(new UnsafeBuffer(good), 0, good.length));
+    }
+}


### PR DESCRIPTION
## Motivation

Follow-up to the `model-protobuf` re-platform (#1912, part of #1857). Two `common-protobuf` additions the converter needs to restore behavior that the streaming library didn't yet expose:

1. **Spec-default strictness for unknown JSON fields.** The proto3 JSON→protobuf mapping says a parser should *reject* unknown fields by default (with an opt-in to ignore) — as `protobuf-java` `JsonFormat`, grpc-gateway, etc. do. `common-protobuf`'s `ProtobufJson` parser currently always *ignores* them, so the re-platformed `model-protobuf` write path lost the old strict rejection.
2. **Descriptive validation failures.** `ProtobufPipelineImpl.feed` caught `ProtobufException` and collapsed it to `REJECTED`, discarding the message — so consumers could only emit a generic failure event.

## Changes

- **`ProtobufJson.REJECT_UNKNOWN_FIELDS`** — a `Map<String, ?>` config key for `ProtobufJson.parser(...)`. When `true`, an unknown JSON field makes the message reach `REJECTED`; absent/`false` keeps the existing ignore behavior (so `ProtobufJsonTest.shouldIgnoreUnknownJsonField` is unchanged). The internal `ProtobufJsonParserImpl` gains a `rejectUnknownFields` flag; the existing 3-arg constructor delegates with `false`.
- **`ProtobufPipeline.reason()`** — a `default String reason()` returning a short human-readable reason for the most recent `REJECTED` (e.g. `unknown field nope`, `unknown enum value …`, `truncated json`), or `null` otherwise; cleared by `reset()`. `ProtobufPipelineImpl` records `ProtobufException.getMessage()` in the catch.

Both are additive; default behavior is unchanged.

## Tests

`ProtobufJsonStrictTest` — reject-unknown rejects with a reason containing the field name; default ignores (and `reason()` is null); `reason()` null on success; `reason()` cleared by `reset()`.

`./mvnw clean install -pl runtime/common-protobuf -DskipITs` passes (tests, checkstyle, license, JaCoCo, moditect).

## Next

#1912 will consume these: enable `REJECT_UNKNOWN_FIELDS` on the write path (reverting its `shouldWriteInvalidProtobufEventFormatJson` test to the unknown-field case), and emit `pipeline.reason()` as the descriptive validation-failure event message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfzS5MmFH2NQBefvoB3o7d

---
_Generated by [Claude Code](https://claude.ai/code/session_01MfzS5MmFH2NQBefvoB3o7d)_