### PR TITLE
Add diagnostic reporting for pipeline rejections

### DIFF
--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroDiagnostic.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroDiagnostic.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.avro;
+
+/**
+ * A description of a terminal {@link AvroPipeline.Status#REJECTED} failure, populated at the point of
+ * detection — by the parser for binary that cannot be decoded against its schema — and handed to an
+ * {@link AvroReporter}.
+ * <p>
+ * The instance is a reused, call-scoped view: it is valid only for the duration of the
+ * {@link AvroReporter#rejected(AvroDiagnostic)} callback. A reporter that needs to retain any of it must
+ * copy the value out immediately, before returning.
+ * <p>
+ * Starts with {@link #message()}; structured accessors (byte offset, field, category) may be added without
+ * changing the pipeline's {@code Status} contract.
+ */
+public interface AvroDiagnostic
+{
+    /**
+     * A short, human-readable reason for the rejection — e.g. an out-of-range union branch or enum ordinal,
+     * a negative block count, or a truncated variable-length integer — or {@code null} when the rejecting
+     * component supplied no message.
+     */
+    String message();
+}

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroReporter.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroReporter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.avro;
+
+/**
+ * Receives an {@link AvroDiagnostic} the pipeline pushes immediately before returning a terminal
+ * {@link AvroPipeline.Status#REJECTED} — and only then, never on {@link AvroPipeline.Status#STARVED} or
+ * {@link AvroPipeline.Status#SUSPENDED} back-pressure. Wire one at pipeline construction with
+ * {@link AvroStream#reporting(AvroReporter)}.
+ * <p>
+ * The callback runs on the engine worker thread on the cold failure path. The supplied diagnostic is a
+ * reused, call-scoped view valid only for the duration of the call; copy out anything that must outlive it
+ * before returning. Do not block or perform I/O.
+ */
+@FunctionalInterface
+public interface AvroReporter
+{
+    void rejected(
+        AvroDiagnostic diagnostic);
+}

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroStream.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroStream.java
@@ -17,14 +17,22 @@ package io.aklivity.zilla.runtime.common.avro;
 /**
  * A description of a {@code common-avro} pipeline — the schema-bound parse driver (from
  * {@link AvroSchema#parser()}) plus an ordered list of {@link AvroTransform} stages. Append stages with
- * {@link #transform(AvroTransform)} (left-to-right, in data-flow order); terminate with
- * {@link #into(AvroSink)} to obtain the runnable, resumable {@link AvroPipeline}. An {@code AvroStream}
- * carries no state and is not itself runnable.
+ * {@link #transform(AvroTransform)} (left-to-right, in data-flow order); optionally attach an
+ * {@link AvroReporter} with {@link #reporting(AvroReporter)}; terminate with {@link #into(AvroSink)} to
+ * obtain the runnable, resumable {@link AvroPipeline}. An {@code AvroStream} carries no state and is not
+ * itself runnable.
  */
 public interface AvroStream
 {
     AvroStream transform(
         AvroTransform transform);
+
+    /**
+     * Attaches the {@link AvroReporter} the pipeline pushes an {@link AvroDiagnostic} to on a terminal
+     * {@link AvroPipeline.Status#REJECTED}. The last attached reporter wins; the default is none.
+     */
+    AvroStream reporting(
+        AvroReporter reporter);
 
     AvroPipeline into(
         AvroSink sink);

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroPipelineImpl.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroPipelineImpl.java
@@ -22,10 +22,12 @@ import static io.aklivity.zilla.runtime.common.avro.AvroPipeline.Status.SUSPENDE
 import org.agrona.DirectBuffer;
 
 import io.aklivity.zilla.runtime.common.avro.AvroController;
+import io.aklivity.zilla.runtime.common.avro.AvroDiagnostic;
 import io.aklivity.zilla.runtime.common.avro.AvroEvent;
 import io.aklivity.zilla.runtime.common.avro.AvroLocation;
 import io.aklivity.zilla.runtime.common.avro.AvroParser;
 import io.aklivity.zilla.runtime.common.avro.AvroPipeline;
+import io.aklivity.zilla.runtime.common.avro.AvroReporter;
 import io.aklivity.zilla.runtime.common.avro.AvroSink;
 import io.aklivity.zilla.runtime.common.avro.AvroSource;
 import io.aklivity.zilla.runtime.common.avro.AvroType;
@@ -48,18 +50,23 @@ final class AvroPipelineImpl implements AvroPipeline
     private final Source source;
     private final Control control;
     private final AvroSink root;
+    private final AvroReporter reporter;
+    private final Diagnostic diagnostic;
 
     private boolean suspended;
     private AvroEvent suspendedEvent;
 
     AvroPipelineImpl(
         AvroParser parser,
-        AvroSink root)
+        AvroSink root,
+        AvroReporter reporter)
     {
         this.parser = parser;
         this.source = new Source(parser);
         this.control = new Control(parser);
         this.root = root;
+        this.reporter = reporter;
+        this.diagnostic = new Diagnostic();
     }
 
     @Override
