### PR TITLE
fix(common-json): compile JSON Schema pattern with ECMA-262 brace semantics

### DIFF
--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
@@ -604,7 +604,103 @@ public final class JsonSchemaImpl implements JsonSchema
             matcher.appendReplacement(result, replacement);
         }
         matcher.appendTail(result);
-        return Pattern.compile(result.toString());
+        return Pattern.compile(escapeLiteralBraces(result.toString()));
+    }
+
+    // ECMA-262 treats a "{" that does not form a well-formed quantifier as a literal, whereas
+    // java.util.regex rejects it with PatternSyntaxException; escape such braces so an ECMA-valid
+    // pattern compiles. Valid quantifiers ({n}, {n,}, {n,m}), unicode property escapes (\p{...},
+    // \P{...}, \x{...}) and character classes are left untouched.
+    private static String escapeLiteralBraces(
+        String regex)
+    {
+        StringBuilder result = new StringBuilder(regex.length());
+        int length = regex.length();
+        int index = 0;
+        boolean inCharClass = false;
+        while (index < length)
+        {
+            char ch = regex.charAt(index);
+            if (ch == '\\' && index + 1 < length)
+            {
+                char escaped = regex.charAt(index + 1);
+                result.append(ch).append(escaped);
+                index += 2;
+                if ((escaped == 'p' || escaped == 'P' || escaped == 'x') &&
+                    index < length && regex.charAt(index) == '{')
+                {
+                    int close = regex.indexOf('}', index);
+                    int end = close < 0 ? length : close + 1;
+                    result.append(regex, index, end);
+                    index = end;
+                }
+            }
+            else if (ch == '[')
+            {
+                inCharClass = true;
+                result.append(ch);
+                index++;
+            }
+            else if (ch == ']')
+            {
+                inCharClass = false;
+                result.append(ch);
+                index++;
+            }
+            else if (ch == '{' && !inCharClass)
+            {
+                int end = quantifierEnd(regex, index);
+                if (end > index)
+                {
+                    result.append(regex, index, end);
+                    index = end;
+                }
+                else
+                {
+                    result.append("\\{");
+                    index++;
+                }
+            }
+            else
+            {
+                result.append(ch);
+                index++;
+            }
+        }
+        return result.toString();
+    }
+
+    // Returns the index just past a well-formed ECMA-262 quantifier ({n}, {n,}, {n,m}) starting at
+    // start, or start itself when the brace does not open a valid quantifier.
+    private static int quantifierEnd(
+        String regex,
+        int start)
+    {
+        int length = regex.length();
+        int index = start + 1;
+        int digits = 0;
+        int result = start;
+        while (index < length && Character.isDigit(regex.charAt(index)))
+        {
+            index++;
+            digits++;
+        }
+        if (digits > 0)
+        {
+            if (index < length && regex.charAt(index) == ',')
+            {
+                index++;
+                while (index < length && Character.isDigit(regex.charAt(index)))
+                {
+                    index++;
+                }
+            }
+            if (index < length && regex.charAt(index) == '}')
+            {
+                result = index + 1;
+            }
+        }
+        return result;
     }
 
     private static Map<Pattern, JsonSchemaImpl> parsePatternProperties(

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaTest.java
@@ -219,6 +219,26 @@ class JsonSchemaTest
     }
 
     @Test
+    void shouldTreatNonQuantifierBraceAsLiteral()
+    {
+        // ECMA-262 treats a "{" that is not a well-formed quantifier as a literal; java.util.regex rejects it
+        assertTrue(valid("{\"pattern\":\"^a{z$\"}", "\"a{z\""));
+        assertFalse(valid("{\"pattern\":\"^a{z$\"}", "\"az\""));
+        assertTrue(valid("{\"pattern\":\"^x{2}y{z$\"}", "\"xxy{z\""));
+        assertFalse(valid("{\"pattern\":\"^x{2}y{z$\"}", "\"xy{z\""));
+    }
+
+    @Test
+    void shouldCompileEcmaLiteralBracePlaceholderPattern()
+    {
+        // valid ECMA-262 pattern with a literal "{...}" placeholder group, e.g. kafka-proxy host schema (issue #1935)
+        String schema = "{\"pattern\":\"^[^:]+(?:-({[^}]+}|[^.]+))?(?::(\\\\d+)\\\\+)?$\"}";
+        assertTrue(valid(schema, "\"broker-{node}\""));
+        assertTrue(valid(schema, "\"broker-0:9092+\""));
+        assertTrue(valid(schema, "\"localhost\""));
+    }
+
+    @Test
     void shouldTreatFormatAsAnnotationNotAssertion()
     {
         String schema = "{\"type\":\"string\",\"format\":\"email\"}";


### PR DESCRIPTION
## Summary

Fixes #1935.

`common-json`'s `JsonSchemaImpl.compilePattern(...)` compiled a JSON Schema `pattern` keyword with Java's `java.util.regex.Pattern.compile(...)`. JSON Schema regexes are **ECMA-262**, where a `{` that does not form a well-formed quantifier is treated as a **literal**, whereas Java throws `PatternSyntaxException`. As a result, valid schema patterns (e.g. a literal `{...}` placeholder group) failed to compile and the whole engine configuration failed to load.

## Changes

- `JsonSchemaImpl.compilePattern(...)` now pre-processes the pattern (after the existing `\p{...}` unicode-property translation) to escape braces that do not open a valid quantifier (`{n}`, `{n,}`, `{n,m}`).
- Unicode property escapes (`\p{...}`, `\P{...}`, `\x{...}`) and character classes are left untouched, and existing valid quantifiers are preserved.
- This path is shared by both the `pattern` keyword and `patternProperties`.

## Tests

Added two tests to `JsonSchemaTest` (test-first; confirmed they fail with `PatternSyntaxException` against the unfixed code, then pass with the fix):

- `shouldTreatNonQuantifierBraceAsLiteral` — a `{` not forming a quantifier is matched as a literal, while real quantifiers still apply.
- `shouldCompileEcmaLiteralBracePlaceholderPattern` — reproduces the kafka-proxy host schema pattern from the issue (`^[^:]+(?:-({[^}]+}|[^.]+))?(?::(\d+)\+)?$`).

`JsonSchemaTest` passes (27/27) and `checkstyle:check` is clean for the module.

## Follow-up

The downstream workaround in `aklivity/zilla-plus` (`{[^}]+}` → `\{[^}]+\}` in the kafka-proxy schema) can be reverted once an engine containing this fix is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRF4YGLs99kMV5n6eryrU3)_