### PR TITLE
Convert test config assertions from JSON to YAML format

### DIFF
--- a/incubator/binding-risingwave/src/test/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveOptionsConfigAdapterTest.java
+++ b/incubator/binding-risingwave/src/test/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveOptionsConfigAdapterTest.java
@@ -37,6 +37,7 @@ import io.aklivity.zilla.runtime.binding.risingwave.config.RisingwaveKafkaConfig
 import io.aklivity.zilla.runtime.binding.risingwave.config.RisingwaveKafkaPropertiesConfig;
 import io.aklivity.zilla.runtime.binding.risingwave.config.RisingwaveOptionsConfig;
 import io.aklivity.zilla.runtime.binding.risingwave.config.RisingwaveUdfConfig;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 import io.aklivity.zilla.runtime.engine.config.CatalogedConfig;
 import io.aklivity.zilla.runtime.engine.config.ConfigAdapterContext;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfigAdapter;
@@ -59,43 +60,33 @@ public class RisingwaveOptionsConfigAdapterTest
         adapter.adaptType("risingwave");
         JsonbConfig config = new JsonbConfig()
             .withAdapters(adapter);
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+            .withProvider(YamlJson.provider())
+            .withConfig(config)
+            .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
-        String text =
+        String yaml =
             """
-                {\
-                  "kafka": {
-                    "properties": {
-                      "bootstrap.server": "localhost:9092"
-                    },
-                    "format": {
-                      "model": "test",
-                      "length": 0,
-                      "catalog": {
-                        "test0": [
-                          {
-                            "id": 1
-                          }
-                        ]
-                      }
-                    }
-                  },
-                  "udf": [
-                    {
-                      "server": "http://udf.zillabase.dev:8815"
-                    },
-                    {
-                      "server": "http://udf-python.zillabase.dev:8815",
-                      "language": "python"
-                    }
-                    ]
-                }""";
+            kafka:
+              properties:
+                bootstrap.server: localhost:9092
+              format:
+                model: test
+                length: 0
+                catalog:
+                  test0:
+                    - id: 1
+            udf:
+              - server: http://udf.zillabase.dev:8815
+              - server: http://udf-python.zillabase.dev:8815
+                language: python
+            """;
 
-        RisingwaveOptionsConfig options = jsonb.fromJson(text, RisingwaveOptionsConfig.class);
+        RisingwaveOptionsConfig options = jsonb.fromJson(yaml, RisingwaveOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertEquals(options.udfs.get(0).server, "http://udf.zillabase.dev:8815");
@@ -105,8 +96,16 @@ public class RisingwaveOptionsConfigAdapterTest
     @Test
     public void shouldWriteOptions()
     {
-        String expected = "{\"kafka\":{\"properties\":{\"bootstrap.server\":\"localhost:9092\"},\"format\":\"test\"}," +
-            "\"udf\":[{\"server\":\"http://udf-python.zillabase.dev:8815\",\"language\":\"python\"}]}";
+        String expected =
+            """
+            kafka:
+              properties:
+                bootstrap.server: "localhost:9092"
+              format: test
+            udf:
+              - server: "http://udf-python.zillabase.dev:8815"
+                language: python
+            """;
 
         RisingwaveKafkaPropertiesConfig properties = RisingwaveKafkaPropertiesConfig.builder()
             .inject(identity())
@@ -137,9 +136,9 @@ public class RisingwaveOptionsConfigAdapterTest
             .udf(udf)
             .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertEquals(expected, text);
+        assertThat(yaml, not(nullValue()));
+        assertEquals(expected, yaml);
     }
 }

--- a/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiOptionsConfigAdapterTest.java
+++ b/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiOptionsConfigAdapterTest.java
@@ -43,6 +43,7 @@ import io.aklivity.zilla.runtime.binding.kafka.config.KafkaOptionsConfig;
 import io.aklivity.zilla.runtime.binding.kafka.config.KafkaSaslConfig;
 import io.aklivity.zilla.runtime.binding.tcp.config.TcpOptionsConfig;
 import io.aklivity.zilla.runtime.binding.tls.config.TlsOptionsConfig;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 import io.aklivity.zilla.runtime.engine.config.ConfigAdapterContext;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfigAdapter;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfigAdapterSpi;
@@ -62,62 +63,41 @@ public class AsyncapiOptionsConfigAdapterTest
         adapter.adaptType("asyncapi");
         JsonbConfig config = new JsonbConfig()
             .withAdapters(adapter);
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+            .withProvider(YamlJson.provider())
+            .withConfig(config)
+            .build();
     }
 
     @Test
     public void shouldReadOptionsMqtt() throws IOException
     {
-        String text =
-                "{" +
-                    "\"specs\":" +
-                    "{" +
-                        "\"mqtt-api\":" +
-                        "{" +
-                            "\"catalog\":" +
-                            "{" +
-                                "\"catalog0\":" +
-                                "{" +
-                                    "\"subject\": \"smartylighting\"," +
-                                    "\"version\": \"latest\"" +
-                                "}" +
-                            "}," +
-                            "\"servers\":" +
-                            "[" +
-                                "{" +
-                                    "\"host\":\"test.mosquitto.org:1883\"" +
-                                "}" +
-                            "]" +
-                        "}" +
-                    "}," +
-                    "\"tcp\":" +
-                    "{" +
-                        "\"host\":\"localhost\"," +
-                        "\"port\":7183" +
-                    "}," +
-                    "\"tls\":" +
-                    "{" +
-                        "\"keys\":" +
-                        "[" +
-                            "\"localhost\"" +
-                        "]," +
-                        "\"trust\":" +
-                        "[" +
-                            "\"serverca\"" +
-                        "]," +
-                        "\"trustcacerts\":true," +
-                        "\"sni\":" +
-                        "[" +
-                            "\"mqtt.example.net\"" +
-                        "]," +
-                        "\"alpn\":" +
-                        "[" +
-                            "\"mqtt\"" +
-                        "]" +
-                    "}" +
-                "}";
+        String yaml =
+                """
+                specs:
+                  mqtt-api:
+                    catalog:
+                      catalog0:
+                        subject: smartylighting
+                        version: latest
+                    servers:
+                      - host: test.mosquitto.org:1883
+                tcp:
+                  host: localhost
+                  port: 7183
+                tls:
+                  keys:
+                    - localhost
+                  trust:
+                    - serverca
+                  trustcacerts: true
+                  sni:
+                    - mqtt.example.net
+                  alpn:
+                    - mqtt
+                """;
 
-        AsyncapiOptionsConfig options = jsonb.fromJson(text, AsyncapiOptionsConfig.class);
+        AsyncapiOptionsConfig options = jsonb.fromJson(yaml, AsyncapiOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         AsyncapiSpecificationConfig asyncapi = options.specs.get(0);
@@ -169,129 +149,77 @@ public class AsyncapiOptionsConfigAdapterTest
                 .build())
             .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo(
-            "{" +
-                "\"specs\":" +
-                "{" +
-                    "\"mqtt-api\":" +
-                    "{" +
-                        "\"catalog\":" +
-                        "{" +
-                            "\"catalog0\":" +
-                            "{" +
-                                "\"subject\":\"smartylighting\"," +
-                                "\"version\":\"latest\"" +
-                            "}" +
-                        "}," +
-                        "\"servers\":" +
-                        "[" +
-                            "{" +
-                                "\"host\":\"test.mosquitto.org:1883\"" +
-                            "}" +
-                        "]" +
-                    "}" +
-                "}," +
-                "\"tcp\":" +
-                "{" +
-                    "\"host\":\"localhost\"," +
-                    "\"port\":7183" +
-                "}," +
-                "\"tls\":" +
-                "{" +
-                    "\"keys\":" +
-                    "[" +
-                        "\"localhost\"" +
-                    "]," +
-                    "\"trust\":" +
-                    "[" +
-                        "\"serverca\"" +
-                    "]," +
-                    "\"trustcacerts\":true," +
-                    "\"sni\":" +
-                    "[" +
-                        "\"mqtt.example.net\"" +
-                    "]," +
-                    "\"alpn\":" +
-                    "[" +
-                        "\"mqtt\"" +
-                    "]" +
-                "}," +
-                 "\"kafka\":" +
-                 "{" +
-                     "\"sasl\":" +
-                     "{" +
-                         "\"mechanism\":\"plain\"," +
-                         "\"username\":\"username\"," +
-                         "\"password\":\"password\"" +
-                     "}" +
-                 "}," +
-                "\"mqtt-kafka\":" +
-                "{" +
-                    "\"channels\":" +
-                    "{" +
-                        "\"sessions\":\"mqttSessions\"," +
-                        "\"messages\":\"mqttMessages\"," +
-                        "\"retained\":\"mqttRetained\"" +
-                    "}" +
-                "}" +
-            "}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+            """
+            specs:
+              mqtt-api:
+                catalog:
+                  catalog0:
+                    subject: smartylighting
+                    version: latest
+                servers:
+                  - host: "test.mosquitto.org:1883"
+            tcp:
+              host: localhost
+              port: 7183
+            tls:
+              keys:
+                - localhost
+              trust:
+                - serverca
+              trustcacerts: true
+              sni:
+                - mqtt.example.net
+              alpn:
+                - mqtt
+            kafka:
+              sasl:
+                mechanism: plain
+                username: username
+                password: password
+            mqtt-kafka:
+              channels:
+                sessions: mqttSessions
+                messages: mqttMessages
+                retained: mqttRetained
+            """));
     }
 
     @Test
     public void shouldReadOptionsKafka() throws IOException
     {
-        String text =
-                "{" +
-                    "\"specs\": {" +
-                    "  \"kafka_api\": {" +
-                    "    \"catalog\": {" +
-                    "      \"catalog0\": {" +
-                    "        \"subject\": \"smartylighting\"," +
-                    "        \"version\": \"latest\"" +
-                    "      }" +
-                    "    }" +
-                    "  }" +
-                    "}," +
-                    "\"tcp\":" +
-                    "{" +
-                        "\"host\":\"localhost\"," +
-                        "\"port\":9092" +
-                    "}," +
-                    "\"tls\":" +
-                    "{" +
-                        "\"keys\":" +
-                        "[" +
-                            "\"localhost\"" +
-                        "]," +
-                        "\"trust\":" +
-                        "[" +
-                            "\"serverca\"" +
-                        "]," +
-                        "\"trustcacerts\":true," +
-                        "\"sni\":" +
-                        "[" +
-                            "\"kafka.example.net\"" +
-                        "]," +
-                        "\"alpn\":" +
-                        "[" +
-                            "\"kafka\"" +
-                        "]" +
-                    "}," +
-                    "\"kafka\":" +
-                    "{" +
-                        "\"sasl\":" +
-                        "{" +
-                            "\"mechanism\":\"plain\"," +
-                            "\"username\":\"username\"," +
-                            "\"password\":\"password\"" +
-                        "}" +
-                    "}" +
-                "}";
+        String yaml =
+                """
+                specs:
+                  kafka_api:
+                    catalog:
+                      catalog0:
+                        subject: smartylighting
+                        version: latest
+                tcp:
+                  host: localhost
+                  port: 9092
+                tls:
+                  keys:
+                    - localhost
+                  trust:
+                    - serverca
+                  trustcacerts: true
+                  sni:
+                    - kafka.example.net
+                  alpn:
+                    - kafka
+                kafka:
+                  sasl:
+                    mechanism: plain
+                    username: username
+                    password: password
+                """;
 
-        AsyncapiOptionsConfig options = jsonb.fromJson(text, AsyncapiOptionsConfig.class);
+        AsyncapiOptionsConfig options = jsonb.fromJson(yaml, AsyncapiOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.tcp.host, equalTo("localhost"));
@@ -324,81 +252,53 @@ public class AsyncapiOptionsConfigAdapterTest
                 .build())
             .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo(
-            "{" +
-                "\"tcp\":" +
-                "{" +
-                    "\"host\":\"localhost\"," +
-                    "\"port\":7080" +
-                "}," +
-                "\"tls\":" +
-                "{" +
-                    "\"keys\":" +
-                    "[" +
-                        "\"localhost\"" +
-                    "]," +
-                    "\"trust\":" +
-                    "[" +
-                        "\"serverca\"" +
-                    "]," +
-                    "\"trustcacerts\":true," +
-                    "\"sni\":" +
-                    "[" +
-                        "\"http.example.net\"" +
-                    "]," +
-                    "\"alpn\":" +
-                    "[" +
-                        "\"http\"" +
-                    "]" +
-                "}," +
-                "\"mqtt-kafka\":" +
-                "{" +
-                    "\"channels\":" +
-                    "{" +
-                        "\"sessions\":\"mqttSessions\"," +
-                        "\"messages\":\"mqttMessages\"," +
-                        "\"retained\":\"mqttRetained\"" +
-                    "}" +
-                "}" +
-            "}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+            """
+            tcp:
+              host: localhost
+              port: 7080
+            tls:
+              keys:
+                - localhost
+              trust:
+                - serverca
+              trustcacerts: true
+              sni:
+                - http.example.net
+              alpn:
+                - http
+            mqtt-kafka:
+              channels:
+                sessions: mqttSessions
+                messages: mqttMessages
+                retained: mqttRetained
+            """));
     }
 
     @Test
     public void shouldReadOptionsHttp() throws IOException
     {
-        String text =
-                "{" +
-                    "\"tcp\":" +
-                    "{" +
-                        "\"host\":\"localhost\"," +
-                        "\"port\":7080" +
-                    "}," +
-                    "\"tls\":" +
-                    "{" +
-                        "\"keys\":" +
-                        "[" +
-                            "\"localhost\"" +
-                        "]," +
-                        "\"trust\":" +
-                        "[" +
-                            "\"serverca\"" +
-                        "]," +
-                        "\"trustcacerts\":true," +
-                        "\"sni\":" +
-                        "[" +
-                            "\"http.example.net\"" +
-                        "]," +
-                        "\"alpn\":" +
-                        "[" +
-                            "\"http\"" +
-                        "]" +
-                    "}" +
-                "}";
+        String yaml =
+                """
+                tcp:
+                  host: localhost
+                  port: 7080
+                tls:
+                  keys:
+                    - localhost
+                  trust:
+                    - serverca
+                  trustcacerts: true
+                  sni:
+                    - http.example.net
+                  alpn:
+                    - http
+                """;
 
-        AsyncapiOptionsConfig options = jsonb.fromJson(text, AsyncapiOptionsConfig.class);
+        AsyncapiOptionsConfig options = jsonb.fromJson(yaml, AsyncapiOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.tcp.host, equalTo("localhost"));
@@ -435,74 +335,50 @@ public class AsyncapiOptionsConfigAdapterTest
                 .build())
             .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo(
-            "{" +
-                "\"tcp\":" +
-                "{" +
-                    "\"host\":\"localhost\"," +
-                    "\"port\":9092" +
-                "}," +
-                "\"tls\":" +
-                "{" +
-                    "\"keys\":" +
-                    "[" +
-                        "\"localhost\"" +
-                    "]," +
-                    "\"trust\":" +
-                    "[" +
-                        "\"serverca\"" +
-                    "]," +
-                    "\"trustcacerts\":true," +
-                    "\"sni\":" +
-                    "[" +
-                        "\"kafka.example.net\"" +
-                    "]," +
-                    "\"alpn\":" +
-                    "[" +
-                        "\"kafka\"" +
-                    "]" +
-                "}," +
-                 "\"kafka\":" +
-                 "{" +
-                     "\"sasl\":" +
-                     "{" +
-                         "\"mechanism\":\"plain\"," +
-                         "\"username\":\"username\"," +
-                         "\"password\":\"password\"" +
-                     "}" +
-                 "}," +
-                "\"mqtt-kafka\":" +
-                "{" +
-                    "\"channels\":" +
-                    "{" +
-                        "\"sessions\":\"mqttSessions\"," +
-                        "\"messages\":\"mqttMessages\"," +
-                        "\"retained\":\"mqttRetained\"" +
-                    "}" +
-                "}" +
-            "}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+            """
+            tcp:
+              host: localhost
+              port: 9092
+            tls:
+              keys:
+                - localhost
+              trust:
+                - serverca
+              trustcacerts: true
+              sni:
+                - kafka.example.net
+              alpn:
+                - kafka
+            kafka:
+              sasl:
+                mechanism: plain
+                username: username
+                password: password
+            mqtt-kafka:
+              channels:
+                sessions: mqttSessions
+                messages: mqttMessages
+                retained: mqttRetained
+            """));
     }
 
     @Test
     public void shouldReadOptionsMqttKafka() throws IOException
     {
-        String text =
-                "{" +
-                    "\"mqtt-kafka\":" +
-                    "{" +
-                        "\"channels\":" +
-                        "{" +
-                            "\"sessions\":\"sessionsChannel\"," +
-                            "\"messages\":\"messagesChannel\"," +
-                            "\"retained\":\"retainedChannel\"" +
-                        "}" +
-                    "}" +
-                "}";
+        String yaml =
+                """
+                mqtt-kafka:
+                  channels:
+                    sessions: sessionsChannel
+                    messages: messagesChannel
+                    retained: retainedChannel
+                """;
 
-        AsyncapiOptionsConfig options = jsonb.fromJson(text, AsyncapiOptionsConfig.class);
+        AsyncapiOptionsConfig options = jsonb.fromJson(yaml, AsyncapiOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.mqttKafka.channels.sessions, equalTo("sessionsChannel"));
@@ -523,20 +399,16 @@ public class AsyncapiOptionsConfigAdapterTest
                 .build())
             .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo(
-            "{" +
-                    "\"mqtt-kafka\":" +
-                    "{" +
-                        "\"channels\":" +
-                        "{" +
-                            "\"sessions\":\"sessionsChannel\"," +
-                            "\"messages\":\"messagesChannel\"," +
-                            "\"retained\":\"retainedChannel\"" +
-                        "}" +
-                    "}" +
-                "}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+            """
+            mqtt-kafka:
+              channels:
+                sessions: sessionsChannel
+                messages: messagesChannel
+                retained: retainedChannel
+            """));
     }
 }

--- a/runtime/binding-filesystem/src/test/java/io/aklivity/zilla/runtime/binding/filesystem/internal/config/FileSystemOptionsConfigAdapterTest.java
+++ b/runtime/binding-filesystem/src/test/java/io/aklivity/zilla/runtime/binding/filesystem/internal/config/FileSystemOptionsConfigAdapterTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import io.aklivity.zilla.runtime.binding.filesystem.config.FileSystemOptionsConfig;
 import io.aklivity.zilla.runtime.binding.filesystem.config.FileSystemSymbolicLinksConfig;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 
 public class FileSystemOptionsConfigAdapterTest
 {
@@ -40,19 +41,22 @@ public class FileSystemOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(new FileSystemOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
-        String text =
-                "{" +
-                    "\"location\":\"target/files\"," +
-                    "\"symlinks\":\"follow\"" +
-                "}";
+        String yaml =
+                """
+                location: target/files
+                symlinks: follow
+                """;
 
-        FileSystemOptionsConfig options = jsonb.fromJson(text, FileSystemOptionsConfig.class);
+        FileSystemOptionsConfig options = jsonb.fromJson(yaml, FileSystemOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.location, equalTo(URI.create("target/files")));
@@ -66,13 +70,13 @@ public class FileSystemOptionsConfigAdapterTest
                 URI.create("target/files"),
                 FileSystemSymbolicLinksConfig.FOLLOW);
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo(
-                    "{" +
-                        "\"location\":\"target/files\"," +
-                        "\"symlinks\":\"follow\"" +
-                    "}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                location: target/files
+                symlinks: follow
+                """));
     }
 }