@@ -68,6 +75,7 @@ final class AvroPipelineImpl implements AvroPipeline
         parser.reset();
         root.reset();
         suspended = false;
+        diagnostic.message = null;
     }
 
     @Override
@@ -114,6 +122,13 @@ final class AvroPipelineImpl implements AvroPipeline
         catch (AvroValidationException ex)
         {
             status = REJECTED;
+            diagnostic.message = ex.getMessage();
+        }
+        if (status == REJECTED && reporter != null)
+        {
+            // terminal failure only — never STARVED/SUSPENDED back-pressure; the diagnostic is a reused,
+            // call-scoped view, so the reporter must copy out anything it needs before returning
+            reporter.rejected(diagnostic);
         }
         suspended = status == SUSPENDED;
         // the pump remembers which event suspended (so the sink keeps no resume state); a re-suspend on
@@ -243,6 +258,19 @@ final class AvroPipelineImpl implements AvroPipeline
             AvroParser.Mode mode = segmented ? AvroParser.Mode.SEGMENTED : AvroParser.Mode.STRUCTURED;
             segmented = false;
             return mode;
+        }
+    }
+
+    // the reused, call-scoped diagnostic pushed to the reporter: its message is whatever the rejecting
+    // component populated — here the parser's caught validation exception
+    private static final class Diagnostic implements AvroDiagnostic
+    {
+        private String message;
+
+        @Override
+        public String message()
+        {
+            return message;
         }
     }
 }

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroStreamImpl.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroStreamImpl.java
@@ -22,6 +22,7 @@ import io.aklivity.zilla.runtime.common.avro.AvroEvent;
 import io.aklivity.zilla.runtime.common.avro.AvroParser;
 import io.aklivity.zilla.runtime.common.avro.AvroPipeline;
 import io.aklivity.zilla.runtime.common.avro.AvroPipeline.Status;
+import io.aklivity.zilla.runtime.common.avro.AvroReporter;
 import io.aklivity.zilla.runtime.common.avro.AvroSink;
 import io.aklivity.zilla.runtime.common.avro.AvroSource;
 import io.aklivity.zilla.runtime.common.avro.AvroStream;
@@ -31,6 +32,8 @@ public final class AvroStreamImpl implements AvroStream
 {
     private final AvroParser driver;
     private final List<AvroTransform> transforms;
+
+    private AvroReporter reporter;
 
     public AvroStreamImpl(
         AvroParser driver)
@@ -48,6 +51,14 @@ public final class AvroStreamImpl implements AvroStream
     }
 
     @Override
+    public AvroStream reporting(
+        AvroReporter reporter)
+    {
+        this.reporter = reporter;
+        return this;
+    }
+
+    @Override
     public AvroPipeline into(
         AvroSink sink)
     {
@@ -56,7 +67,7 @@ public final class AvroStreamImpl implements AvroStream
         {
             head = new BoundSink(transforms.get(i), head);
         }
-        return new AvroPipelineImpl(driver, head);
+        return new AvroPipelineImpl(driver, head, reporter);
     }
 
     private static final class BoundSink implements AvroSink

--- a/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/AvroMalformedTest.java
+++ b/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/AvroMalformedTest.java
@@ -14,9 +14,13 @@
  */
 package io.aklivity.zilla.runtime.common.avro;
 
+import static io.aklivity.zilla.runtime.common.avro.AvroPipeline.Status.COMPLETED;
 import static io.aklivity.zilla.runtime.common.avro.AvroPipeline.Status.REJECTED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
 public class AvroMalformedTest
