### PR TITLE
refactor(common-protobuf): retire the ProtobufJson staging buffers (key accumulator + value buffer)

### DIFF
--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/json/internal/ProtobufJsonGeneratorImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/json/internal/ProtobufJsonGeneratorImpl.java
@@ -14,12 +14,9 @@
  */
 package io.aklivity.zilla.runtime.common.protobuf.json.internal;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import java.util.BitSet;
 
 import org.agrona.DirectBuffer;
-import org.agrona.ExpandableArrayBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -62,7 +59,6 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
     private final boolean protoFieldNames;
     private final boolean includeDefaults;
     private final StringBuilder scratch;
-    private final ExpandableArrayBuffer accumulator;
     private final UnsafeBuffer byteView;
 
     private Scope[] scopes;
@@ -74,7 +70,6 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
 
     private boolean segmentActive;
     private boolean segmentOpened;
-    private int segmentLength;
     private int consumed;
     private boolean flushed;
 
@@ -99,7 +94,6 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
         this.protoFieldNames = protoFieldNames;
         this.includeDefaults = includeDefaults;
         this.scratch = new StringBuilder();
-        this.accumulator = new ExpandableArrayBuffer();
         this.byteView = new UnsafeBuffer();
         this.scopes = new Scope[8];
         for (int i = 0; i < scopes.length; i++)
@@ -127,7 +121,6 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
             rootOpened = false;
             segmentActive = false;
             segmentOpened = false;
-            segmentLength = 0;
         }
         consumed = 0;
         return this;
@@ -411,7 +404,6 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
             prepare(field);
             segmentActive = true;
             segmentOpened = false;
-            segmentLength = 0;
         }
         if (scalarKey)
         {
@@ -733,16 +725,17 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
         int length,
         int deferred)
     {
-        accumulator.putBytes(segmentLength, value, offset, length);
-        segmentLength += length;
+        if (!segmentOpened)
+        {
+            scratch.setLength(0);
+            segmentOpened = true;
+        }
+        appendUtf8(value, offset, length);
         consumed += length;
         if (deferred == 0)
         {
-            byte[] bytes = new byte[segmentLength];
-            accumulator.getBytes(0, bytes);
-            captureKey(new String(bytes, UTF_8));
+            captureKey(scratch.toString());
             segmentActive = false;
-            segmentLength = 0;
         }
     }
 
@@ -766,7 +759,6 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
         if (charsWritten == scratch.length() && deferred == 0)
         {
             segmentActive = false;
-            segmentLength = 0;
         }
     }
 
@@ -824,7 +816,6 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
         if (complete)
         {
             segmentActive = false;
-            segmentLength = 0;
         }
     }
 

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/json/internal/ProtobufJsonParserImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/json/internal/ProtobufJsonParserImpl.java
@@ -14,10 +14,7 @@
  */
 package io.aklivity.zilla.runtime.common.protobuf.json.internal;
 
-import java.util.Base64;
-
 import org.agrona.DirectBuffer;
-import org.agrona.ExpandableArrayBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
 import io.aklivity.zilla.runtime.common.json.JsonEvent;
@@ -49,13 +46,22 @@ import io.aklivity.zilla.runtime.common.protobuf.ProtobufWireType;
  * view); message structure may split across windows at any token boundary.
  * <p>
  * Allocation: scalar values and keys are read through the parser's non-owning char views and parsed/encoded
