### PR TITLE
Introduce BudgetCredit and BudgetDebit handle APIs

### DIFF
--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpServerFactory.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpServerFactory.java
@@ -2297,7 +2297,6 @@ public final class AmqpServerFactory implements AmqpStreamFactory
             final long authorization = abort.authorization();
 
             cleanupStreams(traceId, authorization);
-            cleanupBudgetCreditorIfNecessary();
             cleanupEncodeSlotIfNecessary();
 
             doNetworkAbort(traceId, authorization);
@@ -2380,7 +2379,6 @@ public final class AmqpServerFactory implements AmqpStreamFactory
             final long authorization = reset.authorization();
 
             cleanupStreams(traceId, authorization);
-            cleanupBudgetCreditorIfNecessary();
             cleanupEncodeSlotIfNecessary();
 
             doNetworkReset(traceId, authorization);
@@ -2509,7 +2507,6 @@ public final class AmqpServerFactory implements AmqpStreamFactory
         {
             state = AmqpState.closeReply(state);
 
-            cleanupBudgetCreditorIfNecessary();
             cleanupEncodeSlotIfNecessary();
 
             doEnd(network, originId, routedId, replyId, replySeq, replyAck, replyMax, traceId, authorization, EMPTY_OCTETS);
@@ -2521,7 +2518,6 @@ public final class AmqpServerFactory implements AmqpStreamFactory
         {
             state = AmqpState.closeReply(state);
 
-            cleanupBudgetCreditorIfNecessary();
             cleanupEncodeSlotIfNecessary();
 
             doAbort(network, originId, routedId, replyId, replySeq, replyAck, replyMax, traceId, authorization, EMPTY_OCTETS);
@@ -2943,15 +2939,6 @@ public final class AmqpServerFactory implements AmqpStreamFactory
             {
                 signaler.cancel(closeTimeoutId);
                 closeTimeoutId = NO_CANCEL_ID;
-            }
-        }
-
-        private void cleanupBudgetCreditorIfNecessary()
-        {
-            if (replyCredit != null)
-            {
-                replyCredit.close();
-                replyCredit = null;
             }
         }
 
@@ -3616,11 +3603,7 @@ public final class AmqpServerFactory implements AmqpStreamFactory
 
                     state = AmqpState.closeInitial(state);
 
-                    if (debit != null)
-                    {
-                        debit.close();
-                        debit = null;
-                    }
+                    debit = null;
 
                     if (AmqpState.closed(state))
                     {

--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpServerFactory.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpServerFactory.java
@@ -75,8 +75,6 @@ import static io.aklivity.zilla.runtime.binding.amqp.internal.types.codec.AmqpTy
 import static io.aklivity.zilla.runtime.binding.amqp.internal.util.AmqpTypeUtil.amqpCapabilities;
 import static io.aklivity.zilla.runtime.binding.amqp.internal.util.AmqpTypeUtil.amqpReceiverSettleMode;
 import static io.aklivity.zilla.runtime.binding.amqp.internal.util.AmqpTypeUtil.amqpSenderSettleMode;
-import static io.aklivity.zilla.runtime.engine.budget.BudgetCreditor.NO_CREDITOR_INDEX;
-import static io.aklivity.zilla.runtime.engine.budget.BudgetDebitor.NO_DEBITOR_INDEX;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
 import static io.aklivity.zilla.runtime.engine.concurrent.Signaler.NO_CANCEL_ID;
 import static java.lang.System.currentTimeMillis;
@@ -89,7 +87,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.function.LongFunction;
 import java.util.function.LongSupplier;
 import java.util.function.LongUnaryOperator;
 
@@ -174,8 +171,8 @@ import io.aklivity.zilla.runtime.binding.amqp.internal.types.stream.WindowFW;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
-import io.aklivity.zilla.runtime.engine.budget.BudgetCreditor;
-import io.aklivity.zilla.runtime.engine.budget.BudgetDebitor;
+import io.aklivity.zilla.runtime.engine.budget.BudgetCredit;
+import io.aklivity.zilla.runtime.engine.budget.BudgetDebit;
 import io.aklivity.zilla.runtime.engine.buffer.BufferPool;
 import io.aklivity.zilla.runtime.engine.concurrent.Signaler;
 import io.aklivity.zilla.runtime.engine.config.BindingConfig;
@@ -452,12 +449,11 @@ public final class AmqpServerFactory implements AmqpStreamFactory
     private final LongUnaryOperator supplyReplyId;
     private final LongSupplier supplyTraceId;
     private final LongSupplier supplyBudgetId;
-    private final LongFunction<BudgetDebitor> supplyDebitor;
 
     private final BufferPool bufferPool;
-    private final BudgetCreditor creditor;
     private final Signaler signaler;
     private final BindingHandler streamFactory;
+    private final EngineContext context;
 
     private final Long2ObjectHashMap<AmqpBindingConfig> bindings;
     private final int amqpTypeId;
@@ -481,10 +477,9 @@ public final class AmqpServerFactory implements AmqpStreamFactory
         this.stringBuffer = new UnsafeBuffer(new byte[writeBuffer.capacity()]);
         this.valueBuffer = new UnsafeBuffer(new byte[writeBuffer.capacity()]);
         this.bufferPool = context.bufferPool();
-        this.creditor = context.creditor();
         this.signaler = context.signaler();
         this.streamFactory = context.streamFactory();
-        this.supplyDebitor = context::supplyDebitor;
+        this.context = context;
         this.supplyInitialId = context::supplyInitialId;
         this.supplyReplyId = context::supplyReplyId;
         this.supplyBudgetId = context::supplyBudgetId;
@@ -1238,9 +1233,9 @@ public final class AmqpServerFactory implements AmqpStreamFactory
                 int reserved = fragmentSize + sender.initialPad;
                 boolean canSend = reserved <= sender.initialMax;
 
-                if (canSend && sender.debitorIndex != NO_DEBITOR_INDEX)
+                if (canSend && sender.debit != null)
                 {
-                    reserved = sender.debitor.claim(traceId, sender.debitorIndex, sender.initialId, reserved, reserved, 0);
+                    reserved = sender.debit.claim(traceId, reserved, reserved);
                 }
 
                 if (canSend && reserved != 0)
@@ -1472,7 +1467,7 @@ public final class AmqpServerFactory implements AmqpStreamFactory
         private int replyPad;
         private long replyBudgetId;
 
-        private long replyBudgetIndex = NO_CREDITOR_INDEX;
+        private BudgetCredit replyCredit;
         private int replySharedBudget;
         private int replyBudgetReserved;
 
@@ -2369,12 +2364,9 @@ public final class AmqpServerFactory implements AmqpStreamFactory
 
             if (replySharedCredit != 0 && replyBudgetReserved == 0)
             {
-                final long replySharedBudgetPrevious = creditor.credit(traceId, replyBudgetIndex, replySharedCredit);
+                replyCredit.capacity(traceId, replySharedCredit);
 
                 this.replySharedBudget += replySharedCredit;
-                assert replySharedBudgetPrevious <= slotCapacity
-                    : String.format("%d <= %d, replyBudget = %d",
-                    replySharedBudgetPrevious, slotCapacity, budget);
 
                 assert replySharedBudget <= slotCapacity
                     : String.format("%d <= %d", replySharedBudget, slotCapacity);
@@ -2480,8 +2472,8 @@ public final class AmqpServerFactory implements AmqpStreamFactory
             doBegin(network, originId, routedId, replyId, replySeq, replyAck, replyMax,
                     traceId, authorization, affinity, EMPTY_OCTETS);
 
-            assert replyBudgetIndex == NO_CREDITOR_INDEX;
-            this.replyBudgetIndex = creditor.acquire(replySharedBudgetId);
+            assert replyCredit == null;
+            this.replyCredit = context.supplyCredit(replyId, replySharedBudgetId);
         }
 
         private void doNetworkData(
@@ -2956,10 +2948,10 @@ public final class AmqpServerFactory implements AmqpStreamFactory
 
         private void cleanupBudgetCreditorIfNecessary()
         {
-            if (replyBudgetIndex != NO_CREDITOR_INDEX)
+            if (replyCredit != null)
             {
-                creditor.release(replyBudgetIndex);
-                replyBudgetIndex = NO_CREDITOR_INDEX;
+                replyCredit.close();
+                replyCredit = null;
             }
         }
 
@@ -3312,8 +3304,7 @@ public final class AmqpServerFactory implements AmqpStreamFactory
                 private int remoteLinkCredit;
                 private int linkCredit;
 
-                private BudgetDebitor debitor;
-                private long debitorIndex = NO_DEBITOR_INDEX;
+                private BudgetDebit debit;
 
                 private long initialBudgetId;
 
@@ -3625,10 +3616,10 @@ public final class AmqpServerFactory implements AmqpStreamFactory
 
                     state = AmqpState.closeInitial(state);
 
-                    if (debitorIndex != NO_DEBITOR_INDEX)
+                    if (debit != null)
                     {
-                        debitor.release(debitorIndex, initialId);
-                        debitorIndex = NO_DEBITOR_INDEX;
+                        debit.close();
+                        debit = null;
                     }
 
                     if (AmqpState.closed(state))
@@ -3706,10 +3697,10 @@ public final class AmqpServerFactory implements AmqpStreamFactory
 
                     assert initialAck <= initialSeq;
 
-                    if (budgetId != 0L && debitorIndex == NO_DEBITOR_INDEX)
+                    if (budgetId != 0L && debit == null)
                     {
-                        debitor = supplyDebitor.apply(budgetId);
-                        debitorIndex = debitor.acquire(budgetId, initialId, AmqpServer.this::decodeNetworkIfNecessary);
+                        debit = context.supplyDebit(initialId, budgetId, AmqpServer.this::decodeNetworkIfNecessary);
+                        debit.declare(traceId, 0, 0);
                     }
 
                     flushInitialWindow(traceId, authorization);

--- a/runtime/binding-echo/src/test/java/io/aklivity/zilla/runtime/binding/echo/internal/bench/EchoWorker.java
+++ b/runtime/binding-echo/src/test/java/io/aklivity/zilla/runtime/binding/echo/internal/bench/EchoWorker.java
@@ -29,8 +29,11 @@ import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageReader;
+import io.aklivity.zilla.runtime.engine.budget.BudgetCredit;
 import io.aklivity.zilla.runtime.engine.budget.BudgetCreditor;
+import io.aklivity.zilla.runtime.engine.budget.BudgetDebit;
 import io.aklivity.zilla.runtime.engine.budget.BudgetDebitor;
+import io.aklivity.zilla.runtime.engine.budget.BudgetFlusher;
 import io.aklivity.zilla.runtime.engine.buffer.BufferPool;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
 import io.aklivity.zilla.runtime.engine.concurrent.Signaler;
@@ -184,6 +187,18 @@ public class EchoWorker implements EngineContext
 
     @Override
     public BudgetDebitor supplyDebitor(long budgetId)
+    {
+        return null;
+    }
+
+    @Override
+    public BudgetDebit supplyDebit(long streamId, long sharedStreamId, BudgetFlusher onResume)
+    {
+        return null;
+    }
+
+    @Override
+    public BudgetCredit supplyCredit(long streamId, long sharedStreamId)
     {
         return null;
     }

--- a/runtime/binding-echo/src/test/java/io/aklivity/zilla/runtime/binding/echo/internal/bench/EchoWorker.java
+++ b/runtime/binding-echo/src/test/java/io/aklivity/zilla/runtime/binding/echo/internal/bench/EchoWorker.java
@@ -180,12 +180,14 @@ public class EchoWorker implements EngineContext
     }
 
     @Override
+    @Deprecated
     public BudgetCreditor creditor()
     {
         return null;
     }
 
     @Override
+    @Deprecated
     public BudgetDebitor supplyDebitor(long budgetId)
     {
         return null;

--- a/runtime/binding-fan/src/main/java/io/aklivity/zilla/runtime/binding/fan/internal/stream/FanServerFactory.java
+++ b/runtime/binding-fan/src/main/java/io/aklivity/zilla/runtime/binding/fan/internal/stream/FanServerFactory.java
@@ -16,14 +16,11 @@
 package io.aklivity.zilla.runtime.binding.fan.internal.stream;
 
 import static io.aklivity.zilla.runtime.engine.budget.BudgetCreditor.NO_BUDGET_ID;
-import static io.aklivity.zilla.runtime.engine.budget.BudgetCreditor.NO_CREDITOR_INDEX;
-import static io.aklivity.zilla.runtime.engine.budget.BudgetDebitor.NO_DEBITOR_INDEX;
 import static java.util.function.UnaryOperator.identity;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
-import java.util.function.LongFunction;
 import java.util.function.LongSupplier;
 import java.util.function.LongUnaryOperator;
 
@@ -43,8 +40,8 @@ import io.aklivity.zilla.runtime.binding.fan.internal.types.stream.WindowFW;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
-import io.aklivity.zilla.runtime.engine.budget.BudgetCreditor;
-import io.aklivity.zilla.runtime.engine.budget.BudgetDebitor;
+import io.aklivity.zilla.runtime.engine.budget.BudgetCredit;
+import io.aklivity.zilla.runtime.engine.budget.BudgetDebit;
 import io.aklivity.zilla.runtime.engine.config.BindingConfig;
 import io.aklivity.zilla.runtime.engine.config.RouteConfig;
 
@@ -72,8 +69,7 @@ public final class FanServerFactory implements FanStreamFactory
 
     private final MutableDirectBuffer writeBuffer;
     private final BindingHandler streamFactory;
-    private final BudgetCreditor creditor;
-    private final LongFunction<BudgetDebitor> supplyDebitor;
+    private final EngineContext context;
     private final LongUnaryOperator supplyInitialId;
     private final LongUnaryOperator supplyReplyId;
     private final LongSupplier supplyTraceId;
@@ -87,8 +83,7 @@ public final class FanServerFactory implements FanStreamFactory
     {
         this.writeBuffer = context.writeBuffer();
         this.streamFactory = context.streamFactory();
-        this.creditor = context.creditor();
-        this.supplyDebitor = context::supplyDebitor;
+        this.context = context;
         this.supplyInitialId = context::supplyInitialId;
         this.supplyReplyId = context::supplyReplyId;
         this.supplyTraceId = context::supplyTraceId;
@@ -175,7 +170,7 @@ public final class FanServerFactory implements FanStreamFactory
         private int initialMax;
         private int initialPad;
         private long initialBud;
-        private long initialBudIndex;
+        private BudgetCredit initialBudCredit;
 
         private long replySeq;
         private long replyAck;
@@ -365,22 +360,22 @@ public final class FanServerFactory implements FanStreamFactory
 
             if (!FanState.initialOpened(state))
             {
-                long initialBudIndex = NO_CREDITOR_INDEX;
+                BudgetCredit initialBudCredit = null;
                 long initialBud = budgetId;
                 if (initialBud == NO_BUDGET_ID)
                 {
                     initialBud = supplyBudgetId.getAsLong();
-                    initialBudIndex = creditor.acquire(initialBud);
+                    initialBudCredit = context.supplyCredit(initialId, initialBud);
                 }
                 this.initialBud = initialBud;
-                this.initialBudIndex = initialBudIndex;
+                this.initialBudCredit = initialBudCredit;
 
                 state = FanState.openedInitial(state);
             }
 
-            if (initialBudIndex != NO_CREDITOR_INDEX && credit > 0)
+            if (initialBudCredit != null && credit > 0)
             {
-                creditor.credit(traceId, initialBudIndex, credit);
+                initialBudCredit.capacity(traceId, (int) credit);
             }
 
             final int pendingAck = (int)(initialSeq - initialAck);
@@ -487,10 +482,10 @@ public final class FanServerFactory implements FanStreamFactory
 
         private void cleanupInitial()
         {
-            if (initialBudIndex != NO_CREDITOR_INDEX)
+            if (initialBudCredit != null)
             {
-                creditor.release(initialBudIndex);
-                initialBudIndex = NO_CREDITOR_INDEX;
+                initialBudCredit.close();
+                initialBudCredit = null;
             }
         }
 
@@ -525,8 +520,7 @@ public final class FanServerFactory implements FanStreamFactory
         private int replyMax;
         private int replyPad;
         private long replyBud;
-        private long replyBudIndex;
-        private BudgetDebitor replyDeb;
+        private BudgetDebit replyDebit;
 
         private int state;
 
@@ -693,9 +687,9 @@ public final class FanServerFactory implements FanStreamFactory
 
                 if (replyBud != NO_BUDGET_ID)
                 {
-                    replyDeb = supplyDebitor.apply(replyBud);
-                    replyBudIndex = replyDeb.acquire(replyBud, replyId,
-                        tid -> replyDeb.claim(tid, replyBudIndex, replyId, 0, 0, 0));
+                    replyDebit = context.supplyDebit(replyId, replyBud,
+                        tid -> replyDebit.claim(tid, 0, 0));
+                    replyDebit.declare(traceId, 0, 0);
                 }
             }
 
@@ -753,9 +747,9 @@ public final class FanServerFactory implements FanStreamFactory
             OctetsFW payload,
             OctetsFW extension)
         {
-            if (replyBud != NO_BUDGET_ID)
+            if (replyDebit != null)
             {
-                reserved = replyDeb.claim(traceId, replyBudIndex, replyId, reserved, reserved, 0);
+                reserved = replyDebit.claim(traceId, reserved, reserved);
             }
 
             // TODO: cache + replay
@@ -791,11 +785,10 @@ public final class FanServerFactory implements FanStreamFactory
 
         private void cleanupReply()
         {
-            if (replyBud != NO_BUDGET_ID)
+            if (replyDebit != null)
             {
-                replyDeb.release(replyBudIndex, replyId);
-                replyBudIndex = NO_DEBITOR_INDEX;
-                replyDeb = null;
+                replyDebit.close();
+                replyDebit = null;
             }
         }
     }

--- a/runtime/binding-fan/src/main/java/io/aklivity/zilla/runtime/binding/fan/internal/stream/FanServerFactory.java
+++ b/runtime/binding-fan/src/main/java/io/aklivity/zilla/runtime/binding/fan/internal/stream/FanServerFactory.java
@@ -482,11 +482,7 @@ public final class FanServerFactory implements FanStreamFactory
 
         private void cleanupInitial()
         {
-            if (initialBudCredit != null)
-            {
-                initialBudCredit.close();
-                initialBudCredit = null;
-            }
+            initialBudCredit = null;
         }
 
         private void join(
@@ -785,11 +781,7 @@ public final class FanServerFactory implements FanStreamFactory
 
         private void cleanupReply()
         {
-            if (replyDebit != null)
-            {
-                replyDebit.close();
-                replyDebit = null;
-            }
+            replyDebit = null;
         }
     }
 

--- a/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/stream/FileSystemServerFactory.java
+++ b/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/stream/FileSystemServerFactory.java
@@ -22,7 +22,6 @@ import static io.aklivity.zilla.runtime.binding.filesystem.internal.types.stream
 import static io.aklivity.zilla.runtime.binding.filesystem.internal.types.stream.FileSystemError.FILE_MODIFIED;
 import static io.aklivity.zilla.runtime.binding.filesystem.internal.types.stream.FileSystemError.FILE_NOT_FOUND;
 import static io.aklivity.zilla.runtime.binding.filesystem.internal.types.stream.FileSystemError.FILE_TAG_MISSING;
-import static io.aklivity.zilla.runtime.engine.budget.BudgetDebitor.NO_DEBITOR_INDEX;
 import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
 import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
@@ -45,7 +44,6 @@ import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.function.LongFunction;
 import java.util.function.LongUnaryOperator;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -81,7 +79,7 @@ import io.aklivity.zilla.runtime.binding.filesystem.internal.types.stream.Window
 import io.aklivity.zilla.runtime.binding.filesystem.model.FileSystemObject;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
-import io.aklivity.zilla.runtime.engine.budget.BudgetDebitor;
+import io.aklivity.zilla.runtime.engine.budget.BudgetDebit;
 import io.aklivity.zilla.runtime.engine.buffer.BufferPool;
 import io.aklivity.zilla.runtime.engine.concurrent.Signaler;
 import io.aklivity.zilla.runtime.engine.config.BindingConfig;
@@ -137,7 +135,7 @@ public final class FileSystemServerFactory implements FileSystemStreamFactory
     private final MutableDirectBuffer errorBuffer;
     private final MutableDirectBuffer readBuffer;
     private final MutableDirectBuffer directoryBuffer;
-    private final LongFunction<BudgetDebitor> supplyDebitor;
+    private final EngineContext context;
     private final LongUnaryOperator supplyReplyId;
     private final int fileSystemTypeId;
     private final URI serverRoot;
@@ -161,7 +159,7 @@ public final class FileSystemServerFactory implements FileSystemStreamFactory
         this.readBuffer = new UnsafeBuffer(new byte[writeBuffer.capacity()]);
         this.errorBuffer = new UnsafeBuffer(new byte[1]);
         this.directoryBuffer = new UnsafeBuffer();
-        this.supplyDebitor = context::supplyDebitor;
+        this.context = context;
         this.supplyReplyId = context::supplyReplyId;
         this.fileSystemTypeId = context.supplyTypeId(FileSystemBinding.NAME);
         this.bindings = new Long2ObjectHashMap<>();
@@ -321,8 +319,7 @@ public final class FileSystemServerFactory implements FileSystemStreamFactory
         private int replyPad;
         private long replyBud;
         private long replyBytes;
-        private BudgetDebitor replyDeb;
-        private long replyDebIndex = NO_DEBITOR_INDEX;
+        private BudgetDebit replyDebit;
 
         private int state;
 
@@ -549,10 +546,10 @@ public final class FileSystemServerFactory implements FileSystemStreamFactory
             {
                 state = FileSystemState.openReply(state);
 
-                if (replyBud != 0L && replyDebIndex == NO_DEBITOR_INDEX)
+                if (replyBud != 0L && replyDebit == null)
                 {
-                    replyDeb = supplyDebitor.apply(budgetId);
-                    replyDebIndex = replyDeb.acquire(budgetId, replyId, this::flushAppData);
+                    replyDebit = context.supplyDebit(replyId, budgetId, this::flushAppData);
+                    replyDebit.declare(traceId, 0, 0);
                 }
                 flushAppData(traceId);
             }
@@ -722,10 +719,10 @@ public final class FileSystemServerFactory implements FileSystemStreamFactory
                                 int reserved = Math.min(replyWin, size + replyPad);
                                 int length = Math.max(reserved - replyPad, 0);
 
-                                if (length > 0 && replyDebIndex != NO_DEBITOR_INDEX && replyDeb != null)
+                                if (length > 0 && replyDebit != null)
                                 {
                                     final int minimum = Math.min(bufferPool.slotCapacity(), reserved);
-                                    reserved = replyDeb.claim(traceId, replyDebIndex, replyId, minimum, reserved, 0);
+                                    reserved = replyDebit.claim(traceId, minimum, reserved);
                                     length = Math.max(reserved - replyPad, 0);
                                 }
 
@@ -766,10 +763,10 @@ public final class FileSystemServerFactory implements FileSystemStreamFactory
                             int reserved = Math.min(replyWin, available + replyPad);
                             int length = Math.max(reserved - replyPad, 0);
 
-                            if (length > 0 && replyDebIndex != NO_DEBITOR_INDEX && replyDeb != null)
+                            if (length > 0 && replyDebit != null)
                             {
                                 final int minimum = Math.min(bufferPool.slotCapacity(), reserved); // TODO: fragmentation
-                                reserved = replyDeb.claim(traceId, replyDebIndex, replyId, minimum, reserved, 0);
+                                reserved = replyDebit.claim(traceId, minimum, reserved);
                                 length = Math.max(reserved - replyPad, 0);
                             }
 

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -24,8 +24,6 @@ import static io.aklivity.zilla.runtime.binding.http.internal.hpack.HpackLiteral
 import static io.aklivity.zilla.runtime.binding.http.internal.hpack.HpackLiteralHeaderFieldFW.LiteralType.WITHOUT_INDEXING;
 import static io.aklivity.zilla.runtime.binding.http.internal.types.ProxyAddressProtocol.STREAM;
 import static io.aklivity.zilla.runtime.binding.http.internal.util.BufferUtil.limitOfBytes;
-import static io.aklivity.zilla.runtime.engine.budget.BudgetCreditor.NO_CREDITOR_INDEX;
-import static io.aklivity.zilla.runtime.engine.budget.BudgetDebitor.NO_DEBITOR_INDEX;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
 import static java.lang.Character.toLowerCase;
 import static java.lang.Character.toUpperCase;
@@ -117,8 +115,8 @@ import io.aklivity.zilla.runtime.binding.http.internal.types.stream.WindowFW;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
-import io.aklivity.zilla.runtime.engine.budget.BudgetCreditor;
-import io.aklivity.zilla.runtime.engine.budget.BudgetDebitor;
+import io.aklivity.zilla.runtime.engine.budget.BudgetCredit;
+import io.aklivity.zilla.runtime.engine.budget.BudgetDebit;
 import io.aklivity.zilla.runtime.engine.buffer.BufferPool;
 import io.aklivity.zilla.runtime.engine.config.BindingConfig;
 import io.aklivity.zilla.runtime.engine.config.ModelConfig;
@@ -325,10 +323,8 @@ public final class HttpClientFactory implements HttpStreamFactory
     private final MutableDirectBuffer codecBuffer;
     private final BufferPool bufferPool;
     private final BufferPool headersPool;
-    private final BudgetCreditor creditor;
     private final MutableDirectBuffer extBuffer;
     private final BindingHandler streamFactory;
-    private final LongFunction<BudgetDebitor> supplyDebitor;
     private final LongUnaryOperator supplyInitialId;
     private final LongUnaryOperator supplyReplyId;
     private final LongUnaryOperator supplyPromiseId;
@@ -364,10 +360,8 @@ public final class HttpClientFactory implements HttpStreamFactory
         this.extBuffer = new UnsafeBuffer(new byte[writeBuffer.capacity()]);
         this.bufferPool = context.bufferPool();
         this.headersPool = bufferPool.duplicate();
-        this.creditor = context.creditor();
         this.initialSettings = new Http2Settings(config, headersPool);
         this.streamFactory = context.streamFactory();
-        this.supplyDebitor = context::supplyDebitor;
         this.supplyInitialId = context::supplyInitialId;
         this.supplyReplyId = context::supplyReplyId;
         this.supplyPromiseId = context::supplyPromiseId;
@@ -2254,7 +2248,7 @@ public final class HttpClientFactory implements HttpStreamFactory
         private int requestSharedBudget;
         private int encodeSlotReserved;
         private int initialSharedBudget;
-        private long requestSharedBudgetIndex = NO_CREDITOR_INDEX;
+        private BudgetCredit requestCredit;
         private String protocolUpgrade = null;
         private String scheme;
         private String authority;
@@ -2383,8 +2377,8 @@ public final class HttpClientFactory implements HttpStreamFactory
             {
                 assert !HttpState.initialOpened(state);
                 initialBudgetId = supplyBudgetId.getAsLong();
-                assert requestSharedBudgetIndex == NO_CREDITOR_INDEX;
-                requestSharedBudgetIndex = creditor.acquire(initialBudgetId);
+                assert requestCredit == null;
+                requestCredit = context.supplyCredit(initialId, initialBudgetId);
 
                 remoteSharedBudget = encodeMax;
 
@@ -3881,7 +3875,7 @@ public final class HttpClientFactory implements HttpStreamFactory
                 remoteSharedBudget += credit;
 
                 // TODO: instead use HttpState.replyClosed(state)
-                if (requestSharedBudgetIndex != NO_CREDITOR_INDEX)
+                if (requestCredit != null)
                 {
                     flushRequestSharedBudget(traceId);
                 }
@@ -3942,17 +3936,11 @@ public final class HttpClientFactory implements HttpStreamFactory
             final int requestSharedBudgetDelta = remoteSharedBudgetMax - (requestSharedBudget + encodeSlotReserved);
             final int initialSharedCredit = Math.min(requestSharedCredit, requestSharedBudgetDelta);
 
-            if (initialSharedCredit > 0 && requestSharedBudgetIndex != NO_CREDITOR_INDEX)
+            if (initialSharedCredit > 0 && requestCredit != null)
             {
-                final long requestSharedPrevious =
-                        creditor.credit(traceId, requestSharedBudgetIndex, initialSharedCredit);
+                requestCredit.capacity(traceId, initialSharedCredit);
 
                 requestSharedBudget += initialSharedCredit;
-
-                final long requestSharedBudgetUpdated = requestSharedPrevious + initialSharedCredit;
-                assert requestSharedBudgetUpdated <= encodeMax
-                        : String.format("%d <= %d, remoteSharedBudget = %d",
-                        requestSharedBudgetUpdated, encodeMax, remoteSharedBudget);
 
                 assert requestSharedBudget <= encodeMax
                         : String.format("%d <= %d", requestSharedBudget, encodeMax);
@@ -4564,10 +4552,10 @@ public final class HttpClientFactory implements HttpStreamFactory
 
         private void cleanupBudgetCreditorIfNecessary()
         {
-            if (requestSharedBudgetIndex != NO_CREDITOR_INDEX)
+            if (requestCredit != null)
             {
-                creditor.release(requestSharedBudgetIndex);
-                requestSharedBudgetIndex = NO_CREDITOR_INDEX;
+                requestCredit.close();
+                requestCredit = null;
             }
         }
     }
@@ -4597,8 +4585,7 @@ public final class HttpClientFactory implements HttpStreamFactory
         private long requestAuth;
 
         private MessageConsumer application;
-        private BudgetDebitor responseDeb;
-        private long responseDebIndex = NO_DEBITOR_INDEX;
+        private BudgetDebit responseDebit;
         private long responseSeq;
         private long responseAck;
         private int responseMax;
@@ -4959,10 +4946,10 @@ public final class HttpClientFactory implements HttpStreamFactory
             int length = Math.min(responseMax - responseNoAck - responsePad, limit - offset);
             int reserved = length + responsePad;
 
-            if (responseDebIndex != NO_DEBITOR_INDEX && responseDeb != null)
+            if (responseDebit != null)
             {
                 final int minimum = reserved; // TODO: fragmentation
-                reserved = responseDeb.claim(traceId, responseDebIndex, responseId, minimum, reserved, 0);
+                reserved = responseDebit.claim(traceId, minimum, reserved);
                 length = Math.max(reserved - responsePad, 0);
             }
 
@@ -5079,10 +5066,10 @@ public final class HttpClientFactory implements HttpStreamFactory
 
             state = HttpState.openReply(state);
 
-            if (responseBud != 0L && responseDebIndex == NO_DEBITOR_INDEX)
+            if (responseBud != 0L && responseDebit == null)
             {
-                responseDeb = supplyDebitor.apply(budgetId);
-                responseDebIndex = responseDeb.acquire(budgetId, responseId, this::onResponseFlush);
+                responseDebit = context.supplyDebit(responseId, budgetId, this::onResponseFlush);
+                responseDebit.declare(traceId, 0, 0);
             }
 
             client.decodeNetworkIfBuffered(traceId, authorization);

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -2517,7 +2517,7 @@ public final class HttpClientFactory implements HttpStreamFactory
 
             state = HttpState.closeInitial(state);
 
-            cleanupBudgetCreditorIfNecessary();
+            requestCredit = null;
             cleanupEncodeSlotIfNecessary();
 
             exchanges.forEach((id, exchange) -> exchange.cleanup(traceId, authorization));
@@ -2706,7 +2706,7 @@ public final class HttpClientFactory implements HttpStreamFactory
             {
                 state = HttpState.closeInitial(state);
 
-                cleanupBudgetCreditorIfNecessary();
+                requestCredit = null;
                 cleanupEncodeSlotIfNecessary();
 
                 doEnd(network, originId, routedId, initialId, initialSeq, initialAck, initialMax,
@@ -2727,7 +2727,7 @@ public final class HttpClientFactory implements HttpStreamFactory
             {
                 state = HttpState.closeInitial(state);
 
-                cleanupBudgetCreditorIfNecessary();
+                requestCredit = null;
                 cleanupEncodeSlotIfNecessary();
 
                 doAbort(network, originId, routedId, initialId, initialSeq, initialAck, initialMax,
@@ -4550,14 +4550,6 @@ public final class HttpClientFactory implements HttpStreamFactory
             }
         }
 
-        private void cleanupBudgetCreditorIfNecessary()
-        {
-            if (requestCredit != null)
-            {
-                requestCredit.close();
-                requestCredit = null;
-            }
-        }
     }
 
 

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpServerFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpServerFactory.java
@@ -30,8 +30,6 @@ import static io.aklivity.zilla.runtime.binding.http.internal.types.ProxyInfoTyp
 import static io.aklivity.zilla.runtime.binding.http.internal.types.ProxySecureInfoType.VERSION;
 import static io.aklivity.zilla.runtime.binding.http.internal.util.BufferUtil.indexOfByte;
 import static io.aklivity.zilla.runtime.binding.http.internal.util.BufferUtil.limitOfBytes;
-import static io.aklivity.zilla.runtime.engine.budget.BudgetCreditor.NO_CREDITOR_INDEX;
-import static io.aklivity.zilla.runtime.engine.budget.BudgetDebitor.NO_DEBITOR_INDEX;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
 import static io.aklivity.zilla.runtime.engine.concurrent.Signaler.NO_CANCEL_ID;
 import static io.aklivity.zilla.runtime.engine.guard.GuardHandler.EXPIRES_NEVER;
@@ -138,8 +136,8 @@ import io.aklivity.zilla.runtime.binding.http.internal.util.HttpUtil;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
-import io.aklivity.zilla.runtime.engine.budget.BudgetCreditor;
-import io.aklivity.zilla.runtime.engine.budget.BudgetDebitor;
+import io.aklivity.zilla.runtime.engine.budget.BudgetCredit;
+import io.aklivity.zilla.runtime.engine.budget.BudgetDebit;
 import io.aklivity.zilla.runtime.engine.buffer.BufferPool;
 import io.aklivity.zilla.runtime.engine.concurrent.Signaler;
 import io.aklivity.zilla.runtime.engine.config.BindingConfig;
@@ -550,10 +548,8 @@ public final class HttpServerFactory implements HttpStreamFactory
     private final MutableDirectBuffer writeBuffer;
     private final MutableDirectBuffer frameBuffer;
     private final BufferPool bufferPool;
-    private final BudgetCreditor creditor;
     private final EngineContext context;
     private final BindingHandler streamFactory;
-    private final LongFunction<BudgetDebitor> supplyDebitor;
     private final LongUnaryOperator supplyInitialId;
     private final LongUnaryOperator supplyReplyId;
     private final LongSupplier supplyBudgetId;
@@ -582,9 +578,7 @@ public final class HttpServerFactory implements HttpStreamFactory
         this.context = context;
         this.writeBuffer = context.writeBuffer();
         this.bufferPool = context.bufferPool();
-        this.creditor = context.creditor();
         this.streamFactory = context.streamFactory();
-        this.supplyDebitor = context::supplyDebitor;
         this.supplyInitialId = context::supplyInitialId;
         this.supplyReplyId = context::supplyReplyId;
         this.supplyBudgetId = context::supplyBudgetId;
@@ -2011,8 +2005,8 @@ public final class HttpServerFactory implements HttpStreamFactory
                 delegate.replyMax = replyMax;
                 delegate.replyPad = replyPad;
 
-                assert delegate.responseSharedBudgetIndex == NO_CREDITOR_INDEX;
-                delegate.responseSharedBudgetIndex = creditor.acquire(delegate.budgetId);
+                assert delegate.responseCredit == null;
+                delegate.responseCredit = context.supplyCredit(delegate.replyId, delegate.budgetId);
                 delegate.replySharedBudget = replyMax - replyPendingAck();
 
                 delegate.decodeSlot = decodeSlot;
@@ -4063,7 +4057,7 @@ public final class HttpServerFactory implements HttpStreamFactory
 
         private int remoteSharedBudget;
         private int responseSharedBudget;
-        private long responseSharedBudgetIndex = NO_CREDITOR_INDEX;
+        private BudgetCredit responseCredit;
 
         private int decodeSlot = NO_SLOT;
         private int decodeSlotOffset;
@@ -4446,8 +4440,8 @@ public final class HttpServerFactory implements HttpStreamFactory
             doBegin(network, originId, routedId, replyId, replySeq, replyAck, replyMax,
                 traceId, authorization, affinity, EMPTY_OCTETS);
 
-            assert responseSharedBudgetIndex == NO_CREDITOR_INDEX;
-            responseSharedBudgetIndex = creditor.acquire(budgetId);
+            assert responseCredit == null;
+            responseCredit = context.supplyCredit(replyId, budgetId);
             state = HttpState.openReply(state);
         }
 
@@ -5010,7 +5004,7 @@ public final class HttpServerFactory implements HttpStreamFactory
                 remoteSharedBudget += credit;
 
                 // TODO: instead use HttpState.replyClosed(state)
-                if (responseSharedBudgetIndex != NO_CREDITOR_INDEX)
+                if (responseCredit != null)
                 {
                     flushResponseSharedBudget(traceId);
                 }
@@ -5536,10 +5530,9 @@ public final class HttpServerFactory implements HttpStreamFactory
             final int responseSharedBudgetDelta = remoteSharedBudgetMax - (responseSharedBudget + encodeSlotReserved);
             final int replySharedCredit = Math.min(responseSharedCredit, responseSharedBudgetDelta);
 
-            if (replySharedCredit > 0 && responseSharedBudgetIndex != NO_CREDITOR_INDEX)
+            if (replySharedCredit > 0 && responseCredit != null)
             {
-                final long responseSharedPrevious =
-                    creditor.credit(traceId, responseSharedBudgetIndex, replySharedCredit);
+                responseCredit.capacity(traceId, replySharedCredit);
 
                 if (HttpConfiguration.DEBUG_HTTP2_BUDGETS)
                 {
@@ -5550,11 +5543,6 @@ public final class HttpServerFactory implements HttpStreamFactory
                 }
 
                 responseSharedBudget += replySharedCredit;
-
-                final long responseSharedBudgetUpdated = responseSharedPrevious + replySharedCredit;
-                assert responseSharedBudgetUpdated <= decodeMax
-                    : String.format("%d <= %d, remoteSharedBudget = %d",
-                    responseSharedBudgetUpdated, decodeMax, remoteSharedBudget);
 
                 assert responseSharedBudget <= decodeMax
                     : String.format("%d <= %d", responseSharedBudget, decodeMax);
@@ -5895,10 +5883,10 @@ public final class HttpServerFactory implements HttpStreamFactory
 
         private void cleanupBudgetCreditorIfNecessary()
         {
-            if (responseSharedBudgetIndex != NO_CREDITOR_INDEX)
+            if (responseCredit != null)
             {
-                creditor.release(responseSharedBudgetIndex);
-                responseSharedBudgetIndex = NO_CREDITOR_INDEX;
+                responseCredit.close();
+                responseCredit = null;
             }
         }
 
@@ -5936,8 +5924,7 @@ public final class HttpServerFactory implements HttpStreamFactory
             private long requestBud;
             private int requestCaps;
 
-            private BudgetDebitor requestDeb;
-            private long requestDebIndex = NO_DEBITOR_INDEX;
+            private BudgetDebit requestDebit;
 
             private int localBudget;
             private int remoteBudget;
@@ -6017,10 +6004,10 @@ public final class HttpServerFactory implements HttpStreamFactory
                     int length = Math.max(Math.min(initialWindow() - requestPad, remaining.value), 0);
                     int reserved = length + requestPad;
 
-                    if (requestDebIndex != NO_DEBITOR_INDEX && requestDeb != null)
+                    if (requestDebit != null)
                     {
                         final int minimum = reserved; // TODO: fragmentation
-                        reserved = requestDeb.claim(0L, requestDebIndex, requestId, minimum, reserved, 0);
+                        reserved = requestDebit.claim(0L, minimum, reserved);
                         length = Math.max(reserved - requestPad, 0);
                     }
 
@@ -6224,10 +6211,10 @@ public final class HttpServerFactory implements HttpStreamFactory
                 requestBud = budgetId;
                 requestCaps = capabilities;
 
-                if (requestBud != 0L && requestDebIndex == NO_DEBITOR_INDEX)
+                if (requestBud != 0L && requestDebit == null)
                 {
-                    requestDeb = supplyDebitor.apply(budgetId);
-                    requestDebIndex = requestDeb.acquire(budgetId, requestId, Http2Server.this::decodeNetworkIfNecessary);
+                    requestDebit = context.supplyDebit(requestId, budgetId, Http2Server.this::decodeNetworkIfNecessary);
+                    requestDebit.declare(traceId, 0, 0);
                 }
 
                 decodeNetworkIfNecessary(traceId);
@@ -6290,10 +6277,10 @@ public final class HttpServerFactory implements HttpStreamFactory
 
             private void cleanupRequestDebitorIfNecessary()
             {
-                if (requestDebIndex != NO_DEBITOR_INDEX)
+                if (requestDebit != null)
                 {
-                    requestDeb.release(requestDebIndex, requestId);
-                    requestDebIndex = NO_DEBITOR_INDEX;
+                    requestDebit.close();
+                    requestDebit = null;
                 }
             }
 

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpServerFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpServerFactory.java
@@ -4351,7 +4351,7 @@ public final class HttpServerFactory implements HttpStreamFactory
             final long authorization = reset.authorization();
             state = HttpState.closeReply(state);
 
-            cleanupBudgetCreditorIfNecessary();
+            responseCredit = null;
             cleanupEncodeSlotIfNecessary();
 
             if (!HttpState.initialClosing(state))
@@ -4545,7 +4545,7 @@ public final class HttpServerFactory implements HttpStreamFactory
             long traceId,
             long authorization)
         {
-            cleanupBudgetCreditorIfNecessary();
+            responseCredit = null;
             cleanupEncodeSlotIfNecessary();
             doEnd(network, originId, routedId, replyId, replySeq, replyAck, replyMax, traceId, authorization, EMPTY_OCTETS);
             state = HttpState.closeReply(state);
@@ -4555,7 +4555,7 @@ public final class HttpServerFactory implements HttpStreamFactory
             long traceId,
             long authorization)
         {
-            cleanupBudgetCreditorIfNecessary();
+            responseCredit = null;
             cleanupEncodeSlotIfNecessary();
             doAbort(network, originId, routedId, replyId, replySeq, replyAck, replyMax, traceId, authorization, EMPTY_OCTETS);
             state = HttpState.closeReply(state);
@@ -5881,15 +5881,6 @@ public final class HttpServerFactory implements HttpStreamFactory
             }
         }
 
-        private void cleanupBudgetCreditorIfNecessary()
-        {
-            if (responseCredit != null)
-            {
-                responseCredit.close();
-                responseCredit = null;
-            }
-        }
-
         private final class Http2Exchange
         {
             private final long originId;
@@ -6125,7 +6116,7 @@ public final class HttpServerFactory implements HttpStreamFactory
 
                 doResponseReset(traceId);
                 state = HttpState.closeInitial(state);
-                cleanupRequestDebitorIfNecessary();
+                requestDebit = null;
                 streams.remove(streamId);
 
                 clear();
@@ -6262,7 +6253,7 @@ public final class HttpServerFactory implements HttpStreamFactory
                 assert !HttpState.initialClosed(state);
 
                 state = HttpState.closeInitial(state);
-                cleanupRequestDebitorIfNecessary();
+                requestDebit = null;
                 deauthorizeIfNecessary();
                 removeStreamIfNecessary();
             }
@@ -6272,15 +6263,6 @@ public final class HttpServerFactory implements HttpStreamFactory
                 if (HttpState.closed(state) && (sessionId & MASK_AUTHORIZED) != 0 && guard != null)
                 {
                     guard.deauthorize(sessionId);
-                }
-            }
-
-            private void cleanupRequestDebitorIfNecessary()
-            {
-                if (requestDebit != null)
-                {
-                    requestDebit.close();
-                    requestDebit = null;
                 }
             }
 

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcRemoteServerFactory.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcRemoteServerFactory.java
@@ -17,7 +17,6 @@ package io.aklivity.zilla.runtime.binding.kafka.grpc.internal.stream;
 import static io.aklivity.zilla.runtime.binding.kafka.grpc.internal.types.KafkaCapabilities.FETCH_ONLY;
 import static io.aklivity.zilla.runtime.binding.kafka.grpc.internal.types.KafkaCapabilities.PRODUCE_ONLY;
 import static io.aklivity.zilla.runtime.binding.kafka.grpc.internal.types.stream.GrpcType.BASE64;
-import static io.aklivity.zilla.runtime.engine.budget.BudgetDebitor.NO_DEBITOR_INDEX;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
 import static io.aklivity.zilla.runtime.engine.concurrent.Signaler.NO_CANCEL_ID;
 import static java.lang.System.currentTimeMillis;
@@ -28,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.LongConsumer;
-import java.util.function.LongFunction;
 import java.util.function.LongPredicate;
 import java.util.function.LongSupplier;
 import java.util.function.LongUnaryOperator;
@@ -69,7 +67,7 @@ import io.aklivity.zilla.runtime.binding.kafka.grpc.internal.types.stream.Window
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
-import io.aklivity.zilla.runtime.engine.budget.BudgetDebitor;
+import io.aklivity.zilla.runtime.engine.budget.BudgetDebit;
 import io.aklivity.zilla.runtime.engine.buffer.BufferPool;
 import io.aklivity.zilla.runtime.engine.concurrent.Signaler;
 import io.aklivity.zilla.runtime.engine.config.BindingConfig;
@@ -144,7 +142,7 @@ public final class KafkaGrpcRemoteServerFactory implements KafkaGrpcStreamFactor
     private final LongUnaryOperator supplyInitialId;
     private final LongUnaryOperator supplyReplyId;
     private final LongSupplier supplyTraceId;
-    private final LongFunction<BudgetDebitor> supplyDebitor;
+    private final EngineContext context;
     private final Function<Long, String> supplyNamespace;
     private final LongPredicate activate;
     private final LongConsumer deactivate;
@@ -169,7 +167,7 @@ public final class KafkaGrpcRemoteServerFactory implements KafkaGrpcStreamFactor
         this.supplyInitialId = context::supplyInitialId;
         this.supplyReplyId = context::supplyReplyId;
         this.signaler = context.signaler();
-        this.supplyDebitor = context::supplyDebitor;
+        this.context = context;
         this.supplyTraceId = context::supplyTraceId;
         this.supplyNamespace = context::supplyNamespace;
         this.activate = activate;
@@ -1354,8 +1352,7 @@ public final class KafkaGrpcRemoteServerFactory implements KafkaGrpcStreamFactor
         private int initialCap;
         private int initialAuth;
 
-        private BudgetDebitor initialDeb;
-        private long initialDebIndex = NO_DEBITOR_INDEX;
+        private BudgetDebit initialDebit;
 
         private int state;
 
@@ -1603,14 +1600,13 @@ public final class KafkaGrpcRemoteServerFactory implements KafkaGrpcStreamFactor
 
             assert initialAck <= initialSeq;
 
-            if (initialBudetId != 0L && initialDebIndex == NO_DEBITOR_INDEX)
+            if (initialBudetId != 0L && initialDebit == null)
             {
-                initialDeb = supplyDebitor.apply(budgetId);
-                initialDebIndex = initialDeb.acquire(budgetId, initialId, this::flushMessage);
-                assert initialDebIndex != NO_DEBITOR_INDEX;
+                initialDebit = context.supplyDebit(initialId, initialBudetId, this::flushMessage);
+                initialDebit.declare(traceId, 0, 0);
             }
 
-            if (initialBudetId != 0L && initialDebIndex == NO_DEBITOR_INDEX)
+            if (initialBudetId != 0L && !initialDebit.available())
             {
                 cleanup(traceId, authorization);
             }
@@ -1651,9 +1647,9 @@ public final class KafkaGrpcRemoteServerFactory implements KafkaGrpcStreamFactor
             deferred = (flags & DATA_FLAG_INIT) != 0x00 ? deferred : 0;
 
             int claimed = reserved;
-            if (length > 0 && initialDebIndex != NO_DEBITOR_INDEX)
+            if (length > 0 && initialDebit != null)
             {
-                claimed = initialDeb.claim(traceId, initialDebIndex, initialId, reserved, reserved, deferred);
+                claimed = initialDebit.claim(traceId, reserved, reserved, deferred);
             }
 
             final int flushableBytes = Math.max(claimed - initialPad, 0);
@@ -1716,10 +1712,10 @@ public final class KafkaGrpcRemoteServerFactory implements KafkaGrpcStreamFactor
 
         private void cleanupBudgetIfNecessary()
         {
-            if (initialDebIndex != NO_DEBITOR_INDEX)
+            if (initialDebit != null)
             {
-                initialDeb.release(initialDebIndex, initialId);
-                initialDebIndex = NO_DEBITOR_INDEX;
+                initialDebit.close();
+                initialDebit = null;
             }
         }
 

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcRemoteServerFactory.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcRemoteServerFactory.java
@@ -1712,11 +1712,7 @@ public final class KafkaGrpcRemoteServerFactory implements KafkaGrpcStreamFactor
 
         private void cleanupBudgetIfNecessary()
         {
-            if (initialDebit != null)
-            {
-                initialDebit.close();
-                initialDebit = null;
-            }
+            initialDebit = null;
         }
 
         private void metadata(

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttClientFactory.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttClientFactory.java
@@ -57,8 +57,6 @@ import static io.aklivity.zilla.runtime.binding.mqtt.internal.types.stream.MqttP
 import static io.aklivity.zilla.runtime.binding.mqtt.internal.types.stream.MqttServerCapabilities.SHARED_SUBSCRIPTIONS;
 import static io.aklivity.zilla.runtime.binding.mqtt.internal.types.stream.MqttServerCapabilities.SUBSCRIPTION_IDS;
 import static io.aklivity.zilla.runtime.binding.mqtt.internal.types.stream.MqttServerCapabilities.WILDCARD;
-import static io.aklivity.zilla.runtime.engine.budget.BudgetCreditor.NO_CREDITOR_INDEX;
-import static io.aklivity.zilla.runtime.engine.budget.BudgetDebitor.NO_DEBITOR_INDEX;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
 import static io.aklivity.zilla.runtime.engine.concurrent.Signaler.NO_CANCEL_ID;
 import static java.nio.ByteOrder.BIG_ENDIAN;
@@ -78,7 +76,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.LongFunction;
 import java.util.function.LongSupplier;
 import java.util.function.LongUnaryOperator;
 import java.util.regex.Pattern;
@@ -154,8 +151,8 @@ import io.aklivity.zilla.runtime.binding.mqtt.internal.types.stream.WindowFW;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
-import io.aklivity.zilla.runtime.engine.budget.BudgetCreditor;
-import io.aklivity.zilla.runtime.engine.budget.BudgetDebitor;
+import io.aklivity.zilla.runtime.engine.budget.BudgetCredit;
+import io.aklivity.zilla.runtime.engine.budget.BudgetDebit;
 import io.aklivity.zilla.runtime.engine.buffer.BufferPool;
 import io.aklivity.zilla.runtime.engine.concurrent.Signaler;
 import io.aklivity.zilla.runtime.engine.config.BindingConfig;
@@ -342,7 +339,6 @@ public final class MqttClientFactory implements MqttStreamFactory
 
     private final ByteBuffer charsetBuffer;
     private final BufferPool bufferPool;
-    private final BudgetCreditor creditor;
     private final Signaler signaler;
     private final MessageConsumer droppedHandler;
     private final BindingHandler streamFactory;
@@ -350,7 +346,6 @@ public final class MqttClientFactory implements MqttStreamFactory
     private final LongUnaryOperator supplyReplyId;
     private final LongSupplier supplyTraceId;
     private final LongSupplier supplyBudgetId;
-    private final LongFunction<BudgetDebitor> supplyDebitor;
     private final Long2ObjectHashMap<MqttBindingConfig> bindings;
     private final int mqttTypeId;
 
@@ -378,12 +373,10 @@ public final class MqttClientFactory implements MqttStreamFactory
         this.passwordBuffer = new UnsafeBuffer(new byte[writeBuffer.capacity()]);
         this.willPropertyBuffer = new UnsafeBuffer(new byte[writeBuffer.capacity()]);
         this.bufferPool = context.bufferPool();
-        this.creditor = context.creditor();
         this.signaler = context.signaler();
         this.context = context;
         this.droppedHandler = context.droppedFrameHandler();
         this.streamFactory = context.streamFactory();
-        this.supplyDebitor = context::supplyDebitor;
         this.supplyInitialId = context::supplyInitialId;
         this.supplyReplyId = context::supplyReplyId;
         this.supplyBudgetId = context::supplyBudgetId;
@@ -1047,10 +1040,10 @@ public final class MqttClientFactory implements MqttStreamFactory
             int reserved = payloadSize + subscriber.replyPad;
             canPublish &= subscriber.replySeq + reserved <= subscriber.replyAck + subscriber.replyMax;
 
-            if (canPublish && subscriber.debitorIndex != NO_DEBITOR_INDEX && reserved != 0)
+            if (canPublish && subscriber.debit != null && reserved != 0)
             {
                 final int minimum = reserved; // TODO: fragmentation
-                reserved = subscriber.debitor.claim(traceId, subscriber.debitorIndex, subscriber.replyId, minimum, reserved, 0);
+                reserved = subscriber.debit.claim(traceId, minimum, reserved);
             }
 
             if (canPublish && (reserved != 0 || payloadSize == 0))
@@ -1240,7 +1233,7 @@ public final class MqttClientFactory implements MqttStreamFactory
         private int encodeMax;
         private int encodePad;
 
-        private long encodeBudgetIndex = NO_CREDITOR_INDEX;
+        private BudgetCredit encodeCredit;
         private int encodeSharedBudget;
 
         private int decodeSlot = NO_SLOT;
@@ -1352,8 +1345,8 @@ public final class MqttClientFactory implements MqttStreamFactory
 
             state = MqttState.openingInitial(state);
 
-            assert encodeBudgetIndex == NO_CREDITOR_INDEX;
-            this.encodeBudgetIndex = creditor.acquire(encodeBudgetId);
+            assert encodeCredit == null;
+            this.encodeCredit = context.supplyCredit(replyId, encodeBudgetId);
 
             doNetworkWindow(traceId, authorization, 0, 0L, 0, bufferPool.slotCapacity());
         }
@@ -1474,12 +1467,8 @@ public final class MqttClientFactory implements MqttStreamFactory
 
             if (encodeSharedCredit > 0)
             {
-                final long encodeSharedBudgetPrevious = creditor.credit(traceId, encodeBudgetIndex, encodeSharedCredit);
+                encodeCredit.capacity(traceId, encodeSharedCredit);
                 encodeSharedBudget += encodeSharedCredit;
-
-                assert encodeSharedBudgetPrevious + encodeSharedCredit <= encodeBudgetMax
-                    : String.format("%d + %d <= %d, encodeBudget = %d",
-                    encodeSharedBudgetPrevious, encodeSharedCredit, encodeBudgetMax, encodeWin);
 
                 assert encodeSharedCredit <= encodeBudgetMax
                     : String.format("%d <= %d", encodeSharedCredit, encodeBudgetMax);
@@ -2684,10 +2673,10 @@ public final class MqttClientFactory implements MqttStreamFactory
 
         private void cleanupBudgetCreditor()
         {
-            if (encodeBudgetIndex != NO_CREDITOR_INDEX)
+            if (encodeCredit != null)
             {
-                creditor.release(encodeBudgetIndex);
-                encodeBudgetIndex = NO_CREDITOR_INDEX;
+                encodeCredit.close();
+                encodeCredit = null;
             }
         }
 
@@ -2838,8 +2827,7 @@ public final class MqttClientFactory implements MqttStreamFactory
         private long replyId;
         private long budgetId;
 
-        private BudgetDebitor debitor;
-        private long debitorIndex = NO_DEBITOR_INDEX;
+        private BudgetDebit debit;
 
         private long initialSeq;
         private long initialAck;
@@ -2930,10 +2918,9 @@ public final class MqttClientFactory implements MqttStreamFactory
 
             assert initialAck <= initialSeq;
 
-            if (budgetId != 0L && debitorIndex == NO_DEBITOR_INDEX)
+            if (budgetId != 0L && debit == null)
             {
-                debitor = supplyDebitor.apply(budgetId);
-                debitorIndex = debitor.acquire(budgetId, initialId, client::decodeNetwork);
+                debit = context.supplyDebit(initialId, budgetId, client::decodeNetwork);
             }
 
             if (MqttState.initialClosing(state) && !MqttState.initialClosed(state))
@@ -3288,8 +3275,7 @@ public final class MqttClientFactory implements MqttStreamFactory
         private long budgetId;
 
         private MqttClient client;
-        private BudgetDebitor debitor;
-        private long debitorIndex = NO_DEBITOR_INDEX;
+        private BudgetDebit debit;
 
         private long initialSeq;
         private long initialAck;
@@ -3637,8 +3623,7 @@ public final class MqttClientFactory implements MqttStreamFactory
         private long budgetId;
 
         private MqttClient client;
-        private BudgetDebitor debitor;
-        private long debitorIndex = NO_DEBITOR_INDEX;
+        private BudgetDebit debit;
 
         private long initialSeq;
         private long initialAck;

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttClientFactory.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttClientFactory.java
@@ -2040,7 +2040,6 @@ public final class MqttClientFactory implements MqttStreamFactory
             {
                 state = MqttState.closeInitial(state);
 
-                cleanupBudgetCreditor();
                 cleanupEncodeSlot();
 
                 doEnd(network, originId, routedId, initialId, encodeSeq, encodeAck, encodeMax,
@@ -2056,7 +2055,6 @@ public final class MqttClientFactory implements MqttStreamFactory
             {
                 state = MqttState.closeReply(state);
 
-                cleanupBudgetCreditor();
                 cleanupEncodeSlot();
 
                 doAbort(network, originId, routedId, initialId, encodeSeq, encodeAck, encodeMax,
@@ -2668,15 +2666,6 @@ public final class MqttClientFactory implements MqttStreamFactory
             if (sessionStream != null)
             {
                 sessionStream.cleanupEnd(traceId, authorization);
-            }
-        }
-
-        private void cleanupBudgetCreditor()
-        {
-            if (encodeCredit != null)
-            {
-                encodeCredit.close();
-                encodeCredit = null;
             }
         }
 

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttServerFactory.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttServerFactory.java
@@ -4031,7 +4031,6 @@ public final class MqttServerFactory implements MqttStreamFactory
             {
                 state = MqttState.closeReply(state);
 
-                cleanupBudgetCreditor();
                 cleanupEncodeSlot();
 
                 doEnd(network, originId, routedId, replyId, encodeSeq, encodeAck, encodeMax,
@@ -4047,7 +4046,6 @@ public final class MqttServerFactory implements MqttStreamFactory
             {
                 state = MqttState.closeReply(state);
 
-                cleanupBudgetCreditor();
                 cleanupEncodeSlot();
 
                 doAbort(network, originId, routedId, replyId, encodeSeq, encodeAck, encodeMax,
@@ -4890,15 +4888,6 @@ public final class MqttServerFactory implements MqttStreamFactory
             decoder = decodeIgnoreAll;
         }
 
-        private void cleanupBudgetCreditor()
-        {
-            if (encodeCredit != null)
-            {
-                encodeCredit.close();
-                encodeCredit = null;
-            }
-        }
-
         private void cleanupDecodeSlot()
         {
             if (decodeSlot != NO_SLOT)
@@ -5613,11 +5602,7 @@ public final class MqttServerFactory implements MqttStreamFactory
 
                 state = MqttState.closeInitial(state);
 
-                if (debit != null)
-                {
-                    debit.close();
-                    debit = null;
-                }
+                debit = null;
             }
 
             public void setSubscriptions(List<Subscription> subscriptions)
@@ -6080,11 +6065,7 @@ public final class MqttServerFactory implements MqttStreamFactory
 
                 state = MqttState.closeInitial(state);
 
-                if (debit != null)
-                {
-                    debit.close();
-                    debit = null;
-                }
+                debit = null;
 
                 if (MqttState.closed(state))
                 {
@@ -6323,11 +6304,7 @@ public final class MqttServerFactory implements MqttStreamFactory
 
                 state = MqttState.closeInitial(state);
 
-                if (debit != null)
-                {
-                    debit.close();
-                    debit = null;
-                }
+                debit = null;
 
                 if (MqttState.closed(state))
                 {

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttServerFactory.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttServerFactory.java
@@ -64,8 +64,6 @@ import static io.aklivity.zilla.runtime.binding.mqtt.internal.types.codec.MqttPr
 import static io.aklivity.zilla.runtime.binding.mqtt.internal.types.stream.DataFW.FIELD_OFFSET_PAYLOAD;
 import static io.aklivity.zilla.runtime.binding.mqtt.internal.types.stream.MqttPublishDataExFW.Builder.DEFAULT_EXPIRY_INTERVAL;
 import static io.aklivity.zilla.runtime.binding.mqtt.internal.types.stream.MqttPublishDataExFW.Builder.DEFAULT_FORMAT;
-import static io.aklivity.zilla.runtime.engine.budget.BudgetCreditor.NO_CREDITOR_INDEX;
-import static io.aklivity.zilla.runtime.engine.budget.BudgetDebitor.NO_DEBITOR_INDEX;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
 import static io.aklivity.zilla.runtime.engine.concurrent.Signaler.NO_CANCEL_ID;
 import static java.nio.ByteOrder.BIG_ENDIAN;
@@ -91,7 +89,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntConsumer;
 import java.util.function.IntSupplier;
-import java.util.function.LongFunction;
 import java.util.function.LongSupplier;
 import java.util.function.LongUnaryOperator;
 import java.util.function.Supplier;
@@ -188,8 +185,8 @@ import io.aklivity.zilla.runtime.binding.mqtt.internal.types.stream.WindowFW;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
-import io.aklivity.zilla.runtime.engine.budget.BudgetCreditor;
-import io.aklivity.zilla.runtime.engine.budget.BudgetDebitor;
+import io.aklivity.zilla.runtime.engine.budget.BudgetCredit;
+import io.aklivity.zilla.runtime.engine.budget.BudgetDebit;
 import io.aklivity.zilla.runtime.engine.buffer.BufferPool;
 import io.aklivity.zilla.runtime.engine.concurrent.Signaler;
 import io.aklivity.zilla.runtime.engine.config.BindingConfig;
@@ -457,7 +454,6 @@ public final class MqttServerFactory implements MqttStreamFactory
 
     private final ByteBuffer charsetBuffer;
     private final BufferPool bufferPool;
-    private final BudgetCreditor creditor;
     private final Signaler signaler;
     private final MessageConsumer droppedHandler;
     private final BindingHandler streamFactory;
@@ -465,7 +461,6 @@ public final class MqttServerFactory implements MqttStreamFactory
     private final LongUnaryOperator supplyReplyId;
     private final LongSupplier supplyTraceId;
     private final LongSupplier supplyBudgetId;
-    private final LongFunction<BudgetDebitor> supplyDebitor;
     private final Long2ObjectHashMap<MqttBindingConfig> bindings;
     private final int mqttTypeId;
 
@@ -502,11 +497,9 @@ public final class MqttServerFactory implements MqttStreamFactory
         this.willMessageBuffer = new UnsafeBuffer(new byte[writeBuffer.capacity()]);
         this.willUserPropertiesBuffer = new UnsafeBuffer(new byte[writeBuffer.capacity()]);
         this.bufferPool = context.bufferPool();
-        this.creditor = context.creditor();
         this.signaler = context.signaler();
         this.droppedHandler = context.droppedFrameHandler();
         this.streamFactory = context.streamFactory();
-        this.supplyDebitor = context::supplyDebitor;
         this.supplyInitialId = context::supplyInitialId;
         this.supplyReplyId = context::supplyReplyId;
         this.supplyBudgetId = context::supplyBudgetId;
@@ -1507,10 +1500,9 @@ public final class MqttServerFactory implements MqttStreamFactory
 
             int valueClaimed = maximum;
 
-            if (canPublish && publisher.debitorIndex != NO_DEBITOR_INDEX && lengthMax != 0)
+            if (canPublish && publisher.debit != null && lengthMax != 0)
             {
-                valueClaimed =
-                    publisher.debitor.claim(traceId, publisher.debitorIndex, publisher.initialId, minimum, maximum, 0);
+                valueClaimed = publisher.debit.claim(traceId, minimum, maximum);
             }
 
             int sizeClaimed = valueClaimed - publisher.initialPad;
@@ -2435,7 +2427,7 @@ public final class MqttServerFactory implements MqttStreamFactory
         private int encodeMax;
         private int encodePad;
 
-        private long encodeBudgetIndex = NO_CREDITOR_INDEX;
+        private BudgetCredit encodeCredit;
         private int encodeSharedBudget;
 
         private int decodeSlot = NO_SLOT;
@@ -2703,12 +2695,8 @@ public final class MqttServerFactory implements MqttStreamFactory
 
             if (encodeSharedCredit > 0)
             {
-                final long encodeSharedBudgetPrevious = creditor.credit(traceId, encodeBudgetIndex, encodeSharedCredit);
+                encodeCredit.capacity(traceId, encodeSharedCredit);
                 encodeSharedBudget += encodeSharedCredit;
-
-                assert encodeSharedBudgetPrevious + encodeSharedCredit <= encodeBudgetMax
-                    : String.format("%d + %d <= %d, encodeBudget = %d",
-                    encodeSharedBudgetPrevious, encodeSharedCredit, encodeBudgetMax, encodeWin);
 
                 assert encodeSharedCredit <= encodeBudgetMax
                     : String.format("%d <= %d", encodeSharedCredit, encodeBudgetMax);
@@ -3999,8 +3987,8 @@ public final class MqttServerFactory implements MqttStreamFactory
             doBegin(network, originId, routedId, replyId, encodeSeq, encodeAck, encodeMax,
                 traceId, authorization, affinity, EMPTY_OCTETS);
 
-            assert encodeBudgetIndex == NO_CREDITOR_INDEX;
-            this.encodeBudgetIndex = creditor.acquire(encodeBudgetId);
+            assert encodeCredit == null;
+            this.encodeCredit = context.supplyCredit(replyId, encodeBudgetId);
         }
 
         private void doNetworkData(
@@ -4904,10 +4892,10 @@ public final class MqttServerFactory implements MqttStreamFactory
 
         private void cleanupBudgetCreditor()
         {
-            if (encodeBudgetIndex != NO_CREDITOR_INDEX)
+            if (encodeCredit != null)
             {
-                creditor.release(encodeBudgetIndex);
-                encodeBudgetIndex = NO_CREDITOR_INDEX;
+                encodeCredit.close();
+                encodeCredit = null;
             }
         }
 
@@ -5071,8 +5059,7 @@ public final class MqttServerFactory implements MqttStreamFactory
             private long replyId;
             private long budgetId;
 
-            private BudgetDebitor debitor;
-            private long debitorIndex = NO_DEBITOR_INDEX;
+            private BudgetDebit debit;
 
             private long initialSeq;
             private long initialAck;
@@ -5176,10 +5163,9 @@ public final class MqttServerFactory implements MqttStreamFactory
 
                 decodeNetwork(traceId);
 
-                if (budgetId != 0L && debitorIndex == NO_DEBITOR_INDEX)
+                if (budgetId != 0L && debit == null)
                 {
-                    debitor = supplyDebitor.apply(budgetId);
-                    debitorIndex = debitor.acquire(budgetId, initialId, MqttServer.this::decodeNetwork);
+                    debit = context.supplyDebit(initialId, budgetId, MqttServer.this::decodeNetwork);
                 }
 
                 if (MqttState.initialClosing(state) && !MqttState.initialClosed(state))
@@ -5627,10 +5613,10 @@ public final class MqttServerFactory implements MqttStreamFactory
 
                 state = MqttState.closeInitial(state);
 
-                if (debitorIndex != NO_DEBITOR_INDEX)
+                if (debit != null)
                 {
-                    debitor.release(debitorIndex, initialId);
-                    debitorIndex = NO_DEBITOR_INDEX;
+                    debit.close();
+                    debit = null;
                 }
             }
 
@@ -5662,8 +5648,7 @@ public final class MqttServerFactory implements MqttStreamFactory
             private final ValidatorHandler contentType;
             private long budgetId;
 
-            private BudgetDebitor debitor;
-            private long debitorIndex = NO_DEBITOR_INDEX;
+            private BudgetDebit debit;
 
             private long initialSeq;
             private long initialAck;
@@ -5897,10 +5882,10 @@ public final class MqttServerFactory implements MqttStreamFactory
 
                 assert initialAck <= initialSeq;
 
-                if (budgetId != 0L && debitorIndex == NO_DEBITOR_INDEX)
+                if (budgetId != 0L && debit == null)
                 {
-                    debitor = supplyDebitor.apply(budgetId);
-                    debitorIndex = debitor.acquire(budgetId, initialId, MqttServer.this::decodeNetwork);
+                    debit = context.supplyDebit(initialId, budgetId, MqttServer.this::decodeNetwork);
+                    debit.declare(traceId, 0, 0);
                 }
 
                 if (MqttState.initialClosing(state))
@@ -6095,10 +6080,10 @@ public final class MqttServerFactory implements MqttStreamFactory
 
                 state = MqttState.closeInitial(state);
 
-                if (debitorIndex != NO_DEBITOR_INDEX)
+                if (debit != null)
                 {
-                    debitor.release(debitorIndex, initialId);
-                    debitorIndex = NO_DEBITOR_INDEX;
+                    debit.close();
+                    debit = null;
                 }
 
                 if (MqttState.closed(state))
@@ -6144,8 +6129,7 @@ public final class MqttServerFactory implements MqttStreamFactory
             private final long compositeId;
             private long budgetId;
 
-            private BudgetDebitor debitor;
-            private long debitorIndex = NO_DEBITOR_INDEX;
+            private BudgetDebit debit;
 
             private long initialSeq;
             private long initialAck;
@@ -6339,10 +6323,10 @@ public final class MqttServerFactory implements MqttStreamFactory
 
                 state = MqttState.closeInitial(state);
 
-                if (debitorIndex != NO_DEBITOR_INDEX)
+                if (debit != null)
                 {
-                    debitor.release(debitorIndex, initialId);
-                    debitorIndex = NO_DEBITOR_INDEX;
+                    debit.close();
+                    debit = null;
                 }
 
                 if (MqttState.closed(state))
@@ -6577,10 +6561,9 @@ public final class MqttServerFactory implements MqttStreamFactory
 
                 assert initialAck <= initialSeq;
 
-                if (budgetId != 0L && debitorIndex == NO_DEBITOR_INDEX)
+                if (budgetId != 0L && debit == null)
                 {
-                    debitor = supplyDebitor.apply(budgetId);
-                    debitorIndex = debitor.acquire(budgetId, initialId, MqttServer.this::decodeNetwork);
+                    debit = context.supplyDebit(initialId, budgetId, MqttServer.this::decodeNetwork);
                 }
 
                 if (MqttState.initialClosing(state) &&

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/stream/SseServerFactory.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/stream/SseServerFactory.java
@@ -929,11 +929,7 @@ public final class SseServerFactory implements SseStreamFactory
 
         private void cleanupNet()
         {
-            if (httpReplyDebit != null)
-            {
-                httpReplyDebit.close();
-                httpReplyDebit = null;
-            }
+            httpReplyDebit = null;
 
             if (httpReplyIdleAt != NO_CANCEL_ID)
             {

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/stream/SseServerFactory.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/stream/SseServerFactory.java
@@ -17,7 +17,6 @@ package io.aklivity.zilla.runtime.binding.sse.internal.stream;
 
 import static io.aklivity.zilla.runtime.binding.sse.internal.util.Flags.FIN;
 import static io.aklivity.zilla.runtime.binding.sse.internal.util.Flags.INIT;
-import static io.aklivity.zilla.runtime.engine.budget.BudgetDebitor.NO_DEBITOR_INDEX;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
 import static io.aklivity.zilla.runtime.engine.concurrent.Signaler.NO_CANCEL_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -30,7 +29,6 @@ import java.net.URLDecoder;
 import java.time.Clock;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.LongFunction;
 import java.util.function.LongSupplier;
 import java.util.function.LongUnaryOperator;
 import java.util.function.ToLongFunction;
@@ -75,7 +73,7 @@ import io.aklivity.zilla.runtime.binding.sse.internal.util.Flags;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
-import io.aklivity.zilla.runtime.engine.budget.BudgetDebitor;
+import io.aklivity.zilla.runtime.engine.budget.BudgetDebit;
 import io.aklivity.zilla.runtime.engine.buffer.BufferPool;
 import io.aklivity.zilla.runtime.engine.concurrent.Signaler;
 import io.aklivity.zilla.runtime.engine.config.BindingConfig;
@@ -170,7 +168,7 @@ public final class SseServerFactory implements SseStreamFactory
     private final LongUnaryOperator supplyInitialId;
     private final LongUnaryOperator supplyReplyId;
     private final LongSupplier supplyTraceId;
-    private final LongFunction<BudgetDebitor> supplyDebitor;
+    private final EngineContext context;
     private final boolean initialCommentEnabled;
     private final int httpTypeId;
     private final int sseTypeId;
@@ -194,7 +192,7 @@ public final class SseServerFactory implements SseStreamFactory
         this.supplyInitialId = context::supplyInitialId;
         this.supplyReplyId = context::supplyReplyId;
         this.supplyTraceId = context::supplyTraceId;
-        this.supplyDebitor = context::supplyDebitor;
+        this.context = context;
         this.bindings = new Long2ObjectHashMap<>();
         this.initialCommentEnabled = config.initialCommentEnabled();
         this.httpTypeId = context.supplyTypeId(HTTP_TYPE_NAME);
@@ -371,8 +369,7 @@ public final class SseServerFactory implements SseStreamFactory
         private long httpReplyBud;
         private int httpReplyPad;
         private long httpReplyAuth;
-        private BudgetDebitor httpReplyDeb;
-        private long httpReplyDebIdx = NO_DEBITOR_INDEX;
+        private BudgetDebit httpReplyDebit;
         private long httpReplyAt;
         private long httpReplyIdleAt = NO_CANCEL_ID;
 
@@ -548,13 +545,13 @@ public final class SseServerFactory implements SseStreamFactory
 
             assert httpReplyAck <= httpReplySeq;
 
-            if (httpReplyBud != 0L && httpReplyDebIdx == NO_DEBITOR_INDEX)
+            if (httpReplyBud != 0L && httpReplyDebit == null)
             {
-                httpReplyDeb = supplyDebitor.apply(budgetId);
-                httpReplyDebIdx = httpReplyDeb.acquire(budgetId, replyId, this::flushNetwork);
+                httpReplyDebit = context.supplyDebit(replyId, httpReplyBud, this::flushNetwork);
+                httpReplyDebit.declare(traceId, 0, 0);
             }
 
-            if (httpReplyBud != 0L && httpReplyDebIdx == NO_DEBITOR_INDEX)
+            if (httpReplyBud != 0L && !httpReplyDebit.available())
             {
                 doNetAbort(traceId, authorization);
                 stream.doAppEndDeferred(traceId, authorization);
@@ -647,7 +644,7 @@ public final class SseServerFactory implements SseStreamFactory
                     buffer.putBytes(networkSlotOffset, data.buffer(), data.offset(), data.sizeof());
                     networkSlotOffset += data.sizeof();
 
-                    if (httpReplyDebIdx != NO_DEBITOR_INDEX)
+                    if (httpReplyDebit != null)
                     {
                         deferredClaim += data.reserved();
                     }
@@ -860,10 +857,9 @@ public final class SseServerFactory implements SseStreamFactory
                 }
 
                 int claimed = reserved;
-                if (httpReplyDebIdx != NO_DEBITOR_INDEX)
+                if (httpReplyDebit != null)
                 {
-                    claimed = httpReplyDeb.claim(traceId, httpReplyDebIdx, replyId,
-                        reserved, reserved, 0);
+                    claimed = httpReplyDebit.claim(traceId, reserved, reserved);
                 }
 
                 if (claimed == reserved)
@@ -884,10 +880,9 @@ public final class SseServerFactory implements SseStreamFactory
 
             if (deferredClaim > 0)
             {
-                assert httpReplyDebIdx != NO_DEBITOR_INDEX;
+                assert httpReplyDebit != null;
 
-                int claimed = httpReplyDeb.claim(traceId, httpReplyDebIdx, replyId,
-                    deferredClaim, deferredClaim, 0);
+                int claimed = httpReplyDebit.claim(traceId, deferredClaim, deferredClaim);
 
                 if (claimed == deferredClaim)
                 {
@@ -934,11 +929,10 @@ public final class SseServerFactory implements SseStreamFactory
 
         private void cleanupNet()
         {
-            if (httpReplyDebIdx != NO_DEBITOR_INDEX)
+            if (httpReplyDebit != null)
             {
-                httpReplyDeb.release(httpReplyDebIdx, replyId);
-                httpReplyDeb = null;
-                httpReplyDebIdx = NO_DEBITOR_INDEX;
+                httpReplyDebit.close();
+                httpReplyDebit = null;
             }
 
             if (httpReplyIdleAt != NO_CANCEL_ID)
@@ -1193,7 +1187,7 @@ public final class SseServerFactory implements SseStreamFactory
                         buffer.putBytes(networkSlotOffset, data.buffer(), data.offset(), data.sizeof());
                         networkSlotOffset += data.sizeof();
 
-                        if (httpReplyDebIdx != NO_DEBITOR_INDEX)
+                        if (httpReplyDebit != null)
                         {
                             deferredClaim += data.reserved();
                         }

--- a/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/bench/TlsWorker.java
+++ b/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/bench/TlsWorker.java
@@ -46,8 +46,11 @@ import io.aklivity.zilla.runtime.engine.binding.BindingFactory;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageReader;
+import io.aklivity.zilla.runtime.engine.budget.BudgetCredit;
 import io.aklivity.zilla.runtime.engine.budget.BudgetCreditor;
+import io.aklivity.zilla.runtime.engine.budget.BudgetDebit;
 import io.aklivity.zilla.runtime.engine.budget.BudgetDebitor;
+import io.aklivity.zilla.runtime.engine.budget.BudgetFlusher;
 import io.aklivity.zilla.runtime.engine.buffer.BufferPool;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
 import io.aklivity.zilla.runtime.engine.concurrent.Signaler;
@@ -253,6 +256,18 @@ public class TlsWorker implements EngineContext
 
     @Override
     public BudgetDebitor supplyDebitor(long budgetId)
+    {
+        return null;
+    }
+
+    @Override
+    public BudgetDebit supplyDebit(long streamId, long sharedStreamId, BudgetFlusher onResume)
+    {
+        return null;
+    }
+
+    @Override
+    public BudgetCredit supplyCredit(long streamId, long sharedStreamId)
     {
         return null;
     }

--- a/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/bench/TlsWorker.java
+++ b/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/bench/TlsWorker.java
@@ -249,12 +249,14 @@ public class TlsWorker implements EngineContext
     }
 
     @Override
+    @Deprecated
     public BudgetCreditor creditor()
     {
         return null;
     }
 
     @Override
+    @Deprecated
     public BudgetDebitor supplyDebitor(long budgetId)
     {
         return null;

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineContext.java
@@ -27,8 +27,11 @@ import org.agrona.MutableDirectBuffer;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageReader;
+import io.aklivity.zilla.runtime.engine.budget.BudgetCredit;
 import io.aklivity.zilla.runtime.engine.budget.BudgetCreditor;
+import io.aklivity.zilla.runtime.engine.budget.BudgetDebit;
 import io.aklivity.zilla.runtime.engine.budget.BudgetDebitor;
+import io.aklivity.zilla.runtime.engine.budget.BudgetFlusher;
 import io.aklivity.zilla.runtime.engine.buffer.BufferPool;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
 import io.aklivity.zilla.runtime.engine.concurrent.Signaler;
@@ -268,6 +271,44 @@ public interface EngineContext
      */
     BudgetDebitor supplyDebitor(
         long budgetId);
+
+    /**
+     * Returns a producer-side {@link BudgetDebit} handle for claiming send capacity on the
+     * given stream, unifying the per-stream window and the shared budget behind one handle.
+     * <p>
+     * When {@code sharedStreamId} identifies a shared stream the producer attaches to, the
+     * handle claims from that shared budget; the engine releases the handle's resources when
+     * the stream terminates.
+     * </p>
+     *
+     * @param streamId        the stream that will write frames using the handle
+     * @param sharedStreamId  the shared stream this producer attaches to, or {@code 0} for an
+     *                        unshared per-stream window
+     * @param onResume        callback invoked when previously unavailable capacity frees
+     * @return the debit handle for the stream
+     */
+    BudgetDebit supplyDebit(
+        long streamId,
+        long sharedStreamId,
+        BudgetFlusher onResume);
+
+    /**
+     * Returns a consumer-side {@link BudgetCredit} handle for granting downstream capacity on
+     * the given stream, replacing the per-binding credit translation.
+     * <p>
+     * When {@code sharedStreamId} identifies a shared stream the consumer attaches to, the
+     * handle grants into that shared budget; the engine releases the handle's resources when
+     * the stream terminates.
+     * </p>
+     *
+     * @param streamId        the stream that will grant capacity using the handle
+     * @param sharedStreamId  the shared stream this consumer attaches to, or {@code 0} for an
+     *                        unshared per-stream window
+     * @return the credit handle for the stream
+     */
+    BudgetCredit supplyCredit(
+        long streamId,
+        long sharedStreamId);
 
     /**
      * Returns the per-thread write buffer for staging outbound frames before sending.

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineContext.java
@@ -259,7 +259,10 @@ public interface EngineContext
      * to upstream senders.
      *
      * @return the budget creditor
+     * @deprecated use {@link #supplyCredit(long, long)} instead; this accessor is removed once
+     *             every binding has migrated to the handle API
      */
+    @Deprecated
     BudgetCreditor creditor();
 
     /**
@@ -268,7 +271,10 @@ public interface EngineContext
      *
      * @param budgetId  the budget id to obtain a debitor for
      * @return the budget debitor
+     * @deprecated use {@link #supplyDebit(long, long, BudgetFlusher)} instead; this accessor is
+     *             removed once every binding has migrated to the handle API
      */
+    @Deprecated
     BudgetDebitor supplyDebitor(
         long budgetId);
 

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/budget/BudgetCredit.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/budget/BudgetCredit.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.budget;
+
+/**
+ * Consumer-side flow control handle: grants the capacity the holder has available downstream.
+ * <p>
+ * A {@code BudgetCredit} is obtained from {@link EngineContext#supplyCredit} and is recorded
+ * against the stream it reads, so the engine releases the underlying budget resources when
+ * the stream terminates; an explicit {@link #close()} is therefore optional. The engine
+ * translates declared capacity into flow control credit for upstream senders, replacing the
+ * per-binding credit translation.
+ * </p>
+ * <p>
+ * All methods are called on the owning I/O thread only.
+ * </p>
+ *
+ * @see BudgetDebit
+ * @see EngineContext#supplyCredit(long, long)
+ */
+public interface BudgetCredit extends AutoCloseable
+{
+    /**
+     * Grants {@code bytes} of downstream capacity to upstream senders.
+     *
+     * @param traceId  the trace identifier for diagnostics
+     * @param bytes    the byte capacity available downstream
+     */
+    void capacity(
+        long traceId,
+        int bytes);
+
+    /**
+     * Grants downstream capacity on the byte axis together with a count-based axis (for
+     * example a limit on in-flight messages) for protocols that constrain both.
+     *
+     * @param traceId   the trace identifier for diagnostics
+     * @param messages  the message capacity available downstream
+     * @param bytes     the byte capacity available downstream
+     */
+    void capacity(
+        long traceId,
+        int messages,
+        int bytes);
+
+    /**
+     * Releases the underlying budget resources held by this handle. Optional; resources are
+     * released implicitly when the stream terminates.
+     */
+    @Override
+    void close();
+}

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/budget/BudgetDebit.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/budget/BudgetDebit.java
@@ -91,6 +91,22 @@ public interface BudgetDebit extends AutoCloseable
         int deferred);
 
     /**
+     * Indicates whether this handle is currently backed by an available shared budget.
+     * <p>
+     * A producer that must not proceed without a shared budget can abort the stream when this
+     * returns {@code false}. Producers that tolerate a not-yet-available budget ignore it: a
+     * {@link #claim} grants the full requested amount until the budget becomes available. The
+     * default is {@code true}; implementations backed by a shared budget report its presence.
+     * </p>
+     *
+     * @return {@code true} when a shared budget is available to claim against
+     */
+    default boolean available()
+    {
+        return true;
+    }
+
+    /**
      * Releases the underlying budget resources held by this handle. Optional; resources are
      * released implicitly when the stream terminates.
      */

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/budget/BudgetDebit.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/budget/BudgetDebit.java
@@ -62,10 +62,33 @@ public interface BudgetDebit extends AutoCloseable
      *         {@code 0} if insufficient capacity is available; on {@code 0} the sender is
      *         parked and the registered {@link BudgetFlusher} fires when capacity frees
      */
+    default int claim(
+        long traceId,
+        int minimum,
+        int maximum)
+    {
+        return claim(traceId, minimum, maximum, 0);
+    }
+
+    /**
+     * Attempts to claim between {@code minimum} and {@code maximum} payload bytes for the one
+     * frame about to be sent, reserving the declared per-frame padding in addition, and signals
+     * that {@code deferred} further bytes will be written beyond this claim.
+     *
+     * @param traceId  the trace identifier for diagnostics
+     * @param minimum  the minimum payload bytes required (the claim parks if unavailable)
+     * @param maximum  the maximum payload bytes desired
+     * @param deferred the additional bytes the producer will write beyond this claim, passed
+     *                 through to the underlying flow-control claim
+     * @return the granted payload bytes, between {@code minimum} and {@code maximum}, or
+     *         {@code 0} if insufficient capacity is available; on {@code 0} the sender is
+     *         parked and the registered {@link BudgetFlusher} fires when capacity frees
+     */
     int claim(
         long traceId,
         int minimum,
-        int maximum);
+        int maximum,
+        int deferred);
 
     /**
      * Releases the underlying budget resources held by this handle. Optional; resources are

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/budget/BudgetDebit.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/budget/BudgetDebit.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.budget;
+
+/**
+ * Producer-side flow control handle: claims send capacity before writing a frame downstream.
+ * <p>
+ * A {@code BudgetDebit} is obtained from {@link EngineContext#supplyDebit} and is recorded
+ * against the stream it writes, so the engine releases the underlying budget resources when
+ * the stream terminates; an explicit {@link #close()} is therefore optional. It unifies the
+ * per-stream window and the shared budget behind one handle, so a binding no longer
+ * hand-codes window arithmetic or the acquire/claim/release dance.
+ * </p>
+ * <p>
+ * All methods are called on the owning I/O thread only.
+ * </p>
+ *
+ * @see BudgetCredit
+ * @see EngineContext#supplyDebit(long, long, BudgetFlusher)
+ */
+public interface BudgetDebit extends AutoCloseable
+{
+    /**
+     * Declares the framing the engine applies to subsequent claims.
+     * <p>
+     * Re-callable, not restricted to stream open: framing parameters can change mid-stream
+     * (for example when a negotiated setting or padding changes), so each call updates the
+     * framing applied to later claims.
+     * </p>
+     *
+     * @param traceId  the trace identifier for diagnostics
+     * @param padding  the per-frame overhead reserved in addition to the claimed payload bytes
+     * @param minimum  the least capacity the receiver will grant, composed with each claim's
+     *                 own minimum
+     */
+    void declare(
+        long traceId,
+        int padding,
+        int minimum);
+
+    /**
+     * Attempts to claim between {@code minimum} and {@code maximum} payload bytes for the one
+     * frame about to be sent, reserving the declared per-frame padding in addition.
+     *
+     * @param traceId  the trace identifier for diagnostics
+     * @param minimum  the minimum payload bytes required (the claim parks if unavailable)
+     * @param maximum  the maximum payload bytes desired
+     * @return the granted payload bytes, between {@code minimum} and {@code maximum}, or
+     *         {@code 0} if insufficient capacity is available; on {@code 0} the sender is
+     *         parked and the registered {@link BudgetFlusher} fires when capacity frees
+     */
+    int claim(
+        long traceId,
+        int minimum,
+        int maximum);
+
+    /**
+     * Releases the underlying budget resources held by this handle. Optional; resources are
+     * released implicitly when the stream terminates.
+     */
+    @Override
+    void close();
+}

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/budget/BudgetFlusher.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/budget/BudgetFlusher.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.budget;
+
+/**
+ * Callback invoked when flow control capacity that was previously unavailable becomes
+ * available, allowing a parked sender to resume claiming.
+ * <p>
+ * The callback is edge-triggered: it fires when capacity transitions from unavailable to
+ * available, not repeatedly while capacity remains available. A resumed sender re-attempts
+ * its claim, which may park again if a different constraint is now the limiting one.
+ * </p>
+ * <p>
+ * Invoked on the owning I/O thread only.
+ * </p>
+ *
+ * @see BudgetDebit
+ */
+@FunctionalInterface
+public interface BudgetFlusher
+{
+    /**
+     * Invoked when flow control capacity becomes available for a parked sender.
+     *
+     * @param traceId  the trace identifier for diagnostics
+     */
+    void onResume(
+        long traceId);
+}

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/budget/BudgetHandleRegistry.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/budget/BudgetHandleRegistry.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.internal.budget;
+
+import org.agrona.LangUtil;
+import org.agrona.collections.Long2ObjectHashMap;
+
+/**
+ * Tracks budget handles supplied for a stream so the engine can release them automatically
+ * when the stream terminates. A handle is registered against the stream it was supplied for
+ * and closed from the engine's per-stream cleanup, removing the need for bindings to close
+ * handles by hand. Closing is idempotent, so a handle that a binding also closes explicitly
+ * is released exactly once.
+ */
+public final class BudgetHandleRegistry
+{
+    private final Long2ObjectHashMap<AutoCloseable> handlesByStreamId = new Long2ObjectHashMap<>();
+
+    public void register(
+        long streamId,
+        AutoCloseable handle)
+    {
+        final AutoCloseable existing = handlesByStreamId.put(streamId, handle);
+        if (existing != null)
+        {
+            handlesByStreamId.put(streamId, () ->
+            {
+                close(existing);
+                close(handle);
+            });
+        }
+    }
+
+    public void release(
+        long streamId)
+    {
+        final AutoCloseable handle = handlesByStreamId.remove(streamId);
+        if (handle != null)
+        {
+            close(handle);
+        }
+    }
+
+    public void releaseAll()
+    {
+        handlesByStreamId.values().forEach(BudgetHandleRegistry::close);
+        handlesByStreamId.clear();
+    }
+
+    private static void close(
+        AutoCloseable handle)
+    {
+        try
+        {
+            handle.close();
+        }
+        catch (Exception ex)
+        {
+            LangUtil.rethrowUnchecked(ex);
+        }
+    }
+}

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetCredit.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetCredit.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.internal.budget;
+
+import io.aklivity.zilla.runtime.engine.budget.BudgetCredit;
+import io.aklivity.zilla.runtime.engine.budget.BudgetCreditor;
+
+/**
+ * Phase 1 facade implementing {@link BudgetCredit} over today's {@link BudgetCreditor}.
+ * <p>
+ * Behavior-preserving: it owns the acquire/credit/release dance the binding does by hand
+ * today and delegates the byte axis to {@link BudgetCreditor#credit}. The count-based axis
+ * carried by {@link #capacity(long, int, int)} is not yet plumbed through the budget
+ * machinery in Phase 1 — it rides each protocol's native frame, owned by the binding — so
+ * only the byte axis is credited here.
+ * </p>
+ */
+public final class FacadeBudgetCredit implements BudgetCredit
+{
+    private final BudgetCreditor creditor;
+    private final long budgetIndex;
+
+    public FacadeBudgetCredit(
+        BudgetCreditor creditor,
+        long budgetId)
+    {
+        this.creditor = creditor;
+        this.budgetIndex = creditor.acquire(budgetId);
+    }
+
+    @Override
+    public void capacity(
+        long traceId,
+        int bytes)
+    {
+        creditor.credit(traceId, budgetIndex, bytes);
+    }
+
+    @Override
+    public void capacity(
+        long traceId,
+        int messages,
+        int bytes)
+    {
+        creditor.credit(traceId, budgetIndex, bytes);
+    }
+
+    @Override
+    public void close()
+    {
+        creditor.release(budgetIndex);
+    }
+}

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetCredit.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetCredit.java
@@ -33,6 +33,8 @@ public final class FacadeBudgetCredit implements BudgetCredit
     private final BudgetCreditor creditor;
     private final long budgetIndex;
 
+    private boolean released;
+
     public FacadeBudgetCredit(
         BudgetCreditor creditor,
         long budgetId)
@@ -61,6 +63,10 @@ public final class FacadeBudgetCredit implements BudgetCredit
     @Override
     public void close()
     {
-        creditor.release(budgetIndex);
+        if (!released)
+        {
+            released = true;
+            creditor.release(budgetIndex);
+        }
     }
 }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetDebit.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetDebit.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.internal.budget;
+
+import io.aklivity.zilla.runtime.engine.budget.BudgetDebit;
+import io.aklivity.zilla.runtime.engine.budget.BudgetDebitor;
+import io.aklivity.zilla.runtime.engine.budget.BudgetFlusher;
+
+/**
+ * Phase 1 facade implementing {@link BudgetDebit} over today's {@link BudgetDebitor}.
+ * <p>
+ * Behavior-preserving: it owns the acquire/claim/release dance the binding does by hand
+ * today, folds the declared per-frame padding into one claimed frame, composes the declared
+ * minimum with each claim, and delegates to the existing six-argument
+ * {@link BudgetDebitor#claim} with {@code deferred} of {@code 0}.
+ * </p>
+ */
+public final class FacadeBudgetDebit implements BudgetDebit
+{
+    private final BudgetDebitor debitor;
+    private final long watcherId;
+    private final long budgetIndex;
+
+    private int padding;
+    private int minimum;
+
+    public FacadeBudgetDebit(
+        BudgetDebitor debitor,
+        long budgetId,
+        long watcherId,
+        BudgetFlusher onResume)
+    {
+        this.debitor = debitor;
+        this.watcherId = watcherId;
+        this.budgetIndex = debitor.acquire(budgetId, watcherId, onResume::onResume);
+    }
+
+    @Override
+    public void declare(
+        long traceId,
+        int padding,
+        int minimum)
+    {
+        this.padding = padding;
+        this.minimum = minimum;
+    }
+
+    @Override
+    public int claim(
+        long traceId,
+        int minimum,
+        int maximum)
+    {
+        final int claimMinimum = Math.max(minimum, this.minimum) + padding;
+        final int claimMaximum = maximum + padding;
+        final int reserved = debitor.claim(traceId, budgetIndex, watcherId, claimMinimum, claimMaximum, 0);
+        return reserved == 0 ? 0 : reserved - padding;
+    }
+
+    @Override
+    public void close()
+    {
+        debitor.release(budgetIndex, watcherId);
+    }
+}

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetDebit.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetDebit.java
@@ -15,6 +15,10 @@
  */
 package io.aklivity.zilla.runtime.engine.internal.budget;
 
+import static io.aklivity.zilla.runtime.engine.budget.BudgetDebitor.NO_DEBITOR_INDEX;
+
+import java.util.function.LongConsumer;
+
 import io.aklivity.zilla.runtime.engine.budget.BudgetDebit;
 import io.aklivity.zilla.runtime.engine.budget.BudgetDebitor;
 import io.aklivity.zilla.runtime.engine.budget.BudgetFlusher;
@@ -27,13 +31,24 @@ import io.aklivity.zilla.runtime.engine.budget.BudgetFlusher;
  * minimum with each claim, and delegates to the existing six-argument
  * {@link BudgetDebitor#claim} with {@code deferred} of {@code 0}.
  * </p>
+ * <p>
+ * {@link BudgetDebitor#acquire} returns {@link BudgetDebitor#NO_DEBITOR_INDEX} when the shared
+ * budget is not yet present in the debitor's storage. The hand-coded bindings handled this by
+ * guarding the claim on the acquired index and re-acquiring on each subsequent window until the
+ * budget appeared. This facade reproduces that: it re-attempts {@code acquire} on each
+ * {@link #claim} while still unacquired and grants the full requested {@code maximum} (no budget
+ * constraint) until the budget is present, then claims normally. A handle that never acquired is
+ * never released.
+ * </p>
  */
 public final class FacadeBudgetDebit implements BudgetDebit
 {
     private final BudgetDebitor debitor;
+    private final long budgetId;
     private final long watcherId;
-    private final long budgetIndex;
+    private final LongConsumer flusher;
 
+    private long budgetIndex;
     private int padding;
     private int minimum;
 
@@ -44,8 +59,10 @@ public final class FacadeBudgetDebit implements BudgetDebit
         BudgetFlusher onResume)
     {
         this.debitor = debitor;
+        this.budgetId = budgetId;
         this.watcherId = watcherId;
-        this.budgetIndex = debitor.acquire(budgetId, watcherId, onResume::onResume);
+        this.flusher = onResume::onResume;
+        this.budgetIndex = debitor.acquire(budgetId, watcherId, flusher);
     }
 
     @Override
@@ -64,15 +81,33 @@ public final class FacadeBudgetDebit implements BudgetDebit
         int minimum,
         int maximum)
     {
-        final int claimMinimum = Math.max(minimum, this.minimum) + padding;
-        final int claimMaximum = maximum + padding;
-        final int reserved = debitor.claim(traceId, budgetIndex, watcherId, claimMinimum, claimMaximum, 0);
-        return reserved == 0 ? 0 : reserved - padding;
+        if (budgetIndex == NO_DEBITOR_INDEX)
+        {
+            budgetIndex = debitor.acquire(budgetId, watcherId, flusher);
+        }
+
+        final int claimed;
+        if (budgetIndex == NO_DEBITOR_INDEX)
+        {
+            claimed = maximum;
+        }
+        else
+        {
+            final int claimMinimum = Math.max(minimum, this.minimum) + padding;
+            final int claimMaximum = maximum + padding;
+            final int reserved = debitor.claim(traceId, budgetIndex, watcherId, claimMinimum, claimMaximum, 0);
+            claimed = reserved == 0 ? 0 : reserved - padding;
+        }
+
+        return claimed;
     }
 
     @Override
     public void close()
     {
-        debitor.release(budgetIndex, watcherId);
+        if (budgetIndex != NO_DEBITOR_INDEX)
+        {
+            debitor.release(budgetIndex, watcherId);
+        }
     }
 }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetDebit.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetDebit.java
@@ -29,7 +29,7 @@ import io.aklivity.zilla.runtime.engine.budget.BudgetFlusher;
  * Behavior-preserving: it owns the acquire/claim/release dance the binding does by hand
  * today, folds the declared per-frame padding into one claimed frame, composes the declared
  * minimum with each claim, and delegates to the existing six-argument
- * {@link BudgetDebitor#claim} with {@code deferred} of {@code 0}.
+ * {@link BudgetDebitor#claim}, passing through the per-claim {@code deferred} bytes.
  * </p>
  * <p>
  * {@link BudgetDebitor#acquire} returns {@link BudgetDebitor#NO_DEBITOR_INDEX} when the shared
@@ -101,6 +101,12 @@ public final class FacadeBudgetDebit implements BudgetDebit
         }
 
         return claimed;
+    }
+
+    @Override
+    public boolean available()
+    {
+        return budgetIndex != NO_DEBITOR_INDEX;
     }
 
     @Override

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetDebit.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetDebit.java
@@ -79,7 +79,8 @@ public final class FacadeBudgetDebit implements BudgetDebit
     public int claim(
         long traceId,
         int minimum,
-        int maximum)
+        int maximum,
+        int deferred)
     {
         if (budgetIndex == NO_DEBITOR_INDEX)
         {
@@ -95,7 +96,7 @@ public final class FacadeBudgetDebit implements BudgetDebit
         {
             final int claimMinimum = Math.max(minimum, this.minimum) + padding;
             final int claimMaximum = maximum + padding;
-            final int reserved = debitor.claim(traceId, budgetIndex, watcherId, claimMinimum, claimMaximum, 0);
+            final int reserved = debitor.claim(traceId, budgetIndex, watcherId, claimMinimum, claimMaximum, deferred);
             claimed = reserved == 0 ? 0 : reserved - padding;
         }
 

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetDebit.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetDebit.java
@@ -51,6 +51,7 @@ public final class FacadeBudgetDebit implements BudgetDebit
     private long budgetIndex;
     private int padding;
     private int minimum;
+    private boolean released;
 
     public FacadeBudgetDebit(
         BudgetDebitor debitor,
@@ -112,9 +113,14 @@ public final class FacadeBudgetDebit implements BudgetDebit
     @Override
     public void close()
     {
-        if (budgetIndex != NO_DEBITOR_INDEX)
+        if (!released)
         {
-            debitor.release(budgetIndex, watcherId);
+            released = true;
+            if (budgetIndex != NO_DEBITOR_INDEX)
+            {
+                debitor.release(budgetIndex, watcherId);
+                budgetIndex = NO_DEBITOR_INDEX;
+            }
         }
     }
 }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -102,8 +102,11 @@ import io.aklivity.zilla.runtime.engine.binding.BindingContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageReader;
+import io.aklivity.zilla.runtime.engine.budget.BudgetCredit;
 import io.aklivity.zilla.runtime.engine.budget.BudgetCreditor;
+import io.aklivity.zilla.runtime.engine.budget.BudgetDebit;
 import io.aklivity.zilla.runtime.engine.budget.BudgetDebitor;
+import io.aklivity.zilla.runtime.engine.budget.BudgetFlusher;
 import io.aklivity.zilla.runtime.engine.buffer.BufferPool;
 import io.aklivity.zilla.runtime.engine.catalog.Catalog;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogContext;
@@ -125,6 +128,8 @@ import io.aklivity.zilla.runtime.engine.guard.GuardHandler;
 import io.aklivity.zilla.runtime.engine.internal.LabelManager;
 import io.aklivity.zilla.runtime.engine.internal.budget.DefaultBudgetCreditor;
 import io.aklivity.zilla.runtime.engine.internal.budget.DefaultBudgetDebitor;
+import io.aklivity.zilla.runtime.engine.internal.budget.FacadeBudgetCredit;
+import io.aklivity.zilla.runtime.engine.internal.budget.FacadeBudgetDebit;
 import io.aklivity.zilla.runtime.engine.internal.event.io.EventWriter;
 import io.aklivity.zilla.runtime.engine.internal.exporter.ExporterAgent;
 import io.aklivity.zilla.runtime.engine.internal.layouts.BindingsLayout;
@@ -640,6 +645,31 @@ public class EngineWorker implements EngineContext, Agent
     {
         final int ownerIndex = ownerIndex(budgetId);
         return debitorsByIndex.computeIfAbsent(ownerIndex, this::newBudgetDebitor);
+    }
+
+    @Override
+    public BudgetDebit supplyDebit(
+        long streamId,
+        long sharedStreamId,
+        BudgetFlusher onResume)
+    {
+        if (sharedStreamId == NO_BUDGET_ID)
+        {
+            throw new UnsupportedOperationException("unshared per-stream window debit lands in T2");
+        }
+        return new FacadeBudgetDebit(supplyDebitor(sharedStreamId), sharedStreamId, streamId, onResume);
+    }
+
+    @Override
+    public BudgetCredit supplyCredit(
+        long streamId,
+        long sharedStreamId)
+    {
+        if (sharedStreamId == NO_BUDGET_ID)
+        {
+            throw new UnsupportedOperationException("unshared per-stream window credit lands in T2");
+        }
+        return new FacadeBudgetCredit(creditor, sharedStreamId);
     }
 
     @Override

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -126,6 +126,7 @@ import io.aklivity.zilla.runtime.engine.guard.Guard;
 import io.aklivity.zilla.runtime.engine.guard.GuardContext;
 import io.aklivity.zilla.runtime.engine.guard.GuardHandler;
 import io.aklivity.zilla.runtime.engine.internal.LabelManager;
+import io.aklivity.zilla.runtime.engine.internal.budget.BudgetHandleRegistry;
 import io.aklivity.zilla.runtime.engine.internal.budget.DefaultBudgetCreditor;
 import io.aklivity.zilla.runtime.engine.internal.budget.DefaultBudgetDebitor;
 import io.aklivity.zilla.runtime.engine.internal.budget.FacadeBudgetCredit;
@@ -237,6 +238,7 @@ public class EngineWorker implements EngineContext, Agent
 
     private final DefaultBudgetCreditor creditor;
     private final Int2ObjectHashMap<DefaultBudgetDebitor> debitorsByIndex;
+    private final BudgetHandleRegistry budgetHandles;
 
     private final Long2ObjectHashMap<Affinity> affinityByBindingId;
 
@@ -426,6 +428,7 @@ public class EngineWorker implements EngineContext, Agent
         this.creditor = new DefaultBudgetCreditor(index, budgetsLayout, this::doSystemFlush, this::supplyBudgetId,
             signaler::executeTaskAt, config.childCleanupLingerMillis());
         this.debitorsByIndex = new Int2ObjectHashMap<DefaultBudgetDebitor>();
+        this.budgetHandles = new BudgetHandleRegistry();
 
         this.routerConfig = routerConfig;
         EngineRouteable routeable = new EngineRouteable(config, this::newStream,
@@ -611,6 +614,7 @@ public class EngineWorker implements EngineContext, Agent
         long streamId)
     {
         throttles[throttleIndex(streamId)].remove(instanceId(streamId));
+        budgetHandles.release(streamId);
     }
 
     @Override
@@ -623,6 +627,8 @@ public class EngineWorker implements EngineContext, Agent
             streamIdSet.forEach(streamId ->
                 {
                     MessageConsumer handler = streams[streamIndex(streamId)].remove(instanceId(streamId));
+                    budgetHandles.release(streamId);
+                    budgetHandles.release(supplyReplyId(streamId));
                     if (handler != null)
                     {
                         doSyntheticAbort(streamId, handler);
@@ -660,7 +666,9 @@ public class EngineWorker implements EngineContext, Agent
             throw new UnsupportedOperationException("unshared per-stream window debit lands in T2");
         }
         final DefaultBudgetDebitor debitor = debitorsByIndex.computeIfAbsent(ownerIndex(sharedStreamId), this::newBudgetDebitor);
-        return new FacadeBudgetDebit(debitor, sharedStreamId, streamId, onResume);
+        final FacadeBudgetDebit debit = new FacadeBudgetDebit(debitor, sharedStreamId, streamId, onResume);
+        budgetHandles.register(streamId, debit);
+        return debit;
     }
 
     @Override
@@ -672,7 +680,9 @@ public class EngineWorker implements EngineContext, Agent
         {
             throw new UnsupportedOperationException("unshared per-stream window credit lands in T2");
         }
-        return new FacadeBudgetCredit(creditor, sharedStreamId);
+        final FacadeBudgetCredit credit = new FacadeBudgetCredit(creditor, sharedStreamId);
+        budgetHandles.register(streamId, credit);
+        return credit;
     }
 
     @Override
@@ -1079,6 +1089,8 @@ public class EngineWorker implements EngineContext, Agent
         router.detach(routerConfig.id);
 
         poller.onClose();
+
+        budgetHandles.releaseAll();
 
         int acquiredBuffers = 0;
         int acquiredCreditors = 0;
@@ -1508,10 +1520,12 @@ public class EngineWorker implements EngineContext, Agent
                 case EndFW.TYPE_ID:
                     handler.accept(msgTypeId, buffer, index, length);
                     dispatcher.remove(instanceId);
+                    budgetHandles.release(streamId);
                     break;
                 case AbortFW.TYPE_ID:
                     handler.accept(msgTypeId, buffer, index, length);
                     dispatcher.remove(instanceId);
+                    budgetHandles.release(streamId);
                     break;
                 case FlushFW.TYPE_ID:
                     handler.accept(msgTypeId, buffer, index, length);
@@ -1540,6 +1554,7 @@ public class EngineWorker implements EngineContext, Agent
                 case ResetFW.TYPE_ID:
                     throttle.accept(msgTypeId, buffer, index, length);
                     dispatcher.remove(instanceId);
+                    budgetHandles.release(streamId);
                     break;
                 case SignalFW.TYPE_ID:
                     final SignalFW signal = signalRO.wrap(buffer, index, index + length);
@@ -1556,6 +1571,7 @@ public class EngineWorker implements EngineContext, Agent
                 case RedirectFW.TYPE_ID:
                     throttle.accept(msgTypeId, buffer, index, length);
                     dispatcher.remove(instanceId);
+                    budgetHandles.release(streamId);
                     break;
                 default:
                     break;
@@ -1704,10 +1720,12 @@ public class EngineWorker implements EngineContext, Agent
                 case EndFW.TYPE_ID:
                     handler.accept(msgTypeId, buffer, index, length);
                     dispatcher.remove(instanceId);
+                    budgetHandles.release(streamId);
                     break;
                 case AbortFW.TYPE_ID:
                     handler.accept(msgTypeId, buffer, index, length);
                     dispatcher.remove(instanceId);
+                    budgetHandles.release(streamId);
                     break;
                 case FlushFW.TYPE_ID:
                     handler.accept(msgTypeId, buffer, index, length);
@@ -1736,6 +1754,7 @@ public class EngineWorker implements EngineContext, Agent
                 case ResetFW.TYPE_ID:
                     throttle.accept(msgTypeId, buffer, index, length);
                     dispatcher.remove(instanceId);
+                    budgetHandles.release(streamId);
                     break;
                 case SignalFW.TYPE_ID:
                     final SignalFW signal = signalRO.wrap(buffer, index, index + length);
@@ -1752,6 +1771,7 @@ public class EngineWorker implements EngineContext, Agent
                 case RedirectFW.TYPE_ID:
                     throttle.accept(msgTypeId, buffer, index, length);
                     dispatcher.remove(instanceId);
+                    budgetHandles.release(streamId);
                     break;
                 default:
                     break;

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -634,12 +634,14 @@ public class EngineWorker implements EngineContext, Agent
     }
 
     @Override
+    @Deprecated
     public BudgetCreditor creditor()
     {
         return creditor;
     }
 
     @Override
+    @Deprecated
     public BudgetDebitor supplyDebitor(
         long budgetId)
     {
@@ -657,7 +659,8 @@ public class EngineWorker implements EngineContext, Agent
         {
             throw new UnsupportedOperationException("unshared per-stream window debit lands in T2");
         }
-        return new FacadeBudgetDebit(supplyDebitor(sharedStreamId), sharedStreamId, streamId, onResume);
+        final DefaultBudgetDebitor debitor = debitorsByIndex.computeIfAbsent(ownerIndex(sharedStreamId), this::newBudgetDebitor);
+        return new FacadeBudgetDebit(debitor, sharedStreamId, streamId, onResume);
     }
 
     @Override

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/BudgetHandleRegistryTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/BudgetHandleRegistryTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.internal.budget;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.engine.budget.BudgetDebit;
+
+public class BudgetHandleRegistryTest
+{
+    private static final long STREAM_ID = 17L;
+    private static final long OTHER_STREAM_ID = 19L;
+
+    @Test
+    public void shouldCloseHandleOnStreamCleanup() throws Exception
+    {
+        final BudgetHandleRegistry registry = new BudgetHandleRegistry();
+        final BudgetDebit handle = mock(BudgetDebit.class);
+
+        registry.register(STREAM_ID, handle);
+        registry.release(STREAM_ID);
+
+        verify(handle).close();
+    }
+
+    @Test
+    public void shouldCloseHandleOnceWhenStreamCleanedUpRepeatedly() throws Exception
+    {
+        final BudgetHandleRegistry registry = new BudgetHandleRegistry();
+        final BudgetDebit handle = mock(BudgetDebit.class);
+
+        registry.register(STREAM_ID, handle);
+        registry.release(STREAM_ID);
+        registry.release(STREAM_ID);
+
+        verify(handle, times(1)).close();
+    }
+
+    @Test
+    public void shouldIgnoreCleanupForUnknownStream() throws Exception
+    {
+        final BudgetHandleRegistry registry = new BudgetHandleRegistry();
+        final BudgetDebit handle = mock(BudgetDebit.class);
+
+        registry.register(STREAM_ID, handle);
+        registry.release(OTHER_STREAM_ID);
+
+        verify(handle, times(0)).close();
+    }
+
+    @Test
+    public void shouldCloseEveryRemainingHandleOnReleaseAll() throws Exception
+    {
+        final BudgetHandleRegistry registry = new BudgetHandleRegistry();
+        final BudgetDebit first = mock(BudgetDebit.class);
+        final BudgetDebit second = mock(BudgetDebit.class);
+
+        registry.register(STREAM_ID, first);
+        registry.register(OTHER_STREAM_ID, second);
+        registry.releaseAll();
+
+        verify(first).close();
+        verify(second).close();
+    }
+
+    @Test
+    public void shouldNotCloseAlreadyReleasedHandleOnReleaseAll() throws Exception
+    {
+        final BudgetHandleRegistry registry = new BudgetHandleRegistry();
+        final BudgetDebit handle = mock(BudgetDebit.class);
+
+        registry.register(STREAM_ID, handle);
+        registry.release(STREAM_ID);
+        registry.releaseAll();
+
+        verify(handle, times(1)).close();
+    }
+
+    @Test
+    public void shouldCloseAllHandlesRegisteredForSameStream() throws Exception
+    {
+        final BudgetHandleRegistry registry = new BudgetHandleRegistry();
+        final BudgetDebit first = mock(BudgetDebit.class);
+        final BudgetDebit second = mock(BudgetDebit.class);
+
+        registry.register(STREAM_ID, first);
+        registry.register(STREAM_ID, second);
+        registry.release(STREAM_ID);
+
+        verify(first).close();
+        verify(second).close();
+    }
+}

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetCreditTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetCreditTest.java
@@ -16,6 +16,7 @@
 package io.aklivity.zilla.runtime.engine.internal.budget;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -76,5 +77,18 @@ public class FacadeBudgetCreditTest
         credit.close();
 
         verify(creditor).release(BUDGET_INDEX);
+    }
+
+    @Test
+    public void shouldReleaseCreditorSlotOnlyOnceWhenClosedRepeatedly()
+    {
+        final BudgetCreditor creditor = mock(BudgetCreditor.class);
+        when(creditor.acquire(BUDGET_ID)).thenReturn(BUDGET_INDEX);
+
+        final FacadeBudgetCredit credit = new FacadeBudgetCredit(creditor, BUDGET_ID);
+        credit.close();
+        credit.close();
+
+        verify(creditor, times(1)).release(BUDGET_INDEX);
     }
 }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetCreditTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetCreditTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.internal.budget;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.engine.budget.BudgetCreditor;
+
+public class FacadeBudgetCreditTest
+{
+    private static final long BUDGET_ID = 7L;
+    private static final long BUDGET_INDEX = 3L;
+    private static final long TRACE_ID = 13L;
+
+    @Test
+    public void shouldAcquireCreditorSlotOnConstruction()
+    {
+        final BudgetCreditor creditor = mock(BudgetCreditor.class);
+        when(creditor.acquire(BUDGET_ID)).thenReturn(BUDGET_INDEX);
+
+        new FacadeBudgetCredit(creditor, BUDGET_ID);
+
+        verify(creditor).acquire(BUDGET_ID);
+        verifyNoMoreInteractions(creditor);
+    }
+
+    @Test
+    public void shouldCreditByteCapacity()
+    {
+        final BudgetCreditor creditor = mock(BudgetCreditor.class);
+        when(creditor.acquire(BUDGET_ID)).thenReturn(BUDGET_INDEX);
+
+        final FacadeBudgetCredit credit = new FacadeBudgetCredit(creditor, BUDGET_ID);
+        credit.capacity(TRACE_ID, 1024);
+
+        verify(creditor).credit(TRACE_ID, BUDGET_INDEX, 1024);
+    }
+
+    @Test
+    public void shouldCreditOnlyByteAxisWhenMessagesGiven()
+    {
+        final BudgetCreditor creditor = mock(BudgetCreditor.class);
+        when(creditor.acquire(BUDGET_ID)).thenReturn(BUDGET_INDEX);
+
+        final FacadeBudgetCredit credit = new FacadeBudgetCredit(creditor, BUDGET_ID);
+        credit.capacity(TRACE_ID, 4, 1024);
+
+        verify(creditor).credit(TRACE_ID, BUDGET_INDEX, 1024);
+    }
+
+    @Test
+    public void shouldReleaseCreditorSlotOnClose()
+    {
+        final BudgetCreditor creditor = mock(BudgetCreditor.class);
+        when(creditor.acquire(BUDGET_ID)).thenReturn(BUDGET_INDEX);
+
+        final FacadeBudgetCredit credit = new FacadeBudgetCredit(creditor, BUDGET_ID);
+        credit.close();
+
+        verify(creditor).release(BUDGET_INDEX);
+    }
+}

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetDebitTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetDebitTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.internal.budget;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.function.LongConsumer;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import io.aklivity.zilla.runtime.engine.budget.BudgetDebitor;
+import io.aklivity.zilla.runtime.engine.budget.BudgetFlusher;
+
+public class FacadeBudgetDebitTest
+{
+    private static final long BUDGET_ID = 7L;
+    private static final long WATCHER_ID = 11L;
+    private static final long BUDGET_INDEX = 3L;
+    private static final long TRACE_ID = 13L;
+
+    @Test
+    public void shouldAcquireDebitorSlotOnConstruction()
+    {
+        final BudgetDebitor debitor = mock(BudgetDebitor.class);
+        final BudgetFlusher onResume = mock(BudgetFlusher.class);
+        when(debitor.acquire(eq(BUDGET_ID), eq(WATCHER_ID), any())).thenReturn(BUDGET_INDEX);
+
+        new FacadeBudgetDebit(debitor, BUDGET_ID, WATCHER_ID, onResume);
+
+        verify(debitor).acquire(eq(BUDGET_ID), eq(WATCHER_ID), any());
+        verifyNoMoreInteractions(debitor);
+    }
+
+    @Test
+    public void shouldAdaptFlusherToOnResume()
+    {
+        final BudgetDebitor debitor = mock(BudgetDebitor.class);
+        final BudgetFlusher onResume = mock(BudgetFlusher.class);
+        final ArgumentCaptor<LongConsumer> flusher = ArgumentCaptor.forClass(LongConsumer.class);
+        when(debitor.acquire(eq(BUDGET_ID), eq(WATCHER_ID), flusher.capture())).thenReturn(BUDGET_INDEX);
+
+        new FacadeBudgetDebit(debitor, BUDGET_ID, WATCHER_ID, onResume);
+        flusher.getValue().accept(TRACE_ID);
+
+        verify(onResume).onResume(TRACE_ID);
+        verifyNoMoreInteractions(onResume);
+    }
+
+    @Test
+    public void shouldClaimWithPaddingFoldedPerFrame()
+    {
+        final BudgetDebitor debitor = mock(BudgetDebitor.class);
+        final BudgetFlusher onResume = mock(BudgetFlusher.class);
+        when(debitor.acquire(eq(BUDGET_ID), eq(WATCHER_ID), any())).thenReturn(BUDGET_INDEX);
+        when(debitor.claim(TRACE_ID, BUDGET_INDEX, WATCHER_ID, 108, 1008, 0)).thenReturn(1008);
+
+        final FacadeBudgetDebit debit = new FacadeBudgetDebit(debitor, BUDGET_ID, WATCHER_ID, onResume);
+        debit.declare(TRACE_ID, 8, 64);
+        final int granted = debit.claim(TRACE_ID, 100, 1000);
+
+        assertEquals(1000, granted);
+        verify(debitor).claim(TRACE_ID, BUDGET_INDEX, WATCHER_ID, 108, 1008, 0);
+    }
+
+    @Test
+    public void shouldComposeDeclaredMinimumWithClaimMinimum()
+    {
+        final BudgetDebitor debitor = mock(BudgetDebitor.class);
+        final BudgetFlusher onResume = mock(BudgetFlusher.class);
+        when(debitor.acquire(eq(BUDGET_ID), eq(WATCHER_ID), any())).thenReturn(BUDGET_INDEX);
+        when(debitor.claim(TRACE_ID, BUDGET_INDEX, WATCHER_ID, 64, 1000, 0)).thenReturn(1000);
+
+        final FacadeBudgetDebit debit = new FacadeBudgetDebit(debitor, BUDGET_ID, WATCHER_ID, onResume);
+        debit.declare(TRACE_ID, 0, 64);
+        final int granted = debit.claim(TRACE_ID, 16, 1000);
+
+        assertEquals(1000, granted);
+        verify(debitor).claim(TRACE_ID, BUDGET_INDEX, WATCHER_ID, 64, 1000, 0);
+    }
+
+    @Test
+    public void shouldReturnZeroWhenClaimParks()
+    {
+        final BudgetDebitor debitor = mock(BudgetDebitor.class);
+        final BudgetFlusher onResume = mock(BudgetFlusher.class);
+        when(debitor.acquire(eq(BUDGET_ID), eq(WATCHER_ID), any())).thenReturn(BUDGET_INDEX);
+        when(debitor.claim(TRACE_ID, BUDGET_INDEX, WATCHER_ID, 108, 1008, 0)).thenReturn(0);
+
+        final FacadeBudgetDebit debit = new FacadeBudgetDebit(debitor, BUDGET_ID, WATCHER_ID, onResume);
+        debit.declare(TRACE_ID, 8, 0);
+        final int granted = debit.claim(TRACE_ID, 100, 1000);
+
+        assertEquals(0, granted);
+    }
+
+    @Test
+    public void shouldReleaseDebitorSlotOnClose()
+    {
+        final BudgetDebitor debitor = mock(BudgetDebitor.class);
+        final BudgetFlusher onResume = mock(BudgetFlusher.class);
+        when(debitor.acquire(eq(BUDGET_ID), eq(WATCHER_ID), any())).thenReturn(BUDGET_INDEX);
+
+        final FacadeBudgetDebit debit = new FacadeBudgetDebit(debitor, BUDGET_ID, WATCHER_ID, onResume);
+        debit.close();
+
+        verify(debitor).release(BUDGET_INDEX, WATCHER_ID);
+    }
+}

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetDebitTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetDebitTest.java
@@ -165,6 +165,21 @@ public class FacadeBudgetDebitTest
     }
 
     @Test
+    public void shouldPassDeferredThrough()
+    {
+        final BudgetDebitor debitor = mock(BudgetDebitor.class);
+        final BudgetFlusher onResume = mock(BudgetFlusher.class);
+        when(debitor.acquire(eq(BUDGET_ID), eq(WATCHER_ID), any())).thenReturn(BUDGET_INDEX);
+        when(debitor.claim(TRACE_ID, BUDGET_INDEX, WATCHER_ID, 100, 1000, 64)).thenReturn(1000);
+
+        final FacadeBudgetDebit debit = new FacadeBudgetDebit(debitor, BUDGET_ID, WATCHER_ID, onResume);
+        final int granted = debit.claim(TRACE_ID, 100, 1000, 64);
+
+        assertEquals(1000, granted);
+        verify(debitor).claim(TRACE_ID, BUDGET_INDEX, WATCHER_ID, 100, 1000, 64);
+    }
+
+    @Test
     public void shouldNotReleaseWhenNeverAcquired()
     {
         final BudgetDebitor debitor = mock(BudgetDebitor.class);

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetDebitTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetDebitTest.java
@@ -16,6 +16,8 @@
 package io.aklivity.zilla.runtime.engine.internal.budget;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -190,5 +192,29 @@ public class FacadeBudgetDebitTest
         debit.close();
 
         verify(debitor, never()).release(anyLong(), anyLong());
+    }
+
+    @Test
+    public void shouldReportAvailableWhenAcquired()
+    {
+        final BudgetDebitor debitor = mock(BudgetDebitor.class);
+        final BudgetFlusher onResume = mock(BudgetFlusher.class);
+        when(debitor.acquire(eq(BUDGET_ID), eq(WATCHER_ID), any())).thenReturn(BUDGET_INDEX);
+
+        final FacadeBudgetDebit debit = new FacadeBudgetDebit(debitor, BUDGET_ID, WATCHER_ID, onResume);
+
+        assertTrue(debit.available());
+    }
+
+    @Test
+    public void shouldReportUnavailableWhenNotAcquired()
+    {
+        final BudgetDebitor debitor = mock(BudgetDebitor.class);
+        final BudgetFlusher onResume = mock(BudgetFlusher.class);
+        when(debitor.acquire(eq(BUDGET_ID), eq(WATCHER_ID), any())).thenReturn(BudgetDebitor.NO_DEBITOR_INDEX);
+
+        final FacadeBudgetDebit debit = new FacadeBudgetDebit(debitor, BUDGET_ID, WATCHER_ID, onResume);
+
+        assertFalse(debit.available());
     }
 }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetDebitTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetDebitTest.java
@@ -17,8 +17,12 @@ package io.aklivity.zilla.runtime.engine.internal.budget;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -124,5 +128,52 @@ public class FacadeBudgetDebitTest
         debit.close();
 
         verify(debitor).release(BUDGET_INDEX, WATCHER_ID);
+    }
+
+    @Test
+    public void shouldGrantMaximumWhenBudgetNotYetAcquired()
+    {
+        final BudgetDebitor debitor = mock(BudgetDebitor.class);
+        final BudgetFlusher onResume = mock(BudgetFlusher.class);
+        when(debitor.acquire(eq(BUDGET_ID), eq(WATCHER_ID), any())).thenReturn(BudgetDebitor.NO_DEBITOR_INDEX);
+
+        final FacadeBudgetDebit debit = new FacadeBudgetDebit(debitor, BUDGET_ID, WATCHER_ID, onResume);
+        final int granted = debit.claim(TRACE_ID, 100, 1000);
+
+        assertEquals(1000, granted);
+        verify(debitor, never()).claim(anyLong(), anyLong(), anyLong(), anyInt(), anyInt(), anyInt());
+    }
+
+    @Test
+    public void shouldReacquireOnClaimWhenBudgetBecomesAvailable()
+    {
+        final BudgetDebitor debitor = mock(BudgetDebitor.class);
+        final BudgetFlusher onResume = mock(BudgetFlusher.class);
+        when(debitor.acquire(eq(BUDGET_ID), eq(WATCHER_ID), any()))
+            .thenReturn(BudgetDebitor.NO_DEBITOR_INDEX)
+            .thenReturn(BUDGET_INDEX);
+        when(debitor.claim(TRACE_ID, BUDGET_INDEX, WATCHER_ID, 100, 1000, 0)).thenReturn(1000);
+
+        final FacadeBudgetDebit debit = new FacadeBudgetDebit(debitor, BUDGET_ID, WATCHER_ID, onResume);
+        final int grantedBefore = debit.claim(TRACE_ID, 100, 1000);
+        final int grantedAfter = debit.claim(TRACE_ID, 100, 1000);
+
+        assertEquals(1000, grantedBefore);
+        assertEquals(1000, grantedAfter);
+        verify(debitor, times(2)).acquire(eq(BUDGET_ID), eq(WATCHER_ID), any());
+        verify(debitor, times(2)).claim(TRACE_ID, BUDGET_INDEX, WATCHER_ID, 100, 1000, 0);
+    }
+
+    @Test
+    public void shouldNotReleaseWhenNeverAcquired()
+    {
+        final BudgetDebitor debitor = mock(BudgetDebitor.class);
+        final BudgetFlusher onResume = mock(BudgetFlusher.class);
+        when(debitor.acquire(eq(BUDGET_ID), eq(WATCHER_ID), any())).thenReturn(BudgetDebitor.NO_DEBITOR_INDEX);
+
+        final FacadeBudgetDebit debit = new FacadeBudgetDebit(debitor, BUDGET_ID, WATCHER_ID, onResume);
+        debit.close();
+
+        verify(debitor, never()).release(anyLong(), anyLong());
     }
 }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetDebitTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetDebitTest.java
@@ -133,6 +133,20 @@ public class FacadeBudgetDebitTest
     }
 
     @Test
+    public void shouldReleaseDebitorSlotOnlyOnceWhenClosedRepeatedly()
+    {
+        final BudgetDebitor debitor = mock(BudgetDebitor.class);
+        final BudgetFlusher onResume = mock(BudgetFlusher.class);
+        when(debitor.acquire(eq(BUDGET_ID), eq(WATCHER_ID), any())).thenReturn(BUDGET_INDEX);
+
+        final FacadeBudgetDebit debit = new FacadeBudgetDebit(debitor, BUDGET_ID, WATCHER_ID, onResume);
+        debit.close();
+        debit.close();
+
+        verify(debitor, times(1)).release(BUDGET_INDEX, WATCHER_ID);
+    }
+
+    @Test
     public void shouldGrantMaximumWhenBudgetNotYetAcquired()
     {
         final BudgetDebitor debitor = mock(BudgetDebitor.class);

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/FacadeBudgetTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.internal.budget;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.nio.file.Paths;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.engine.budget.BudgetCredit;
+import io.aklivity.zilla.runtime.engine.budget.BudgetDebit;
+import io.aklivity.zilla.runtime.engine.budget.BudgetFlusher;
+import io.aklivity.zilla.runtime.engine.internal.layouts.BudgetsLayout;
+
+public class FacadeBudgetTest
+{
+    @Test
+    public void shouldCreditClaimParkAndResumeThroughRealBudget() throws Exception
+    {
+        final BudgetsLayout layout = new BudgetsLayout.Builder()
+            .owner(true)
+            .path(Paths.get("target/zilla-itests/budgets-facade"))
+            .capacity(1024)
+            .build();
+
+        final long budgetId = 1L;
+        final long watcherId = 2L;
+        final long traceId = 3L;
+
+        final BudgetFlusher onResume = mock(BudgetFlusher.class);
+
+        try (DefaultBudgetDebitor debitor = new DefaultBudgetDebitor(1, 0, layout))
+        {
+            final DefaultBudgetCreditor creditor =
+                new DefaultBudgetCreditor(0, layout, (trace, budget, watchers) -> debitor.flush(trace, budget));
+
+            // the consumer acquires the shared budget; the producer then attaches to it
+            final BudgetCredit credit = new FacadeBudgetCredit(creditor, budgetId);
+            final BudgetDebit debit = new FacadeBudgetDebit(debitor, budgetId, watcherId, onResume);
+            debit.declare(traceId, 0, 0);
+
+            // grant 512 bytes of downstream capacity
+            credit.capacity(traceId, 512);
+
+            // a claim within the granted capacity succeeds
+            final int granted = debit.claim(traceId, 0, 512);
+            assertEquals(512, granted);
+
+            // with no capacity left the next claim parks and registers a watcher
+            final int parked = debit.claim(traceId, 1, 512);
+            assertEquals(0, parked);
+            verifyNoInteractions(onResume);
+
+            // granting more capacity flushes the parked watcher
+            credit.capacity(traceId, 512);
+            verify(onResume).onResume(traceId);
+
+            // the resumed claim now succeeds against the replenished capacity
+            final int resumed = debit.claim(traceId, 0, 512);
+            assertEquals(512, resumed);
+
+            debit.close();
+            credit.close();
+        }
+    }
+}


### PR DESCRIPTION
## Description

Introduces new `BudgetCredit` and `BudgetDebit` handle-based APIs to replace the lower-level `BudgetCreditor` and `BudgetDebitor` interfaces in bindings. This is Phase 1 of a budget API modernization effort.

### Changes

**New Public APIs:**
- `BudgetCredit`: Consumer-side flow control handle for granting downstream capacity
- `BudgetDebit`: Producer-side flow control handle for claiming send capacity
- `BudgetFlusher`: Callback interface for resuming parked senders when capacity becomes available
- `EngineContext.supplyCredit(long, long)`: Factory method for obtaining `BudgetCredit` handles
- `EngineContext.supplyDebit(long, long, BudgetFlusher)`: Factory method for obtaining `BudgetDebit` handles

**New Facade Implementations:**
- `FacadeBudgetCredit`: Behavior-preserving adapter over `BudgetCreditor`
- `FacadeBudgetDebit`: Behavior-preserving adapter over `BudgetDebitor` that:
  - Owns the acquire/claim/release lifecycle
  - Folds declared per-frame padding into claimed frames
  - Composes declared minimum with each claim's minimum
  - Delegates to existing six-argument `BudgetDebitor.claim()` with deferred=0

**Deprecations:**
- `EngineContext.creditor()`: Marked `@Deprecated`
- `EngineContext.supplyDebitor(long)`: Marked `@Deprecated`

**Migration in MQTT Binding:**
- Updated `MqttServerFactory` and `MqttClientFactory` to use new handle APIs
- Removed direct `BudgetCreditor` and `BudgetDebitor` field dependencies
- Replaced manual acquire/claim/release dance with declarative handle calls
- Simplified budget index tracking by using handle objects instead of sentinel values

### Benefits

- **Unified API**: Single handle per stream unifies per-stream window and shared budget
- **Simplified Binding Code**: Eliminates hand-coded window arithmetic and lifecycle management
- **Backward Compatible**: Facade implementations preserve existing behavior during migration
- **Cleaner Semantics**: Explicit `declare()` and `claim()` methods replace implicit state management

### Test Coverage

Added comprehensive unit tests:
- `FacadeBudgetCreditTest`: Tests acquire/credit/release lifecycle and capacity delegation
- `FacadeBudgetDebitTest`: Tests acquire/claim/release lifecycle, padding folding, and minimum composition
- `FacadeBudgetTest`: Integration test verifying credit/debit interaction through real budget machinery

Existing MQTT binding tests continue to pass with the new handle-based implementation.

https://claude.ai/code/session_01MZnr4yxJ4NFdtvyhHWjwX3