@@ -26,6 +30,37 @@ public class AvroMalformedTest
         byte[] binary)
     {
         return AvroValues.record(Avro.schema(schemaText), binary).status;
+    }
+
+    @Test
+    public void shouldReportReasonWhenRejected()
+    {
+        String[] reason = new String[1];
+        AvroReporter reporter = d -> reason[0] = d.message();
+        AvroPipeline pipeline = Avro.stream(Avro.parser(Avro.schema("\"int\"")))
+            .reporting(reporter)
+            .into(new AvroValues.Recorder());
+        pipeline.reset();
+
+        byte[] overlong = { (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, 0x01 };
+        assertEquals(REJECTED, pipeline.feed(new UnsafeBuffer(overlong), 0, overlong.length));
+        assertNotNull(reason[0]);
+    }
+
+    @Test
+    public void shouldNotReportWhenAccepted()
+    {
+        String[] reason = new String[1];
+        AvroReporter reporter = d -> reason[0] = d.message();
+        AvroPipeline pipeline = Avro.stream(
+                Avro.parser(Avro.schema("{\"type\":\"enum\",\"name\":\"Suit\",\"symbols\":[\"SPADES\",\"HEARTS\"]}")))
+            .reporting(reporter)
+            .into(new AvroValues.Recorder());
+        pipeline.reset();
+
+        byte[] spades = { 0x00 };
+        assertEquals(COMPLETED, pipeline.feed(new UnsafeBuffer(spades), 0, spades.length));
+        assertNull(reason[0]);
     }
 
     @Test

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonDiagnostic.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonDiagnostic.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+/**
+ * A description of a terminal {@link JsonPipeline.Status#REJECTED} failure, populated at the point of
+ * detection — by the parser for malformed or schema-invalid input — and handed to a {@link JsonReporter}.
+ * <p>
+ * The instance is a reused, call-scoped view: it is valid only for the duration of the
+ * {@link JsonReporter#rejected(JsonDiagnostic)} callback. A reporter that needs to retain any of it must
+ * copy the value out immediately, before returning.
+ * <p>
+ * Starts with {@link #message()}; structured accessors (byte offset, JSON pointer, category) may be added
+ * without changing the pipeline's {@code Status} contract.
+ */
+public interface JsonDiagnostic
+{
+    /**
+     * A short, human-readable reason for the rejection — e.g. an invalid token, a schema-constraint
+     * violation, or truncated input — or {@code null} when the rejecting component supplied no message.
+     */
+    String message();
+}

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonReporter.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonReporter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+/**
+ * Receives a {@link JsonDiagnostic} the pipeline pushes immediately before returning a terminal
+ * {@link JsonPipeline.Status#REJECTED} — and only then, never on {@link JsonPipeline.Status#STARVED} or
+ * {@link JsonPipeline.Status#SUSPENDED} back-pressure. Wire one at pipeline construction with
+ * {@link JsonStream#reporting(JsonReporter)}.
+ * <p>
+ * The callback runs on the engine worker thread on the cold failure path. The supplied diagnostic is a
+ * reused, call-scoped view valid only for the duration of the call; copy out anything that must outlive it
+ * before returning. Do not block or perform I/O.
+ */
+@FunctionalInterface
+public interface JsonReporter
+{
+    void rejected(
+        JsonDiagnostic diagnostic);
+}

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonStream.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonStream.java
@@ -17,13 +17,21 @@ package io.aklivity.zilla.runtime.common.json;
 /**
  * A description of a {@code common-json} pipeline — a driver bound by {@link JsonEx#stream(JsonParserEx)} plus
  * an ordered list of {@link JsonTransform} stages. Append stages with {@link #transform(JsonTransform)}
- * (left-to-right, in data-flow order); terminate with {@link #into(JsonSink)} to obtain the runnable,
+ * (left-to-right, in data-flow order); optionally attach a {@link JsonReporter} with
+ * {@link #reporting(JsonReporter)}; terminate with {@link #into(JsonSink)} to obtain the runnable,
  * resumable {@link JsonPipeline}. A {@code JsonStream} carries no state and is not itself runnable.
  */
 public interface JsonStream
 {
     JsonStream transform(
         JsonTransform transform);
+
+    /**
+     * Attaches the {@link JsonReporter} the pipeline pushes a {@link JsonDiagnostic} to on a terminal
+     * {@link JsonPipeline.Status#REJECTED}. The last attached reporter wins; the default is none.
+     */
+    JsonStream reporting(
+        JsonReporter reporter);
 
     JsonPipeline into(
         JsonSink sink);

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
@@ -22,10 +22,12 @@ import jakarta.json.stream.JsonParsingException;
 import org.agrona.DirectBuffer;
 
 import io.aklivity.zilla.runtime.common.json.JsonController;
+import io.aklivity.zilla.runtime.common.json.JsonDiagnostic;
 import io.aklivity.zilla.runtime.common.json.JsonEvent;
 import io.aklivity.zilla.runtime.common.json.JsonParserEx;
 import io.aklivity.zilla.runtime.common.json.JsonParserEx.Mode;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
+import io.aklivity.zilla.runtime.common.json.JsonReporter;
 import io.aklivity.zilla.runtime.common.json.JsonSink;
 import io.aklivity.zilla.runtime.common.json.JsonSource;
 
@@ -41,6 +43,8 @@ public final class JsonPipelineImpl implements JsonPipeline
     private final Source source;
     private final Control control;
     private final JsonSink root;
+    private final JsonReporter reporter;
+    private final Diagnostic diagnostic;
 
     private boolean suspended;
     // the value event in flight across a suspend, handed to root.resume() so no stage stores it
@@ -48,13 +52,16 @@ public final class JsonPipelineImpl implements JsonPipeline
 
     public JsonPipelineImpl(
         JsonParserEx parser,
-        JsonSink root)
+        JsonSink root,
+        JsonReporter reporter)
     {
         this.parser = parser;
         // the source view and the upstream controller a stage steers are adapters over the parser surface
         this.source = new Source(parser);
         this.control = new Control(parser);
         this.root = root;
+        this.reporter = reporter;
+        this.diagnostic = new Diagnostic();
     }
 
     @Override
@@ -63,6 +70,7 @@ public final class JsonPipelineImpl implements JsonPipeline
         parser.reset();
         root.reset();
         suspended = false;
+        diagnostic.message = null;
         resumeEvent = null;
     }
 
