### PR TITLE
Refactor JsonProjector to use trie-based pointer matching

### DIFF
--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
@@ -62,10 +62,10 @@ public final class JsonProjectorImpl implements JsonTransform
     // is the position in the path, replacing the retained ancestor key chain.
     private final Node[] frameNode = new Node[MAX_DEPTH];
 
-    // A kept object key is deferred only as far as its value's first event, so a single reused buffer holds
-    // it: the descend/skip decision is known at the key, but a kept key whose value turns out to be a scalar
-    // under a deeper-only pointer is still dropped, so the key cannot be forwarded until the value's kind is
-    // seen. At most one key is ever pending — the value that follows consumes it before the next key.
+    // Only a DESCEND key is deferred, and only as far as its value's first event: its value may be a
+    // container (forward the key) or a scalar under a deeper-only pointer (drop the key), so the key cannot
+    // be forwarded until the value's kind is seen. A KEEP_ALL key is forwarded live at onKey and never
+    // buffered. At most one key is ever pending — the value that follows consumes it before the next key.
     private final StringBuilder pendingKeyBuffer = new StringBuilder();
 
     private final KeySource keySource = new KeySource();
@@ -217,7 +217,7 @@ public final class JsonProjectorImpl implements JsonTransform
             forward(sink, source, event);
             break;
         case KEY_NAME:
-            onKey(control, source);
+            onKey(control, source, sink);
             break;
         case START_OBJECT:
         case START_ARRAY:
@@ -235,7 +235,8 @@ public final class JsonProjectorImpl implements JsonTransform
 
     private void onKey(
         JsonController control,
-        JsonSource source)
+        JsonSource source,
+        JsonSink sink)
     {
         boolean parentKeepAll = containers > 0 && frameKeepAll[containers - 1];
         Node parentNode = containers > 0 ? frameNode[containers - 1] : root;
@@ -251,14 +252,25 @@ public final class JsonProjectorImpl implements JsonTransform
             d = decide(keyNode);
         }
         keyDecision = d;
-        // A kept key is buffered for its deferred forward at the value event; the SKIP majority copies
-        // nothing. No ancestor key is retained — the match used the live view above.
-        pendingKey = d == Decision.SKIP ? null : copyKey(source.getStringView());
-        // arm the kept value for verbatim segment delivery; best-effort, demand-gated
         boolean parentEmit = containers == 0 || frameEmit[containers - 1];
-        if (parentEmit && d == Decision.KEEP_ALL && downstreamDemand)
+        if (parentEmit && d == Decision.KEEP_ALL)
         {
-            control.segmentable();
+            // A KEEP_ALL value is always emitted, so the key is forwarded live from the still-valid view —
+            // no copy and no deferral. The match above also used the live view, so no ancestor key is
+            // retained. Then arm the kept value for verbatim segment delivery (best-effort, demand-gated).
+            forward(sink, source, JsonEvent.KEY_NAME);
+            pendingKey = null;
+            if (downstreamDemand)
+            {
+                control.segmentable();
+            }
+        }
+        else
+        {
+            // A DESCEND key is buffered for deferral: its value's kind is still unknown, and a scalar under a
+            // deeper-only pointer is dropped, so the key cannot be forwarded until the value event. A SKIP
+            // key copies nothing.
+            pendingKey = d == Decision.SKIP ? null : copyKey(source.getStringView());
         }
     }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
@@ -15,8 +15,9 @@
 package io.aklivity.zilla.runtime.common.json.internal;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import jakarta.json.stream.JsonLocation;
 
