### PR TITLE
feat(common-json): consumer-driven value retention (accumulate on decline, incremental number validation, fail-closed cap, fragment-aware validator)

### DIFF
--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonParserEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonParserEx.java
@@ -30,6 +30,15 @@ import org.agrona.DirectBuffer;
 public interface JsonParserEx extends JsonParser
 {
     /**
+     * Config key (for {@link JsonEx#createParser(java.util.Map)}) whose {@link Integer} value caps the
+     * number of decoded chars retained for a single value or key. A consumer that needs a value whole
+     * declines its fragments (consumed(0)) so the source accumulates them; this bounds that accumulation
+     * so an adversarially large value fails closed with a {@link JsonPipeline.Status#REJECTED} rather than
+     * exhausting memory. Absent ⇒ a generous default.
+     */
+    String MAX_VALUE_SIZE = "io.aklivity.zilla.runtime.common.json.parser.maxValueSize";
+
+    /**
      * Borrows {@code buffer} as the input window for the next pump, the half-open range
      * {@code [offset, limit)}. The buffer is read in place for the duration of the pump.
      * <p>

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -525,6 +525,10 @@ public final class JsonParserImpl implements JsonParserEx
     public BigDecimal getBigDecimal()
     {
         assert currentEvent == Event.VALUE_NUMBER;
+        // getBigDecimal() yields the whole value, so the lexeme must be complete; a caller that needs a
+        // value still spanning windows must first gather it (e.g. push back via consumed(0)) and only
+        // read it once the deferred bytes have arrived
+        assert !deferredBytes();
         return new BigDecimal(numberLexeme().toString());
     }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -188,6 +188,13 @@ public final class JsonParserImpl implements JsonParserEx
         }
         else
         {
+            // before resuming a value that spans windows, tell the tokenizer how much of the prior
+            // fragment the consumer took (the char cursor) so it keeps the unconsumed remainder and
+            // accumulates rather than discarding a declined fragment
+            if (tokenizer.fragmenting())
+            {
+                tokenizer.markScratchConsumed(stringViewOffset);
+            }
             try
             {
                 result = tokenizer.advance(in);

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -48,6 +48,10 @@ public final class JsonParserImpl implements JsonParserEx
     // reject anything longer as too large for a primitive, directing the caller to getBigDecimal()
     private static final int LONG_DIGITS = 19;
 
+    // default cap on the decoded chars retained for one value/key when no MAX_VALUE_SIZE config is given:
+    // generous enough for any reasonable value, bounding only adversarial accumulation
+    private static final int DEFAULT_MAX_VALUE_SIZE = 1 << 24;
+
     private final InputStream in;
     private final DirectBufferInputStreamEx ownedInput;
     private final JsonTokenizer tokenizer;
@@ -95,7 +99,7 @@ public final class JsonParserImpl implements JsonParserEx
     {
         this.ownedInput = new DirectBufferInputStreamEx();
         this.in = ownedInput;
-        this.tokenizer = new JsonTokenizer();
+        this.tokenizer = new JsonTokenizer(false, maxValueSize(config));
         this.location = new JsonLocationImpl(tokenizer);
     }
 
@@ -118,8 +122,15 @@ public final class JsonParserImpl implements JsonParserEx
         // A DirectBufferInputStreamEx is a resumable frame source whose EOF is a frame boundary;
         // any other stream is one-shot, so its EOF is the terminal delimiter for a trailing number.
         this.tokenizer = new JsonTokenizer(
-            !(in instanceof DirectBufferInputStreamEx));
+            !(in instanceof DirectBufferInputStreamEx), maxValueSize(config));
         this.location = new JsonLocationImpl(tokenizer);
+    }
+
+    private static int maxValueSize(
+        Map<String, ?> config)
+    {
+        final Object value = config.get(JsonParserEx.MAX_VALUE_SIZE);
+        return value instanceof Integer size ? size : DEFAULT_MAX_VALUE_SIZE;
     }
 
     @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -44,6 +44,10 @@ import io.aklivity.zilla.runtime.common.json.internal.json.JsonValues;
 
 public final class JsonParserImpl implements JsonParserEx
 {
+    // a non-negative integer lexeme of at most this many digits is within long range; getInt()/getLong()
+    // reject anything longer as too large for a primitive, directing the caller to getBigDecimal()
+    private static final int LONG_DIGITS = 19;
+
     private final InputStream in;
     private final DirectBufferInputStreamEx ownedInput;
     private final JsonTokenizer tokenizer;
@@ -490,7 +494,9 @@ public final class JsonParserImpl implements JsonParserEx
     public boolean isIntegralNumber()
     {
         assert currentEvent == Event.VALUE_NUMBER;
-        final CharSequence v = numberLexeme();
+        // the current number's char view (not stringValue()), so scanning it materializes no String; with
+        // consumed(0) accumulation a value the caller needs whole is fully present in scratch by this point
+        final CharSequence v = tokenizer.stringView();
         if (v == null)
         {
             throw new IllegalStateException("Not a number");
@@ -508,11 +514,12 @@ public final class JsonParserImpl implements JsonParserEx
     public int getInt()
     {
         assert currentEvent == Event.VALUE_NUMBER;
-        if (tokenizer.numberFragmented())
-        {
-            throw new IllegalStateException("number spans multiple windows; use getBigDecimal()");
-        }
+        assert !deferredBytes();
         final CharSequence lexeme = tokenizer.stringView();
+        if (integerDigits(lexeme) > LONG_DIGITS)
+        {
+            throw new IllegalStateException("number exceeds long range; use getBigDecimal()");
+        }
         return Integer.parseInt(lexeme, 0, lexeme.length(), 10);
     }
 
@@ -520,11 +527,12 @@ public final class JsonParserImpl implements JsonParserEx
     public long getLong()
     {
         assert currentEvent == Event.VALUE_NUMBER;
-        if (tokenizer.numberFragmented())
-        {
-            throw new IllegalStateException("number spans multiple windows; use getBigDecimal()");
-        }
+        assert !deferredBytes();
         final CharSequence lexeme = tokenizer.stringView();
+        if (integerDigits(lexeme) > LONG_DIGITS)
+        {
+            throw new IllegalStateException("number exceeds long range; use getBigDecimal()");
+        }
         return Long.parseLong(lexeme, 0, lexeme.length(), 10);
     }
 
@@ -536,14 +544,22 @@ public final class JsonParserImpl implements JsonParserEx
         // value still spanning windows must first gather it (e.g. push back via consumed(0)) and only
         // read it once the deferred bytes have arrived
         assert !deferredBytes();
-        return new BigDecimal(numberLexeme().toString());
+        return new BigDecimal(tokenizer.stringView().toString());
     }
 
-    // the current number's full lexeme; the char view (not stringValue()), so a caller that only scans
-    // it — e.g. isIntegralNumber() — materializes no String
-    private CharSequence numberLexeme()
+    // count of leading integer digits after an optional sign; a longer integer lexeme cannot fit a long,
+    // so getInt()/getLong() reject it rather than overflow, directing the caller to getBigDecimal()
+    private static int integerDigits(
+        CharSequence lexeme)
     {
-        return tokenizer.numberFragmented() ? tokenizer.numberLexeme() : tokenizer.stringView();
+        int index = lexeme.length() > 0 && lexeme.charAt(0) == '-' ? 1 : 0;
+        int digits = 0;
+        while (index < lexeme.length() && lexeme.charAt(index) >= '0' && lexeme.charAt(index) <= '9')
+        {
+            index++;
+            digits++;
+        }
+        return digits;
     }
 
     @Override
@@ -578,7 +594,7 @@ public final class JsonParserImpl implements JsonParserEx
         case START_OBJECT -> getObject();
         case START_ARRAY -> getArray();
         case VALUE_STRING, KEY_NAME -> JsonValues.string(getString());
-        case VALUE_NUMBER -> JsonValues.numberLiteral(numberLexeme().toString());
+        case VALUE_NUMBER -> JsonValues.numberLiteral(tokenizer.stringView().toString());
         case VALUE_TRUE -> JsonValue.TRUE;
         case VALUE_FALSE -> JsonValue.FALSE;
         case VALUE_NULL -> JsonValue.NULL;

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
@@ -2175,15 +2175,39 @@ public final class JsonSchemaImpl implements JsonSchema
             JsonSink sink)
         {
             upstreamControl = control;
-            Status downstream = sink.feed(decline, source, event);
             Status status;
+            boolean scalar = event == JsonEvent.VALUE_STRING || event == JsonEvent.VALUE_NUMBER;
             if (event.segmented() || event == JsonEvent.START_DOCUMENT || event == JsonEvent.END_DOCUMENT)
             {
+                Status downstream = sink.feed(decline, source, event);
                 status = downstream == Status.REJECTED ? Status.REJECTED
                     : downstream == Status.SUSPENDED ? Status.SUSPENDED : Status.ADVANCED;
             }
+            else if (scalar && source.deferredBytes())
+            {
+                // Eval is not fragment-aware: a value spanning windows must be reassembled before it can be
+                // validated against any keyword. Decline the fragment (consumed(0), do not forward) so the
+                // source accumulates it and re-presents the value whole on a later window; only then validate.
+                control.consumed(0);
+                status = Status.STARVED;
+            }
+            else if (scalar)
+            {
+                // a complete scalar: validate before forwarding, so eval reads the whole value rather than the
+                // remainder the sink leaves after advancing the consumed cursor
+                Verdict verdict = eval.feed(toEvent(event), source);
+                if (verdict == Verdict.INVALID)
+                {
+                    throw new JsonValidationException(diagnostics);
+                }
+                Status downstream = sink.feed(decline, source, event);
+                status = verdictStatus(verdict, downstream);
+            }
             else
             {
+                // structural events and keys forward first, preserving the emit-then-reject ordering (e.g. a
+                // missing required property is detected at END_OBJECT only after the object has been emitted)
+                Status downstream = sink.feed(decline, source, event);
                 Verdict verdict = eval.feed(toEvent(event), source);
                 // throw a descriptive exception at the point of detection so the pipeline maps it to REJECTED
                 // and pushes the diagnostic to the reporter, rather than rejecting structurally with no message
@@ -2191,20 +2215,18 @@ public final class JsonSchemaImpl implements JsonSchema
                 {
                     throw new JsonValidationException(diagnostics);
                 }
-                else if (downstream == Status.REJECTED)
-                {
-                    status = Status.REJECTED;
-                }
-                else if (verdict == Verdict.VALID)
-                {
-                    status = Status.COMPLETED;
-                }
-                else
-                {
-                    status = downstream == Status.SUSPENDED ? Status.SUSPENDED : Status.ADVANCED;
-                }
+                status = verdictStatus(verdict, downstream);
             }
             return status;
+        }
+
+        private Status verdictStatus(
+            Verdict verdict,
+            Status downstream)
+        {
+            return downstream == Status.REJECTED ? Status.REJECTED
+                : verdict == Verdict.VALID ? Status.COMPLETED
+                : downstream == Status.SUSPENDED ? Status.SUSPENDED : Status.ADVANCED;
         }
 
         @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -273,7 +273,10 @@ public final class JsonTokenizer
                 resumeUnicodePending = 0;
                 resumeUnicodeValue = 0;
                 fragmenting = true;
-                if (scalarSegment ? streamOffset > fragmentStart : scratch.length() > 0)
+                // ship a fragment only when this round scanned new bytes; with consumed(0) accumulation the
+                // retained remainder keeps scratch non-empty, so a non-empty scratch alone is not progress and
+                // re-shipping it would spin the pump — require streamOffset to have advanced past fragmentStart
+                if (streamOffset > fragmentStart)
                 {
                     valueStreamStart = fragmentStart;
                     valueStreamEnd = streamOffset;

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -49,6 +49,20 @@ public final class JsonTokenizer
         VALUE_NULL
     }
 
+    // states of the RFC 8259 number grammar, advanced one char at a time by validateNumberChar
+    private enum NumberState
+    {
+        START,
+        SIGN,
+        ZERO,
+        INT,
+        DOT,
+        FRAC,
+        EXP,
+        EXP_SIGN,
+        EXP_INT
+    }
+
     private static final int MAX_DEPTH = 64;
 
     private final Deque<ParseState> stack = new ArrayDeque<>();
@@ -108,6 +122,9 @@ public final class JsonTokenizer
     // true once the current/just-completed number was delivered in more than one fragment: getInt()/
     // getLong() then throw (the value would overflow) and getBigDecimal() reads the accumulated lexeme.
     private boolean numberFragmented;
+    // RFC 8259 number grammar validated incrementally as each char is scanned, so a number spanning
+    // windows needs no retained whole lexeme to validate; the state persists across fragments.
+    private NumberState numberState;
 
     // set at each VALUE_STRING delivery: true when the value-string was streamed verbatim as raw bytes
     // (a segment scan or an armed scalar leaf), so the caller splices its raw token bytes; false when it
@@ -151,6 +168,7 @@ public final class JsonTokenizer
         scratchConsumed = 0;
         numberLexeme.setLength(0);
         numberFragmented = false;
+        numberState = NumberState.START;
         stringVerbatim = false;
         pathDepth = 0;
         state = ParseState.DOC_START;
@@ -607,20 +625,16 @@ public final class JsonTokenizer
     }
 
     // Completes a VALUE_NUMBER scan: continueNumberContent only returns here once the number terminator
-    // (or the terminal window's EOF) is seen, so the number is whole. A fragmented number's full lexeme
-    // is validated from numberLexeme (the final fragment's digits appended); an unfragmented one from
-    // scratch. Captured lazily and the parse state advances.
+    // (or the terminal window's EOF) is seen, so the number is whole. The grammar was validated char by
+    // char as the lexeme was scanned; here only the accepting-state check remains. A fragmented number's
+    // full lexeme is still gathered in numberLexeme for getBigDecimal until the source accumulates it.
     private void finishNumberValue()
     {
         if (numberFragmented)
         {
             numberLexeme.append(scratch);
-            validateNumber(numberLexeme);
         }
-        else
-        {
-            validateNumber(scratch);
-        }
+        validateNumberComplete();
         valueStreamStart = fragmentStart;
         valueStreamEnd = streamOffset;
         pendingEvent = JsonParser.Event.VALUE_NUMBER;
@@ -806,7 +820,9 @@ public final class JsonTokenizer
                 numberLexeme.setLength(0);
                 numberFragmented = false;
                 scratch.setLength(0);
+                numberState = NumberState.START;
                 scratch.append((char) c);
+                validateNumberChar(c);
                 resumeOp = ResumeOp.VALUE_NUMBER;
                 continueNumberContent(in);
                 if (!starved)
@@ -1150,6 +1166,7 @@ public final class JsonTokenizer
             {
                 streamOffset++;
                 advance(c);
+                validateNumberChar(c);
                 appendScratch((char) c);
             }
             else
@@ -1160,60 +1177,67 @@ public final class JsonTokenizer
         }
     }
 
-    // RFC 8259 number grammar: -?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][+-]?[0-9]+)?. scratch holds the
-    // complete lexeme (numbers are always retained in scratch for validation and lazy materialization).
-    private void validateNumber(
-        CharSequence lexeme)
+    // RFC 8259 number grammar -?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][+-]?[0-9]+)? validated as a state machine,
+    // one char at a time as it is scanned. The state persists across windows, so a number spanning windows
+    // is validated without retaining its whole lexeme. continueNumberContent only feeds the number-class
+    // chars [0-9.+-eE], so this rejects any that are illegal in their position.
+    private void validateNumberChar(
+        int c)
     {
-        final int length = lexeme.length();
-        int index = 0;
-        boolean valid = length > 0;
-        if (valid && lexeme.charAt(index) == '-')
+        switch (numberState)
         {
-            index++;
+        case START:
+            numberState = c == '-' ? NumberState.SIGN : c == '0' ? NumberState.ZERO
+                : isDigit((char) c) ? NumberState.INT : rejectNumber(c);
+            break;
+        case SIGN:
+            numberState = c == '0' ? NumberState.ZERO : isDigit((char) c) ? NumberState.INT : rejectNumber(c);
+            break;
+        case ZERO:
+            numberState = c == '.' ? NumberState.DOT : c == 'e' || c == 'E' ? NumberState.EXP : rejectNumber(c);
+            break;
+        case INT:
+            numberState = isDigit((char) c) ? NumberState.INT : c == '.' ? NumberState.DOT
+                : c == 'e' || c == 'E' ? NumberState.EXP : rejectNumber(c);
+            break;
+        case DOT:
+            numberState = isDigit((char) c) ? NumberState.FRAC : rejectNumber(c);
+            break;
+        case FRAC:
+            numberState = isDigit((char) c) ? NumberState.FRAC : c == 'e' || c == 'E' ? NumberState.EXP : rejectNumber(c);
+            break;
+        case EXP:
+            numberState = c == '+' || c == '-' ? NumberState.EXP_SIGN
+                : isDigit((char) c) ? NumberState.EXP_INT : rejectNumber(c);
+            break;
+        case EXP_SIGN:
+            numberState = isDigit((char) c) ? NumberState.EXP_INT : rejectNumber(c);
+            break;
+        case EXP_INT:
+            numberState = isDigit((char) c) ? NumberState.EXP_INT : rejectNumber(c);
+            break;
+        default:
+            rejectNumber(c);
+            break;
         }
-        final int intStart = index;
-        if (index < length && lexeme.charAt(index) == '0')
+    }
+
+    // A complete number must end in an accepting state: an integer (with or without leading zero), a
+    // fractional part, or an exponent's digits — not a dangling sign, dot, or exponent marker.
+    private void validateNumberComplete()
+    {
+        boolean accepting = numberState == NumberState.ZERO || numberState == NumberState.INT ||
+            numberState == NumberState.FRAC || numberState == NumberState.EXP_INT;
+        if (!accepting)
         {
-            index++;
+            throw new JsonParsingException("Invalid JSON number: " + scratch, null);
         }
-        else
-        {
-            while (index < length && isDigit(lexeme.charAt(index)))
-            {
-                index++;
-            }
-        }
-        valid &= index > intStart;
-        if (valid && index < length && lexeme.charAt(index) == '.')
-        {
-            index++;
-            final int fracStart = index;
-            while (index < length && isDigit(lexeme.charAt(index)))
-            {
-                index++;
-            }
-            valid &= index > fracStart;
-        }
-        if (valid && index < length && (lexeme.charAt(index) == 'e' || lexeme.charAt(index) == 'E'))
-        {
-            index++;
-            if (index < length && (lexeme.charAt(index) == '+' || lexeme.charAt(index) == '-'))
-            {
-                index++;
-            }
-            final int expStart = index;
-            while (index < length && isDigit(lexeme.charAt(index)))
-            {
-                index++;
-            }
-            valid &= index > expStart;
-        }
-        valid &= index == length;
-        if (!valid)
-        {
-            throw new JsonParsingException("Invalid JSON number: " + lexeme, null);
-        }
+    }
+
+    private NumberState rejectNumber(
+        int c)
+    {
+        throw new JsonParsingException("Invalid JSON number char: " + describe(c), null);
     }
 
     private static boolean isDigit(

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -71,6 +71,9 @@ public final class JsonTokenizer
     // unconsumed remainder accumulates, letting a consumer that declines fragments (consumed(0)) receive
     // the value whole. Set by the parser from its consumed cursor before each resuming advance.
     private int scratchConsumed;
+    // cap on the decoded chars retained for one value/key; appendScratch fails closed past it so a
+    // consumer that declines fragments cannot grow scratch without bound
+    private final int maxValueSize;
     private boolean terminalEof;
     // byte length of the current input window; a value whose own bytes reach this length without
     // completing fills the window and is delivered as fragments rather than reassembled across windows.
@@ -141,14 +144,23 @@ public final class JsonTokenizer
         this(false);
     }
 
+    public JsonTokenizer(
+        boolean terminalEof)
+    {
+        this(terminalEof, Integer.MAX_VALUE);
+    }
+
     // terminalEof distinguishes a one-shot stream (EOF is the final delimiter) from the chunked
     // wrap()/feed model (EOF marks a frame boundary with more bytes possibly still to come). It
     // only matters for numbers, which unlike strings and the true/false/null literals are not
     // self-terminating and need a following non-digit byte to know they have ended.
+    // maxValueSize caps the decoded chars retained for one value/key; growth past it fails closed.
     public JsonTokenizer(
-        boolean terminalEof)
+        boolean terminalEof,
+        int maxValueSize)
     {
         this.terminalEof = terminalEof;
+        this.maxValueSize = maxValueSize;
         for (int i = 0; i < MAX_DEPTH; i++)
         {
             pathKeyChars[i] = new StringBuilder();
@@ -797,7 +809,7 @@ public final class JsonTokenizer
                 scratch.setLength(0);
                 scratchConsumed = 0;
                 numberState = NumberState.START;
-                scratch.append((char) c);
+                appendScratch((char) c);
                 validateNumberChar(c);
                 resumeOp = ResumeOp.VALUE_NUMBER;
                 continueNumberContent(in);
@@ -1046,6 +1058,10 @@ public final class JsonTokenizer
     {
         if (!streamingValue())
         {
+            if (scratch.length() >= maxValueSize)
+            {
+                throw resourceExhausted();
+            }
             scratch.append(c);
         }
     }
@@ -1055,8 +1071,20 @@ public final class JsonTokenizer
     {
         if (!streamingValue())
         {
+            if (scratch.length() >= maxValueSize)
+            {
+                throw resourceExhausted();
+            }
             scratch.appendCodePoint(codePoint);
         }
+    }
+
+    // fail closed when a retained value/key exceeds the cap: a consumer that declines fragments to gather
+    // a value whole must not be able to drive scratch past maxValueSize. Surfaced as REJECTED by the pump.
+    private JsonParsingException resourceExhausted()
+    {
+        return new JsonParsingException("JSON value exceeds the maximum retained size of " + maxValueSize +
+            " chars (resource exhausted)", null);
     }
 
     // A value-string being streamed as raw segment bytes is not retained in scratch; keys and numbers

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -71,9 +71,6 @@ public final class JsonTokenizer
     // unconsumed remainder accumulates, letting a consumer that declines fragments (consumed(0)) receive
     // the value whole. Set by the parser from its consumed cursor before each resuming advance.
     private int scratchConsumed;
-    // accumulates the full lexeme of a fragmented number across its fragments (scratch holds only the
-    // current fragment); getBigDecimal() reads this on the final fragment to read the value whole.
-    private final StringBuilder numberLexeme = new StringBuilder();
     private boolean terminalEof;
     // byte length of the current input window; a value whose own bytes reach this length without
     // completing fills the window and is delivered as fragments rather than reassembled across windows.
@@ -119,9 +116,6 @@ public final class JsonTokenizer
     // to unitStartOffset) for the caller to re-present, so no partial state crosses a wrap.
     private boolean fragmenting;
     private long unitStartOffset;
-    // true once the current/just-completed number was delivered in more than one fragment: getInt()/
-    // getLong() then throw (the value would overflow) and getBigDecimal() reads the accumulated lexeme.
-    private boolean numberFragmented;
     // RFC 8259 number grammar validated incrementally as each char is scanned, so a number spanning
     // windows needs no retained whole lexeme to validate; the state persists across fragments.
     private NumberState numberState;
@@ -166,8 +160,6 @@ public final class JsonTokenizer
         stack.clear();
         scratch.setLength(0);
         scratchConsumed = 0;
-        numberLexeme.setLength(0);
-        numberFragmented = false;
         numberState = NumberState.START;
         stringVerbatim = false;
         pathDepth = 0;
@@ -309,13 +301,11 @@ public final class JsonTokenizer
             }
             else if (fragment)
             {
-                // number: every digit is a complete unit so nothing is rewound; accumulate the whole
-                // lexeme and ship the digits scanned so far
+                // number: every digit is a complete unit so nothing is rewound; ship only when this round
+                // scanned new bytes (consumed(0) accumulation keeps the rest in scratch, re-presented whole)
                 fragmenting = true;
-                numberFragmented = true;
-                if (scratch.length() > 0)
+                if (streamOffset > fragmentStart)
                 {
-                    numberLexeme.append(scratch);
                     valueStreamStart = fragmentStart;
                     valueStreamEnd = streamOffset;
                     pendingEvent = JsonParser.Event.VALUE_NUMBER;
@@ -427,23 +417,11 @@ public final class JsonTokenizer
         return fragmenting;
     }
 
-    // True when the current/just-completed number was delivered in more than one fragment, so its whole
-    // lexeme is in numberLexeme() rather than the current scratch.
-    public boolean numberFragmented()
-    {
-        return numberFragmented;
-    }
-
     // True when the just-delivered value-string was streamed verbatim as raw bytes rather than decoded
     // into scratch; the parser then splices its raw token bytes instead of rendering canonically.
     public boolean stringVerbatim()
     {
         return stringVerbatim;
-    }
-
-    public CharSequence numberLexeme()
-    {
-        return numberLexeme;
     }
 
     public String currentPath()
@@ -561,7 +539,10 @@ public final class JsonTokenizer
             }
             break;
         case VALUE_NUMBER:
-            scratch.setLength(0);
+            // keep the unconsumed remainder (a decliner keeps all of it via consumed(0)) so the next
+            // fragment accumulates onto it and the number is re-presented whole; full consumption drops it
+            scratch.delete(0, Math.min(scratchConsumed, scratch.length()));
+            scratchConsumed = 0;
             fragmentStart = streamOffset;
             continueNumberContent(in);
             if (!starved)
@@ -626,14 +607,10 @@ public final class JsonTokenizer
 
     // Completes a VALUE_NUMBER scan: continueNumberContent only returns here once the number terminator
     // (or the terminal window's EOF) is seen, so the number is whole. The grammar was validated char by
-    // char as the lexeme was scanned; here only the accepting-state check remains. A fragmented number's
-    // full lexeme is still gathered in numberLexeme for getBigDecimal until the source accumulates it.
+    // char as the lexeme was scanned; here only the accepting-state check remains. The whole lexeme, when
+    // a consumer needs it, lives in scratch via consumed(0) accumulation — no separate retained buffer.
     private void finishNumberValue()
     {
-        if (numberFragmented)
-        {
-            numberLexeme.append(scratch);
-        }
         validateNumberComplete();
         valueStreamStart = fragmentStart;
         valueStreamEnd = streamOffset;
@@ -817,9 +794,8 @@ public final class JsonTokenizer
                 fragmentStart = streamOffset - 1;
                 valueLine = line;
                 valueColumn = column - 1;
-                numberLexeme.setLength(0);
-                numberFragmented = false;
                 scratch.setLength(0);
+                scratchConsumed = 0;
                 numberState = NumberState.START;
                 scratch.append((char) c);
                 validateNumberChar(c);

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -53,6 +53,10 @@ public final class JsonTokenizer
 
     private final Deque<ParseState> stack = new ArrayDeque<>();
     private final StringBuilder scratch = new StringBuilder();
+    // chars of the current scratch the consumer has taken; on resume only this prefix is dropped so the
+    // unconsumed remainder accumulates, letting a consumer that declines fragments (consumed(0)) receive
+    // the value whole. Set by the parser from its consumed cursor before each resuming advance.
+    private int scratchConsumed;
     // accumulates the full lexeme of a fragmented number across its fragments (scratch holds only the
     // current fragment); getBigDecimal() reads this on the final fragment to read the value whole.
     private final StringBuilder numberLexeme = new StringBuilder();
@@ -144,6 +148,7 @@ public final class JsonTokenizer
     {
         stack.clear();
         scratch.setLength(0);
+        scratchConsumed = 0;
         numberLexeme.setLength(0);
         numberFragmented = false;
         stringVerbatim = false;
@@ -342,6 +347,14 @@ public final class JsonTokenizer
         return valuePending ? scratch : pendingString;
     }
 
+    // The parser reports, before a resuming advance, how many chars of the current fragment the consumer
+    // took, so resume keeps the unconsumed remainder rather than discarding the whole fragment.
+    void markScratchConsumed(
+        int consumed)
+    {
+        this.scratchConsumed = consumed;
+    }
+
     public long streamOffset()
     {
         return streamOffset;
@@ -514,9 +527,11 @@ public final class JsonTokenizer
             }
             break;
         case VALUE_STRING:
-            // discard the prior fragment's chars (already shipped, captured lazily) before decoding the
-            // next fragment into scratch
-            scratch.setLength(0);
+            // keep the part of the prior fragment the consumer did not take (a decliner keeps all of it
+            // via consumed(0)) so the next fragment accumulates onto the remainder and the value is
+            // re-presented whole; a consumer that took the whole fragment drops it all, as before
+            scratch.delete(0, Math.min(scratchConsumed, scratch.length()));
+            scratchConsumed = 0;
             fragmentStart = streamOffset;
             continueStringContent(in);
             if (!starved)

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonParserNumberRetentionTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonParserNumberRetentionTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+class JsonParserNumberRetentionTest
+{
+    // a number lexeme longer than the feed window, with no terminator: the window ends mid-number so
+    // the parser delivers a VALUE_NUMBER with bytes still deferred rather than the whole value
+    private static final byte[] LONG_NUMBER =
+        "12345678901234567890123456789012345678901234567890".getBytes(UTF_8);
+
+    @Test
+    void shouldAssertGetBigDecimalWhileValueDeferred()
+    {
+        JsonParserEx parser = JsonEx.createParser();
+        parser.wrap(new UnsafeBuffer(LONG_NUMBER), 0, LONG_NUMBER.length, false);
+
+        assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
+        assertEquals(JsonEvent.VALUE_NUMBER, parser.nextEvent());
+        assertTrue(parser.deferredBytes());
+
+        // getBigDecimal() promises the whole value; calling it while bytes are still deferred is a
+        // contract violation, caught by assertion rather than silently returning a partial number
+        assertThrows(AssertionError.class, parser::getBigDecimal);
+    }
+
+    @Test
+    void shouldReturnWholeBigDecimalWhenComplete()
+    {
+        JsonParserEx parser = JsonEx.createParser();
+        // last == true: terminal EOF completes the trailing number, so the whole value is present
+        parser.wrap(new UnsafeBuffer(LONG_NUMBER), 0, LONG_NUMBER.length, true);
+
+        assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
+        assertEquals(JsonEvent.VALUE_NUMBER, parser.nextEvent());
+        assertFalse(parser.deferredBytes());
+        assertEquals(new BigDecimal(new String(LONG_NUMBER, UTF_8)), parser.getBigDecimal());
+    }
+}

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonPipelineDeferralTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonPipelineDeferralTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
+
+class JsonPipelineDeferralTest
+{
+    private final MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
+
+    // a transform that needs each scalar whole: while a value still has deferred bytes it pushes back via
+    // consumed(0) and does not forward; once the value is complete it forwards it downstream. The source
+    // must accumulate the declined fragments and re-present the value whole rather than dropping them.
+    private static final class WholeValueTransform implements JsonTransform
+    {
+        @Override
+        public Status feed(
+            JsonController control,
+            JsonSource source,
+            JsonEvent event,
+            JsonSink sink)
+        {
+            Status status;
+            boolean scalar = event == JsonEvent.VALUE_STRING || event == JsonEvent.VALUE_NUMBER;
+            if (scalar && source.deferredBytes())
+            {
+                control.consumed(0);
+                status = Status.STARVED;
+            }
+            else
+            {
+                status = sink.feed(control, source, event);
+            }
+            return status;
+        }
+    }
+
+    @Test
+    @Disabled("pins the consumed(0) re-present contract; enabled when the source accumulation lands")
+    void shouldAccumulateDeferredStringAcrossWindows()
+    {
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(new WholeValueTransform())
+            .into(JsonEx.createSink(gen));
+        pipeline.reset();
+
+        // a bare string split across two windows: open-quote + 20 'a' (no close), then 20 'b' + close-quote
+        byte[] f1 = "\"aaaaaaaaaaaaaaaaaaaa".getBytes(UTF_8);
+        byte[] f2 = "bbbbbbbbbbbbbbbbbbbb\"".getBytes(UTF_8);
+        assertEquals(Status.STARVED, pipeline.feed(new UnsafeBuffer(f1), 0, f1.length, false));
+        Status status = pipeline.feed(new UnsafeBuffer(f2), 0, f2.length, true);
+
+        assertEquals(Status.COMPLETED, status);
+        byte[] out = new byte[gen.length()];
+        buffer.getBytes(0, out);
+        assertEquals("\"aaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbb\"", new String(out, UTF_8));
+    }
+}

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonPipelineDeferralTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonPipelineDeferralTest.java
@@ -17,6 +17,8 @@ package io.aklivity.zilla.runtime.common.json;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Map;
+
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
@@ -73,5 +75,24 @@ class JsonPipelineDeferralTest
         byte[] out = new byte[gen.length()];
         buffer.getBytes(0, out);
         assertEquals("\"aaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbb\"", new String(out, UTF_8));
+    }
+
+    @Test
+    void shouldRejectWhenDeclinedValueExceedsCap()
+    {
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        // cap the retained value at 16 chars; a decliner that grows the value past it must fail closed
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser(Map.of(JsonParserEx.MAX_VALUE_SIZE, 16)))
+            .transform(new WholeValueTransform())
+            .into(JsonEx.createSink(gen));
+        pipeline.reset();
+
+        // a bare string declined fragment by fragment grows past the 16-char cap on the second window
+        byte[] f1 = "\"aaaaaaaaaa".getBytes(UTF_8);
+        byte[] f2 = "bbbbbbbbbb".getBytes(UTF_8);
+        assertEquals(Status.STARVED, pipeline.feed(new UnsafeBuffer(f1), 0, f1.length, false));
+        Status status = pipeline.feed(new UnsafeBuffer(f2), 0, f2.length, false);
+
+        assertEquals(Status.REJECTED, status);
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonPipelineDeferralTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonPipelineDeferralTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
@@ -56,7 +55,6 @@ class JsonPipelineDeferralTest
     }
 
     @Test
-    @Disabled("pins the consumed(0) re-present contract; enabled when the source accumulation lands")
     void shouldAccumulateDeferredStringAcrossWindows()
     {
         JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorChainTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorChainTest.java
@@ -55,6 +55,61 @@ class JsonValidatorChainTest
     }
 
     @Test
+    void shouldValidateWindowFragmentedStringAgainstPattern()
+    {
+        JsonSchema schema = JsonSchema.of("{\"type\":\"string\",\"pattern\":\"^a+$\"}");
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(schema.validator())
+            .into(JsonEx.createSink(gen));
+        pipeline.reset();
+
+        // a string long enough to fragment across 8-byte windows; ^a+$ holds only when the whole value is
+        // reassembled, so the validator must decline the fragments and match the complete value
+        byte[] bytes = ("\"" + "a".repeat(40) + "\" ").getBytes(UTF_8);
+        Status status = feedWindowed(pipeline, bytes, 8);
+
+        assertEquals(Status.COMPLETED, status);
+    }
+
+    @Test
+    void shouldRejectWindowFragmentedStringViolatingPattern()
+    {
+        JsonSchema schema = JsonSchema.of("{\"type\":\"string\",\"pattern\":\"^a+$\"}");
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(schema.validator())
+            .into(JsonEx.createSink(gen));
+        pipeline.reset();
+
+        // a 'b' buried deep in the value violates ^a+$, detectable only once the whole value is reassembled;
+        // validating any single fragment would miss it
+        byte[] bytes = ("\"" + "a".repeat(30) + "b" + "a".repeat(9) + "\" ").getBytes(UTF_8);
+        Status status = feedWindowed(pipeline, bytes, 8);
+
+        assertEquals(Status.REJECTED, status);
+    }
+
+    private static Status feedWindowed(
+        JsonPipeline pipeline,
+        byte[] bytes,
+        int step)
+    {
+        int progress = 0;
+        int limit = 0;
+        Status status = Status.STARVED;
+        int guard = 0;
+        while (guard++ < 100_000 && status == Status.STARVED)
+        {
+            limit = Math.min(limit + step, bytes.length);
+            boolean last = limit >= bytes.length;
+            status = pipeline.feed(new UnsafeBuffer(bytes), progress, limit, last);
+            progress = limit - pipeline.remaining();
+        }
+        return status;
+    }
+
+    @Test
     void shouldValidateFullStreamWhileProjectingSubset()
     {
         JsonSchema schema = JsonSchema.of(OBJECT_SCHEMA);

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -322,8 +322,10 @@ class JsonPipelineChunkingTest
     @Test
     void shouldReadWindowFragmentedNumberAsBigDecimalAndRejectGetInt()
     {
-        // a number far longer than long range fragments across small windows; getBigDecimal() reads the
-        // whole value from the accumulated lexeme, while getInt()/getLong() reject the fragmented number
+        // a number far longer than long range fragments across small windows. A consumer that needs the
+        // whole value declines each fragment via consumed(0); the source accumulates the declined fragments
+        // and re-presents the value whole, so at completion getBigDecimal() reads it from scratch while
+        // getInt()/getLong() reject it as too large for a primitive
         String bigNumber = "12345678901234567890123456789012";
         String json = "{\"n\":" + bigNumber + "}";
 
@@ -333,21 +335,32 @@ class JsonPipelineChunkingTest
         List<Boolean> intRejected = new ArrayList<>();
         JsonTransform probe = (control, source, event, sink) ->
         {
-            if (event == JsonEvent.VALUE_NUMBER && !source.deferredBytes())
+            Status result;
+            if (event == JsonEvent.VALUE_NUMBER && source.deferredBytes())
             {
-                wholes.add(source.getBigDecimal());
-                boolean rejected = false;
-                try
-                {
-                    source.getInt();
-                }
-                catch (IllegalStateException ex)
-                {
-                    rejected = true;
-                }
-                intRejected.add(rejected);
+                // need the whole number; decline this fragment and wait for the rest
+                control.consumed(0);
+                result = Status.STARVED;
             }
-            return sink.feed(control, source, event);
+            else
+            {
+                if (event == JsonEvent.VALUE_NUMBER)
+                {
+                    wholes.add(source.getBigDecimal());
+                    boolean rejected = false;
+                    try
+                    {
+                        source.getInt();
+                    }
+                    catch (IllegalStateException ex)
+                    {
+                        rejected = true;
+                    }
+                    intRejected.add(rejected);
+                }
+                result = sink.feed(control, source, event);
+            }
+            return result;
         };
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
             .transform(probe)


### PR DESCRIPTION
## Summary

Makes `common-json` retain whole values only when a consumer actually needs them. The source streams values as fragments and **forgets** each fragment once relayed; a consumer that needs a value whole **opts in** by declining its fragments via `JsonController.consumed(0)`, and the source accumulates them and re-presents the value whole. This removes unconditional whole-value buffering from the source while keeping correctness for consumers that need the whole value (regex/enum/numeric bounds, `getBigDecimal`).

Self-contained to `common-json`; no engine/binding changes.

## Motivation

Previously the tokenizer retained values regardless of whether any consumer needed them — most visibly `numberLexeme`, which accumulated every fragmented number's full lexeme unconditionally. The streaming pipeline already pushes back via `consumed()`; this work uses that same channel as the opt-in retention signal, so "free if not retained, buffered only if retained" falls out of the existing back-pressure mechanism.

## What changed (each increment test-first, suite-verified)

1. **`getBigDecimal()` completeness assert** — asserts the value is complete (`!deferredBytes()`) so a caller can't silently read a partial number.
2. **`consumed(0)` accumulation (strings)** — on resume the tokenizer drops only the *consumed* prefix of `scratch` and keeps the rest, so a decliner's fragments accumulate and the value is re-presented whole. Full consumption behaves exactly as before.
   - **fix**: ship a fragment only when new bytes were scanned (`streamOffset > fragmentStart`); the prior `scratch.length() > 0` guard re-shipped retained-but-unconsumed content and spun the pump.
3. **Incremental number validation** — RFC 8259 grammar validated by a state machine one char at a time (state persists across windows), so no whole lexeme is needed to validate a fragmented number.
4. **Delete `numberLexeme`/`numberFragmented`** — numbers accumulate in `scratch` via the same `consumed(0)` path; `getBigDecimal()` reads the whole value from `scratch`; `getInt()`/`getLong()` use a lexeme-length guard. **Contract change (approved):** reading a window-fragmented number whole now requires the consumer to decline its fragments — a forwarding/streaming consumer no longer gets the whole number retained for free.
5. **Fail-closed cap** — new `JsonParserEx.MAX_VALUE_SIZE` (Integer chars, default `1<<24`) bounds retained `scratch`; overflow throws a resource-exhaustion `JsonParsingException` surfaced as `Status.REJECTED`. Verbatim/segment values (raw-byte streamed, never accumulating) are exempt.
6. **Fragment-aware schema validator** — `JsonSchemaImpl.Validator` declines a deferred scalar until whole, then validates the complete value (`Eval` is not fragment-aware); validates a complete scalar **before** forwarding so eval reads the whole value, not the sink-consumed remainder; keeps structural events/keys forward-first to preserve emit-then-reject. Fixes a latent bug where a window-fragmented value was validated on its first fragment only.

## Follow-up

Per-keyword streaming of *unconstrained* values through the validator (forward fragments + feed eval once at completion) is deferred to #1926 — it needs a per-position "needs content" signal and is out of scope here.

## Testing

Full `common-json` suite (46 test classes) green, plus checkstyle and license, run under a Surefire fork-timeout guard. New tests pin: the `getBigDecimal` completeness assert, `consumed(0)` re-present for strings and numbers, the fail-closed cap, and window-fragmented validation against a `pattern` (match and violation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019YL2uqgwVoN3nqUxnfaj6g)_