@@ -117,6 +125,13 @@ public final class JsonPipelineImpl implements JsonPipeline
         catch (JsonParsingException ex)
         {
             status = Status.REJECTED;
+            diagnostic.message = ex.getMessage();
+        }
+        if (status == Status.REJECTED && reporter != null)
+        {
+            // terminal failure only — never STARVED/SUSPENDED back-pressure; the diagnostic is a reused,
+            // call-scoped view, so the reporter must copy out anything it needs before returning
+            reporter.rejected(diagnostic);
         }
         suspended = status == Status.SUSPENDED;
         return status;
@@ -221,6 +236,19 @@ public final class JsonPipelineImpl implements JsonPipeline
             Mode mode = segmented ? Mode.SEGMENTED : Mode.STRUCTURED;
             segmented = false;
             return mode;
+        }
+    }
+
+    // the reused, call-scoped diagnostic pushed to the reporter: its message is whatever the rejecting
+    // component populated — here the parser's caught parsing exception, or null for a truncated value
+    private static final class Diagnostic implements JsonDiagnostic
+    {
+        private String message;
+
+        @Override
+        public String message()
+        {
+            return message;
         }
     }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonStreamImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonStreamImpl.java
@@ -22,6 +22,7 @@ import io.aklivity.zilla.runtime.common.json.JsonEvent;
 import io.aklivity.zilla.runtime.common.json.JsonParserEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
+import io.aklivity.zilla.runtime.common.json.JsonReporter;
 import io.aklivity.zilla.runtime.common.json.JsonSink;
 import io.aklivity.zilla.runtime.common.json.JsonSource;
 import io.aklivity.zilla.runtime.common.json.JsonStream;
@@ -37,6 +38,8 @@ public final class JsonStreamImpl implements JsonStream
 {
     private final JsonParserEx parser;
     private final List<JsonTransform> transforms;
+
+    private JsonReporter reporter;
 
     public JsonStreamImpl(
         JsonParserEx parser)
@@ -54,6 +57,14 @@ public final class JsonStreamImpl implements JsonStream
     }
 
     @Override
+    public JsonStream reporting(
+        JsonReporter reporter)
+    {
+        this.reporter = reporter;
+        return this;
+    }
+
+    @Override
     public JsonPipeline into(
         JsonSink sink)
     {
@@ -62,7 +73,7 @@ public final class JsonStreamImpl implements JsonStream
         {
             root = new BoundSink(transforms.get(i), root);
         }
-        return new JsonPipelineImpl(parser, root);
+        return new JsonPipelineImpl(parser, root, reporter);
     }
 
     private static final class BoundSink implements JsonSink

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineRejectTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineRejectTest.java
@@ -16,6 +16,8 @@ package io.aklivity.zilla.runtime.common.json.internal;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -25,9 +27,14 @@ import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
+import io.aklivity.zilla.runtime.common.json.JsonReporter;
 
 class JsonPipelineRejectTest
 {
+    // captures the call-scoped diagnostic the pipeline pushes on a terminal REJECTED, copying the message out
+    private final String[] reason = new String[1];
+    private final JsonReporter reporter = d -> reason[0] = d.message();
+
     // Malformed JSON is a rejection of the value, surfaced as the terminal REJECTED status rather than
     // an exception escaping feed() — mirroring how the protobuf pipeline maps a decode failure.
     @Test
@@ -44,5 +51,39 @@ class JsonPipelineRejectTest
         Status status = pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length);
 
         assertEquals(Status.REJECTED, status);