@@ -34,6 +35,12 @@ import io.aklivity.zilla.runtime.common.json.JsonTransform;
  * RFC 6901 pointers, forwarding the kept events to the downstream {@code sink} passed into each
  * {@link #feed(JsonController, JsonSource, JsonEvent, JsonSink)}. This class holds the per-value descent
  * state only; the downstream is bound once at assembly and supplied per event.
+ * <p>
+ * The retained pointer set is compiled once into a {@link Node trie}: each node has children keyed by
+ * segment plus a {@code keepAll} terminal flag (a pointer ends here, so the whole subtree is retained).
+ * Descent tracks a per-depth stack of node references ({@code frameNode}) rather than the absolute path,
+ * so matching a key is an {@code O(children)} lookup of the live {@link JsonSource#getStringView()} in the
+ * current node's children — no ancestor key chain is ever retained and no absolute pointer is manifested.
  */
 public final class JsonProjectorImpl implements JsonTransform
 {
@@ -45,28 +52,31 @@ public final class JsonProjectorImpl implements JsonTransform
         KEEP_ALL, DESCEND, SKIP
     }
 
-    private final List<String[]> retained;
-
-    // Per-depth reused key buffers — an object-key segment is captured here char-by-char (no String);
-    // segmentIsKey distinguishes an object key from an array index at this depth.
-    private final StringBuilder[] segmentKeys = new StringBuilder[MAX_DEPTH];
-    private final boolean[] segmentIsKey = new boolean[MAX_DEPTH];
-    private final int[] indexes = new int[MAX_DEPTH];
+    private final Node root;
 
     private final boolean[] frameInArray = new boolean[MAX_DEPTH];
     private final boolean[] frameEmit = new boolean[MAX_DEPTH];
     private final boolean[] frameKeepAll = new boolean[MAX_DEPTH];
     private final int[] frameNextIndex = new int[MAX_DEPTH];
-    private final int[] frameDepthAtOpen = new int[MAX_DEPTH];
+    // The trie node whose children are matched against the entries of this container — the node reference
+    // is the position in the path, replacing the retained ancestor key chain.
+    private final Node[] frameNode = new Node[MAX_DEPTH];
+
+    // A kept object key is deferred only as far as its value's first event, so a single reused buffer holds
+    // it: the descend/skip decision is known at the key, but a kept key whose value turns out to be a scalar
+    // under a deeper-only pointer is still dropped, so the key cannot be forwarded until the value's kind is
+    // seen. At most one key is ever pending — the value that follows consumes it before the next key.
+    private final StringBuilder pendingKeyBuffer = new StringBuilder();
 
     private final KeySource keySource = new KeySource();
 
     private final DownstreamControl downstreamControl = new DownstreamControl();
 
     private JsonController upstreamControl;
-    private int depth;
     private int containers;
     private Decision keyDecision;
+    private Node keyNode;
+    private Node valueNode;
     private CharSequence pendingKey;
     private boolean rootDone;
     private boolean downstreamDemand;
@@ -84,19 +94,16 @@ public final class JsonProjectorImpl implements JsonTransform
     public JsonProjectorImpl(
         List<String> pointers)
     {
-        this.retained = compileAll(pointers);
-        for (int i = 0; i < MAX_DEPTH; i++)
-        {
-            segmentKeys[i] = new StringBuilder();
-        }
+        this.root = compile(pointers);
     }
 
     @Override
     public void reset()
     {
-        depth = 0;
         containers = 0;
         keyDecision = null;
+        keyNode = null;
+        valueNode = null;
         pendingKey = null;
         rootDone = false;
         downstreamDemand = false;
@@ -230,24 +237,37 @@ public final class JsonProjectorImpl implements JsonTransform
         JsonController control,
         JsonSource source)
     {
-        StringBuilder key = segmentKeys[depth];
-        key.setLength(0);
-        key.append(source.getStringView());
-        segmentIsKey[depth] = true;
-        indexes[depth] = -1;
-        depth++;
         boolean parentKeepAll = containers > 0 && frameKeepAll[containers - 1];
-        Decision d = parentKeepAll ? Decision.KEEP_ALL : decide();
+        Node parentNode = containers > 0 ? frameNode[containers - 1] : root;
+        Decision d;
+        if (parentKeepAll)
+        {
+            keyNode = null;
+            d = Decision.KEEP_ALL;
+        }
+        else
+        {
+            keyNode = lookup(parentNode, source.getStringView());
+            d = decide(keyNode);
+        }
         keyDecision = d;
-        // A forwarded key reuses the char view already buffered above for path matching, so no key
-        // ever materializes a String — neither the SKIP majority nor the KEEP keys carried downstream.
-        pendingKey = d == Decision.SKIP ? null : key;
+        // A kept key is buffered for its deferred forward at the value event; the SKIP majority copies
+        // nothing. No ancestor key is retained — the match used the live view above.
+        pendingKey = d == Decision.SKIP ? null : copyKey(source.getStringView());
         // arm the kept value for verbatim segment delivery; best-effort, demand-gated
         boolean parentEmit = containers == 0 || frameEmit[containers - 1];
         if (parentEmit && d == Decision.KEEP_ALL && downstreamDemand)
         {
             control.segmentable();
         }
+    }
+
+    private CharSequence copyKey(
+        CharSequence view)
+    {
+        pendingKeyBuffer.setLength(0);
+        pendingKeyBuffer.append(view);
+        return pendingKeyBuffer;
     }
 
     private void forwardPendingKey(
@@ -269,7 +289,7 @@ public final class JsonProjectorImpl implements JsonTransform
         frameEmit[containers] = emit;
         frameKeepAll[containers] = d == Decision.KEEP_ALL;
         frameNextIndex[containers] = 0;
-        frameDepthAtOpen[containers] = depth;
+        frameNode[containers] = valueNode;
         containers++;
     }
 
@@ -347,10 +367,6 @@ public final class JsonProjectorImpl implements JsonTransform
         {
             rootDone = true;
         }
-        else
-        {
-            depth--;
-        }
     }
 
     private void onEnd(
@@ -365,12 +381,7 @@ public final class JsonProjectorImpl implements JsonTransform
         }
         if (containers == 0)
         {
-            depth = 0;
             rootDone = true;
-        }
-        else
-        {
-            depth = frameDepthAtOpen[containers] - 1;
         }
     }
 