--- a/runtime/binding-grpc-kafka/src/test/java/io/aklivity/zilla/runtime/blinding/grpc/kafka/internal/config/GrpcKafkaOptionsConfigAdapterTest.java
+++ b/runtime/binding-grpc-kafka/src/test/java/io/aklivity/zilla/runtime/blinding/grpc/kafka/internal/config/GrpcKafkaOptionsConfigAdapterTest.java
@@ -33,6 +33,7 @@ import io.aklivity.zilla.runtime.binding.grpc.kafka.config.GrpcKafkaReliabilityC
 import io.aklivity.zilla.runtime.binding.grpc.kafka.internal.config.GrpcKafkaOptionsConfigAdapter;
 import io.aklivity.zilla.runtime.binding.grpc.kafka.internal.types.String16FW;
 import io.aklivity.zilla.runtime.binding.grpc.kafka.internal.types.String8FW;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 
 public class GrpcKafkaOptionsConfigAdapterTest
 {
@@ -43,31 +44,28 @@ public class GrpcKafkaOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(new GrpcKafkaOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
-        String text =
-                "{" +
-                    "\"reliability\":" +
-                    "{" +
-                        "\"field\": 255," +
-                        "\"metadata\": \"last-message-id-x\"" +
-                    "}," +
-                    "\"correlation\":" +
-                    "{" +
-                        "\"headers\":" +
-                    "   {" +
-                            "\"service\":\"zilla:service-x\"," +
-                            "\"method\":\"zilla:method-x\"," +
-                            "\"correlation-id\":\"zilla:correlation-id-x\"" +
-                        "}" +
-                    "}" +
-                "}";
+        String yaml =
+                """
+                reliability:
+                  field: 255
+                  metadata: last-message-id-x
+                correlation:
+                  headers:
+                    service: zilla:service-x
+                    method: zilla:method-x
+                    correlation-id: zilla:correlation-id-x
+                """;
 
-        GrpcKafkaOptionsConfig options = jsonb.fromJson(text, GrpcKafkaOptionsConfig.class);
+        GrpcKafkaOptionsConfig options = jsonb.fromJson(yaml, GrpcKafkaOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.correlation, not(nullValue()));
@@ -91,30 +89,22 @@ public class GrpcKafkaOptionsConfigAdapterTest
                     new String16FW("zilla:x-method"),
                     new String16FW("zilla:x-reply-to")));
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo(
-                "{" +
-                    "\"reliability\":" +
-                    "{" +
-                        "\"field\":255," +
-                        "\"metadata\":\"x-last-message-id\"" +
-                    "}," +
-                    "\"idempotency\":" +
-                    "{" +
-                        "\"metadata\":\"x-idempotency-key\"" +
-                    "}," +
-                    "\"correlation\":" +
-                    "{" +
-                        "\"headers\":" +
-                        "{" +
-                            "\"service\":\"zilla:x-service\"," +
-                            "\"method\":\"zilla:x-method\"," +
-                            "\"correlation-id\":\"zilla:x-correlation-id\"," +
-                            "\"reply-to\":\"zilla:x-reply-to\"" +
-                        "}" +
-                    "}" +
-                "}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                reliability:
+                  field: 255
+                  metadata: x-last-message-id
+                idempotency:
+                  metadata: x-idempotency-key
+                correlation:
+                  headers:
+                    service: "zilla:x-service"
+                    method: "zilla:x-method"
+                    correlation-id: "zilla:x-correlation-id"
+                    reply-to: "zilla:x-reply-to"
+                """));
     }
 }

--- a/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcOptionsConfigAdapterTest.java
+++ b/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcOptionsConfigAdapterTest.java
@@ -41,6 +41,7 @@ import io.aklivity.zilla.runtime.binding.grpc.config.GrpcMethodConfig;
 import io.aklivity.zilla.runtime.binding.grpc.config.GrpcOptionsConfig;
 import io.aklivity.zilla.runtime.binding.grpc.config.GrpcProtobufConfig;
 import io.aklivity.zilla.runtime.binding.grpc.config.GrpcServiceConfig;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 import io.aklivity.zilla.runtime.engine.config.ConfigAdapterContext;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfigAdapter;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfigAdapterSpi;
@@ -71,18 +72,22 @@ public class GrpcOptionsConfigAdapterTest
         adapter.adaptType("grpc");
         JsonbConfig config = new JsonbConfig()
             .withAdapters(adapter);
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+            .withProvider(YamlJson.provider())
+            .withConfig(config)
+            .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
-        String text =
-            "{" +
-                "\"services\": [\"protobuf/echo.proto\"]" +
-            "}";
+        String yaml =
+            """
+            services:
+              - protobuf/echo.proto
+            """;
 
-        GrpcOptionsConfig options = jsonb.fromJson(text, GrpcOptionsConfig.class);
+        GrpcOptionsConfig options = jsonb.fromJson(yaml, GrpcOptionsConfig.class);
         GrpcProtobufConfig protobuf = options.protobufs.stream().findFirst().get();
         GrpcServiceConfig service = protobuf.services.stream().findFirst().get();
         GrpcMethodConfig method = service.methods.stream().filter(m -> "EchoUnary".equals(m.method)).findFirst().get();
@@ -99,9 +104,13 @@ public class GrpcOptionsConfigAdapterTest
         GrpcOptionsConfig options = new GrpcOptionsConfig(Arrays.asList(
             new GrpcProtobufConfig("protobuf/echo.proto", Collections.emptySet())));
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertEquals("{\"services\":[\"protobuf/echo.proto\"]}", text);
+        assertThat(yaml, not(nullValue()));
+        assertEquals(
+            """
+            services:
+              - protobuf/echo.proto
+            """, yaml);
     }
 }

--- a/runtime/binding-http-kafka/src/test/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaOptionsConfigAdapterTest.java
+++ b/runtime/binding-http-kafka/src/test/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaOptionsConfigAdapterTest.java
@@ -31,6 +31,7 @@ import io.aklivity.zilla.runtime.binding.http.kafka.config.HttpKafkaIdempotencyC
 import io.aklivity.zilla.runtime.binding.http.kafka.config.HttpKafkaOptionsConfig;
 import io.aklivity.zilla.runtime.binding.http.kafka.internal.types.String16FW;
 import io.aklivity.zilla.runtime.binding.http.kafka.internal.types.String8FW;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 
 public class HttpKafkaOptionsConfigAdapterTest
 {
@@ -41,29 +42,26 @@ public class HttpKafkaOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(new HttpKafkaOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
-        String text =
-                "{" +
-                    "\"idempotency\":" +
-                    "{" +
-                        "\"header\":\"idempotency-key\"" +
-                    "}," +
-                    "\"correlation\":" +
-                    "{" +
-                        "\"headers\":" +
-                        "{" +
-                            "\"reply-to\":\"zilla:reply-to\"," +
-                            "\"correlation-id\":\"zilla:correlation-id\"" +
-                        "}" +
-                    "}" +
-                "}";
+        String yaml =
+                """
+                idempotency:
+                  header: idempotency-key
+                correlation:
+                  headers:
+                    reply-to: zilla:reply-to
+                    correlation-id: zilla:correlation-id
+                """;
 
-        HttpKafkaOptionsConfig options = jsonb.fromJson(text, HttpKafkaOptionsConfig.class);
+        HttpKafkaOptionsConfig options = jsonb.fromJson(yaml, HttpKafkaOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.idempotency, not(nullValue()));
@@ -83,23 +81,17 @@ public class HttpKafkaOptionsConfigAdapterTest
                     new String16FW("zilla:x-reply-to"),
                     new String16FW("zilla:x-correlation-id")));
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo(
-                "{" +
-                    "\"idempotency\":" +
-                    "{" +
-                        "\"header\":\"x-idempotency-key\"" +
-                    "}," +
-                    "\"correlation\":" +
-                    "{" +
-                        "\"headers\":" +
-                        "{" +
-                            "\"reply-to\":\"zilla:x-reply-to\"," +
-                            "\"correlation-id\":\"zilla:x-correlation-id\"" +
-                        "}" +
-                    "}" +
-                "}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                idempotency:
+                  header: x-idempotency-key
+                correlation:
+                  headers:
+                    reply-to: "zilla:x-reply-to"
+                    correlation-id: "zilla:x-correlation-id"
+                """));
     }
 }

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpOptionsConfigAdapterTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpOptionsConfigAdapterTest.java
@@ -42,6 +42,7 @@ import io.aklivity.zilla.runtime.binding.http.config.HttpRequestConfig;
 import io.aklivity.zilla.runtime.binding.http.config.HttpVersion;
 import io.aklivity.zilla.runtime.binding.http.internal.types.String16FW;
 import io.aklivity.zilla.runtime.binding.http.internal.types.String8FW;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 import io.aklivity.zilla.runtime.engine.test.internal.model.config.TestModelConfig;
 
 public class HttpOptionsConfigAdapterTest
