### PR TITLE
feat(common-json): surface verbatim schema diagnostics with accurate line/column

### DIFF
--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonLocationImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonLocationImpl.java
@@ -29,13 +29,13 @@ final class JsonLocationImpl implements JsonLocation
     @Override
     public long getLineNumber()
     {
-        return -1;
+        return tokenizer.line();
     }
 
     @Override
     public long getColumnNumber()
     {
-        return -1;
+        return tokenizer.column();
     }
 
     @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
@@ -16,8 +16,8 @@ package io.aklivity.zilla.runtime.common.json.internal;
 
 import java.math.BigDecimal;
 
+import jakarta.json.JsonException;
 import jakarta.json.stream.JsonLocation;
-import jakarta.json.stream.JsonParsingException;
 
 import org.agrona.DirectBuffer;
 
@@ -122,7 +122,7 @@ public final class JsonPipelineImpl implements JsonPipeline
                 status = last ? Status.REJECTED : Status.STARVED;
             }
         }
-        catch (JsonParsingException ex)
+        catch (JsonException ex)
         {
             status = Status.REJECTED;
             diagnostic.message = ex.getMessage();

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
@@ -2157,13 +2157,14 @@ public final class JsonSchemaImpl implements JsonSchema
         }
 
         private final JsonController decline = new Decline();
+        private final List<JsonSchemaDiagnostic> diagnostics = new ArrayList<>();
 
         private JsonController upstreamControl;
         private Eval eval;
 
         private Validator()
         {
-            this.eval = eval();
+            this.eval = eval(new Trace(diagnostics::add));
         }
 
         @Override
@@ -2184,7 +2185,13 @@ public final class JsonSchemaImpl implements JsonSchema
             else
             {
                 Verdict verdict = eval.feed(toEvent(event), source);
-                if (downstream == Status.REJECTED || verdict == Verdict.INVALID)
+                // throw a descriptive exception at the point of detection so the pipeline maps it to REJECTED
+                // and pushes the diagnostic to the reporter, rather than rejecting structurally with no message
+                if (verdict == Verdict.INVALID)
+                {
+                    throw new JsonValidationException(diagnostics);
+                }
+                else if (downstream == Status.REJECTED)
                 {
                     status = Status.REJECTED;
                 }
@@ -2203,7 +2210,8 @@ public final class JsonSchemaImpl implements JsonSchema
         @Override
         public void reset()
         {
-            eval = eval();
+            diagnostics.clear();
+            eval = eval(new Trace(diagnostics::add));
         }
     }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -77,6 +77,14 @@ public final class JsonTokenizer
     private long streamOffset;
     private long valueStreamStart;
     private long valueStreamEnd;
+    // 1-based line/column of the next byte to read; snapshots restore them when the scan rewinds the
+    // stream offset to a value start (value*) or a complete-unit boundary (unit*) at a window edge
+    private long line = 1;
+    private long column = 1;
+    private long valueLine = 1;
+    private long valueColumn = 1;
+    private long unitLine = 1;
+    private long unitColumn = 1;
     // raw stream offset where the current value (string or number) fragment began; getSegment() of a
     // fragmented value returns [fragmentStart, valueStreamEnd] so each fragment's verbatim bytes splice
     // back to the whole token (fragment 1 includes the opening quote, the final fragment the closing one)
@@ -145,6 +153,12 @@ public final class JsonTokenizer
         pendingString = null;
         valuePending = false;
         streamOffset = 0;
+        line = 1;
+        column = 1;
+        valueLine = 1;
+        valueColumn = 1;
+        unitLine = 1;
+        unitColumn = 1;
         fragmentStart = 0;
         segmenting = false;
         scalarSegment = false;