@@ -425,10 +436,6 @@ public final class JsonProjectorImpl implements JsonTransform
         {
             rootDone = true;
         }
-        else
-        {
-            depth--;
-        }
     }
 
     private Decision enterValue()
@@ -436,83 +443,118 @@ public final class JsonProjectorImpl implements JsonTransform
         Decision result;
         if (containers == 0)
         {
-            result = decide();
+            valueNode = root;
+            result = decide(root);
         }
         else
         {
             int parent = containers - 1;
             if (frameInArray[parent])
             {
-                segmentIsKey[depth] = false;
-                indexes[depth] = frameNextIndex[parent];
-                frameNextIndex[parent] = frameNextIndex[parent] + 1;
-                depth++;
-                result = frameKeepAll[parent] ? Decision.KEEP_ALL : decide();
+                int index = frameNextIndex[parent];
+                frameNextIndex[parent] = index + 1;
+                if (frameKeepAll[parent])
+                {
+                    valueNode = null;
+                    result = Decision.KEEP_ALL;
+                }
+                else
+                {
+                    valueNode = lookupIndex(frameNode[parent], index);
+                    result = decide(valueNode);
+                }
             }
             else
             {
+                valueNode = keyNode;
                 result = keyDecision;
+                keyNode = null;
                 keyDecision = null;
             }
         }
         return result;
     }
 
-    private Decision decide()
+    private static Decision decide(
+        Node node)
     {
-        boolean keepAll = false;
-        boolean descend = false;
-        for (String[] pointer : retained)
+        Decision result;
+        if (node == null)
         {
-            if (pointer.length <= depth)
+            result = Decision.SKIP;
+        }
+        else if (node.keepAll)
+        {
+            result = Decision.KEEP_ALL;
+        }
+        else if (node.keys.length > 0)
+        {
+            result = Decision.DESCEND;
+        }
+        else
+        {
+            result = Decision.SKIP;
+        }
+        return result;
+    }
+
+    // Matches an object key against a node's children by the live char view, allocation-free.
+    private static Node lookup(
+        Node node,
+        CharSequence key)
+    {
+        Node result = null;
+        if (node != null)
+        {
+            for (int i = 0; result == null && i < node.keys.length; i++)
             {
-                if (matchesPrefix(pointer, pointer.length))
+                if (charsEqual(node.keys[i], key))
                 {
-                    keepAll = true;
-                    break;
+                    result = node.nodes[i];
                 }
             }
-            else if (matchesPrefix(pointer, depth))
-            {
-                descend = true;
-            }
         }
-        return keepAll ? Decision.KEEP_ALL : descend ? Decision.DESCEND : Decision.SKIP;
+        return result;
     }
 
-    private boolean matchesPrefix(
-        String[] pointer,
-        int length)
+    // Matches an array index against a node's children, preferring an explicit canonical-index child over
+    // the "-" wildcard; the wildcard applies only to arrays, while an object key "-" matches via lookup.
+    private static Node lookupIndex(
+        Node node,
+        int index)
     {
-        boolean matches = true;
-        for (int i = 0; i < length; i++)
+        Node result = null;
+        if (node != null)
         {
-            if (!segmentMatches(pointer[i], i))
+            Node wildcard = null;
+            for (int i = 0; result == null && i < node.keys.length; i++)
             {
-                matches = false;
-                break;
+                String segment = node.keys[i];
+                if (WILDCARD.equals(segment))
+                {
+                    wildcard = node.nodes[i];
+                }
+                else if (matchesIndex(segment, index))
+                {
+                    result = node.nodes[i];
+                }
+            }
+            if (result == null)
+            {
+                result = wildcard;
             }
         }
-        return matches;
-    }
-
-    private boolean segmentMatches(
-        String pointerSegment,
-        int pathIndex)
-    {
-        return segmentIsKey[pathIndex]
-            ? charsEqual(pointerSegment, segmentKeys[pathIndex])
-            : WILDCARD.equals(pointerSegment) || matchesIndex(pointerSegment, indexes[pathIndex]);
+        return result;
     }
 
     private static boolean charsEqual(
-        String pointerSegment,
+        String segment,
         CharSequence key)
     {
-        boolean matches = pointerSegment.length() == key.length();
-        for (int i = 0; matches && i < pointerSegment.length(); i++)
+        boolean matches = segment.length() == key.length();
+        for (int i = 0; matches && i < segment.length(); i++)
         {
-            matches = pointerSegment.charAt(i) == key.charAt(i);
+            matches = segment.charAt(i) == key.charAt(i);
         }
         return matches;
     }