@@ -53,84 +54,59 @@ public class HttpOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(new HttpOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
         // GIVEN
-        String json =
-            "{" +
-                "\"versions\":" +
-                "[" +
-                    "\"http/1.1\"," +
-                    "\"h2\"" +
-                "]," +
-                "\"access-control\":" +
-                "{" +
-                    "\"policy\": \"cross-origin\"," +
-                    "\"allow\":" +
-                    "{" +
-                        "\"origins\": [ \"https://example.com:9090\" ]," +
-                        "\"methods\": [ \"DELETE\" ]," +
-                        "\"headers\": [ \"x-api-key\" ]," +
-                        "\"credentials\": true" +
-                    "}," +
-                    "\"max-age\": 10," +
-                    "\"expose\":" +
-                    "{" +
-                        "\"headers\": [ \"x-custom-header\" ]" +
-                    "}" +
-                "}," +
-                "\"authorization\":" +
-                "{" +
-                    "\"test0\":" +
-                    "{" +
-                        "\"credentials\":" +
-                        "{" +
-                            "\"headers\":" +
-                            "{" +
-                                "\"authorization\":\"Bearer {credentials}\"" +
-                            "}" +
-                        "}" +
-                    "}" +
-                "}," +
-                "\"overrides\":" +
-                "{" +
-                    "\":authority\": \"example.com:443\"" +
-                "}," +
-                "\"requests\":" +
-                "[" +
-                    "{" +
-                        "\"path\": \"/hello\"," +
-                        "\"method\": \"GET\"," +
-                        "\"content-type\": " +
-                        "[" +
-                            "\"application/json\"" +
-                        "]," +
-                        "\"headers\": " +
-                        "{" +
-                            "\"content-type\": \"test\"" +
-                        "}," +
-                        "\"params\": " +
-                        "{" +
-                            "\"path\":" +
-                            "{" +
-                                "\"id\": \"test\"" +
-                            "}," +
-                            "\"query\":" +
-                            "{" +
-                                "\"index\": \"test\"" +
-                            "}" +
-                        "}," +
-                        "\"content\": \"test\"" +
-                     "}" +
-                "]" +
-            "}";
+        String yaml =
+            """
+            versions:
+              - http/1.1
+              - h2
+            access-control:
+              policy: cross-origin
+              allow:
+                origins:
+                  - "https://example.com:9090"
+                methods:
+                  - DELETE
+                headers:
+                  - x-api-key
+                credentials: true
+              max-age: 10
+              expose:
+                headers:
+                  - x-custom-header
+            authorization:
+              test0:
+                credentials:
+                  headers:
+                    authorization: "Bearer {credentials}"
+            overrides:
+              ":authority": "example.com:443"
+            requests:
+              - path: /hello
+                method: GET
+                content-type:
+                  - application/json
+                headers:
+                  content-type: test
+                params:
+                  path:
+                    id: test
+                  query:
+                    index: test
+                content: test
+            """;
 
         // WHEN
-        HttpOptionsConfig options = jsonb.fromJson(json, HttpOptionsConfig.class);
+        HttpOptionsConfig options = jsonb.fromJson(yaml, HttpOptionsConfig.class);
 
         // THEN
         assertThat(options, not(nullValue()));
@@ -174,74 +150,46 @@ public class HttpOptionsConfigAdapterTest
     public void shouldWriteOptions()
     {
         // GIVEN
-        String expectedJson =
-            "{" +
-                "\"versions\":" +
-                "[" +
-                    "\"http/1.1\"," +
-                    "\"h2\"" +
-                "]," +
-                "\"access-control\":" +
-                "{" +
-                    "\"policy\":\"cross-origin\"," +
-                    "\"allow\":" +
-                    "{" +
-                        "\"origins\":[\"https://example.com:9090\"]," +
-                        "\"methods\":[\"DELETE\"]," +
-                        "\"headers\":[\"x-api-key\"]," +
-                        "\"credentials\":true" +
-                    "}," +
-                    "\"max-age\":10," +
-                    "\"expose\":" +
-                    "{" +
-                        "\"headers\":[\"x-custom-header\"]" +
-                    "}" +
-                "}," +
-                "\"authorization\":" +
-                "{" +
-                    "\"test0\":" +
-                    "{" +
-                        "\"credentials\":" +
-                        "{" +
-                            "\"headers\":" +
-                            "{" +
-                                "\"authorization\":\"Bearer {credentials}\"" +
-                            "}" +
-                        "}" +
-                    "}" +
-                "}," +
-                "\"overrides\":" +
-                "{" +
-                    "\":authority\":\"example.com:443\"" +
-                "}," +
-                "\"requests\":" +
-                "[" +
-                    "{" +
-                        "\"path\":\"/hello\"," +
-                        "\"method\":\"GET\"," +
-                        "\"content-type\":" +
-                        "[" +
-                            "\"application/json\"" +
-                        "]," +
-                        "\"headers\":" +
-                        "{" +
-                            "\"content-type\":\"test\"" +
-                        "}," +
-                        "\"params\":" +
-                        "{" +
-                            "\"path\":" +
-                            "{" +
-                                "\"id\":\"test\"" +
-                            "}," +
-                            "\"query\":" +
-                            "{" +
-                                "\"index\":\"test\"" +
-                            "}" +
-                        "}," +
-                        "\"content\":\"test\"" +
-                    "}" +
-                "]" +
-            "}";
+        String expectedYaml =
+            """
+            versions:
+              - http/1.1
+              - h2
+            access-control:
+              policy: cross-origin
+              allow:
+                origins:
+                  - "https://example.com:9090"
+                methods:
+                  - DELETE
+                headers:
+                  - x-api-key
+                credentials: true
+              max-age: 10
+              expose:
+                headers:
+                  - x-custom-header
+            authorization:
+              test0:
+                credentials:
+                  headers:
+                    authorization: "Bearer {credentials}"
+            overrides:
+              ":authority": "example.com:443"
+            requests:
+              - path: /hello
+                method: GET
+                content-type:
+                  - application/json
+                headers:
+                  content-type: test
+                params:
+                  path:
+                    id: test
+                  query:
+                    index: test
+                content: test
+            """;
         HttpOptionsConfig options = HttpOptionsConfig.builder()
             .inject(identity())
             .version(HttpVersion.HTTP_1_1)
@@ -299,10 +247,10 @@ public class HttpOptionsConfigAdapterTest
             .build();
 
         // WHEN
-        String json = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
         // THEN
-        assertThat(json, not(nullValue()));
-        assertThat(json, equalTo(expectedJson));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(expectedYaml));
     }
 }