- * straight into a reused buffer — integers via {@code Long.parseLong(CharSequence, …)}, strings UTF-8-encoded
- * into the value buffer — so no per-value {@code String}/{@code byte[]} is materialized (floats, enum names by
- * string, and {@code bytes} base64 still round-trip through a {@code String}).
+ * straight into a reused buffer — integers via {@code Long.parseLong(CharSequence, …)} — so no per-value
+ * {@code String}/{@code byte[]} is materialized (floats and enum names by string still round-trip through a
+ * {@code String}).
+ * <p>
+ * Large {@code string}/{@code bytes} values stream as BOUNDED chunks through a small FIXED staging buffer
+ * rather than being materialized whole: each {@code VALUE} event carries the next run of transcoded output
+ * (UTF-8 for {@code string}, base64-decoded for {@code bytes}), aligned so a chunk never splits a code point
+ * or base64 group, and {@link #deferredBytes()} reports the still-untranscoded remainder so the wire generator
+ * keeps its length prefix open across chunks — mirroring the wire parser's length-delimited leaf streaming.
  */
 public final class ProtobufJsonParserImpl implements ProtobufParser
 {
     private static final int ESTIMATE = 1 << 16;
+    // the fixed staging buffer that holds one bounded run of transcoded value bytes; a multiple of 3 so a
+    // whole base64 4-char -> 3-byte group always fits without straddling the buffer end
+    private static final int VALUE_CHUNK = 4092;
 
     private enum Kind
     {
@@ -70,7 +76,7 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
     private final String messageName;
     private final boolean rejectUnknownFields;
     private final UnsafeBuffer estimateView;
-    private final ExpandableArrayBuffer valueBuffer;
+    private final UnsafeBuffer valueChunk;
     private final UnsafeBuffer valueView;
     private final ProtobufLocation location = new ProtobufLocation()
     {
@@ -97,8 +103,23 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
     private long longValue;
     private double doubleValue;
     private float floatValue;
-    private int valueLength;
+    // bytes of transcoded output currently staged in valueChunk
+    private int decodedLength;
+    // bytes of the current chunk the sink has drained; the output-pushback cursor within the chunk
     private int valueConsumed;
+
+    // streaming-value state: a large string/bytes value is transcoded incrementally into valueChunk and
+    // delivered as bounded VALUE chunks, the source chars cursored across without re-pulling the JSON parser
+    private boolean valueStreaming;
+    private boolean valueString;
+    private CharSequence valueSource;
+    private int valueCursor;
+    private int valueSourceLength;
+    // decoded bytes not yet transcoded into a chunk; reported as deferredBytes() so the generator's length
+    // prefix counts the whole value and stays open until the last chunk
+    private int valueRemaining;
+    private ProtobufField valueField;
+    private boolean valueClosesMapEntry;
 
     private boolean last;
     private boolean primed;
@@ -126,7 +147,7 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
         this.messageName = messageName;
         this.rejectUnknownFields = rejectUnknownFields;
         this.estimateView = new UnsafeBuffer(new byte[ESTIMATE]);
-        this.valueBuffer = new ExpandableArrayBuffer();
+        this.valueChunk = new UnsafeBuffer(new byte[VALUE_CHUNK]);
         this.valueView = new UnsafeBuffer();
         this.frames = new Frame[8];
         for (int i = 0; i < frames.length; i++)
@@ -154,6 +175,9 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
         queueHead = 0;
         queueSize = 0;
         valueConsumed = 0;
+        decodedLength = 0;
+        valueStreaming = false;
+        valueSource = null;
         primed = false;
         finished = false;
         skipping = false;
@@ -269,7 +293,9 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
         }
         else
         {
-            valueView.wrap(valueBuffer, valueConsumed, valueLength - valueConsumed);
+            // the current chunk's undrained bytes; on a within-chunk output pushback (resume) this re-exposes
+            // [valueConsumed, decodedLength) so the sink continues where it left off
+            valueView.wrap(valueChunk, valueConsumed, decodedLength - valueConsumed);
             segment = valueView;
         }
         return segment;
@@ -278,14 +304,19 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
     @Override
     public int deferredBytes()
     {
-        return 0;
+        // decoded value bytes still to come after this chunk's exposed slice: the not-yet-transcoded source
+        // remainder. > 0 while the value continues, 0 only on the last chunk, so the generator's length prefix
+        // (total = chunk length + deferred on the first call) is correct and the value stays open across chunks
+        return valueRemaining;
     }
 
     @Override
     public void consumed(
         int sourceBytes)
     {
-        // advance past the written prefix so segment() re-exposes the value's unconsumed remainder on resume
+        // advance past the written prefix so segment() re-exposes this chunk's unconsumed remainder on resume;
+        // a chunk drained short of decodedLength is output back-pressure — the next chunk is not staged until
+        // the sink fully drains this one (handled by streamValueStep on the ADVANCED re-entry)
         valueConsumed += sourceBytes;
     }
 
@@ -302,7 +333,11 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
     private boolean step()
     {
         boolean progress;
-        if (!primed)
+        if (valueStreaming)
+        {
+            progress = streamValueStep();
+        }
+        else if (!primed)
         {
             progress = prime();
         }
@@ -453,8 +488,7 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
             else if (token != JsonEvent.VALUE_NULL)
             {
                 enqueue(ProtobufEvent.FIELD, field, null);
-                decodeValue(field, token);
-                enqueue(ProtobufEvent.VALUE, field, null);
+                emitValue(field, token, false);
             }
             progress = true;
         }
@@ -484,8 +518,7 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
                 enqueue(ProtobufEvent.FIELD, frame.field, null);
                 enqueue(ProtobufEvent.START_MESSAGE, null, entry);
                 enqueue(ProtobufEvent.FIELD, keyField, null);
-                decodeKey(keyField);
-                enqueue(ProtobufEvent.VALUE, keyField, null);
+                emitKey(keyField);
                 frame.mapStep = 1;
                 progress = true;
             }
@@ -520,9 +553,7 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
                 else
                 {
                     enqueue(ProtobufEvent.FIELD, valueField, null);
-                    decodeValue(valueField, token);
-                    enqueue(ProtobufEvent.VALUE, valueField, null);
-                    enqueue(ProtobufEvent.END_MESSAGE, null, null);
+                    emitValue(valueField, token, true);
                 }
                 progress = true;
             }
@@ -562,8 +593,7 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
         else
         {
             enqueue(ProtobufEvent.FIELD, field, null);
-            decodeValue(field, token);
-            enqueue(ProtobufEvent.VALUE, field, null);
+            emitValue(field, token, false);
         }
     }
 
@@ -639,7 +669,66 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
         return parser.hasNextEvent() ? parser.nextEvent() : null;
     }
 