+    }
+
+    @Test
+    void shouldReportReasonOnMalformedJson()
+    {
+        JsonGeneratorEx generator = JsonEx.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .reporting(reporter)
+            .into(JsonEx.createSink(generator));
+
+        byte[] bytes = "[1 2]".getBytes(UTF_8);
+        generator.wrap(output, 0, output.capacity());
+        pipeline.reset();
+
+        assertEquals(Status.REJECTED, pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length));
+        assertNotNull(reason[0]);
+    }
+
+    @Test
+    void shouldNotReportOnValidJson()
+    {
+        JsonGeneratorEx generator = JsonEx.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .reporting(reporter)
+            .into(JsonEx.createSink(generator));
+
+        byte[] bytes = "[1,2]".getBytes(UTF_8);
+        generator.wrap(output, 0, output.capacity());
+        pipeline.reset();
+
+        assertEquals(Status.COMPLETED, pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length));
+        assertNull(reason[0]);
     }
 }

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufDiagnostic.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufDiagnostic.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.protobuf;
+
+/**
+ * A description of a terminal {@link ProtobufPipeline.Status#REJECTED} failure, populated at the point
+ * of detection — by the parser for a malformed-wire failure, or by the validator for a structural one
+ * (e.g. a missing proto2 {@code required} field) — and handed to a {@link ProtobufReporter}.
+ * <p>
+ * The instance is a reused, call-scoped view: it is valid only for the duration of the
+ * {@link ProtobufReporter#rejected(ProtobufDiagnostic)} callback. A reporter that needs to retain any of
+ * it must copy the value out immediately, before returning.
+ * <p>
+ * Starts with {@link #message()}; structured accessors (byte offset, field number, category) may be added
+ * without changing the pipeline's {@code Status} contract.
+ */
+public interface ProtobufDiagnostic
+{
+    /**
+     * A short, human-readable reason for the rejection — e.g. an unknown field, an unknown enum value, a
+     * missing required field, or truncated input — or {@code null} when the rejecting component supplied
+     * no message.
+     */
+    String message();
+}

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufPipeline.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufPipeline.java
@@ -76,16 +76,6 @@ public interface ProtobufPipeline
     void reset();
 
     /**
-     * A short, human-readable reason for the most recent {@link Status#REJECTED} — e.g. an unknown
-     * field, an unknown enum value, or truncated input — or {@code null} when the last feed did not
-     * reject. Cleared by {@link #reset()}.
-     */
-    default String reason()
-    {
-        return null;
-    }
-
-    /**
      * The number of bytes at the tail of the most recently fed window not yet consumed — exactly what the
      * caller retains (typically in its own reassembly slot) and re-presents, contiguous, at the front of the
      * next {@link #feed}. A caller buffering across windows keeps this many bytes without tracking the

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufReporter.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufReporter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.protobuf;
+
+/**
+ * Receives a {@link ProtobufDiagnostic} the pipeline pushes immediately before returning a terminal
+ * {@link ProtobufPipeline.Status#REJECTED} — and only then, never on {@link ProtobufPipeline.Status#STARVED}
+ * or {@link ProtobufPipeline.Status#SUSPENDED} back-pressure. Wire one at pipeline construction with
+ * {@link ProtobufStream#reporting(ProtobufReporter)}.
+ * <p>
+ * The callback runs on the engine worker thread on the cold failure path. The supplied diagnostic is a
+ * reused, call-scoped view valid only for the duration of the call; copy out anything that must outlive it
+ * before returning. Do not block or perform I/O.
+ */
+@FunctionalInterface
+public interface ProtobufReporter
+{
+    void rejected(
+        ProtobufDiagnostic diagnostic);
+}

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufStream.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufStream.java
@@ -17,13 +17,21 @@ package io.aklivity.zilla.runtime.common.protobuf;
 /**
  * A description of a {@code common-protobuf} pipeline — a descriptor-bound driver plus an ordered list
  * of {@link ProtobufTransform} stages. Append stages with {@link #transform(ProtobufTransform)}
- * (left-to-right, in data-flow order); terminate with {@link #into(ProtobufSink)} to obtain the runnable
+ * (left-to-right, in data-flow order); optionally attach a {@link ProtobufReporter} with
+ * {@link #reporting(ProtobufReporter)}; terminate with {@link #into(ProtobufSink)} to obtain the runnable
  * {@link ProtobufPipeline}. A {@code ProtobufStream} carries no state and is not itself runnable.
  */
 public interface ProtobufStream
 {
     ProtobufStream transform(
         ProtobufTransform transform);
+
+    /**
+     * Attaches the {@link ProtobufReporter} the pipeline pushes a {@link ProtobufDiagnostic} to on a terminal
+     * {@link ProtobufPipeline.Status#REJECTED}. The last attached reporter wins; the default is none.
+     */
+    ProtobufStream reporting(
+        ProtobufReporter reporter);
 
     ProtobufPipeline into(
         ProtobufSink sink);

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufPipelineImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufPipelineImpl.java
@@ -19,12 +19,14 @@ import java.util.List;
 import org.agrona.DirectBuffer;
 
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufController;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufDiagnostic;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufEvent;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufException;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufField;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufMessage;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufParser;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufReporter;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufSink;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufSource;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufTransform;
@@ -43,19 +45,23 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
     private final Source source;
     private final Control control;
     private final ProtobufSink head;
+    private final ProtobufReporter reporter;
+    private final Diagnostic diagnostic;
 
     private boolean suspended;
     private boolean starved;
-    private String reason;
     // the event in flight across an output suspend, handed to head.resume() so no sink stores it
     private ProtobufEvent resumeEvent;
 
     public ProtobufPipelineImpl(
         ProtobufParser parser,
         List<ProtobufTransform> transforms,
-        ProtobufSink sink)
+        ProtobufSink sink,
+        ProtobufReporter reporter)
     {
         this.parser = parser;
+        this.reporter = reporter;
+        this.diagnostic = new Diagnostic();
         // the per-edge handles the stages see: a read-only source view of the parser, and a control handle
         // that records a stage's segment request which the pump turns into the SEGMENTED mode on the next pull
         this.source = new Source(parser);
@@ -75,7 +81,7 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
         head.reset();
         suspended = false;
         starved = false;
-        reason = null;
+        diagnostic.message = null;
         resumeEvent = null;
     }
 
@@ -83,12 +89,6 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
     public int remaining()
     {
         return parser.remaining();
-    }
-
-    @Override
-    public String reason()
-    {
-        return reason;
     }
 
     @Override
@@ -138,7 +138,13 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
         catch (ProtobufException ex)
         {
             status = Status.REJECTED;
-            reason = ex.getMessage();
+            diagnostic.message = ex.getMessage();
+        }
+        if (status == Status.REJECTED && reporter != null)
+        {
+            // terminal failure only — never STARVED/SUSPENDED back-pressure; the diagnostic is a reused,
+            // call-scoped view, so the reporter must copy out anything it needs before returning
+            reporter.rejected(diagnostic);
         }
         return status;
     }
