### PR TITLE
Add common-json dependency to model-protobuf module

### DIFF
--- a/runtime/binding-grpc/NOTICE
+++ b/runtime/binding-grpc/NOTICE
@@ -10,4 +10,5 @@ WARRANTIES OF ANY KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations under the License.
 
 This project includes:
+  ANTLR 4 Runtime under BSD-3-Clause
 

--- a/runtime/binding-grpc/pom.xml
+++ b/runtime/binding-grpc/pom.xml
@@ -44,7 +44,6 @@
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/runtime/common-protobuf/NOTICE
+++ b/runtime/common-protobuf/NOTICE
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 
 This project includes:
   agrona under The Apache License, Version 2.0
+  ANTLR 4 Runtime under BSD-3-Clause
   Jakarta JSON Processing API under Eclipse Public License 2.0 or GNU General Public License, version 2 with the GNU Classpath Exception
   zilla::runtime::common-json under Aklivity Community License Agreement
   zilla::runtime::common-lang under Aklivity Community License Agreement

--- a/runtime/common-protobuf/pom.xml
+++ b/runtime/common-protobuf/pom.xml
@@ -44,7 +44,6 @@
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/runtime/model-protobuf/NOTICE
+++ b/runtime/model-protobuf/NOTICE
@@ -10,6 +10,12 @@ WARRANTIES OF ANY KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations under the License.
 
 This project includes:
+  agrona under The Apache License, Version 2.0
+  ANTLR 4 Runtime under BSD-3-Clause
+  Jakarta JSON Processing API under Eclipse Public License 2.0 or GNU General Public License, version 2 with the GNU Classpath Exception
+  zilla::runtime::common-json under Aklivity Community License Agreement
+  zilla::runtime::common-lang under Aklivity Community License Agreement
+  zilla::runtime::common-protobuf under Aklivity Community License Agreement
 
 
 This project also includes code under copyright of the following entities:

--- a/runtime/model-protobuf/pom.xml
+++ b/runtime/model-protobuf/pom.xml
@@ -45,7 +45,11 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>common-protobuf</artifactId>
       <version>${project.version}</version>
-      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>common-json</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/runtime/model-protobuf/src/main/moditect/module-info.java
+++ b/runtime/model-protobuf/src/main/moditect/module-info.java
@@ -15,6 +15,7 @@
 module io.aklivity.zilla.runtime.model.protobuf
 {
     requires io.aklivity.zilla.runtime.common.protobuf;
+    requires io.aklivity.zilla.runtime.common.json;
     requires io.aklivity.zilla.runtime.engine;
     requires java.logging;
 


### PR DESCRIPTION
## Description

This change updates the dependency configuration for the protobuf-related modules to properly expose transitive dependencies that are required at runtime.

### Changes Made

1. **model-protobuf**: 
   - Removed `provided` scope from `common-protobuf` dependency
   - Added new `common-json` dependency (compile scope)
   - Updated module-info.java to require `common.json` module

2. **common-protobuf**:
   - Removed `provided` scope from `antlr4-runtime` dependency

3. **binding-grpc**:
   - Removed `provided` scope from `antlr4-runtime` dependency

4. **NOTICE files**: Updated to reflect the newly exposed transitive dependencies (agrona, ANTLR 4 Runtime, Jakarta JSON Processing API, and internal modules)

### Motivation

The `provided` scope was preventing necessary dependencies from being included in the runtime classpath. By changing these to compile scope (default), the modules will properly include their transitive dependencies, ensuring that ANTLR runtime and JSON processing capabilities are available when these modules are used.

### Dependencies

No new external dependencies added; this change exposes existing transitive dependencies that were previously marked as `provided`.

https://claude.ai/code/session_01XAhRKVzoxC4hCvBneU82fy