-    private void decodeValue(
+    // a field value: a string/bytes value begins a bounded streaming run (FIELD already enqueued), every other
+    // scalar decodes whole and enqueues its single VALUE. closesMapEntry defers the map-entry END_MESSAGE until
+    // the (possibly multi-chunk) value finishes
+    private void emitValue(
+        ProtobufField field,
+        JsonEvent token,
+        boolean closesMapEntry)
+    {
+        switch (field.type())
+        {
+        case STRING:
+            beginStringStream(field, parser.getStringView(), closesMapEntry);
+            break;
+        case BYTES:
+            beginBytesStream(field, parser.getStringView(), closesMapEntry);
+            break;
+        default:
+            decodeScalar(field, token);
+            enqueue(ProtobufEvent.VALUE, field, null);
+            if (closesMapEntry)
+            {
+                enqueue(ProtobufEvent.END_MESSAGE, null, null);
+            }
+            break;
+        }
+    }
+
+    // a map key (FIELD already enqueued, no map-entry END_MESSAGE follows): a string key streams; the other
+    // legal key types decode whole into longValue with key-specific semantics
+    private void emitKey(
+        ProtobufField keyField)
+    {
+        CharSequence text = parser.getStringView();
+        switch (keyField.type())
+        {
+        case STRING:
+            beginStringStream(keyField, text, false);
+            break;
+        case BOOL:
+            longValue = "true".contentEquals(text) ? 1L : 0L;
+            enqueue(ProtobufEvent.VALUE, keyField, null);
+            break;
+        case UINT32:
+        case FIXED32:
+            longValue = parseLong(text) & 0xffffffffL;
+            enqueue(ProtobufEvent.VALUE, keyField, null);
+            break;
+        case UINT64:
+        case FIXED64:
+            longValue = parseUnsignedLong(text);
+            enqueue(ProtobufEvent.VALUE, keyField, null);
+            break;
+        default:
+            longValue = parseLong(text);
+            enqueue(ProtobufEvent.VALUE, keyField, null);
+            break;
+        }
+    }
+
+    private void decodeScalar(
         ProtobufField field,
         JsonEvent token)
     {
@@ -675,50 +764,258 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
                 ? enumNumber(field, parser.getStringView().toString())
                 : parseLong(parser.getStringView());
             break;
-        case STRING:
-            putUtf8(parser.getStringView());
-            break;
-        case BYTES:
-            putBytes(decodeBase64(parser.getStringView().toString()));
-            break;
         default:
             throw new ProtobufException("unsupported scalar type " + field.type());
         }
     }
 
-    private void decodeKey(
-        ProtobufField keyField)
+    // open a bounded UTF-8 streaming run over the value's chars: stage the first chunk, set deferredBytes() to
+    // the still-untranscoded byte count (a whole-string UTF-8 length scan, allocation-free), and enqueue the
+    // first VALUE. The whole value's chars are in-window (getStringView requires the leaf present), so this is
+    // a transcode-progress cursor over them, not input back-pressure
+    private void beginStringStream(
+        ProtobufField field,
+        CharSequence value,
+        boolean closesMapEntry)
     {
-        CharSequence text = parser.getStringView();
-        switch (keyField.type())
-        {
-        case STRING:
-            putUtf8(text);
-            break;
-        case BOOL:
-            longValue = "true".contentEquals(text) ? 1L : 0L;
-            break;
-        case UINT32:
-        case FIXED32:
-            longValue = parseLong(text) & 0xffffffffL;
-            break;
-        case UINT64:
-        case FIXED64:
-            longValue = parseUnsignedLong(text);
-            break;
-        default:
-            longValue = parseLong(text);
-            break;
-        }
+        valueStreaming = true;
+        valueString = true;
+        valueSource = value;
+        valueCursor = 0;
+        valueSourceLength = value.length();
+        valueField = field;
+        valueClosesMapEntry = closesMapEntry;
+        valueRemaining = utf8Length(value);
+        refillStringChunk();
+        enqueue(ProtobufEvent.VALUE, field, null);
     }
 