@@ -273,6 +279,19 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
             ProtobufParser.Mode mode = segmented ? ProtobufParser.Mode.SEGMENTED : ProtobufParser.Mode.STRUCTURED;
             segmented = false;
             return mode;
+        }
+    }
+
+    // the reused, call-scoped diagnostic pushed to the reporter: its message is whatever the rejecting
+    // component populated — the parser's caught exception, or the validator's structural-reject exception
+    private static final class Diagnostic implements ProtobufDiagnostic
+    {
+        private String message;
+
+        @Override
+        public String message()
+        {
+            return message;
         }
     }
 }

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufStreamImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufStreamImpl.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufParser;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufReporter;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufSink;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufStream;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufTransform;
@@ -31,6 +32,8 @@ public final class ProtobufStreamImpl implements ProtobufStream
 {
     private final ProtobufParser parser;
     private final List<ProtobufTransform> transforms;
+
+    private ProtobufReporter reporter;
 
     public ProtobufStreamImpl(
         ProtobufParser parser)
@@ -48,9 +51,17 @@ public final class ProtobufStreamImpl implements ProtobufStream
     }
 
     @Override
+    public ProtobufStream reporting(
+        ProtobufReporter reporter)
+    {
+        this.reporter = reporter;
+        return this;
+    }
+
+    @Override
     public ProtobufPipeline into(
         ProtobufSink sink)
     {
-        return new ProtobufPipelineImpl(parser, transforms, sink);
+        return new ProtobufPipelineImpl(parser, transforms, sink, reporter);
     }
 }

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufValidatorImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufValidatorImpl.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufController;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufEvent;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufException;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufField;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufMessage;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline;
@@ -33,7 +34,9 @@ import io.aklivity.zilla.runtime.common.protobuf.ProtobufTransform;
  * every event unchanged. The driver already rejects malformed wire and wire-type/declared-type
  * mismatches; this stage adds descriptor-level semantic validation — proto2 {@code required}-field
  * presence per message scope — and reports failure at the message boundary, after the events are