--- a/runtime/binding-kafka-grpc/src/test/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcOptionsConfigAdapterTest.java
+++ b/runtime/binding-kafka-grpc/src/test/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcOptionsConfigAdapterTest.java
@@ -32,6 +32,7 @@ import io.aklivity.zilla.runtime.binding.kafka.grpc.config.KafkaGrpcIdempotencyC
 import io.aklivity.zilla.runtime.binding.kafka.grpc.config.KafkaGrpcOptionsConfig;
 import io.aklivity.zilla.runtime.binding.kafka.grpc.internal.types.String16FW;
 import io.aklivity.zilla.runtime.binding.kafka.grpc.internal.types.String8FW;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 
 public class KafkaGrpcOptionsConfigAdapterTest
 {
@@ -42,28 +43,27 @@ public class KafkaGrpcOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(new KafkaGrpcOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
-        String text =
-                "{" +
-                    "\"acks\":\"leader_only\"," +
-                    "\"correlation\":" +
-                    "{" +
-                        "\"headers\":" +
-                        "{" +
-                            "\"service\":\"zilla:x-service\"," +
-                            "\"method\":\"zilla:x-method\"," +
-                            "\"correlation-id\":\"zilla:x-correlation-id\"," +
-                            "\"reply-to\":\"zilla:x-reply-to\"" +
-                        "}" +
-                    "}" +
-                "}";
+        String yaml =
+                """
+                acks: leader_only
+                correlation:
+                  headers:
+                    service: zilla:x-service
+                    method: zilla:x-method
+                    correlation-id: zilla:x-correlation-id
+                    reply-to: zilla:x-reply-to
+                """;
 
-        KafkaGrpcOptionsConfig options = jsonb.fromJson(text, KafkaGrpcOptionsConfig.class);
+        KafkaGrpcOptionsConfig options = jsonb.fromJson(yaml, KafkaGrpcOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.acks, equalTo(LEADER_ONLY));
@@ -86,26 +86,20 @@ public class KafkaGrpcOptionsConfigAdapterTest
                     new String16FW("zilla:x-method"),
                     new String16FW("zilla:x-reply-to")));
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo(
-                "{" +
-                    "\"acks\":\"leader_only\"," +
-                    "\"idempotency\":" +
-                    "{" +
-                        "\"metadata\":\"zilla:x-idempotency-key\"" +
-                    "}," +
-                    "\"correlation\":" +
-                    "{" +
-                        "\"headers\":" +
-                        "{" +
-                            "\"service\":\"zilla:x-service\"," +
-                            "\"method\":\"zilla:x-method\"," +
-                            "\"correlation-id\":\"zilla:x-correlation-id\"," +
-                            "\"reply-to\":\"zilla:x-reply-to\"" +
-                        "}" +
-                    "}" +
-                "}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                acks: leader_only
+                idempotency:
+                  metadata: "zilla:x-idempotency-key"
+                correlation:
+                  headers:
+                    service: "zilla:x-service"
+                    method: "zilla:x-method"
+                    correlation-id: "zilla:x-correlation-id"
+                    reply-to: "zilla:x-reply-to"
+                """));
     }
 }

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaOptionsConfigAdapterTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaOptionsConfigAdapterTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 import io.aklivity.zilla.runtime.binding.kafka.config.KafkaOptionsConfig;
 import io.aklivity.zilla.runtime.binding.kafka.config.KafkaTopicConfig;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 import io.aklivity.zilla.runtime.engine.test.internal.model.config.TestModelConfig;
 
 public class KafkaOptionsConfigAdapterTest
@@ -44,35 +45,30 @@ public class KafkaOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(new KafkaOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
-        String text =
-                "{" +
-                    "\"bootstrap\":" +
-                    "[" +
-                        "\"test\"" +
-                    "]," +
-                    "\"topics\":" +
-                    "[" +
-                        "{" +
-                            "\"name\": \"test\"," +
-                            "\"defaultOffset\": \"live\"," +
-                            "\"deltaType\": \"json_patch\"" +
-                        "}" +
-                    "]," +
-                    "\"sasl\":" +
-                    "{" +
-                        "\"mechanism\": \"plain\"," +
-                        "\"username\": \"username\"," +
-                        "\"password\": \"password\"" +
-                    "}" +
-                "}";
+        String yaml =
+                """
+                bootstrap:
+                  - test
+                topics:
+                  - name: test
+                    defaultOffset: live
+                    deltaType: json_patch
+                sasl:
+                  mechanism: plain
+                  username: username
+                  password: password
+                """;
 
-        KafkaOptionsConfig options = jsonb.fromJson(text, KafkaOptionsConfig.class);
+        KafkaOptionsConfig options = jsonb.fromJson(yaml, KafkaOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.bootstrap, equalTo(singletonList("test")));
@@ -105,42 +101,45 @@ public class KafkaOptionsConfigAdapterTest
                 .build()
             .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"bootstrap\":[\"test\"]," +
-                "\"topics\":[{\"name\":\"test\",\"defaultOffset\":\"live\",\"deltaType\":\"json_patch\"," +
-                "\"value\":\"test\"}]," +
-                "\"servers\":[\"localhost:9092\"]," +
-                "\"sasl\":{\"mechanism\":\"plain\",\"username\":\"username\",\"password\":\"password\"}}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                bootstrap:
+                  - test
+                topics:
+                  - name: test
+                    defaultOffset: live
+                    deltaType: json_patch
+                    value: test
+                servers:
+                  - "localhost:9092"
+                sasl:
+                  mechanism: plain
+                  username: username
+                  password: password
+                """));
     }
 
     @Test
     public void shouldReadSaslScramOptions()
     {
-        String text =
-                "{" +
-                        "\"bootstrap\":" +
-                        "[" +
-                        "\"test\"" +
-                        "]," +
-                        "\"topics\":" +
-                        "[" +
-                        "{" +
-                        "\"name\": \"test\"," +
-                        "\"defaultOffset\": \"live\"," +
-                        "\"deltaType\": \"json_patch\"" +
-                        "}" +
-                        "]," +
-                        "\"sasl\":" +
-                        "{" +
-                        "\"mechanism\": \"scram-sha-256\"," +
-                        "\"username\": \"username\"," +
-                        "\"password\": \"password\"" +
-                        "}" +
-                        "}";
+        String yaml =
+                """
+                bootstrap:
+                  - test
+                topics:
+                  - name: test
+                    defaultOffset: live
+                    deltaType: json_patch
+                sasl:
+                  mechanism: scram-sha-256
+                  username: username
+                  password: password
+                """;
 
-        KafkaOptionsConfig options = jsonb.fromJson(text, KafkaOptionsConfig.class);
+        KafkaOptionsConfig options = jsonb.fromJson(yaml, KafkaOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.bootstrap, equalTo(singletonList("test")));
@@ -172,13 +171,24 @@ public class KafkaOptionsConfigAdapterTest
                 .build()
             .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"bootstrap\":[\"test\"]," +
-                "\"topics\":[{\"name\":\"test\",\"defaultOffset\":\"live\",\"deltaType\":\"json_patch\"}]," +
-                "\"servers\":[\"localhost:9092\"]," +
-                "\"sasl\":{\"mechanism\":\"scram-sha-256\",\"username\":\"username\",\"password\":\"password\"}}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                bootstrap:
+                  - test
+                topics:
+                  - name: test
+                    defaultOffset: live
+                    deltaType: json_patch
+                servers:
+                  - "localhost:9092"
+                sasl:
+                  mechanism: scram-sha-256
+                  username: username
+                  password: password
+                """));
     }
 
     @Test
@@ -203,44 +213,43 @@ public class KafkaOptionsConfigAdapterTest
                 .build()
             .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"bootstrap\":[\"test\"]," +
-                "\"topics\":[{\"name\":\"test\",\"defaultOffset\":\"live\",\"deltaType\":\"json_patch\"," +
-                "\"value\":\"test\"}]," +
-                "\"servers\":[\"localhost:9092\"]," +
-                "\"sasl\":{\"mechanism\":\"plain\",\"username\":\"username\",\"password\":\"password\"}}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                bootstrap:
+                  - test
+                topics:
+                  - name: test
+                    defaultOffset: live
+                    deltaType: json_patch
+                    value: test
+                servers:
+                  - "localhost:9092"
+                sasl:
+                  mechanism: plain
+                  username: username
+                  password: password
+                """));
     }
 
     @Test
     public void shouldReadHeadersOptions()
     {
-        String text =
-            "{" +
-                "\"bootstrap\":" +
-                "[" +
-                    "\"test\"" +
-                "]," +
-                "\"topics\":" +
-                "[" +
-                    "{" +
-                        "\"name\": \"test\"," +
-                        "\"transforms\":" +
-                        "[" +
-                            "{" +
-                                "\"extract-key\": \"${message.key.id}\"," +
-                                "\"extract-headers\":" +
-                                "{" +
-                                    "\"correlation-id\": \"${message.value.correlationId}\"" +
-                                "}" +
-                            "}" +
-                        "]" +
-                    "}" +
-                "]" +
-            "}";
+        String yaml =
+            """
+            bootstrap:
+              - test
+            topics:
+              - name: test
+                transforms:
+                  - extract-key: ${message.key.id}
+                    extract-headers:
+                      correlation-id: ${message.value.correlationId}
+            """;
 
-        KafkaOptionsConfig options = jsonb.fromJson(text, KafkaOptionsConfig.class);
+        KafkaOptionsConfig options = jsonb.fromJson(yaml, KafkaOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.bootstrap, equalTo(singletonList("test")));
@@ -262,33 +271,35 @@ public class KafkaOptionsConfigAdapterTest
                 .build()
             .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"bootstrap\":[\"test\"],\"topics\":[{\"name\":\"test\",\"value\":\"test\"," +
-            "\"transforms\":{\"extract-headers\":{\"correlation-id\":\"${message.value.correlationId}\"}}}]}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                bootstrap:
+                  - test
+                topics:
+                  - name: test
+                    value: test
+                    transforms:
+                      extract-headers:
+                        correlation-id: "${message.value.correlationId}"
+                """));
     }
 
     @Test
     public void shouldReadAuthorizationOptions()
     {
-        String text = """
-                {
-                    "authorization":
-                    {
-                        "guard0":
-                        {
-                            "credentials":
-                            {
-                                "mechanism": "scram-sha-512",
-                                "username": "{identity}",
-                                "password": "{credentials}"
-                            }
-                        }
-                    }
-                }""";
+        String yaml = """
+                authorization:
+                  guard0:
+                    credentials:
+                      mechanism: scram-sha-512
+                      username: "{identity}"
+                      password: "{credentials}"
+                """;
 
-        KafkaOptionsConfig options = jsonb.fromJson(text, KafkaOptionsConfig.class);
+        KafkaOptionsConfig options = jsonb.fromJson(yaml, KafkaOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.authorization, not(nullValue()));
@@ -313,24 +324,17 @@ public class KafkaOptionsConfigAdapterTest
             .build();
 
         String expected = """
-                {
-                    "authorization":
-                    {
-                        "guard0":
-                        {
-                            "credentials":
-                            {
-                                "mechanism":"scram-sha-512",
-                                "username":"{identity}",
-                                "password":"{credentials}"
-                            }
-                        }
-                    }
-                }""".replaceAll("\\s*\\n\\s*", "");
+                authorization:
+                  guard0:
+                    credentials:
+                      mechanism: scram-sha-512
+                      username: "{identity}"
+                      password: "{credentials}"
+                """;
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo(expected));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(expected));
     }
 }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpOptionsConfigAdapterTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpOptionsConfigAdapterTest.java
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.aklivity.zilla.runtime.binding.mcp.config.McpOptionsConfig;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfig;
 
 public class McpOptionsConfigAdapterTest
@@ -40,13 +41,20 @@ public class McpOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(new McpOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
     public void shouldReadOptionsWithElicitationTimeout()
     {
-        String text = "{\"elicitation\":{\"timeout\":\"PT30S\"}}";
+        String text =
+                """
+                elicitation:
+                  timeout: PT30S
+                """;
 
         McpOptionsConfig options = (McpOptionsConfig) jsonb.fromJson(text, OptionsConfig.class);
 
@@ -67,13 +75,21 @@ public class McpOptionsConfigAdapterTest
         String text = jsonb.toJson(options);
 
         assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"elicitation\":{\"callback\":\"auth/callback\",\"timeout\":\"PT30S\"}}"));
+        assertThat(text, equalTo(
+                """
+                elicitation:
+                  callback: auth/callback
+                  timeout: PT30S
+                """));
     }
 
     @Test
     public void shouldReadOptionsWithServer()
     {
-        String text = "{\"server\":\"http://localhost:8080/mcp\"}";
+        String text =
+                """
+                server: http://localhost:8080/mcp
+                """;
 
         McpOptionsConfig options = (McpOptionsConfig) jsonb.fromJson(text, OptionsConfig.class);
 
@@ -91,6 +107,9 @@ public class McpOptionsConfigAdapterTest
         String text = jsonb.toJson(options);
 
         assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"server\":\"http://localhost:8080/mcp\"}"));
+        assertThat(text, equalTo(
+                """
+                server: "http://localhost:8080/mcp"
+                """));
     }
 }

--- a/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaOptionsConfigAdapterTest.java
+++ b/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaOptionsConfigAdapterTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import io.aklivity.zilla.runtime.binding.mqtt.kafka.config.MqttKafkaOptionsConfig;
 import io.aklivity.zilla.runtime.binding.mqtt.kafka.config.MqttKafkaTopicsConfig;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 
 public class MqttKafkaOptionsConfigAdapterTest
 {
@@ -40,27 +41,26 @@ public class MqttKafkaOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
             .withAdapters(new MqttKafkaOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+            .withProvider(YamlJson.provider())
+            .withConfig(config)
+            .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
         String text =
-            "{" +
-                "\"server\":\"mqtt-1.example.com:1883\"," +
-                "\"topics\":" +
-                "{" +
-                    "\"sessions\":\"sessions\"," +
-                    "\"messages\":\"messages\"," +
-                    "\"retained\":\"retained\"" +
-                "}," +
-                "\"clients\":" +
-                "[" +
-                    "\"/clients/{identity}/#\"," +
-                    "\"/department/clients/{identity}/#\"" +
-                "]" +
-            "}";
+            """
+            server: mqtt-1.example.com:1883
+            topics:
+              sessions: sessions
+              messages: messages
+              retained: retained
+            clients:
+              - /clients/{identity}/#
+              - /department/clients/{identity}/#
+            """;
 
         MqttKafkaOptionsConfig options = jsonb.fromJson(text, MqttKafkaOptionsConfig.class);
 
@@ -93,34 +93,28 @@ public class MqttKafkaOptionsConfigAdapterTest
 
         assertThat(text, not(nullValue()));
         assertThat(text, equalTo(
-                "{" +
-                "\"server\":\"mqtt-1.example.com:1883\"," +
-                "\"topics\":" +
-                "{" +
-                    "\"sessions\":\"sessions\"," +
-                    "\"messages\":\"messages\"," +
-                    "\"retained\":\"retained\"" +
-                "}," +
-                "\"clients\":" +
-                "[" +
-                    "\"/clients/{identity}/#\"," +
-                    "\"/department/clients/{identity}/#\"" +
-                "]" +
-            "}"));
+            """
+            server: "mqtt-1.example.com:1883"
+            topics:
+              sessions: sessions
+              messages: messages
+              retained: retained
+            clients:
+              - "/clients/{identity}/#"
+              - "/department/clients/{identity}/#"
+            """));
     }
 
     @Test
     public void shouldReadOptionsWithoutClients()
     {
         String text =
-            "{" +
-                "\"topics\":" +
-                "{" +
-                    "\"sessions\":\"sessions\"," +
-                    "\"messages\":\"messages\"," +
-                    "\"retained\":\"retained\"" +
-                "}" +
-            "}";
+            """
+            topics:
+              sessions: sessions
+              messages: messages
+              retained: retained
+            """;
 
         MqttKafkaOptionsConfig options = jsonb.fromJson(text, MqttKafkaOptionsConfig.class);
 
@@ -146,13 +140,11 @@ public class MqttKafkaOptionsConfigAdapterTest
 
         assertThat(text, not(nullValue()));
         assertThat(text, equalTo(
-            "{" +
-                    "\"topics\":" +
-                    "{" +
-                        "\"sessions\":\"sessions\"," +
-                        "\"messages\":\"messages\"," +
-                        "\"retained\":\"retained\"" +
-                    "}" +
-                "}"));
+            """
+            topics:
+              sessions: sessions
+              messages: messages
+              retained: retained
+            """));
     }
 }

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttOptionsConfigAdapterTest.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttOptionsConfigAdapterTest.java
@@ -40,6 +40,7 @@ import io.aklivity.zilla.runtime.binding.mqtt.config.MqttOptionsConfig;
 import io.aklivity.zilla.runtime.binding.mqtt.config.MqttPatternConfig;
 import io.aklivity.zilla.runtime.binding.mqtt.config.MqttTopicConfig;
 import io.aklivity.zilla.runtime.binding.mqtt.config.MqttUserPropertyConfig;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 import io.aklivity.zilla.runtime.engine.test.internal.model.config.TestModelConfig;
 
 public class MqttOptionsConfigAdapterTest