-    private void putUtf8(
+    // open a bounded base64-decode streaming run: the decoded length is computed from the base64 length and
+    // padding without decoding, so the first chunk reports the correct deferred remainder
+    private void beginBytesStream(
+        ProtobufField field,
+        CharSequence value,
+        boolean closesMapEntry)
+    {
+        valueStreaming = true;
+        valueString = false;
+        valueSource = value;
+        valueCursor = 0;
+        valueSourceLength = base64SignificantLength(value);
+        valueField = field;
+        valueClosesMapEntry = closesMapEntry;
+        valueRemaining = base64DecodedLength(value, valueSourceLength);
+        refillBytesChunk();
+        enqueue(ProtobufEvent.VALUE, field, null);
+    }
+
+    // drive the in-flight streaming value: when the current chunk is fully drained, stage the next bounded run
+    // (resetting the output-pushback cursor) and enqueue another VALUE; when the source is exhausted, close the
+    // run and emit the deferred map-entry END_MESSAGE if any
+    private boolean streamValueStep()
+    {
+        if (valueCursor < valueSourceLength)
+        {
+            if (valueString)
+            {
+                refillStringChunk();
+            }
+            else
+            {
+                refillBytesChunk();
+            }
+            enqueue(ProtobufEvent.VALUE, valueField, null);
+        }
+        else
+        {
+            valueStreaming = false;
+            valueSource = null;
+            if (valueClosesMapEntry)
+            {
+                enqueue(ProtobufEvent.END_MESSAGE, null, null);
+            }
+        }
+        return true;
+    }
+
+    // encode whole UTF-8 code points into valueChunk until the next code point would not fit; advance the char
+    // cursor and decrement the still-to-come (deferred) byte count by exactly what was staged
+    private void refillStringChunk()
+    {
+        valueConsumed = 0;
+        CharSequence value = valueSource;
+        int length = valueSourceLength;
+        int i = valueCursor;
+        int index = 0;
+        boolean room = true;
+        while (i < length && room)
+        {
+            int codePoint = value.charAt(i);
+            int next = i + 1;
+            if (codePoint >= 0xd800 && codePoint <= 0xdbff && next < length)
+            {
+                char low = value.charAt(next);
+                if (low >= 0xdc00 && low <= 0xdfff)
+                {
+                    codePoint = ((codePoint - 0xd800) << 10) + (low - 0xdc00) + 0x10000;
+                    next++;
+                }
+            }
+            int width = codePoint < 0x80 ? 1 : codePoint < 0x800 ? 2 : codePoint < 0x10000 ? 3 : 4;
+            if (index + width > VALUE_CHUNK)
+            {
+                room = false;
+            }
+            else
+            {
+                if (codePoint < 0x80)
+                {
+                    valueChunk.putByte(index++, (byte) codePoint);
+                }
+                else if (codePoint < 0x800)
+                {
+                    valueChunk.putByte(index++, (byte) (0xc0 | codePoint >> 6));
+                    valueChunk.putByte(index++, (byte) (0x80 | codePoint & 0x3f));
+                }
+                else if (codePoint < 0x10000)
+                {
+                    valueChunk.putByte(index++, (byte) (0xe0 | codePoint >> 12));
+                    valueChunk.putByte(index++, (byte) (0x80 | codePoint >> 6 & 0x3f));
+                    valueChunk.putByte(index++, (byte) (0x80 | codePoint & 0x3f));
+                }
+                else
+                {
+                    valueChunk.putByte(index++, (byte) (0xf0 | codePoint >> 18));
+                    valueChunk.putByte(index++, (byte) (0x80 | codePoint >> 12 & 0x3f));
+                    valueChunk.putByte(index++, (byte) (0x80 | codePoint >> 6 & 0x3f));
+                    valueChunk.putByte(index++, (byte) (0x80 | codePoint & 0x3f));
+                }
+                i = next;
+            }
+        }
+        valueCursor = i;
+        decodedLength = index;
+        valueRemaining -= index;
+    }
+
+    // decode whole base64 4-char -> 3-byte groups into valueChunk until the next group would not fit; the final
+    // group (with '='/'==' padding -> 1-2 bytes) is decoded on the last chunk. VALUE_CHUNK is a multiple of 3
+    // so a whole group always fits up to the buffer end
+    private void refillBytesChunk()
+    {
+        valueConsumed = 0;
+        CharSequence value = valueSource;
+        int length = valueSourceLength;
+        int i = valueCursor;
+        int index = 0;
+        boolean room = true;
+        while (i < length && room)
+        {
+            if (index + 3 > VALUE_CHUNK)
+            {
+                room = false;
+            }
+            else
+            {
+                int avail = length - i;
+                int s0 = base64Decode(value.charAt(i));
+                int s1 = base64Decode(value.charAt(i + 1));
+                if (avail == 2)
+                {
+                    // final group, two significant chars (one '=' or unpadded) -> 1 byte
+                    valueChunk.putByte(index++, (byte) (s0 << 2 | s1 >> 4));
+                }
+                else if (avail == 3)
+                {
+                    // final group, three significant chars (one '=' or unpadded) -> 2 bytes
+                    int s2 = base64Decode(value.charAt(i + 2));
+                    valueChunk.putByte(index++, (byte) (s0 << 2 | s1 >> 4));
+                    valueChunk.putByte(index++, (byte) (s1 << 4 | s2 >> 2));
+                }
+                else
+                {
+                    int s2 = base64Decode(value.charAt(i + 2));
+                    int s3 = base64Decode(value.charAt(i + 3));
+                    valueChunk.putByte(index++, (byte) (s0 << 2 | s1 >> 4));
+                    valueChunk.putByte(index++, (byte) (s1 << 4 | s2 >> 2));
+                    valueChunk.putByte(index++, (byte) (s2 << 6 | s3));
+                }
+                i += Math.min(avail, 4);
+            }
+        }
+        valueCursor = i;
+        decodedLength = index;
+        valueRemaining -= index;
+    }
+
+    private int base64Decode(
+        int ch)
+    {
+        int value;
+        if (ch >= 'A' && ch <= 'Z')
+        {
+            value = ch - 'A';
+        }
+        else if (ch >= 'a' && ch <= 'z')
+        {
+            value = ch - 'a' + 26;
+        }
+        else if (ch >= '0' && ch <= '9')
+        {
+            value = ch - '0' + 52;
+        }
+        else if (ch == '+' || ch == '-')
+        {
+            value = 62;
+        }
+        else if (ch == '/' || ch == '_')
+        {
+            value = 63;
+        }
+        else
+        {
+            throw new ProtobufException("invalid base64 character " + ch);
+        }
+        return value;
+    }
+
+    // the count of significant (non-padding) base64 characters: the whole length less any 1-2 trailing '='. The
+    // final group's decoded width is then derived from how many significant chars remain (2 -> 1 byte, 3 -> 2)
+    private static int base64SignificantLength(
         CharSequence value)
     {
-        // a fresh value: rewind the output-pushback cursor so segment() starts at the new value's first byte
-        valueConsumed = 0;
         int length = value.length();
-        int index = 0;
+        int pad = 0;
+        if (length > 0 && value.charAt(length - 1) == '=')
+        {
+            pad++;
+            if (length > 1 && value.charAt(length - 2) == '=')
+            {
+                pad++;
+            }
+        }
+        return length - pad;
+    }
+
+    // decoded byte count for a base64 string given its significant length: full groups yield 3 bytes, a 2-char
+    // tail yields 1 byte, a 3-char tail yields 2 bytes — matching JDK Base64 decode
+    private static int base64DecodedLength(
+        CharSequence value,
+        int significant)
+    {
+        int groups = significant / 4;
+        int tail = significant - groups * 4;
+        int extra = tail == 0 ? 0 : tail - 1;
+        return groups * 3 + extra;
+    }
+
+    // the UTF-8 byte length of the char sequence, allocation-free, with the same surrogate-pair handling as the
+    // encoder so the total reported up front matches the bytes later staged
+    private static int utf8Length(
+        CharSequence value)
+    {
+        int length = value.length();
+        int bytes = 0;
         int i = 0;
         while (i < length)
         {
@@ -732,30 +1029,9 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
                     i++;
                 }
             }
-            if (codePoint < 0x80)
-            {
-                valueBuffer.putByte(index++, (byte) codePoint);
-            }
-            else if (codePoint < 0x800)
-            {
-                valueBuffer.putByte(index++, (byte) (0xc0 | codePoint >> 6));
-                valueBuffer.putByte(index++, (byte) (0x80 | codePoint & 0x3f));
-            }
-            else if (codePoint < 0x10000)
-            {
-                valueBuffer.putByte(index++, (byte) (0xe0 | codePoint >> 12));
-                valueBuffer.putByte(index++, (byte) (0x80 | codePoint >> 6 & 0x3f));
-                valueBuffer.putByte(index++, (byte) (0x80 | codePoint & 0x3f));
-            }
-            else
-            {
-                valueBuffer.putByte(index++, (byte) (0xf0 | codePoint >> 18));
-                valueBuffer.putByte(index++, (byte) (0x80 | codePoint >> 12 & 0x3f));
-                valueBuffer.putByte(index++, (byte) (0x80 | codePoint >> 6 & 0x3f));
-                valueBuffer.putByte(index++, (byte) (0x80 | codePoint & 0x3f));
-            }
+            bytes += codePoint < 0x80 ? 1 : codePoint < 0x800 ? 2 : codePoint < 0x10000 ? 3 : 4;
         }