@@ -540,18 +582,23 @@ public final class JsonProjectorImpl implements JsonTransform
         return matches && value == index;
     }
 
-    private static List<String[]> compileAll(
+    private static Node compile(
         List<String> pointers)
     {
-        List<String[]> compiled = new ArrayList<>();
+        NodeBuilder builder = new NodeBuilder();
         for (String pointer : pointers)
         {
-            compiled.add(compile(pointer));
+            NodeBuilder node = builder;
+            for (String segment : segments(pointer))
+            {
+                node = node.child(segment);
+            }
+            node.keepAll = true;
         }
-        return compiled;
+        return builder.build();
     }
 
-    private static String[] compile(
+    private static String[] segments(
         String pointer)
     {
         String[] result;
@@ -569,6 +616,52 @@ public final class JsonProjectorImpl implements JsonTransform
             result = parts;
         }
         return result;
+    }
+
+    // An immutable trie node: children are parallel key/node arrays scanned linearly (a handful of children
+    // per node), and keepAll marks a node where a retained pointer terminates.
+    private static final class Node
+    {
+        private final String[] keys;
+        private final Node[] nodes;
+        private final boolean keepAll;
+
+        private Node(
+            String[] keys,
+            Node[] nodes,
+            boolean keepAll)
+        {
+            this.keys = keys;
+            this.nodes = nodes;
+            this.keepAll = keepAll;
+        }
+    }
+
+    private static final class NodeBuilder
+    {
+        private final Map<String, NodeBuilder> children = new LinkedHashMap<>();
+        private boolean keepAll;
+
+        private NodeBuilder child(
+            String segment)
+        {
+            return children.computeIfAbsent(segment, ignored -> new NodeBuilder());
+        }
+
+        private Node build()
+        {
+            int size = children.size();
+            String[] keys = new String[size];
+            Node[] nodes = new Node[size];
+            int i = 0;
+            for (Map.Entry<String, NodeBuilder> entry : children.entrySet())
+            {
+                keys[i] = entry.getKey();
+                nodes[i] = entry.getValue().build();
+                i++;
+            }
+            return new Node(keys, nodes, keepAll);
+        }
     }
 
     private static final class KeySource implements JsonSource

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
@@ -163,6 +163,29 @@ class JsonProjectorTest
         assertEquals("[\"a\",\"c\"]", project(List.of("/0", "/2"), "[\"a\",\"b\",\"c\"]"));
     }
 
+    @Test
+    void shouldMatchNumericObjectKeyByIndexPointer()
+    {
+        // an index-looking segment matches a literal object key with that name when the data is an object
+        assertEquals("{\"items\":{\"1\":\"x\"}}",
+            project(List.of("/items/1"), "{\"items\":{\"1\":\"x\",\"2\":\"y\"}}"));
+    }
+
+    @Test
+    void shouldRetainDeeplyNestedArrayWildcardLeaf()
+    {
+        assertEquals("{\"a\":[{\"b\":1},{\"b\":3}]}",
+            project(List.of("/a/-/b"), "{\"a\":[{\"b\":1,\"x\":2},{\"b\":3,\"y\":4}],\"z\":9}"));
+    }
+
+    @Test
+    void shouldRetainLiteralHyphenObjectKey()
+    {
+        // "-" is the array wildcard, but against an object it matches a literal "-" key, not every member
+        assertEquals("{\"-\":1}",
+            project(List.of("/-"), "{\"-\":1,\"b\":2}"));
+    }
+
     private static String project(
         List<String> retained,
         String input)

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
@@ -186,6 +186,16 @@ class JsonProjectorTest
             project(List.of("/-"), "{\"-\":1,\"b\":2}"));
     }
 