@@ -51,44 +52,31 @@ public class MqttOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(new MqttOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
         String text =
-                "{" +
-                    "\"versions\":" +
-                    "[" +
-                        "\"v3.1.1\"," +
-                        "\"v5\"" +
-                    "]," +
-                    "\"authorization\":" +
-                    "{" +
-                        "\"test0\":" +
-                        "{" +
-                            "\"credentials\":" +
-                            "{" +
-                                "\"connect\":" +
-                                "{" +
-                                    "\"username\":\"Bearer {credentials}\"" +
-                                "}" +
-                            "}" +
-                        "}" +
-                    "}," +
-                    "\"topics\":" +
-                    "[" +
-                        "{" +
-                            "\"name\": \"sensor/one\"," +
-                            "\"content\":\"test\"," +
-                            "\"user-properties\":" +
-                            "{" +
-                                "\"user-property\":\"test\"" +
-                            "}" +
-                        "}" +
-                    "]" +
-                "}";
+                """
+                versions:
+                  - v3.1.1
+                  - v5
+                authorization:
+                  test0:
+                    credentials:
+                      connect:
+                        username: "Bearer {credentials}"
+                topics:
+                  - name: sensor/one
+                    content: test
+                    user-properties:
+                      user-property: test
+                """;
 
         MqttOptionsConfig options = jsonb.fromJson(text, MqttOptionsConfig.class);
 
@@ -146,36 +134,20 @@ public class MqttOptionsConfigAdapterTest
 
         assertThat(text, not(nullValue()));
         assertThat(text, equalTo(
-                    "{" +
-                        "\"authorization\":" +
-                        "{" +
-                            "\"test0\":" +
-                            "{" +
-                                "\"credentials\":" +
-                                "{" +
-                                    "\"connect\":" +
-                                    "{" +
-                                        "\"username\":\"Bearer {credentials}\"" +
-                                    "}" +
-                                "}" +
-                            "}" +
-                        "}," +
-                        "\"topics\":" +
-                        "[" +
-                            "{" +
-                                "\"name\":\"sensor/one\"," +
-                                "\"content\":\"test\"," +
-                                "\"user-properties\":" +
-                                "{" +
-                                    "\"user-property\":\"test\"" +
-                                "}" +
-                            "}" +
-                        "]," +
-                        "\"versions\":" +
-                        "[" +
-                            "\"v3.1.1\"," +
-                            "\"v5\"" +
-                        "]" +
-                    "}"));
+                """
+                authorization:
+                  test0:
+                    credentials:
+                      connect:
+                        username: "Bearer {credentials}"
+                topics:
+                  - name: sensor/one
+                    content: test
+                    user-properties:
+                      user-property: test
+                versions:
+                  - v3.1.1
+                  - v5
+                """));
     }
 }

--- a/runtime/binding-openapi-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiOptionsConfigAdapterTest.java
+++ b/runtime/binding-openapi-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiOptionsConfigAdapterTest.java
@@ -40,6 +40,7 @@ import io.aklivity.zilla.runtime.binding.openapi.asyncapi.config.OpenapiAsyncapi
 import io.aklivity.zilla.runtime.binding.openapi.asyncapi.config.OpenapiAsyncapiSpecConfig;
 import io.aklivity.zilla.runtime.binding.openapi.config.OpenapiCatalogConfig;
 import io.aklivity.zilla.runtime.binding.openapi.config.OpenapiSpecificationConfig;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 import io.aklivity.zilla.runtime.engine.config.ConfigAdapterContext;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfigAdapter;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfigAdapterSpi;
@@ -60,37 +61,31 @@ public class OpenapiAsyncapiOptionsConfigAdapterTest
         adapter.adaptType("openapi-asyncapi");
         JsonbConfig config = new JsonbConfig()
             .withAdapters(adapter);
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+            .withProvider(YamlJson.provider())
+            .withConfig(config)
+            .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
         String text =
-            "{" +
-                "  \"specs\": {" +
-                "    \"openapi\": {" +
-                "      \"openapi-id\": {" +
-                "        \"catalog\": {" +
-                "          \"catalog0\": {" +
-                "            \"subject\": \"petstore\"," +
-                "            \"version\": \"latest\"" +
-                "          }" +
-                "        }" +
-                "      }" +
-                "    }," +
-                "    \"asyncapi\": {" +
-                "      \"asyncapi-id\": {" +
-                "        \"catalog\": {" +
-                "          \"catalog0\": {" +
-                "            \"subject\": \"petstore\"," +
-                "            \"version\": \"latest\"" +
-                "          }" +
-                "        }" +
-                "      }" +
-                "    }" +
-                "  }" +
-                "}";
+            """
+            specs:
+              openapi:
+                openapi-id:
+                  catalog:
+                    catalog0:
+                      subject: petstore
+                      version: latest
+              asyncapi:
+                asyncapi-id:
+                  catalog:
+                    catalog0:
+                      subject: petstore
+                      version: latest
+            """;
 
         OpenapiAsyncapiOptionsConfig options = jsonb.fromJson(text, OpenapiAsyncapiOptionsConfig.class);
         assertThat(options, not(nullValue()));
@@ -105,9 +100,22 @@ public class OpenapiAsyncapiOptionsConfigAdapterTest
     @Test
     public void shouldWriteOptions()
     {
-        String expected = "{\"specs\":{\"openapi\":{\"openapi-id\":{\"catalog\":{\"catalog0\":{\"subject\":\"petstore\"," +
-            "\"version\":\"latest\"}}}},\"asyncapi\":{\"asyncapi-id\":{\"catalog\":" +
-            "{\"catalog0\":{\"subject\":\"petstore\",\"version\":\"latest\"}}}}}}";
+        String expected =
+            """
+            specs:
+              openapi:
+                openapi-id:
+                  catalog:
+                    catalog0:
+                      subject: petstore
+                      version: latest
+              asyncapi:
+                asyncapi-id:
+                  catalog:
+                    catalog0:
+                      subject: petstore
+                      version: latest
+            """;
 
         Set<OpenapiSpecificationConfig> openapiConfigs = new HashSet<>();
         openapiConfigs.add(new OpenapiSpecificationConfig("openapi-id",

--- a/runtime/binding-openapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiOptionsConfigAdapterTest.java
+++ b/runtime/binding-openapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiOptionsConfigAdapterTest.java
@@ -39,6 +39,7 @@ import io.aklivity.zilla.runtime.binding.openapi.config.OpenapiOptionsConfig;
 import io.aklivity.zilla.runtime.binding.openapi.config.OpenapiSpecificationConfig;
 import io.aklivity.zilla.runtime.binding.tcp.config.TcpOptionsConfig;
 import io.aklivity.zilla.runtime.binding.tls.config.TlsOptionsConfig;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 import io.aklivity.zilla.runtime.engine.config.ConfigAdapterContext;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfigAdapter;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfigAdapterSpi;
@@ -59,50 +60,39 @@ public class OpenapiOptionsConfigAdapterTest
         adapter.adaptType("openapi");
         JsonbConfig config = new JsonbConfig()
             .withAdapters(adapter);
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+            .withProvider(YamlJson.provider())
+            .withConfig(config)
+            .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
         String text =
-            "{" +
-            "\"specs\": {" +
-            "    \"petstore\": {" +
-            "      \"catalog\": {" +
-            "        \"catalog0\": {" +
-            "          \"subject\": \"petstore\"," +
-            "          \"version\": \"latest\"" +
-            "        }" +
-            "      }" +
-            "    }" +
-            "  }," +
-            "    \"tls\": {" +
-            "      \"keys\": [" +
-            "        \"localhost\"" +
-            "      ]," +
-            "      \"alpn\": [" +
-            "        \"localhost\"" +
-            "      ]" +
-            "    }," +
-            "    \"http\": {" +
-            "      \"authorization\": {" +
-            "        \"test0\": {" +
-            "          \"credentials\": {" +
-            "            \"cookies\": {" +
-            "              \"access_token\": \"{credentials}\"" +
-            "            }," +
-            "            \"headers\": {" +
-            "              \"authorization\": \"Bearer {credentials}\"" +
-            "            }," +
-            "            \"query\": {" +
-            "              \"access_token\": \"{credentials}\"" +
-            "            }" +
-            "          }" +
-            "        }" +
-            "      }" +
-            "    }" +
-            "  }";
+            """
+            specs:
+              petstore:
+                catalog:
+                  catalog0:
+                    subject: petstore
+                    version: latest
+            tls:
+              keys:
+                - localhost
+              alpn:
+                - localhost
+            http:
+              authorization:
+                test0:
+                  credentials:
+                    cookies:
+                      access_token: "{credentials}"
+                    headers:
+                      authorization: "Bearer {credentials}"
+                    query:
+                      access_token: "{credentials}"
+            """;
 
         OpenapiOptionsConfig options = jsonb.fromJson(text, OpenapiOptionsConfig.class);
 
@@ -112,8 +102,21 @@ public class OpenapiOptionsConfigAdapterTest
     @Test
     public void shouldWriteOptions()
     {
-        String expected = "{\"tcp\":{\"host\":\"localhost\",\"port\":8080},\"tls\":{\"sni\":[\"example.net\"]}," +
-            "\"specs\":{\"test\":{\"catalog\":{\"catalog0\":{\"subject\":\"petstore\",\"version\":\"latest\"}}}}}";
+        String expected =
+            """
+            tcp:
+              host: localhost
+              port: 8080
+            tls:
+              sni:
+                - example.net
+            specs:
+              test:
+                catalog:
+                  catalog0:
+                    subject: petstore
+                    version: latest
+            """;
 
         TcpOptionsConfig tcp = TcpOptionsConfig.builder()
             .inject(identity())

--- a/runtime/binding-proxy/src/test/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyOptionsConfigAdapterTest.java
+++ b/runtime/binding-proxy/src/test/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyOptionsConfigAdapterTest.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.aklivity.zilla.runtime.binding.proxy.config.ProxyOptionsConfig;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 
 public class ProxyOptionsConfigAdapterTest
 {
@@ -38,7 +39,10 @@ public class ProxyOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(new ProxyOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
@@ -59,6 +63,9 @@ public class ProxyOptionsConfigAdapterTest
         String text = jsonb.toJson(options);
 
         assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{}"));
+        assertThat(text, equalTo(
+                """
+                {}
+                """));
     }
 }

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseOptionsConfigAdapterTest.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseOptionsConfigAdapterTest.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.aklivity.zilla.runtime.binding.sse.config.SseOptionsConfig;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 
 public class SseOptionsConfigAdapterTest
 {
@@ -38,16 +39,19 @@ public class SseOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(new SseOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
         String text =
-                "{" +
-                    "\"retry\": 3000" +
-                "}";
+                """
+                retry: 3000
+                """;
 
         SseOptionsConfig options = jsonb.fromJson(text, SseOptionsConfig.class);
 
@@ -63,6 +67,9 @@ public class SseOptionsConfigAdapterTest
         String text = jsonb.toJson(options);
 
         assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"retry\":3000}"));
+        assertThat(text, equalTo(
+                """
+                retry: 3000
+                """));
     }
 }

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpOptionsConfigAdapterTest.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpOptionsConfigAdapterTest.java
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.aklivity.zilla.runtime.binding.tcp.config.TcpOptionsConfig;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 
 public class TcpOptionsConfigAdapterTest
 {
@@ -39,19 +40,22 @@ public class TcpOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(new TcpOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
-        String text =
-                "{" +
-                    "\"host\": \"localhost\"," +
-                    "\"port\": 12345" +
-                "}";
+        String yaml =
+                """
+                host: localhost
+                port: 12345
+                """;
 
-        TcpOptionsConfig options = jsonb.fromJson(text, TcpOptionsConfig.class);
+        TcpOptionsConfig options = jsonb.fromJson(yaml, TcpOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.host, equalTo("localhost"));
@@ -63,13 +67,13 @@ public class TcpOptionsConfigAdapterTest
     @Test
     public void shouldReadOptionsWithPortRange()
     {
-        String text =
-                "{" +
-                    "\"host\": \"localhost\"," +
-                    "\"port\": \"12345-12346\"" +
-                "}";
+        String yaml =
+                """
+                host: localhost
+                port: "12345-12346"
+                """;
 
-        TcpOptionsConfig options = jsonb.fromJson(text, TcpOptionsConfig.class);
+        TcpOptionsConfig options = jsonb.fromJson(yaml, TcpOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.host, equalTo("localhost"));
@@ -82,13 +86,13 @@ public class TcpOptionsConfigAdapterTest
     @Test
     public void shouldReadOptionsWithPortRangeSingleton()
     {
-        String text =
-                "{" +
-                    "\"host\": \"localhost\"," +
-                    "\"port\": \"12345\"" +
-                "}";
+        String yaml =
+                """
+                host: localhost
+                port: "12345"
+                """;
 
-        TcpOptionsConfig options = jsonb.fromJson(text, TcpOptionsConfig.class);
+        TcpOptionsConfig options = jsonb.fromJson(yaml, TcpOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.host, equalTo("localhost"));
@@ -106,23 +110,27 @@ public class TcpOptionsConfigAdapterTest
             .ports(new int[] { 12345 })
             .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"host\":\"localhost\",\"port\":12345}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                host: localhost
+                port: 12345
+                """));
     }
 
     @Test
     public void shouldReadOptionsWithBacklog()
     {
-        String text =
-                "{" +
-                    "\"host\": \"localhost\"," +
-                    "\"port\": 12345," +
-                    "\"backlog\": 1000" +
-                "}";
+        String yaml =
+                """
+                host: localhost
+                port: 12345
+                backlog: 1000
+                """;
 
-        TcpOptionsConfig options = jsonb.fromJson(text, TcpOptionsConfig.class);
+        TcpOptionsConfig options = jsonb.fromJson(yaml, TcpOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.host, equalTo("localhost"));
@@ -142,9 +150,14 @@ public class TcpOptionsConfigAdapterTest
                 .backlog(1000)
                 .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"host\":\"localhost\",\"port\":12345,\"backlog\":1000}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                host: localhost
+                port: 12345
+                backlog: 1000
+                """));
     }
 }

--- a/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsOptionsConfigAdapterTest.java
+++ b/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsOptionsConfigAdapterTest.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.aklivity.zilla.runtime.binding.tls.config.TlsOptionsConfig;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 
 public class TlsOptionsConfigAdapterTest
 {
@@ -41,18 +42,21 @@ public class TlsOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(new TlsOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
-        String text =
-                "{" +
-                    "\"version\": \"TLSv1.2\"" +
-                "}";
+        String yaml =
+                """
+                version: TLSv1.2
+                """;
 
-        TlsOptionsConfig options = jsonb.fromJson(text, TlsOptionsConfig.class);
+        TlsOptionsConfig options = jsonb.fromJson(yaml, TlsOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.version, equalTo("TLSv1.2"));
@@ -66,21 +70,25 @@ public class TlsOptionsConfigAdapterTest
             .version("TLSv1.2")
             .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"version\":\"TLSv1.2\"}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                version: TLSv1.2
+                """));
     }
 
     @Test
     public void shouldReadOptionsWithKeys()
     {
-        String text =
-                "{" +
-                    "\"trust\": [ \"serverca\" ]" +
-                "}";
+        String yaml =
+                """
+                trust:
+                  - serverca
+                """;
 
-        TlsOptionsConfig options = jsonb.fromJson(text, TlsOptionsConfig.class);
+        TlsOptionsConfig options = jsonb.fromJson(yaml, TlsOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.trust, equalTo(asList("serverca")));
@@ -94,21 +102,26 @@ public class TlsOptionsConfigAdapterTest
                 .keys(asList("localhost"))
                 .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"keys\":[\"localhost\"]}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                keys:
+                  - localhost
+                """));
     }
 
     @Test
     public void shouldReadOptionsWithTrust()
     {
-        String text =
-                "{" +
-                    "\"trust\": [ \"serverca\" ]" +
-                "}";
+        String yaml =
+                """
+                trust:
+                  - serverca
+                """;
 
-        TlsOptionsConfig options = jsonb.fromJson(text, TlsOptionsConfig.class);
+        TlsOptionsConfig options = jsonb.fromJson(yaml, TlsOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.trust, equalTo(asList("serverca")));
@@ -122,21 +135,25 @@ public class TlsOptionsConfigAdapterTest
             .trust(asList("serverca"))
             .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"trust\":[\"serverca\"]}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                trust:
+                  - serverca
+                """));
     }
 
     @Test
     public void shouldReadOptionsWithTrustcacerts()
     {
-        String text =
-                "{" +
-                    "\"trustcacerts\": true" +
-                "}";
+        String yaml =
+                """
+                trustcacerts: true
+                """;
 
-        TlsOptionsConfig options = jsonb.fromJson(text, TlsOptionsConfig.class);
+        TlsOptionsConfig options = jsonb.fromJson(yaml, TlsOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.trustcacerts, equalTo(true));
@@ -150,21 +167,25 @@ public class TlsOptionsConfigAdapterTest
             .trustcacerts(false)
             .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"trustcacerts\":false}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                trustcacerts: false
+                """));
     }
 
     @Test
     public void shouldReadOptionsWithServerName()
     {
-        String text =
-                "{" +
-                    "\"sni\": [ \"example.net\" ]" +
-                "}";
+        String yaml =
+                """
+                sni:
+                  - example.net
+                """;
 
-        TlsOptionsConfig options = jsonb.fromJson(text, TlsOptionsConfig.class);
+        TlsOptionsConfig options = jsonb.fromJson(yaml, TlsOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.sni, equalTo(asList("example.net")));
@@ -178,21 +199,26 @@ public class TlsOptionsConfigAdapterTest
             .sni(asList("example.net"))
             .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"sni\":[\"example.net\"]}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                sni:
+                  - example.net
+                """));
     }
 
     @Test
     public void shouldReadOptionsWithAlpn()
     {
-        String text =
-                "{" +
-                    "\"alpn\": [ \"echo\" ]" +
-                "}";
+        String yaml =
+                """
+                alpn:
+                  - echo
+                """;
 
-        TlsOptionsConfig options = jsonb.fromJson(text, TlsOptionsConfig.class);
+        TlsOptionsConfig options = jsonb.fromJson(yaml, TlsOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.alpn, equalTo(asList("echo")));
@@ -206,21 +232,25 @@ public class TlsOptionsConfigAdapterTest
             .alpn(asList("echo"))
             .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"alpn\":[\"echo\"]}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                alpn:
+                  - echo
+                """));
     }
 
     @Test
     public void shouldReadOptionsWithMutual()
     {
-        String text =
-                "{" +
-                    "\"mutual\": \"requested\"" +
-                "}";
+        String yaml =
+                """
+                mutual: requested
+                """;
 
-        TlsOptionsConfig options = jsonb.fromJson(text, TlsOptionsConfig.class);
+        TlsOptionsConfig options = jsonb.fromJson(yaml, TlsOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.mutual, equalTo(REQUESTED));
@@ -234,21 +264,25 @@ public class TlsOptionsConfigAdapterTest
             .mutual(REQUESTED)
             .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"mutual\":\"requested\"}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                mutual: requested
+                """));
     }
 
     @Test
     public void shouldReadOptionsWithSigners()
     {
-        String text =
-                "{" +
-                    "\"signers\": [ \"clientca\" ]" +
-                "}";
+        String yaml =
+                """
+                signers:
+                  - clientca
+                """;
 
-        TlsOptionsConfig options = jsonb.fromJson(text, TlsOptionsConfig.class);
+        TlsOptionsConfig options = jsonb.fromJson(yaml, TlsOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.signers, equalTo(asList("clientca")));
@@ -262,9 +296,13 @@ public class TlsOptionsConfigAdapterTest
             .signers(asList("clientca"))
             .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"signers\":[\"clientca\"]}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                signers:
+                  - clientca
+                """));
     }
 }