-        valueLength = index;
+        return bytes;
     }
 
     private static long parseLong(
@@ -1007,15 +1283,6 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
         return number;
     }
 
-    private void putBytes(
-        byte[] bytes)
-    {
-        // a fresh value: rewind the output-pushback cursor so segment() starts at the new value's first byte
-        valueConsumed = 0;
-        valueBuffer.putBytes(0, bytes);
-        valueLength = bytes.length;
-    }
-
     private void expectStartObject(
         JsonEvent token)
     {
@@ -1063,21 +1330,6 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
     {
         ProtobufMessage message = field.message();
         return field.repeated() && message != null && message.mapEntry();
-    }
-
-    private static byte[] decodeBase64(
-        String value)
-    {
-        byte[] bytes;
-        try
-        {
-            bytes = Base64.getDecoder().decode(value);
-        }
-        catch (IllegalArgumentException ex)
-        {
-            bytes = Base64.getUrlDecoder().decode(value);
-        }
-        return bytes;
     }
 
     private static final class Frame

--- a/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/json/ProtobufJsonChunkingTest.java
+++ b/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/json/ProtobufJsonChunkingTest.java
@@ -198,6 +198,29 @@ public class ProtobufJsonChunkingTest
         assertArrayEquals(blob, Base64.getDecoder().decode(object.getString("by")));
     }
 