@@ -248,6 +262,8 @@ public final class JsonTokenizer
             {
                 // rewind to the last complete code-point/escape boundary, leaving the partial unit for the caller
                 streamOffset = unitStartOffset;
+                line = unitLine;
+                column = unitColumn;
                 resumeEscape = false;
                 resumeUnicodePending = 0;
                 resumeUnicodeValue = 0;
@@ -285,6 +301,8 @@ public final class JsonTokenizer
             {
                 // value fits a window (or terminal): rewind to its start and reassemble whole next window
                 streamOffset = valueStreamStart;
+                line = valueLine;
+                column = valueColumn;
                 scratch.setLength(0);
                 resumeOp = ResumeOp.NONE;
                 resumeEscape = false;
@@ -327,6 +345,16 @@ public final class JsonTokenizer
     public long streamOffset()
     {
         return streamOffset;
+    }
+
+    public long line()
+    {
+        return line;
+    }
+
+    public long column()
+    {
+        return column;
     }
 
     // Stream-offset span of the most recent readable scalar token (a VALUE_STRING including its
@@ -705,6 +733,8 @@ public final class JsonTokenizer
         case '"':
             valueStreamStart = streamOffset - 1;
             fragmentStart = streamOffset - 1;
+            valueLine = line;
+            valueColumn = column - 1;
             scratch.setLength(0);
             resumeEscape = false;
             resumeUnicodePending = 0;
@@ -753,6 +783,8 @@ public final class JsonTokenizer
             {
                 valueStreamStart = streamOffset - 1;
                 fragmentStart = streamOffset - 1;
+                valueLine = line;
+                valueColumn = column - 1;
                 numberLexeme.setLength(0);
                 numberFragmented = false;
                 scratch.setLength(0);
@@ -923,6 +955,8 @@ public final class JsonTokenizer
             if (!resumeEscape && resumeUnicodePending == 0)
             {
                 unitStartOffset = streamOffset;
+                unitLine = line;
+                unitColumn = column;
             }
             int c = readByte(in);
             if (!starved)
@@ -1097,6 +1131,7 @@ public final class JsonTokenizer
             else if (c >= '0' && c <= '9' || c == '.' || c == '-' || c == '+' || c == 'e' || c == 'E')
             {
                 streamOffset++;
+                advance(c);
                 appendScratch((char) c);
             }
             else
@@ -1180,8 +1215,25 @@ public final class JsonTokenizer
         else
         {
             streamOffset++;
+            advance(c);
         }
         return c;
+    }
+
+    // Advances line/column for one consumed byte: a newline opens the next line; every other byte that
+    // begins a character (i.e. not a UTF-8 continuation byte) advances the column by one.
+    private void advance(
+        int c)
+    {
+        if (c == '\n')
+        {
+            line++;
+            column = 1;
+        }
+        else if ((c & 0xC0) != 0x80)
+        {
+            column++;
+        }
     }
 
     private static String describe(

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonLocationTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonLocationTest.java
@@ -26,12 +26,39 @@ import org.junit.jupiter.api.Test;
 class JsonLocationTest
 {
     @Test
-    void shouldReturnMinusOneForLineAndColumn()
+    void shouldStartAtLineOneColumnOne()
     {
         JsonLocation location = parserFor("{}").getLocation();
 
-        assertEquals(-1L, location.getLineNumber());
-        assertEquals(-1L, location.getColumnNumber());
+        assertEquals(1L, location.getLineNumber());
+        assertEquals(1L, location.getColumnNumber());
+    }
+
+    @Test
+    void shouldTrackColumnOnSingleLine()
+    {
+        JsonParser parser = parserFor("[1,2]");
+
+        parser.next();
+        assertEquals(1L, parser.getLocation().getLineNumber());
+        assertEquals(2L, parser.getLocation().getColumnNumber());
+        parser.next();
+        assertEquals(1L, parser.getLocation().getLineNumber());
+        assertEquals(3L, parser.getLocation().getColumnNumber());
+    }
+
+    @Test
+    void shouldTrackLineAcrossNewlines()
+    {
+        JsonParser parser = parserFor("{\n\"a\":1\n}");
+
+        parser.next();
+        parser.next();
+        assertEquals(2L, parser.getLocation().getLineNumber());
+        assertEquals(4L, parser.getLocation().getColumnNumber());
+        parser.next();
+        assertEquals(2L, parser.getLocation().getLineNumber());
+        assertEquals(6L, parser.getLocation().getColumnNumber());
     }
 
     @Test

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineRejectTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineRejectTest.java
@@ -28,6 +28,7 @@ import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
 import io.aklivity.zilla.runtime.common.json.JsonReporter;
+import io.aklivity.zilla.runtime.common.json.JsonSchema;
 
 class JsonPipelineRejectTest
 {
@@ -68,6 +69,47 @@ class JsonPipelineRejectTest
 
         assertEquals(Status.REJECTED, pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length));
         assertNotNull(reason[0]);
+    }
+
+    // A schema violation is well-formed JSON the validator rejects; the validator throws a descriptive
+    // JsonValidationException at the point of detection so the pipeline pushes the verbatim diagnostic —
+    // including the accurate line/column — to the reporter, rather than rejecting with no message.
+    @Test
+    void shouldReportSchemaViolationWithLocation()
+    {
+        JsonSchema schema = JsonSchema.of("{\"properties\":{\"id\":{\"type\":\"string\"}}}");
+        JsonGeneratorEx generator = JsonEx.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(schema.validator())
+            .reporting(reporter)
+            .into(JsonEx.createSink(generator));
+
+        byte[] bytes = "{\"id\": 123}".getBytes(UTF_8);
+        generator.wrap(output, 0, output.capacity());
+        pipeline.reset();
+
+        assertEquals(Status.REJECTED, pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length));
+        assertEquals("[1,11][/id] expected string but was number", reason[0]);
+    }
+
+    @Test
+    void shouldReportSchemaViolationLocationAcrossNewlines()
+    {
+        JsonSchema schema = JsonSchema.of("{\"properties\":{\"id\":{\"type\":\"string\"}}}");
+        JsonGeneratorEx generator = JsonEx.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[128]);
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(schema.validator())
+            .reporting(reporter)
+            .into(JsonEx.createSink(generator));
+
+        byte[] bytes = "{\n  \"id\": 123\n}".getBytes(UTF_8);
+        generator.wrap(output, 0, output.capacity());
+        pipeline.reset();
+
+        assertEquals(Status.REJECTED, pipeline.feed(new UnsafeBuffer(bytes), 0, bytes.length));
+        assertEquals("[2,12][/id] expected string but was number", reason[0]);
     }
 
     @Test


### PR DESCRIPTION
Fixes #1919

## Problem

The streaming `common-json` pipeline did not deliver the verbatim validation-failure diagnostic the non-streaming parser produced (e.g. `A message payload failed validation. [1,11][/id] expected string but was number`). Two distinct gaps were responsible:

1. **Schema-validation rejections never reached the reporter.** `JsonSchemaImpl.Validator.feed(...)` signalled a violation by returning a silent `Verdict.INVALID` → `Status.REJECTED`, with no message. `JsonPipelineImpl.feed(...)` only set `diagnostic.message` from a caught `JsonParsingException` (malformed input), so for a schema violation the reporter fired with a `null` message. This is the "rejecting structurally with no message" anti-pattern that `ProtobufValidatorImpl` explicitly avoids.

2. **The streaming parser didn't track line/column.** `JsonLocationImpl.getLineNumber()`/`getColumnNumber()` were hardcoded to `-1` (the parser is byte-offset based), so the diagnostic rendered `[-1,-1]`.

## Changes

1. **Validator throws at the point of detection** — `JsonSchemaImpl.Validator` collects diagnostics via an active `Trace` and throws a descriptive `JsonValidationException` on `Verdict.INVALID`, mirroring `ProtobufValidatorImpl`. `JsonPipelineImpl`'s `catch` is broadened from `JsonParsingException` to `JsonException`, so both malformed and schema-invalid rejections set `diagnostic.message` and reach the `JsonReporter`.

2. **Streaming line/column tracking** — `JsonTokenizer` now tracks 1-based line/column as bytes are consumed (counting characters, skipping UTF-8 continuation bytes), snapshots them at the value-start and complete-unit marks, and restores them on the window-edge rewinds so multi-window values stay accurate. `JsonLocationImpl` returns the tracked values. Because the parser always knows its position at the point of rejection, line/column are **always** available — there is no "unknown" case and no conditional rendering.

The reporter now delivers e.g. `[1,11][/id] expected string but was number` entirely from the streaming pipeline.

## Scope

- **JSON**: fixed (this PR).
- **Protobuf**: `ProtobufValidatorImpl` already throws a descriptive `ProtobufException`, so its reporter already receives the message; it's a binary format, so line/column don't apply. No change needed.
- **Avro**: binary format (no line/column); no analogous validator-transform gap. No change needed.

## Tests

- `JsonPipelineRejectTest` — schema-violation reporter diagnostics asserting the verbatim message **and** location, single line (`[1,11]`) and across newlines (`[2,12]`).
- `JsonLocationTest` — parser line/column tracking on a single line and across newlines (replacing the obsolete `-1` assertion).
- Full `common-json` suite green (4793 tests) with coverage met.

## Follow-up

Once this lands, the `model-json` pipeline-uptake PR (#1907) can adopt `JsonStream.reporting(...)` in its validator + converters and drop the cold-path re-parse, with the failure event sourced entirely from the reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019YL2uqgwVoN3nqUxnfaj6g)_