+    @Test
+    void shouldNotDuplicateKeptKeysAcrossOutputBoundSuspends()
+    {
+        // kept keys are forwarded live at the key event, so a key write can land on an output-bound
+        // boundary and suspend; the drain/resume must advance to the value without re-emitting the key
+        assertEquals("{\"alpha\":1,\"gamma\":3,\"epsilon\":5}",
+            projectBounded(List.of("/alpha", "/gamma", "/epsilon"),
+                "{\"alpha\":1,\"beta\":2,\"gamma\":3,\"delta\":4,\"epsilon\":5}", 12));
+    }
+
     private static String project(
         List<String> retained,
         String input)
@@ -200,6 +210,43 @@ class JsonProjectorTest
         byte[] out = new byte[gen.length()];
         buffer.getBytes(0, out);
         return new String(out, UTF_8);
+    }
+
+    // Drives the projection through an output buffer bounded at outBound, draining and re-targeting the
+    // generator on each SUSPENDED and concatenating the drained chunks into one document.
+    private static String projectBounded(
+        List<String> retained,
+        String input,
+        int outBound)
+    {
+        JsonGeneratorEx gen = JsonEx.createGenerator();
+        MutableDirectBuffer buffer = new UnsafeBuffer(new byte[outBound]);
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonEx.projector(retained))
+            .into(JsonEx.createSink(gen));
+
+        byte[] bytes = (input + " ").getBytes(UTF_8);
+        UnsafeBuffer in = new UnsafeBuffer(bytes);
+        StringBuilder result = new StringBuilder();
+        pipeline.reset();
+        gen.wrap(buffer, 0, outBound);
+        int guard = 0;
+        Status status;
+        do
+        {
+            status = pipeline.feed(in, 0, bytes.length);
+            byte[] chunk = new byte[gen.length()];
+            buffer.getBytes(0, chunk);
+            result.append(new String(chunk, UTF_8));
+            if (status == Status.SUSPENDED)
+            {
+                gen.wrap(buffer, 0, outBound);
+            }
+            guard++;
+        }
+        while (status == Status.SUSPENDED && guard < 10_000);
+        assertEquals(Status.COMPLETED, status);
+        return result.toString();
     }
 
     private static Status feed(


### PR DESCRIPTION
## Description

Fixes #1930

Refactors `JsonProjectorImpl` to compile retained RFC 6901 pointers into an immutable trie structure instead of storing them as a list of string arrays. This improves the efficiency and clarity of pointer matching during JSON traversal.

### Key Changes

**Data Structure Refactoring:**
- Replaced `List retained` with a `Node root` trie structure
- Introduced `Node` and `NodeBuilder` classes to represent the compiled pointer trie
- Each trie node contains parallel `keys` and `nodes` arrays for children, plus a `keepAll` terminal flag

**Path Tracking Simplification:**
- Removed depth-based path tracking (`depth`, `segmentKeys[]`, `segmentIsKey[]`, `indexes[]`, `frameDepthAtOpen[]`)
- Replaced with per-frame `frameNode[]` references that point to the current position in the trie
- Eliminates the need to retain ancestor key chains; matching is now an O(children) lookup of the live `JsonSource.getStringView()` against a node's children

**Key Handling Improvements:**
- Separated key forwarding logic: `KEEP_ALL` keys are forwarded live at the key event (no buffering), while `DESCEND` keys are deferred until the value's kind is known
- Introduced `pendingKeyBuffer` to defer key copies only when necessary
- Added `keyNode` and `valueNode` to track trie positions for the current key and value

**Matching Logic:**
- Introduced `lookup()` for object key matching and `lookupIndex()` for array index matching (with wildcard support)
- Simplified `decide()` to work with a single `Node` parameter instead of iterating over all retained pointers
- Removed `matchesPrefix()` and `segmentMatches()` in favor of direct trie traversal

### Testing

Added four new test cases:
- `shouldMatchNumericObjectKeyByIndexPointer()` — verifies index-like segments match literal object keys
- `shouldRetainDeeplyNestedArrayWildcardLeaf()` — tests array wildcard matching in nested structures
- `shouldRetainLiteralHyphenObjectKey()` — confirms "-" matches a literal object key, not array members
- `shouldNotDuplicateKeptKeysAcrossOutputBoundSuspends()` — validates that live key forwarding doesn't duplicate keys across output buffer boundaries

All existing tests continue to pass, confirming backward compatibility.

### Benefits

- **Efficiency:** Pointer matching is now O(children per node) instead of O(retained pointers × depth)
- **Clarity:** Trie structure makes the pointer hierarchy explicit and easier to reason about
- **Memory:** No ancestor key chains are retained; only the current trie node reference is stored per frame
- **Correctness:** Separating live vs. deferred key forwarding prevents key duplication on output suspends

https://claude.ai/code/session_015eVPLi4KPadJhFnwEu86jt