+    @Test
+    public void shouldFragmentMapKeyAcrossTinyInputWindows()
+    {
+        // a string map key long enough that its wire bytes split across several tiny input windows, exercising
+        // the multi-fragment accumulation path that materializes the key once complete
+        String key = "the-quick-brown-fox-jumps-over-the-lazy-dog";
+
+        byte[] wire = wire(g -> g
+            .startMessage(1, 64)
+            .writeString(1, key)
+            .writeString(2, "v")
+            .endMessage());
+
+        // a 4-byte input window forces the key's wire bytes to arrive in many fragments (STARVED), while a
+        // generous output window keeps the whole document in one chunk
+        TwoAxisDrained drained = toJsonTwoAxis("Props", wire, 4, 8192);
+
+        assertTrue(drained.starves >= 1, "expected at least one STARVED (input) chunk boundary");
+
+        JsonObject object = parse(drained.json);
+        assertEquals("v", object.getJsonObject("props").getString(key));
+    }
+
     private WireDrained fromJsonWindowed(
         String messageName,
         byte[] json,
@@ -407,6 +430,15 @@ public class ProtobufJsonChunkingTest
                 .field(ProtobufField.builder().number(13).name("bo").type(ProtobufType.BOOL).build())
                 .field(ProtobufField.builder().number(14).name("st").type(ProtobufType.STRING).build())
                 .field(ProtobufField.builder().number(15).name("by").type(ProtobufType.BYTES).build())
+                .build())
+            .message(ProtobufMessage.builder("PropsEntry")
+                .mapEntry(true)
+                .field(ProtobufField.builder().number(1).name("key").type(ProtobufType.STRING).build())
+                .field(ProtobufField.builder().number(2).name("value").type(ProtobufType.STRING).build())
+                .build())
+            .message(ProtobufMessage.builder("Props")
+                .field(ProtobufField.builder().number(1).name("props").type(ProtobufType.MESSAGE).typeName("PropsEntry")
+                    .repeated(true).build())
                 .build())
             .build();
     }

--- a/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/json/ProtobufJsonTest.java
+++ b/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/json/ProtobufJsonTest.java
@@ -252,6 +252,13 @@ public class ProtobufJsonTest
     }
 
     @Test