--- a/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/config/WsOptionsConfigAdapterTest.java
+++ b/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/config/WsOptionsConfigAdapterTest.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.aklivity.zilla.runtime.binding.ws.config.WsOptionsConfig;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 
 public class WsOptionsConfigAdapterTest
 {
@@ -38,22 +39,23 @@ public class WsOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(new WsOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
-        String text =
-                "{" +
-                    "\"defaults\":" +
-                    "{" +
-                        "\"protocol\": \"echo\"," +
-                        "\"authority\": \"example.net:443\"" +
-                    "}" +
-                "}";
+        String yaml =
+                """
+                defaults:
+                  protocol: echo
+                  authority: "example.net:443"
+                """;
 
-        WsOptionsConfig options = jsonb.fromJson(text, WsOptionsConfig.class);
+        WsOptionsConfig options = jsonb.fromJson(yaml, WsOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.protocol, equalTo("echo"));
@@ -65,9 +67,14 @@ public class WsOptionsConfigAdapterTest
     {
         WsOptionsConfig options = new WsOptionsConfig("echo", null, "example.net:443", null);
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"defaults\":{\"protocol\":\"echo\",\"authority\":\"example.net:443\"}}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                defaults:
+                  protocol: echo
+                  authority: "example.net:443"
+                """));
     }
 }

--- a/runtime/catalog-apicurio/src/test/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/config/ApicurioOptionsConfigAdapterTest.java
+++ b/runtime/catalog-apicurio/src/test/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/config/ApicurioOptionsConfigAdapterTest.java
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.aklivity.zilla.runtime.catalog.apicurio.config.ApicurioOptionsConfig;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 
 public class ApicurioOptionsConfigAdapterTest
 {
@@ -39,19 +40,22 @@ public class ApicurioOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(new ApicurioOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
     public void shouldReadCondition()
     {
-        String text =
-                "{" +
-                    "\"url\": \"http://localhost:8081\"," +
-                    "\"group-id\": \"default\"" +
-                "}";
+        String yaml =
+                """
+                url: "http://localhost:8081"
+                group-id: default
+                """;
 
-        ApicurioOptionsConfig catalog = jsonb.fromJson(text, ApicurioOptionsConfig.class);
+        ApicurioOptionsConfig catalog = jsonb.fromJson(yaml, ApicurioOptionsConfig.class);
 
         assertThat(catalog, not(nullValue()));
         assertThat(catalog.url, equalTo("http://localhost:8081"));
@@ -68,9 +72,14 @@ public class ApicurioOptionsConfigAdapterTest
             .maxAge(Duration.ofSeconds(300))
             .build();
 
-        String text = jsonb.toJson(catalog);
+        String yaml = jsonb.toJson(catalog);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"url\":\"http://localhost:8081\",\"group-id\":\"default\",\"max-age\":300}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                url: "http://localhost:8081"
+                group-id: default
+                max-age: 300
+                """));
     }
 }

