### PR TITLE
perf(common-protobuf): allocation-free finite float/double parse on the JSON→protobuf write path

### DIFF
--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/json/internal/ProtobufJsonParserImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/json/internal/ProtobufJsonParserImpl.java
@@ -665,10 +665,10 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
             longValue = token == JsonEvent.VALUE_TRUE ? 1L : 0L;
             break;
         case FLOAT:
-            floatValue = Float.parseFloat(parser.getStringView().toString());
+            floatValue = parseFloat(parser.getStringView());
             break;
         case DOUBLE:
-            doubleValue = Double.parseDouble(parser.getStringView().toString());
+            doubleValue = parseDouble(parser.getStringView());
             break;
         case ENUM:
             longValue = token == JsonEvent.VALUE_STRING
@@ -768,6 +768,231 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
         CharSequence value)
     {
         return Long.parseUnsignedLong(value, 0, value.length(), 10);
+    }
+
+    // 10^n is exactly representable as a double for n in [0, 22].
+    private static final double[] POW10_DOUBLE =
+    {
+        1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11,
+        1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19, 1e20, 1e21, 1e22
+    };
+
+    // largest significand for which signif and signif * 10^k are exact: 2^53 - 1.
+    private static final long MAX_DOUBLE_SIGNIF = 9_007_199_254_740_991L;
+
+    // 10^n is exactly representable as a float for n in [0, 10].
+    private static final float[] POW10_FLOAT =
+    {
+        1e0f, 1e1f, 1e2f, 1e3f, 1e4f, 1e5f, 1e6f, 1e7f, 1e8f, 1e9f, 1e10f
+    };
+
+    // largest significand for which signif and signif * 10^k are exact in float: 2^24.
+    private static final long MAX_FLOAT_SIGNIF = 1L << 24;
+
+    // Parse a finite decimal CharSequence allocation-free using a Clinger fast path
+    // (exactly rounded single multiply/divide), falling back to Double.parseDouble for
+    // anything outside the fast-path bounds or any non-numeric lexeme (Infinity/NaN).
+    static double parseDouble(
+        CharSequence value)
+    {
+        int length = value.length();
+        int index = 0;
+        boolean negative = false;
+        if (index < length)
+        {
+            char c = value.charAt(index);
+            if (c == '-')
+            {
+                negative = true;
+                index++;
+            }
+            else if (c == '+')
+            {
+                index++;
+            }
+        }
+
+        long signif = 0L;
+        int digits = 0;
+        int fractionExponent = 0;
+        boolean dotSeen = false;
+        boolean fastPath = index < length;
+        boolean overflow = false;
+        while (index < length)
+        {
+            char c = value.charAt(index);
+            if (c >= '0' && c <= '9')
+            {
+                if (signif > (MAX_DOUBLE_SIGNIF - 9) / 10)
+                {
+                    overflow = true;
+                    break;
+                }
+                signif = signif * 10 + (c - '0');
+                digits++;
+                if (dotSeen)
+                {
+                    fractionExponent--;
+                }
+                index++;
+            }
+            else if (c == '.' && !dotSeen)
+            {
+                dotSeen = true;
+                index++;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        int explicitExponent = 0;
+        if (!overflow && index < length && (value.charAt(index) == 'e' || value.charAt(index) == 'E'))
+        {
+            index++;
+            boolean expNegative = false;
+            if (index < length && (value.charAt(index) == '-' || value.charAt(index) == '+'))
+            {
+                expNegative = value.charAt(index) == '-';
+                index++;
+            }
+            int expStart = index;
+            int exp = 0;
+            while (index < length && value.charAt(index) >= '0' && value.charAt(index) <= '9')
+            {
+                exp = exp * 10 + (value.charAt(index) - '0');
+                if (exp > 1000)
+                {
+                    exp = 1000;
+                }
+                index++;
+            }
+            if (index == expStart)
+            {
+                fastPath = false;
+            }
+            explicitExponent = expNegative ? -exp : exp;
+        }
+
+        double result;
+        int exponent = fractionExponent + explicitExponent;
+        if (fastPath && !overflow && index == length && digits > 0 && digits <= 15 &&
+            exponent >= -22 && exponent <= 22)
+        {
+            result = exponent >= 0
+                ? signif * POW10_DOUBLE[exponent]
+                : signif / POW10_DOUBLE[-exponent];
+            result = negative ? -result : result;
+        }
+        else
+        {
+            result = Double.parseDouble(value.toString());
+        }
+        return result;
+    }
+
+    // Parse a finite decimal CharSequence to float allocation-free using a float-domain
+    // Clinger fast path (no double narrowing, to avoid double rounding), falling back to
+    // Float.parseFloat for anything outside the fast-path bounds or non-numeric lexemes.
+    static float parseFloat(
+        CharSequence value)
+    {
+        int length = value.length();
+        int index = 0;
+        boolean negative = false;
+        if (index < length)
+        {
+            char c = value.charAt(index);
+            if (c == '-')
+            {
+                negative = true;
+                index++;
+            }
+            else if (c == '+')
+            {
+                index++;
+            }
+        }
+
+        long signif = 0L;
+        int digits = 0;
+        int fractionExponent = 0;
+        boolean dotSeen = false;
+        boolean fastPath = index < length;
+        boolean overflow = false;
+        while (index < length)
+        {
+            char c = value.charAt(index);
+            if (c >= '0' && c <= '9')
+            {
+                if (signif > (MAX_FLOAT_SIGNIF - 9) / 10)
+                {
+                    overflow = true;
+                    break;
+                }
+                signif = signif * 10 + (c - '0');
+                digits++;
+                if (dotSeen)
+                {
+                    fractionExponent--;
+                }
+                index++;
+            }
+            else if (c == '.' && !dotSeen)
+            {
+                dotSeen = true;
+                index++;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        int explicitExponent = 0;
+        if (!overflow && index < length && (value.charAt(index) == 'e' || value.charAt(index) == 'E'))
+        {
+            index++;
+            boolean expNegative = false;
+            if (index < length && (value.charAt(index) == '-' || value.charAt(index) == '+'))
+            {
+                expNegative = value.charAt(index) == '-';
+                index++;
+            }
+            int expStart = index;
+            int exp = 0;
+            while (index < length && value.charAt(index) >= '0' && value.charAt(index) <= '9')
+            {
+                exp = exp * 10 + (value.charAt(index) - '0');
+                if (exp > 1000)
+                {
+                    exp = 1000;
+                }
+                index++;
+            }
+            if (index == expStart)
+            {
+                fastPath = false;
+            }
+            explicitExponent = expNegative ? -exp : exp;
+        }
+
+        float result;
+        int exponent = fractionExponent + explicitExponent;
+        if (fastPath && !overflow && index == length && digits > 0 && digits <= 7 &&
+            exponent >= -10 && exponent <= 10)
+        {
+            result = exponent >= 0
+                ? signif * POW10_FLOAT[exponent]
+                : signif / POW10_FLOAT[-exponent];
+            result = negative ? -result : result;
+        }
+        else
+        {
+            result = Float.parseFloat(value.toString());
+        }
+        return result;
     }
 
     private int enumNumber(

--- a/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/json/internal/ProtobufJsonNumberParseTest.java
+++ b/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/json/internal/ProtobufJsonNumberParseTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.protobuf.json.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+public class ProtobufJsonNumberParseTest
+{
+    private void assertDoubleBits(
+        String value)
+    {
+        long expected = Double.doubleToLongBits(Double.parseDouble(value));
+        long actual = Double.doubleToLongBits(ProtobufJsonParserImpl.parseDouble(value));
+        assertEquals(expected, actual, () -> "double mismatch for \"" + value + "\"");
+    }
+
+    private void assertFloatBits(
+        String value)
+    {
+        int expected = Float.floatToIntBits(Float.parseFloat(value));
+        int actual = Float.floatToIntBits(ProtobufJsonParserImpl.parseFloat(value));
+        assertEquals(expected, actual, () -> "float mismatch for \"" + value + "\"");
+    }
+
+    @Test
+    public void shouldParseDoubleLiterals()
+    {
+        String[] values =
+        {
+            "0", "-0", "0.0", "-0.0", "1", "-1", "1.5", "-1.5", "1.0",
+            "3.141592653589793", "2.718281828459045",
+            "100", "1000000", "1234567890", "123456789012345",
+            "0.1", "0.2", "0.3", "0.5", "0.25", "0.125",
+            "10", "100", "1000", "0.001", "0.0001",
+            "1e0", "1e1", "1e-1", "1e10", "1e-10", "1e22", "1e-22",
+            "1e23", "1e-23", "1e100", "1e-100", "1e308", "1e-308",
+            "1.7976931348623157e308", "4.9e-324",
+            "9007199254740991", "9007199254740992", "9007199254740993",
+            "12345678901234567890", "0.123456789012345678",
+            "+1", "+1.5", "+0", "+1e5", "1E10", "1E-10", "1.5E3", "1.5e3",
+            "00.5", "0.50", "000123", "1.500", "0010",
+            "Infinity", "-Infinity", "NaN",
+            String.valueOf(Double.MIN_VALUE),
+            String.valueOf(Double.MAX_VALUE),
+            String.valueOf(Double.MIN_NORMAL),
+            String.valueOf(-Double.MAX_VALUE),
+        };
+        for (String value : values)
+        {
+            assertDoubleBits(value);
+        }
+    }
+
+    @Test
+    public void shouldParseFloatLiterals()
+    {
+        String[] values =
+        {
+            "0", "-0", "0.0", "-0.0", "1", "-1", "1.5", "-1.5", "1.0",
+            "3.14159", "2.71828",
+            "100", "1000000", "16777215", "16777216", "16777217",
+            "0.1", "0.2", "0.3", "0.5", "0.25", "0.125",
+            "1e0", "1e1", "1e-1", "1e10", "1e-10", "1e7", "1e-7", "1e8", "1e-8",
+            "1e38", "1e-38", "1e39", "1e-45",
+            "3.4028235e38", "1.4e-45",
+            "+1", "+1.5", "+0", "1E10", "1.5E3", "1.5e3",
+            "00.5", "0.50", "000123", "1.500", "0010",
+            "Infinity", "-Infinity", "NaN",
+            String.valueOf(Float.MIN_VALUE),
+            String.valueOf(Float.MAX_VALUE),
+            String.valueOf(Float.MIN_NORMAL),
+            String.valueOf(-Float.MAX_VALUE),
+        };
+        for (String value : values)
+        {
+            assertFloatBits(value);
+        }
+    }
+
+    @Test
+    public void shouldParseRandomDoublesBitExact()
+    {
+        Random random = new Random(20260619L);
+        for (int i = 0; i < 100_000; i++)
+        {
+            double d = Double.longBitsToDouble(random.nextLong());
+            if (Double.isFinite(d))
+            {
+                assertDoubleBits(Double.toString(d));
+            }
+        }
+    }
+
+    @Test
+    public void shouldParseRandomFloatsBitExact()
+    {
+        Random random = new Random(20260620L);
+        for (int i = 0; i < 100_000; i++)
+        {
+            float f = Float.intBitsToFloat(random.nextInt());
+            if (Float.isFinite(f))
+            {
+                assertFloatBits(Float.toString(f));
+            }
+        }
+    }
+
+    @Test
+    public void shouldParseRandomDigitStringsBitExact()
+    {
+        Random random = new Random(20260621L);
+        for (int i = 0; i < 50_000; i++)
+        {
+            StringBuilder builder = new StringBuilder();
+            if (random.nextBoolean())
+            {
+                builder.append(random.nextBoolean() ? '-' : '+');
+            }
+            int intDigits = random.nextInt(20);
+            int fracDigits = random.nextInt(20);
+            if (intDigits == 0 && fracDigits == 0)
+            {
+                intDigits = 1;
+            }
+            for (int d = 0; d < intDigits; d++)
+            {
+                builder.append((char) ('0' + random.nextInt(10)));
+            }
+            if (fracDigits > 0)
+            {
+                builder.append('.');
+                for (int d = 0; d < fracDigits; d++)
+                {
+                    builder.append((char) ('0' + random.nextInt(10)));
+                }
+            }
+            if (random.nextBoolean())
+            {
+                builder.append(random.nextBoolean() ? 'e' : 'E');
+                if (random.nextBoolean())
+                {
+                    builder.append(random.nextBoolean() ? '-' : '+');
+                }
+                builder.append(random.nextInt(330));
+            }
+            assertDoubleBits(builder.toString());
+        }
+    }
+
+    @Test
+    public void shouldParseRandomDigitStringsBitExactFloat()
+    {
+        Random random = new Random(20260622L);
+        for (int i = 0; i < 50_000; i++)
+        {
+            StringBuilder builder = new StringBuilder();
+            if (random.nextBoolean())
+            {
+                builder.append(random.nextBoolean() ? '-' : '+');
+            }
+            int intDigits = random.nextInt(12);
+            int fracDigits = random.nextInt(12);
+            if (intDigits == 0 && fracDigits == 0)
+            {
+                intDigits = 1;
+            }
+            for (int d = 0; d < intDigits; d++)
+            {
+                builder.append((char) ('0' + random.nextInt(10)));
+            }
+            if (fracDigits > 0)
+            {
+                builder.append('.');
+                for (int d = 0; d < fracDigits; d++)
+                {
+                    builder.append((char) ('0' + random.nextInt(10)));
+                }
+            }
+            if (random.nextBoolean())
+            {
+                builder.append(random.nextBoolean() ? 'e' : 'E');
+                if (random.nextBoolean())
+                {
+                    builder.append(random.nextBoolean() ? '-' : '+');
+                }
+                builder.append(random.nextInt(50));
+            }
+            assertFloatBits(builder.toString());
+        }
+    }
+
+    @Test
+    public void shouldParseExponentBoundaries()
+    {
+        for (int exp = -30; exp <= 30; exp++)
+        {
+            assertDoubleBits("1e" + exp);
+            assertDoubleBits("1.5e" + exp);
+            assertDoubleBits("9007199254740991e" + exp);
+            assertFloatBits("1e" + exp);
+            assertFloatBits("1.5e" + exp);
+        }
+    }
+
+    @Test
+    public void shouldParseCharSequenceSubviews()
+    {
+        CharSequence view = new StringBuilder("1.5");
+        assertEquals(Double.doubleToLongBits(1.5),
+            Double.doubleToLongBits(ProtobufJsonParserImpl.parseDouble(view)));
+        assertEquals(Float.floatToIntBits(1.5f),
+            Float.floatToIntBits(ProtobufJsonParserImpl.parseFloat(new StringBuilder("1.5"))));
+    }
+}


### PR DESCRIPTION
## Motivation

`ProtobufJsonPipelineBM.jsonToProtobuf` (JSON→protobuf write path) allocated **~104 B/op**, traced entirely to a single `double` field. The decode did:
```java
floatValue  = Float.parseFloat(parser.getStringView().toString());
doubleValue = Double.parseDouble(parser.getStringView().toString());
```
which allocates both the `.toString()` `String` **and** the JDK parser's internal buffer (the parse side has no thread-local cache, unlike the format side that the read path's `StringBuilder.append(double)` benefits from). Integer/string/bool values were already 0 B/op (`parseLong(CharSequence)`, manual `putUtf8`).

## Change

Add `parseDouble(CharSequence)` / `parseFloat(CharSequence)` to `ProtobufJsonParserImpl`, mirroring the existing `parseLong`/`parseUnsignedLong`, and point the `FLOAT`/`DOUBLE` cases at them (dropping `.toString()`). Each:

1. Scans the view once for sign, integer/fraction digits, and an optional `e`/`E` exponent into a `long` significand + decimal exponent — no allocation.
2. **Clinger exactly-rounded fast path** (single IEEE multiply/divide against a power-of-ten table): `double` when `digits ≤ 15` and `|exp| ≤ 22`; `float` when `digits ≤ 7` and `|exp| ≤ 10`, computed entirely in the **float domain** (`long * 10^n` / `long / 10^n`) so it is never narrowed from a `double` (no double-rounding).
3. **Fallback** to `Double/Float.parseXxx(view.toString())` for too-many-digits, out-of-range exponent, or non-numeric lexemes (`Infinity`/`-Infinity`/`NaN`) — still correct, allocates only on the rare path.

The string-form `enum` and base64 `bytes` `.toString()` paths are intentionally left untouched (out of scope; not on the number hot path).

## Tests

`ProtobufJsonNumberParseTest` round-trips both parsers **bit-exactly** against the JDK via `Double.doubleToLongBits` / `Float.floatToIntBits` (so `NaN` and `-0.0` are checked by bits) across literals, significand/exponent boundaries (`2^53±`, `2^24±`, `|exp|` at/beyond 22 and 10), subnormals, `MIN`/`MAX`, the non-finite strings, and ~300k randomized samples — driving **both** the fast path and the fallback.

## Result

`ProtobufJsonPipelineBM.jsonToProtobuf` `gc.alloc.rate.norm`: **104.020 → 0.019 B/op** (≈ zero). `./mvnw clean install -pl runtime/common-protobuf` → BUILD SUCCESS (tests, checkstyle, license, JaCoCo, moditect).

## Scope

Pre-existing allocation (predates #1917/#1921, in code those PRs didn't touch); split out as its own follow-up. Independent of the streaming work — this is in the JSON `ProtobufJsonParserImpl`, not the wire parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfzS5MmFH2NQBefvoB3o7d

---
_Generated by [Claude Code](https://claude.ai/code/session_01MfzS5MmFH2NQBefvoB3o7d)_