+    public void shouldRoundTripMultiCharacterMapKey()
+    {
+        assertEquals("{\"props\":{\"hello-world\":\"v\"}}",
+            roundTrip("Person", "{\"props\":{\"hello-world\":\"v\"}}"));
+    }
+
+    @Test
     public void shouldRoundTripNonFinite()
     {
         assertEquals("{\"fl\":\"NaN\",\"db\":\"-Infinity\"}",

--- a/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/json/ProtobufJsonValueChunkingTest.java
+++ b/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/json/ProtobufJsonValueChunkingTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.protobuf.json;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
+import java.util.Base64;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+import io.aklivity.zilla.runtime.common.json.JsonEx;
+import io.aklivity.zilla.runtime.common.protobuf.Protobuf;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufEnum;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufField;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufGenerator;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufMessage;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline.Status;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufSchema;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufSink;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufType;
+
+// Exercises the JSON -> wire write path's bounded value streaming: the parser stages each large string/bytes
+// value through a small FIXED buffer, transcoding incrementally and delivering BOUNDED chunks. Drives both
+// chunk refills (decoded length far exceeds the fixed staging buffer) and within-chunk output back-pressure
+// (a tiny output window forces SUSPEND mid-chunk), asserting the decoded wire round-trips bit-exactly.
+public class ProtobufJsonValueChunkingTest
+{
+    private final ProtobufSchema schema = newSchema();
+
+    @Test
+    public void shouldRoundTripLargeMultibyteStringAndPaddedBytesThroughTinyOutputWindow()
+    {
+        // a 20k-char string mixing ASCII, 2-byte (é), 3-byte (中), and surrogate-pair emoji code points so the
+        // UTF-8 encoder must align chunk refills on whole code points across the fixed staging buffer
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < 5000; i++)
+        {
+            builder.append("aé中😀");
+        }
+        String text = builder.toString();
+        assertTrue(text.length() >= 20000, "string under 20k chars");
+
+        // ~15k bytes whose length is NOT a multiple of 3, so the final base64 group is padded (1 trailing byte)
+        byte[] blob = new byte[15001];
+        for (int i = 0; i < blob.length; i++)
+        {
+            blob[i] = (byte) (i * 31 + 7);
+        }
+
+        String json = json(text, blob);
+
+        // a 40-byte output window is far smaller than either value, forcing SUSPEND within most chunks
+        WireDrained drained = fromJsonWindowed("Scalars", json.getBytes(UTF_8), 40);
+        assertTrue(drained.suspends >= 1, "expected at least one SUSPENDED chunk boundary");
+
+        JsonObject object = parse(toJson("Scalars", drained.wire));
+        assertEquals(text, object.getString("st"));
+        assertArrayEquals(blob, Base64.getDecoder().decode(object.getString("by")));
+    }
+
+    @Test
+    public void shouldRoundTripValueStraddlingFixedBufferAndOutputWindowSimultaneously()
+    {
+        // values sized so the decoded length straddles the parser's fixed staging buffer (forcing refills) while
+        // the output window forces a within-chunk pushback at the same time — both axes active together
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < 3000; i++)
+        {
+            builder.append("中é𐍈x");
+        }
+        String text = builder.toString();
+
+        byte[] blob = new byte[9007];
+        for (int i = 0; i < blob.length; i++)
+        {
+            blob[i] = (byte) (i * 17 + 3);
+        }
+
+        String json = json(text, blob);
+
+        // a 37-byte output window forces within-chunk pushback; the values dwarf the fixed staging buffer so
+        // multiple refills also occur
+        WireDrained bounded = fromJsonWindowed("Scalars", json.getBytes(UTF_8), 37);
+        assertTrue(bounded.suspends >= 1, "expected SUSPENDED chunk boundaries");
+
+        // a generous single-feed window must produce the identical wire bytes
+        WireDrained whole = fromJsonWindowed("Scalars", json.getBytes(UTF_8), 1 << 17);
+        assertEquals(0, whole.suspends, "generous window must not suspend");
+        assertArrayEquals(whole.wire, bounded.wire, "chunked wire must concatenate to the same bytes");
+
+        JsonObject object = parse(toJson("Scalars", bounded.wire));
+        assertEquals(text, object.getString("st"));
+        assertArrayEquals(blob, Base64.getDecoder().decode(object.getString("by")));
+    }
+
+    @Test
+    public void shouldRoundTripBytesWithTwoPaddingBytes()
+    {
+        // a bytes length == 2 mod 3 produces a final group with one '=' pad -> 2 decoded bytes on the last chunk
+        byte[] blob = new byte[8000 + 2];
+        for (int i = 0; i < blob.length; i++)
+        {
+            blob[i] = (byte) (i * 13 + 1);
+        }
+        String json = json("short", blob);
+
+        WireDrained bounded = fromJsonWindowed("Scalars", json.getBytes(UTF_8), 48);
+        WireDrained whole = fromJsonWindowed("Scalars", json.getBytes(UTF_8), 1 << 17);
+        assertArrayEquals(whole.wire, bounded.wire, "chunked wire must concatenate to the same bytes");
+
+        JsonObject object = parse(toJson("Scalars", bounded.wire));
+        assertArrayEquals(blob, Base64.getDecoder().decode(object.getString("by")));
+    }
+
+    @Test
+    public void shouldStageValueInBoundedFixedBuffer() throws Exception
+    {
+        Object parser = ProtobufJson.parser(JsonEx.createParser(), schema, "Scalars");
+        boolean fixedFound = false;
+        for (Field field : parser.getClass().getDeclaredFields())
+        {
+            assertTrue(!ExpandableArrayBuffer.class.isAssignableFrom(field.getType()),
+                "no growable ExpandableArrayBuffer may stage the value");
+            if ("valueChunk".equals(field.getName()))
+            {
+                field.setAccessible(true);
+                Object value = field.get(parser);
+                assertTrue(value instanceof UnsafeBuffer, "valueChunk must be a fixed UnsafeBuffer");
+                int capacity = ((UnsafeBuffer) value).capacity();
+                assertTrue(capacity > 0 && capacity <= 1 << 13, "value staging buffer must be small and bounded");
+                assertEquals(0, capacity % 3, "value staging buffer must be a multiple of 3 for base64 groups");
+                fixedFound = true;
+            }
+        }
+        assertTrue(fixedFound, "expected a fixed valueChunk staging buffer");
+    }
+
+    private WireDrained fromJsonWindowed(
+        String messageName,
+        byte[] json,
+        int window)
+    {
+        MutableDirectBuffer out = new UnsafeBuffer(new byte[window]);
+        ProtobufGenerator generator = Protobuf.generator();
+        generator.wrap(out, 0, window);
+        ProtobufPipeline pipeline = Protobuf.stream(ProtobufJson.parser(JsonEx.createParser(), schema, messageName))
+            .into(ProtobufSink.of(generator, schema, messageName));
+        pipeline.reset();
+
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+        UnsafeBuffer in = new UnsafeBuffer(json);
+        int suspends = 0;
+        int guard = 0;
+        Status status = pipeline.feed(in, 0, json.length);
+        while (status == Status.SUSPENDED && guard < 10_000_000)
+        {
+            assertTrue(generator.length() <= window, "chunk exceeded the generator limit");
+            result.writeBytes(bytes(out, generator.length()));
+            generator.wrap(out, 0, window);
+            suspends++;
+            guard++;
+            status = pipeline.feed(in, 0, json.length);
+        }
+        assertEquals(Status.COMPLETED, status);
+        generator.flush();
+        result.writeBytes(bytes(out, generator.length()));
+
+        return new WireDrained(result.toByteArray(), suspends);
+    }
+
+    private String toJson(
+        String messageName,
+        byte[] wire)
+    {
+        MutableDirectBuffer out = new UnsafeBuffer(new byte[1 << 18]);
+        ProtobufGenerator generator = ProtobufJson.generator(JsonEx.createGenerator(), schema, messageName);
+        generator.wrap(out, 0, out.capacity());
+        ProtobufPipeline pipeline = Protobuf.stream(Protobuf.parser(schema, messageName))
+            .into(ProtobufSink.of(generator, schema, messageName));
+        pipeline.reset();
+        Status status = pipeline.feed(new UnsafeBuffer(wire), 0, wire.length);
+        assertEquals(Status.COMPLETED, status);
+        generator.flush();
+        byte[] bytes = new byte[generator.length()];
+        out.getBytes(0, bytes);
+        return new String(bytes, UTF_8);
+    }
+
+    private static String json(
+        String st,
+        byte[] by)
+    {
+        return Json.createObjectBuilder()
+            .add("st", st)
+            .add("by", Base64.getEncoder().encodeToString(by))
+            .build()
+            .toString();
+    }
+
+    private static byte[] bytes(
+        MutableDirectBuffer buffer,
+        int length)
+    {
+        byte[] bytes = new byte[length];
+        buffer.getBytes(0, bytes);
+        return bytes;
+    }
+
+    private static JsonObject parse(
+        String json)
+    {
+        try (JsonReader reader = Json.createReader(new ByteArrayInputStream(json.getBytes(UTF_8))))
+        {
+            return reader.readObject();
+        }
+    }
+
+    private static ProtobufSchema newSchema()
+    {
+        return Protobuf.schema()
+            .enumeration(ProtobufEnum.builder("Color")
+                .value("RED", 0)
+                .value("GREEN", 1)
+                .value("BLUE", 2)
+                .build())
+            .message(ProtobufMessage.builder("Scalars")
+                .field(ProtobufField.builder().number(14).name("st").type(ProtobufType.STRING).build())
+                .field(ProtobufField.builder().number(15).name("by").type(ProtobufType.BYTES).build())
+                .build())
+            .build();
+    }
+
+    private static final class WireDrained
+    {
+        private final byte[] wire;
+        private final int suspends;
+
+        private WireDrained(
+            byte[] wire,
+            int suspends)
+        {
+            this.wire = wire;
+            this.suspends = suspends;
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

Retire the two remaining staging buffers in the `common-protobuf` JSON adapters, so the protobuf↔JSON path holds no per-value growable buffer. Both are replaced without leaking JSON concerns (base64) into the wire codec.

## `ProtobufJsonGeneratorImpl.accumulator` — removed
`writeKeySegment` staged a **map key**'s bytes across fragments in a dedicated `ExpandableArrayBuffer` and materialized them via `new byte[]` + `new String`. The existing `scratch` `StringBuilder` already does cross-fragment staging for string values, so the key path reuses it: reset on the first fragment, `appendUtf8` each fragment, `captureKey(scratch.toString())` on completion (a key never touches the bounded output — it's emitted later via `writeKey` when the value's field is prepared — so each fragment is always fully consumed). Drops the buffer **and** the per-key `new byte[]`; the `segmentLength` counter falls out as dead.

## `ProtobufJsonParserImpl.valueBuffer` — replaced with bounded streaming
The parser staged the **whole** transcoded value (UTF-8-encoded string / base64-decoded bytes) in a growable `ExpandableArrayBuffer`. Replace it with a small **fixed** reused buffer (`valueChunk = new byte[4092]`, a multiple of 3 so a base64 4→3 group never straddles the end) and transcode incrementally, delivering the value as bounded chunks (mirroring the wire parser's `leafChunk`). **The transcode stays in the parser — `ProtobufGeneratorImpl` is untouched, so no base64/JSON concern leaks into the wire codec.**

State machine: the value's chars are already wholly in-window (`getStringView` requires the leaf present), so a source cursor drives transcode progress, not input back-pressure.
- `segment()` exposes `valueChunk[valueConsumed, decodedLength)`;
- `consumed(n)` advances `valueConsumed` only — within-chunk output back-pressure, never refills;
- `deferredBytes()` returns the bytes not yet transcoded (> 0 until the last chunk), so the generator's length prefix (`total = length + deferred` on the first `writeSegment`) is correct and the segment stays open across chunks;
- `streamValueStep()` (on the pump's ADVANCED re-entry) refills only once the chunk is fully drained: STRING encodes whole code points until the next won't fit; BYTES decodes whole 4→3 groups until the next won't fit, the final padded group on the last chunk; decoded length computed up front, allocation-free.

## Tests

- `accumulator`: a multi-character string map key (single feed) and a 43-char key driven through a 4-byte input window (the prior tests used only single-char keys, exercising neither the cross-fragment accumulation nor the reset).
- `valueBuffer` (`ProtobufJsonValueChunkingTest`): a 20k-char multibyte/surrogate string and ~15k padded bytes through a **40-byte** wire output window (within-chunk SUSPEND); a value straddling both the fixed buffer (refills) and the output window simultaneously; and a reflection check that the staging buffer is a fixed bounded `UnsafeBuffer` with no `ExpandableArrayBuffer` — all **bit-exact** against the single-feed wire.

`./mvnw clean install -pl runtime/common-protobuf` → BUILD SUCCESS (177 tests incl. `ProtobufJsonTest`/`ProtobufJsonChunkingTest`/`ProtobufPipelineTest`, checkstyle, license, JaCoCo, moditect). `ProtobufJsonPipelineBM.jsonToProtobuf` stays ~0 B/op.

## Result

No growable per-value buffer remains in the protobuf↔JSON adapters; both staging buffers are gone (generator) / bounded (parser), with the transcode in the correct layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfzS5MmFH2NQBefvoB3o7d

---
_Generated by [Claude Code](https://claude.ai/code/session_01MfzS5MmFH2NQBefvoB3o7d)_