--- a/runtime/catalog-filesystem/src/test/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/config/FilesystemOptionsConfigAdapterTest.java
+++ b/runtime/catalog-filesystem/src/test/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/config/FilesystemOptionsConfigAdapterTest.java
@@ -27,6 +27,8 @@ import jakarta.json.bind.JsonbConfig;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
+
 public class FilesystemOptionsConfigAdapterTest
 {
     private Jsonb jsonb;
@@ -36,23 +38,23 @@ public class FilesystemOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(new FilesystemOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
     public void shouldReadCondition()
     {
-        String text = "{" +
-                "\"subjects\":" +
-                    "{" +
-                    "\"subject1\":" +
-                        "{" +
-                            "\"path\":\"asyncapi/mqtt.yaml\"" +
-                        "}" +
-                    "}" +
-                "}";
+        String yaml =
+                """
+                subjects:
+                  subject1:
+                    path: asyncapi/mqtt.yaml
+                """;
 
-        FilesystemOptionsConfig catalog = jsonb.fromJson(text, FilesystemOptionsConfig.class);
+        FilesystemOptionsConfig catalog = jsonb.fromJson(yaml, FilesystemOptionsConfig.class);
 
         assertThat(catalog, not(nullValue()));
         FilesystemSchemaConfig schema = catalog.subjects.get(0);
@@ -63,15 +65,12 @@ public class FilesystemOptionsConfigAdapterTest
     @Test
     public void shouldWriteCondition()
     {
-        String expectedJson = "{" +
-            "\"subjects\":" +
-                "{" +
-                    "\"subject1\":" +
-                        "{" +
-                            "\"path\":\"asyncapi/mqtt.yaml\"" +
-                        "}" +
-                    "}" +
-                "}";
+        String expectedYaml =
+                """
+                subjects:
+                  subject1:
+                    path: asyncapi/mqtt.yaml
+                """;
 
         FilesystemOptionsConfig catalog = (FilesystemOptionsConfig) new FilesystemOptionsConfigBuilder<>(identity())
                 .subjects()
@@ -80,9 +79,9 @@ public class FilesystemOptionsConfigAdapterTest
                         .build()
                 .build();
 
-        String json = jsonb.toJson(catalog);
+        String yaml = jsonb.toJson(catalog);
 
-        assertThat(json, not(nullValue()));
-        assertThat(json, equalTo(expectedJson));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(expectedYaml));
     }
 }

--- a/runtime/catalog-inline/src/test/java/io/aklivity/zilla/runtime/catalog/inline/config/InlineOptionsConfigAdapterTest.java
+++ b/runtime/catalog-inline/src/test/java/io/aklivity/zilla/runtime/catalog/inline/config/InlineOptionsConfigAdapterTest.java
@@ -26,6 +26,8 @@ import jakarta.json.bind.JsonbConfig;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
+
 public class InlineOptionsConfigAdapterTest
 {
     private Jsonb jsonb;
@@ -35,26 +37,26 @@ public class InlineOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(new InlineOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
     public void shouldReadCondition()
     {
-        String text = "{" +
-                "\"subjects\":" +
-                    "{" +
-                    "\"subject1\":" +
-                        "{" +
-                            "\"version\": \"latest\"," +
-                            "\"schema\": \"{\\\"type\\\":\\\"object\\\",\\\"properties\\\":" +
-                                "{\\\"id\\\":{\\\"type\\\":\\\"string\\\"},\\\"status\\\":{\\\"type\\\":\\\"string\\\"}}," +
-                                "\\\"required\\\":[\\\"id\\\",\\\"status\\\"]}\"" +
-                        "}" +
-                    "}" +
-                "}";
+        String yaml =
+                """
+                subjects:
+                  subject1:
+                    version: latest
+                    schema: "{\\"type\\":\\"object\\",\\"properties\\":\
+                {\\"id\\":{\\"type\\":\\"string\\"},\\"status\\":{\\"type\\":\\"string\\"}},\
+                \\"required\\":[\\"id\\",\\"status\\"]}"
+                """;
 
-        InlineOptionsConfig catalog = jsonb.fromJson(text, InlineOptionsConfig.class);
+        InlineOptionsConfig catalog = jsonb.fromJson(yaml, InlineOptionsConfig.class);
 
         assertThat(catalog, not(nullValue()));
         InlineSchemaConfig schema = catalog.subjects.get(0);
@@ -68,18 +70,15 @@ public class InlineOptionsConfigAdapterTest
     @Test
     public void shouldWriteCondition()
     {
-        String expectedJson = "{" +
-            "\"subjects\":" +
-                "{" +
-                    "\"subject1\":" +
-                        "{" +
-                            "\"schema\":\"{\\\"type\\\":\\\"object\\\",\\\"properties\\\":" +
-                            "{\\\"id\\\":{\\\"type\\\":\\\"string\\\"},\\\"status\\\":{\\\"type\\\":\\\"string\\\"}}," +
-                            "\\\"required\\\":[\\\"id\\\",\\\"status\\\"]}\"," +
-                            "\"version\":\"latest\"" +
-                        "}" +
-                    "}" +
-                "}";
+        String expectedYaml =
+                """
+                subjects:
+                  subject1:
+                    schema: "{\\"type\\":\\"object\\",\\"properties\\":\
+                {\\"id\\":{\\"type\\":\\"string\\"},\\"status\\":{\\"type\\":\\"string\\"}},\
+                \\"required\\":[\\"id\\",\\"status\\"]}"
+                    version: latest
+                """;
 
         InlineOptionsConfig catalog = InlineOptionsConfig.builder()
             .schema()
@@ -91,9 +90,9 @@ public class InlineOptionsConfigAdapterTest
                 .build()
             .build();
 
-        String json = jsonb.toJson(catalog);
+        String yaml = jsonb.toJson(catalog);
 
-        assertThat(json, not(nullValue()));
-        assertThat(json, equalTo(expectedJson));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(expectedYaml));
     }
 }

--- a/runtime/catalog-karapace/src/test/java/io/aklivity/zilla/runtime/catalog/karapace/internal/config/KarapaceOptionsConfigAdapterTest.java
+++ b/runtime/catalog-karapace/src/test/java/io/aklivity/zilla/runtime/catalog/karapace/internal/config/KarapaceOptionsConfigAdapterTest.java
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.aklivity.zilla.runtime.catalog.karapace.config.KarapaceOptionsConfig;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 
 public class KarapaceOptionsConfigAdapterTest
 {
@@ -39,19 +40,22 @@ public class KarapaceOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(new KarapaceOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
-        String text =
-                "{" +
-                    "\"url\": \"http://localhost:8081\"," +
-                    "\"context\": \"default\"" +
-                "}";
+        String yaml =
+                """
+                url: "http://localhost:8081"
+                context: default
+                """;
 
-        KarapaceOptionsConfig catalog = jsonb.fromJson(text, KarapaceOptionsConfig.class);
+        KarapaceOptionsConfig catalog = jsonb.fromJson(yaml, KarapaceOptionsConfig.class);
 
         assertThat(catalog, not(nullValue()));
         assertThat(catalog.url, equalTo("http://localhost:8081"));
@@ -68,9 +72,14 @@ public class KarapaceOptionsConfigAdapterTest
             .maxAge(Duration.ofSeconds(300))
             .build();
 
-        String text = jsonb.toJson(catalog);
+        String yaml = jsonb.toJson(catalog);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"url\":\"http://localhost:8081\",\"context\":\"default\",\"max-age\":300}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                url: "http://localhost:8081"
+                context: default
+                max-age: 300
+                """));
     }
 }

--- a/runtime/catalog-schema-registry/src/test/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/config/SchemaRegistryOptionsConfigAdapterTest.java
+++ b/runtime/catalog-schema-registry/src/test/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/config/SchemaRegistryOptionsConfigAdapterTest.java
@@ -30,6 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.aklivity.zilla.runtime.catalog.schema.registry.config.SchemaRegistryOptionsConfig;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 
 public class SchemaRegistryOptionsConfigAdapterTest
 {
@@ -40,38 +41,30 @@ public class SchemaRegistryOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(new SchemaRegistryOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
-        String text = """
-            {
-              "url": "http://localhost:8081",
-              "context": "default",
-              "tls":
-              {
-                "keys":
-                [
-                  "client1"
-                ],
-                "trust":
-                [
-                  "serverca"
-                ]
-              },
-              "credentials":
-              {
-                "headers":
-                {
-                  "authorization": "Basic dXNlcjpzZWNyZXQ="
-                }
-              }
-            }
+        String yaml =
+            """
+            url: "http://localhost:8081"
+            context: default
+            tls:
+              keys:
+                - client1
+              trust:
+                - serverca
+            credentials:
+              headers:
+                authorization: "Basic dXNlcjpzZWNyZXQ="
             """;
 
-        SchemaRegistryOptionsConfig catalog = jsonb.fromJson(text, SchemaRegistryOptionsConfig.class);
+        SchemaRegistryOptionsConfig catalog = jsonb.fromJson(yaml, SchemaRegistryOptionsConfig.class);
 
         assertThat(catalog, not(nullValue()));
         assertThat(catalog.url, equalTo("http://localhost:8081"));
@@ -94,35 +87,24 @@ public class SchemaRegistryOptionsConfigAdapterTest
             .authorization("Basic dXNlcjpzZWNyZXQ=")
             .build();
 
-        String text = jsonb.toJson(catalog);
+        String yaml = jsonb.toJson(catalog);
 
-        String expected = """
-            {
-              "url":"http://localhost:8081",
-              "context":"default",
-              "max-age":300,
-              "tls":
-              {
-                "keys":
-                [
-                  "client1"
-                ],
-                "trust":
-                [
-                  "serverca"
-                ]
-              },
-              "credentials":
-              {
-                "headers":
-                {
-                  "authorization":"Basic dXNlcjpzZWNyZXQ="
-                }
-              }
-            }
-            """.replaceAll("\\s*\\n\\s*", "");
+        String expected =
+            """
+            url: "http://localhost:8081"
+            context: default
+            max-age: 300
+            tls:
+              keys:
+                - client1
+              trust:
+                - serverca
+            credentials:
+              headers:
+                authorization: "Basic dXNlcjpzZWNyZXQ="
+            """;
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo(expected));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(expected));
     }
 }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/OptionsConfigAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/OptionsConfigAdapterTest.java
@@ -32,6 +32,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.quality.Strictness;
 
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 import io.aklivity.zilla.runtime.engine.config.ConfigAdapterContext;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfig;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfigAdapter;
@@ -56,18 +57,19 @@ public class OptionsConfigAdapterTest
         adapter.adaptType("test");
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(adapter);
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
-        String text =
-                "{" +
-                    "\"mode\": \"test\"" +
-                "}";
+        String yaml =
+                "mode: test";
 
-        TestBindingOptionsConfig options = (TestBindingOptionsConfig) jsonb.fromJson(text, OptionsConfig.class);
+        TestBindingOptionsConfig options = (TestBindingOptionsConfig) jsonb.fromJson(yaml, OptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.mode, equalTo("test"));
@@ -80,22 +82,20 @@ public class OptionsConfigAdapterTest
             .mode("test")
             .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"mode\":\"test\"}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo("mode: test\n"));
     }
 
     @Test
     public void shouldReadNullWhenNotAdapting()
     {
-        String text =
-                "{" +
-                    "\"mode\": \"test\"" +
-                "}";
+        String yaml =
+                "mode: test";
 
         adapter.adaptType(null);
-        TestBindingOptionsConfig options = (TestBindingOptionsConfig) jsonb.fromJson(text, OptionsConfig.class);
+        TestBindingOptionsConfig options = (TestBindingOptionsConfig) jsonb.fromJson(yaml, OptionsConfig.class);
 
         assertThat(options, nullValue());
     }
@@ -108,9 +108,9 @@ public class OptionsConfigAdapterTest
                 .build();
 
         adapter.adaptType(null);
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("null"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo("null\n"));
     }
 }

--- a/runtime/exporter-otlp/src/test/java/io/aklivity/zilla/runtime/exporter/otlp/internal/config/OtlpOptionsConfigAdapterTest.java
+++ b/runtime/exporter-otlp/src/test/java/io/aklivity/zilla/runtime/exporter/otlp/internal/config/OtlpOptionsConfigAdapterTest.java
@@ -32,6 +32,7 @@ import jakarta.json.bind.JsonbConfig;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 import io.aklivity.zilla.runtime.exporter.otlp.config.OtlpOptionsConfig;
 
 public class OtlpOptionsConfigAdapterTest
@@ -43,33 +44,30 @@ public class OtlpOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
             .withAdapters(new OtlpOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+            .withProvider(YamlJson.provider())
+            .withConfig(config)
+            .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
         // GIVEN
-        String text =
-            "{\n" +
-                "\"interval\": 30,\n" +
-                "\"signals\":\n" +
-                    "[\n" +
-                        "\"metrics\"\n" +
-                    "],\n" +
-                "\"endpoint\":\n" +
-                    "{\n" +
-                        "\"location\": \"http://localhost:4317\",\n" +
-                        "\"overrides\": \n" +
-                            "{\n" +
-                                "\"metrics\": \"/v1/metricsOverride\",\n" +
-                                "\"logs\": \"/v1/logsOverride\"\n" +
-                            "}\n" +
-                    "}\n" +
-            "}";
+        String yaml =
+            """
+            interval: 30
+            signals:
+              - metrics
+            endpoint:
+              location: "http://localhost:4317"
+              overrides:
+                metrics: /v1/metricsOverride
+                logs: /v1/logsOverride
+            """;
 
         // WHEN
-        OtlpOptionsConfig options = jsonb.fromJson(text, OtlpOptionsConfig.class);
+        OtlpOptionsConfig options = jsonb.fromJson(yaml, OtlpOptionsConfig.class);
 
         // THEN
         assertThat(options, not(nullValue()));
@@ -85,22 +83,16 @@ public class OtlpOptionsConfigAdapterTest
     {
         // GIVEN
         String expected =
-            "{" +
-                "\"interval\":30," +
-                "\"signals\":" +
-                    "[" +
-                        "\"metrics\"" +
-                    "]," +
-                "\"endpoint\":" +
-                    "{" +
-                        "\"location\":\"http://localhost:4317\"," +
-                        "\"overrides\":" +
-                            "{" +
-                                "\"metrics\":\"/v1/metrics\"," +
-                                "\"logs\":\"/v1/logs\"" +
-                            "}" +
-                    "}" +
-            "}";
+            """
+            interval: 30
+            signals:
+              - metrics
+            endpoint:
+              location: "http://localhost:4317"
+              overrides:
+                metrics: /v1/metrics
+                logs: /v1/logs
+            """;
 
         OtlpOptionsConfig config = OtlpOptionsConfig.builder()
             .interval(Duration.ofSeconds(30))
@@ -116,10 +108,10 @@ public class OtlpOptionsConfigAdapterTest
             .build();
 
         // WHEN
-        String json = jsonb.toJson(config);
+        String yaml = jsonb.toJson(config);
 
         // THEN
-        assertThat(json, not(nullValue()));
-        assertThat(json, equalTo(expected));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(expected));
     }
 }

