### PR TITLE
build(docker-image): list common-avro explicitly in zpm manifest

### DIFF
--- a/cloud/docker-image/src/main/docker/zpm.json.template
+++ b/cloud/docker-image/src/main/docker/zpm.json.template
@@ -45,6 +45,7 @@
     "io.aklivity.zilla:catalog-karapace",
     "io.aklivity.zilla:catalog-schema-registry",
     "io.aklivity.zilla:common",
+    "io.aklivity.zilla:common-avro",
     "io.aklivity.zilla:common-json",
     "io.aklivity.zilla:common-lang",
     "io.aklivity.zilla:common-yaml",


### PR DESCRIPTION
## Change

List `io.aklivity.zilla:common-avro` explicitly in the docker image `zpm.json` manifest, alongside the other `common-*` modules (`common`, `common-json`, `common-lang`, `common-yaml`).

`common-avro` is already pulled into the image **transitively** (via `model-avro` and bindings that depend on it), so this is not a functional fix — it makes the dependency explicit for clarity and stability, matching how `common-json`/`common-lang`/`common-yaml` are listed. Inserted in alphabetical position between `common` and `common-json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CLYLdgT4B97uSUndTsG6N

---
_Generated by [Claude Code](https://claude.ai/code/session_012CLYLdgT4B97uSUndTsG6N)_