- * forwarded, so callers abort on {@link ProtobufPipeline.Status#REJECTED} (emit-then-abort).
+ * forwarded (emit-then-abort). It throws a descriptive {@link ProtobufException} at the point of detection
+ * so the pipeline maps it to {@link ProtobufPipeline.Status#REJECTED} and pushes the named missing field to
+ * the reporter, rather than rejecting structurally with no message.
  */
 public final class ProtobufValidatorImpl implements ProtobufTransform
 {
@@ -80,7 +83,9 @@ public final class ProtobufValidatorImpl implements ProtobufTransform
         case END_GROUP:
             if (status != ProtobufPipeline.Status.REJECTED && !scope(depth).satisfied())
             {
-                status = ProtobufPipeline.Status.REJECTED;
+                // the validator knows precisely which required field is missing — describe it at the point of
+                // detection so the pipeline pushes a descriptive diagnostic, not a generic structural reject
+                throw new ProtobufException(scope(depth).describe());
             }
             depth--;
             break;
@@ -109,6 +114,7 @@ public final class ProtobufValidatorImpl implements ProtobufTransform
 
     private static final class Scope
     {
+        private String messageName;
         private List<ProtobufField> required;
         private boolean[] seen;
         private int count;
@@ -116,6 +122,7 @@ public final class ProtobufValidatorImpl implements ProtobufTransform
         private void reset(
             ProtobufMessage message)
         {
+            messageName = message.name();
             required = message.requiredFields();
             count = required.size();
             if (seen == null || seen.length < count)
@@ -123,6 +130,21 @@ public final class ProtobufValidatorImpl implements ProtobufTransform
                 seen = new boolean[Math.max(count, 4)];
             }
             Arrays.fill(seen, 0, count, false);
+        }
+
+        private String describe()
+        {
+            ProtobufField missing = null;
+            for (int i = 0; missing == null && i < count; i++)
+            {
+                if (!seen[i])
+                {
+                    missing = required.get(i);
+                }
+            }
+            return missing == null
+                ? String.format("message %s missing a required field", messageName)
+                : String.format("message %s missing required field %s (%d)", messageName, missing.name(), missing.number());
         }
 
         private void see(

--- a/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufPipelineTest.java
+++ b/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufPipelineTest.java
@@ -18,6 +18,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
@@ -38,6 +40,7 @@ import io.aklivity.zilla.runtime.common.protobuf.ProtobufMessage;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufParser;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline.Status;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufReporter;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufSchema;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufSink;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufSource;
@@ -48,6 +51,9 @@ import io.aklivity.zilla.runtime.common.protobuf.ProtobufWireType;
 public class ProtobufPipelineTest
 {
     private final ProtobufSchema schema = newSchema();
+    // captures the call-scoped diagnostic the pipeline pushes on a terminal REJECTED, copying the message out
+    private final String[] reason = new String[1];
+    private final ProtobufReporter reporter = d -> reason[0] = d.message();
 
     private boolean sawSuspended;
     private boolean sawStarved;
@@ -233,6 +239,59 @@ public class ProtobufPipelineTest
         pipeline.reset();
 
         assertEquals(Status.REJECTED, feed(pipeline, message));
+    }
+
+    @Test
+    public void shouldReportNamedFieldWhenRequiredMissing()
+    {
+        byte[] message = wire(w ->
+        {
+            w.writeTag(2, ProtobufWireType.VARINT);
+            w.writeVarint64(4);
+        });
+
+        ProtobufPipeline pipeline = Protobuf.stream(Protobuf.parser(schema, "R"))
+            .transform(schema.validator("R"))
+            .reporting(reporter)
+            .into(new ProtobufDiscardSinkImpl());
+        pipeline.reset();
+
+        // the structural reject names the missing required field "a", closing the reason-less-reject gap
+        assertEquals(Status.REJECTED, feed(pipeline, message));
+        assertTrue(reason[0].contains("a"), reason[0]);
+        assertTrue(reason[0].contains("required"), reason[0]);
+    }
+
+    @Test
+    public void shouldReportReasonWhenMalformed()
+    {
+        ProtobufPipeline pipeline = Protobuf.stream(Protobuf.parser(schema, "P"))
+            .reporting(reporter)
+            .into(new ProtobufDiscardSinkImpl());
+        pipeline.reset();
+
+        assertEquals(Status.REJECTED, feed(pipeline, new byte[]{(byte) 0x10, (byte) 0x80}));
+        assertNotNull(reason[0]);
+    }
+
+    @Test
+    public void shouldNotReportOnStarved()
+    {
+        byte[] message = wire(w ->
+        {
+            w.writeTag(2, ProtobufWireType.VARINT);
+            w.writeVarint64(300);
+        });
+
+        ProtobufPipeline pipeline = Protobuf.stream(Protobuf.parser(schema, "P"))
+            .reporting(reporter)
+            .into(new ProtobufDiscardSinkImpl());
+        pipeline.reset();
+
+        // back-pressure is not failure: a value split mid-varint STARVES without firing the reporter
+        UnsafeBuffer buffer = new UnsafeBuffer(message);
+        assertEquals(Status.STARVED, pipeline.feed(buffer, 0, message.length - 1, false));
+        assertNull(reason[0]);
     }
 
     @Test

--- a/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/json/ProtobufJsonStrictTest.java
+++ b/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/json/ProtobufJsonStrictTest.java
@@ -31,6 +31,7 @@ import io.aklivity.zilla.runtime.common.protobuf.ProtobufGenerator;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufParser;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline.Status;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufReporter;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufSchema;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufSink;
 
@@ -40,6 +41,10 @@ public class ProtobufJsonStrictTest
         "syntax = \"proto3\";\n" +
         "message Person { string name = 1; int32 id = 2; }\n";
 
+    // captures the call-scoped diagnostic the pipeline pushes on a terminal REJECTED, copying the message out
+    private final String[] reason = new String[1];
+    private final ProtobufReporter reporter = d -> reason[0] = d.message();
+
     @Test
     public void shouldRejectUnknownFieldWhenConfigured()
     {
@@ -47,12 +52,13 @@ public class ProtobufJsonStrictTest
         ProtobufGenerator generator = Protobuf.generator().wrap(new UnsafeBuffer(new byte[256]), 0, 256);
         ProtobufParser parser = ProtobufJson.parser(JsonEx.createParser(), schema, "Person",
             Map.of(ProtobufJson.REJECT_UNKNOWN_FIELDS, Boolean.TRUE));
-        ProtobufPipeline pipeline = Protobuf.stream(parser).into(ProtobufSink.of(generator, schema, "Person"));
+        ProtobufPipeline pipeline = Protobuf.stream(parser).reporting(reporter).into(ProtobufSink.of(generator, schema,
+            "Person"));
         pipeline.reset();
 
         byte[] in = "{\"name\":\"neo\",\"nope\":1}".getBytes(UTF_8);
         assertEquals(Status.REJECTED, pipeline.feed(new UnsafeBuffer(in), 0, in.length));
-        assertTrue(pipeline.reason().contains("nope"), pipeline.reason());
+        assertTrue(reason[0].contains("nope"), reason[0]);
     }
 
     @Test
@@ -61,37 +67,40 @@ public class ProtobufJsonStrictTest
         ProtobufSchema schema = Protobuf.schema(SCHEMA);
         ProtobufGenerator generator = Protobuf.generator().wrap(new UnsafeBuffer(new byte[256]), 0, 256);
         ProtobufParser parser = ProtobufJson.parser(JsonEx.createParser(), schema, "Person");
-        ProtobufPipeline pipeline = Protobuf.stream(parser).into(ProtobufSink.of(generator, schema, "Person"));
+        ProtobufPipeline pipeline = Protobuf.stream(parser).reporting(reporter).into(ProtobufSink.of(generator, schema,
+            "Person"));
         pipeline.reset();
 
         byte[] in = "{\"name\":\"neo\",\"nope\":1}".getBytes(UTF_8);
         assertEquals(Status.COMPLETED, pipeline.feed(new UnsafeBuffer(in), 0, in.length));
-        assertNull(pipeline.reason());
+        assertNull(reason[0]);
     }
 
     @Test
-    public void shouldReportNoReasonOnSuccess()
+    public void shouldNotReportOnSuccess()
     {
         ProtobufSchema schema = Protobuf.schema(SCHEMA);
         ProtobufGenerator generator = Protobuf.generator().wrap(new UnsafeBuffer(new byte[256]), 0, 256);
         ProtobufParser parser = ProtobufJson.parser(JsonEx.createParser(), schema, "Person",
             Map.of(ProtobufJson.REJECT_UNKNOWN_FIELDS, Boolean.TRUE));
-        ProtobufPipeline pipeline = Protobuf.stream(parser).into(ProtobufSink.of(generator, schema, "Person"));
+        ProtobufPipeline pipeline = Protobuf.stream(parser).reporting(reporter).into(ProtobufSink.of(generator, schema,
+            "Person"));
         pipeline.reset();
 
         byte[] in = "{\"name\":\"neo\"}".getBytes(UTF_8);
         assertEquals(Status.COMPLETED, pipeline.feed(new UnsafeBuffer(in), 0, in.length));
-        assertNull(pipeline.reason());
+        assertNull(reason[0]);
     }
 
     @Test
-    public void shouldClearReasonOnReset()
+    public void shouldNotReportOnSuccessAfterReject()
     {
         ProtobufSchema schema = Protobuf.schema(SCHEMA);
         ProtobufGenerator generator = Protobuf.generator();
         ProtobufParser parser = ProtobufJson.parser(JsonEx.createParser(), schema, "Person",
             Map.of(ProtobufJson.REJECT_UNKNOWN_FIELDS, Boolean.TRUE));
-        ProtobufPipeline pipeline = Protobuf.stream(parser).into(ProtobufSink.of(generator, schema, "Person"));
+        ProtobufPipeline pipeline = Protobuf.stream(parser).reporting(reporter).into(ProtobufSink.of(generator, schema,
+            "Person"));
 
         MutableDirectBuffer out = new UnsafeBuffer(new byte[256]);
         generator.wrap(out, 0, out.capacity());
@@ -101,8 +110,10 @@ public class ProtobufJsonStrictTest
 
         generator.wrap(out, 0, out.capacity());
         pipeline.reset();
-        assertNull(pipeline.reason());
+        // the prior reject's message must not leak onto a clean value: the reporter fires only on REJECTED
+        reason[0] = null;
         byte[] good = "{\"name\":\"neo\"}".getBytes(UTF_8);
         assertEquals(Status.COMPLETED, pipeline.feed(new UnsafeBuffer(good), 0, good.length));
+        assertNull(reason[0]);
     }
 }


### PR DESCRIPTION
## Description

Introduces a structured diagnostic reporting mechanism for terminal rejections across the protobuf, JSON, and Avro pipelines. This allows callers to receive detailed failure information (e.g., missing required fields, malformed input) through a callback interface rather than relying on a deprecated `reason()` method.

Fixes #1914

### Changes

**New Interfaces:**
- `ProtobufReporter`, `JsonReporter`, `AvroReporter`: Functional interfaces that receive rejection diagnostics
- `ProtobufDiagnostic`, `JsonDiagnostic`, `AvroDiagnostic`: Call-scoped diagnostic views with a `message()` accessor

**Pipeline Updates:**
- Modified `ProtobufPipelineImpl`, `JsonPipelineImpl`, and `AvroPipelineImpl` to:
  - Accept an optional reporter at construction
  - Invoke the reporter with a diagnostic immediately before returning `Status.REJECTED`
  - Only report on terminal rejections, never on `STARVED` or `SUSPENDED` back-pressure
- Updated stream builders (`ProtobufStreamImpl`, `JsonStreamImpl`, `AvroStreamImpl`) to expose `reporting()` method for wiring reporters

**Validation Improvements:**
- `ProtobufValidatorImpl` now throws `ProtobufException` with descriptive messages (e.g., naming missing required fields) instead of silently rejecting, enabling the pipeline to push meaningful diagnostics

**Deprecated:**
- Removed `ProtobufPipeline.reason()` default method in favor of the reporter callback pattern

### Test Coverage

Added comprehensive test cases:
- `ProtobufPipelineTest`: Tests for reporting named missing fields, malformed input, and non-reporting on starvation
- `JsonPipelineRejectTest`: Tests for reporting on malformed JSON and non-reporting on valid input
- `AvroMalformedTest`: Tests for reporting on rejected values and non-reporting on accepted values
- `ProtobufJsonStrictTest`: Updated to use the new reporter pattern

The diagnostic is a reused, call-scoped view valid only during the callback; reporters must copy out any data they need to retain.

https://claude.ai/code/session_01FX1pjzThQtFYZ25XUvAdpS