--- a/runtime/exporter-prometheus/src/test/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/config/PrometheusOptionsConfigAdapterTest.java
+++ b/runtime/exporter-prometheus/src/test/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/config/PrometheusOptionsConfigAdapterTest.java
@@ -26,6 +26,8 @@ import jakarta.json.bind.JsonbConfig;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
+
 public class PrometheusOptionsConfigAdapterTest
 {
     private Jsonb jsonb;
@@ -35,27 +37,26 @@ public class PrometheusOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
             .withAdapters(new PrometheusOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+            .withProvider(YamlJson.provider())
+            .withConfig(config)
+            .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
         // GIVEN
-        String text =
-            "{\n" +
-                "\"endpoints\":\n" +
-                "[\n" +
-                    "{\n" +
-                        "\"scheme\": \"http\",\n" +
-                        "\"port\": 9090,\n" +
-                        "\"path\": \"/metrics\"\n" +
-                    "}\n" +
-                "]\n" +
-            "}";
+        String yaml =
+            """
+            endpoints:
+              - scheme: http
+                port: 9090
+                path: /metrics
+            """;
 
         // WHEN
-        PrometheusOptionsConfig options = jsonb.fromJson(text, PrometheusOptionsConfig.class);
+        PrometheusOptionsConfig options = jsonb.fromJson(yaml, PrometheusOptionsConfig.class);
 
         // THEN
         assertThat(options, not(nullValue()));
@@ -68,19 +69,15 @@ public class PrometheusOptionsConfigAdapterTest
     public void shouldApplyDefaultPath()
     {
         // GIVEN
-        String text =
-            "{\n" +
-                "\"endpoints\":\n" +
-                "[\n" +
-                    "{\n" +
-                        "\"scheme\": \"http\",\n" +
-                        "\"port\": 9090\n" +
-                    "}\n" +
-                "]\n" +
-            "}";
+        String yaml =
+            """
+            endpoints:
+              - scheme: http
+                port: 9090
+            """;
 
         // WHEN
-        PrometheusOptionsConfig options = jsonb.fromJson(text, PrometheusOptionsConfig.class);
+        PrometheusOptionsConfig options = jsonb.fromJson(yaml, PrometheusOptionsConfig.class);
 
         // THEN
         assertThat(options, not(nullValue()));
@@ -97,10 +94,16 @@ public class PrometheusOptionsConfigAdapterTest
         PrometheusOptionsConfig config = new PrometheusOptionsConfig(new PrometheusEndpointConfig[]{endpoint});
 
         // WHEN
-        String text = jsonb.toJson(config);
+        String yaml = jsonb.toJson(config);
 
         // THEN
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"endpoints\":[{\"scheme\":\"http\",\"port\":9090,\"path\":\"/metrics\"}]}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+            """
+            endpoints:
+              - scheme: http
+                port: 9090
+                path: /metrics
+            """));
     }
 }

--- a/runtime/exporter-stdout/src/test/java/io/aklivity/zilla/runtime/exporter/stdout/internal/config/StdoutOptionsConfigAdapterTest.java
+++ b/runtime/exporter-stdout/src/test/java/io/aklivity/zilla/runtime/exporter/stdout/internal/config/StdoutOptionsConfigAdapterTest.java
@@ -26,6 +26,8 @@ import jakarta.json.bind.JsonbConfig;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
+
 public class StdoutOptionsConfigAdapterTest
 {
     private Jsonb jsonb;
@@ -35,17 +37,20 @@ public class StdoutOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
             .withAdapters(new StdoutOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+            .withProvider(YamlJson.provider())
+            .withConfig(config)
+            .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
         // GIVEN
-        String text = "{}";
+        String yaml = "{}";
 
         // WHEN
-        StdoutOptionsConfig options = jsonb.fromJson(text, StdoutOptionsConfig.class);
+        StdoutOptionsConfig options = jsonb.fromJson(yaml, StdoutOptionsConfig.class);
 
         // THEN
         assertThat(options, not(nullValue()));
@@ -55,14 +60,14 @@ public class StdoutOptionsConfigAdapterTest
     public void shouldWriteOptions()
     {
         // GIVEN
-        String expectedText = "{}";
+        String expectedYaml = "{}\n";
         StdoutOptionsConfig config = new StdoutOptionsConfig();
 
         // WHEN
-        String text = jsonb.toJson(config);
+        String yaml = jsonb.toJson(config);
 
         // THEN
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo(expectedText));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(expectedYaml));
     }
 }

--- a/runtime/guard-identity/src/test/java/io/aklivity/zilla/runtime/guard/identity/internal/config/IdentityOptionsConfigAdapterTest.java
+++ b/runtime/guard-identity/src/test/java/io/aklivity/zilla/runtime/guard/identity/internal/config/IdentityOptionsConfigAdapterTest.java
@@ -26,6 +26,8 @@ import jakarta.json.bind.JsonbConfig;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
+
 public class IdentityOptionsConfigAdapterTest
 {
     private Jsonb jsonb;
@@ -35,15 +37,18 @@ public class IdentityOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
             .withAdapters(new IdentityOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+            .withProvider(YamlJson.provider())
+            .withConfig(config)
+            .build();
     }
 
     @Test
     public void shouldReadOptionsWithCredentials()
     {
-        String text = "{\"credentials\":\"token\"}";
+        String yaml = "credentials: token";
 
-        IdentityOptionsConfig options = jsonb.fromJson(text, IdentityOptionsConfig.class);
+        IdentityOptionsConfig options = jsonb.fromJson(yaml, IdentityOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.credentials, equalTo("token"));
@@ -52,9 +57,9 @@ public class IdentityOptionsConfigAdapterTest
     @Test
     public void shouldReadOptionsWithIdentity()
     {
-        String text = "{\"identity\":\"alice\"}";
+        String yaml = "identity: alice";
 
-        IdentityOptionsConfig options = jsonb.fromJson(text, IdentityOptionsConfig.class);
+        IdentityOptionsConfig options = jsonb.fromJson(yaml, IdentityOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.identity, equalTo("alice"));
@@ -65,10 +70,10 @@ public class IdentityOptionsConfigAdapterTest
     {
         IdentityOptionsConfig options = new IdentityOptionsConfig(null, "token");
 
-        String json = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(json, not(nullValue()));
-        assertThat(json, equalTo("{\"credentials\":\"token\"}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo("credentials: token\n"));
     }
 
     @Test
@@ -76,10 +81,10 @@ public class IdentityOptionsConfigAdapterTest
     {
         IdentityOptionsConfig options = new IdentityOptionsConfig("alice", null);
 
-        String json = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(json, not(nullValue()));
-        assertThat(json, equalTo("{\"identity\":\"alice\"}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo("identity: alice\n"));
     }
 
     @Test
@@ -87,9 +92,9 @@ public class IdentityOptionsConfigAdapterTest
     {
         IdentityOptionsConfig options = new IdentityOptionsConfig(null, null);
 
-        String json = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(json, not(nullValue()));
-        assertThat(json, equalTo("{}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo("{}\n"));
     }
 }

--- a/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/config/JwtOptionsConfigAdapterTest.java
+++ b/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/config/JwtOptionsConfigAdapterTest.java
@@ -31,6 +31,7 @@ import jakarta.json.bind.JsonbConfig;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 import io.aklivity.zilla.runtime.guard.jwt.config.JwtOptionsConfig;
 
 public class JwtOptionsConfigAdapterTest
@@ -41,39 +42,33 @@ public class JwtOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(new JwtOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
-        String text = """
-            {
-              "issuer": "https://auth.example.com",
-              "audience": "https://api.example.com",
-              "keys": [
-                {
-                  "kty": "EC",
-                  "crv": "P-256",
-                  "x": "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
-                  "y": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
-                  "use": "enc",
-                  "kid": "1"
-                },
-                {
-                  "kty": "RSA",
-                  "n": "%s",
-                  "e": "AQAB",
-                  "alg": "RS256",
-                  "kid": "2011-04-29"
-                }
-              ],
-              "challenge": 30,
-              "attributes":
-              {
-                  "mail_to": "email"
-              }
-            }
+        String yaml = """
+            issuer: "https://auth.example.com"
+            audience: "https://api.example.com"
+            keys:
+              - kty: EC
+                crv: P-256
+                x: MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4
+                y: 4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM
+                use: enc
+                kid: "1"
+              - kty: RSA
+                n: "%s"
+                e: AQAB
+                alg: RS256
+                kid: 2011-04-29
+            challenge: 30
+            attributes:
+              mail_to: email
             """.formatted("""
                 0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx
                 4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMst
@@ -83,7 +78,7 @@ public class JwtOptionsConfigAdapterTest
                 0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw
                 """.replaceAll("\\n", ""));
 
-        JwtOptionsConfig options = jsonb.fromJson(text, JwtOptionsConfig.class);
+        JwtOptionsConfig options = jsonb.fromJson(yaml, JwtOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.issuer, equalTo("https://auth.example.com"));
@@ -139,35 +134,26 @@ public class JwtOptionsConfigAdapterTest
                 .attributes(Map.of("mail_to", "email"))
                 .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
         String expected = """
-            {
-              "issuer":"https://auth.example.com",
-              "audience":"https://api.example.com",
-              "keys":[
-                {
-                  "kty":"EC",
-                  "crv":"P-256",
-                  "x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
-                  "y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
-                  "use":"enc",
-                  "kid":"1"
-                },
-                {
-                  "kty":"RSA",
-                  "n":"%s",
-                  "e":"AQAB",
-                  "alg":"RS256",
-                  "kid":"2011-04-29"
-                }
-              ],
-              "challenge":30,
-              "attributes":
-              {
-                  "mail_to":"email"
-              }
-            }
+            issuer: "https://auth.example.com"
+            audience: "https://api.example.com"
+            keys:
+              - kty: EC
+                crv: P-256
+                x: MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4
+                y: 4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM
+                use: enc
+                kid: "1"
+              - kty: RSA
+                n: %s
+                e: AQAB
+                alg: RS256
+                kid: 2011-04-29
+            challenge: 30
+            attributes:
+              mail_to: email
             """.formatted("""
                 0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx
                 4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMst
@@ -175,11 +161,10 @@ public class JwtOptionsConfigAdapterTest
                 QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbI
                 SD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw
                 0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw
-                """.replaceAll("\\n", ""))
-            .replaceAll("\\s*\\n\\s*", "");
+                """.replaceAll("\\n", ""));
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo(expected));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(expected));
     }
 
     @Test

--- a/runtime/vault-filesystem/src/test/java/io/aklivity/zilla/runtime/vault/filesystem/internal/config/FileSystemOptionsConfigAdapterTest.java
+++ b/runtime/vault-filesystem/src/test/java/io/aklivity/zilla/runtime/vault/filesystem/internal/config/FileSystemOptionsConfigAdapterTest.java
@@ -28,6 +28,7 @@ import jakarta.json.bind.JsonbConfig;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 import io.aklivity.zilla.runtime.vault.filesystem.config.FileSystemOptionsConfig;
 import io.aklivity.zilla.runtime.vault.filesystem.config.FileSystemStoreConfig;
 
@@ -40,17 +41,19 @@ public class FileSystemOptionsConfigAdapterTest
     {
         JsonbConfig config = new JsonbConfig()
                 .withAdapters(new FileSystemOptionsConfigAdapter());
-        jsonb = JsonbBuilder.create(config);
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
     }
 
     @Test
     public void shouldReadOptions()
     {
-        String text =
-                "{" +
-                "}";
+        String yaml =
+                "{}";
 
-        FileSystemOptionsConfig options = jsonb.fromJson(text, FileSystemOptionsConfig.class);
+        FileSystemOptionsConfig options = jsonb.fromJson(yaml, FileSystemOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.keys, nullValue(FileSystemStoreConfig.class));
@@ -59,17 +62,15 @@ public class FileSystemOptionsConfigAdapterTest
     @Test
     public void shouldReadOptionsWithKeys()
     {
-        String text =
-                "{" +
-                    "\"keys\":" +
-                    "{" +
-                        "\"store\": \"localhost.p12\"," +
-                        "\"type\": \"pkcs12\"," +
-                        "\"password\": \"generated\"" +
-                    "}" +
-                "}";
+        String yaml =
+                """
+                keys:
+                  store: localhost.p12
+                  type: pkcs12
+                  password: generated
+                """;
 
-        FileSystemOptionsConfig options = jsonb.fromJson(text, FileSystemOptionsConfig.class);
+        FileSystemOptionsConfig options = jsonb.fromJson(yaml, FileSystemOptionsConfig.class);
 
         assertThat(options, not(nullValue()));
         assertThat(options.keys, not(nullValue()));
@@ -84,10 +85,10 @@ public class FileSystemOptionsConfigAdapterTest
         FileSystemOptionsConfig options = FileSystemOptionsConfig.builder()
             .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo("{}\n"));
     }
 
     @Test
@@ -103,9 +104,15 @@ public class FileSystemOptionsConfigAdapterTest
                 .build()
             .build();
 
-        String text = jsonb.toJson(options);
+        String yaml = jsonb.toJson(options);
 
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"keys\":{\"store\":\"localhost.p12\",\"type\":\"pkcs12\",\"password\":\"generated\"}}"));
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo(
+                """
+                keys:
+                  store: localhost.p12
+                  type: pkcs12
+                  password: generated
+                """));
     }
 }


### PR DESCRIPTION
## Description

This PR converts configuration adapter test cases across the codebase from JSON string literals to YAML format. The changes enable the use of `YamlJson.provider()` in the Jsonb builder, allowing tests to work with more readable YAML configuration examples while maintaining full compatibility with the existing JSON-based configuration system.

### Changes Made

- Updated all `OptionsConfigAdapterTest` classes to use YAML text blocks instead of JSON string concatenation
- Modified Jsonb initialization to use `JsonbBuilder.newBuilder().withProvider(YamlJson.provider())` instead of `JsonbBuilder.create()`
- Converted test data in `shouldReadOptions()` and `shouldWriteOptions()` methods from JSON to YAML format
- Applied changes across 30+ test files in various binding, catalog, guard, vault, and exporter modules

### Benefits

- **Improved readability**: YAML format is more human-readable than JSON string concatenation
- **Consistency**: Aligns test configuration format with actual user-facing YAML configuration files
- **Maintainability**: Easier to understand and modify test configurations
- **No functional changes**: All tests maintain identical behavior and assertions

### Test Coverage

All existing unit tests pass with the new YAML format. The conversion is purely a formatting change—the underlying configuration objects and assertions remain unchanged.

https://claude.ai/code/session_013CggQpVyzKP3xmRhToiXYE