### PR TITLE
ci(release): route Docker Hub pulls through mirror.gcr.io and cache layers in GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,20 +161,6 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Restore base image cache
-      uses: actions/cache/restore@v5
-      with:
-        path: ~/docker-base-cache/base-images.tar
-        key: docker-base-${{ runner.os }}-${{ github.run_id }}
-        restore-keys: |
-          docker-base-${{ runner.os }}-
-
-    - name: Load cached base images
-      run: |
-        if [ -f ~/docker-base-cache/base-images.tar ]; then
-          docker load -i ~/docker-base-cache/base-images.tar || true
-        fi
-
     - name: Determine docker tag
       id: tag
       run: |
@@ -201,23 +187,6 @@ jobs:
       env:
         GITHUB_ACTOR: ${{ github.actor }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Save base images
-      if: always()
-      run: |
-        mkdir -p ~/docker-base-cache
-        imgs=$(docker images --format '{{.Repository}}:{{.Tag}}' \
-          | grep -Ev '<none>|ghcr.io/aklivity/zilla' \
-          | grep -E '^(eclipse-temurin|ubuntu|alpine):')
-        if [ -n "$imgs" ]; then
-          docker save -o ~/docker-base-cache/base-images.tar $imgs
-        fi
-    - name: Save base image cache
-      if: always()
-      uses: actions/cache/save@v5
-      with:
-        path: ~/docker-base-cache/base-images.tar
-        key: docker-base-${{ runner.os }}-${{ github.run_id }}
 
     - name: Setup buildx to publish multi-arch images
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,6 +245,8 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         provenance: false
+        cache-from: type=registry,ref=ghcr.io/aklivity/zilla:buildcache
+        cache-to: type=registry,ref=ghcr.io/aklivity/zilla:buildcache,mode=max
         tags: |
           ghcr.io/aklivity/zilla:${{ inputs.version }}
           ${{ steps.tag.outputs.latest && format('ghcr.io/aklivity/zilla:{0}', steps.tag.outputs.latest) || '' }}
@@ -257,6 +259,8 @@ jobs:
         platforms: linux/amd64
         push: true
         provenance: false
+        cache-from: type=registry,ref=ghcr.io/aklivity/zilla:buildcache-alpine
+        cache-to: type=registry,ref=ghcr.io/aklivity/zilla:buildcache-alpine,mode=max
         tags: |
           ghcr.io/aklivity/zilla:${{ inputs.version }}-alpine
           ${{ steps.tag.outputs.latest && 'ghcr.io/aklivity/zilla:alpine' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,18 @@ jobs:
         server-username: GITHUB_ACTOR
         server-password: GITHUB_TOKEN
 
+    - name: Route Docker Hub pulls through mirror.gcr.io
+      run: |
+        sudo mkdir -p /etc/docker
+        if [ -f /etc/docker/daemon.json ]; then
+          sudo jq '. + {"registry-mirrors": ["https://mirror.gcr.io"]}' /etc/docker/daemon.json > /tmp/daemon.json
+        else
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' > /tmp/daemon.json
+        fi
+        sudo mv /tmp/daemon.json /etc/docker/daemon.json
+        sudo systemctl restart docker
+        timeout 30 sh -c 'until docker info >/dev/null 2>&1; do sleep 1; done'
+
     - name: Create Maven cache key input
       run: |
         find . -name pom.xml -print0 \
@@ -208,7 +220,15 @@ jobs:
         key: docker-base-${{ runner.os }}-${{ github.run_id }}
 
     - name: Setup buildx to publish multi-arch images
-      run: docker buildx create --driver docker-container --name release --use
+      run: |
+        # The docker-container driver runs its own BuildKit instance that does
+        # not inherit the daemon's registry-mirrors, so scope the mirror to
+        # docker.io here too. ghcr.io is not matched and pulls direct.
+        cat > /tmp/buildkitd.toml <<'EOF'
+        [registry."docker.io"]
+          mirrors = ["mirror.gcr.io"]
+        EOF
+        docker buildx create --driver docker-container --name release --use --config /tmp/buildkitd.toml
 
     - name: Extract docker build contexts
       run: |


### PR DESCRIPTION
## Problem

The release workflow gets throttled by Docker Hub pull rate limits, which can break a release mid-run. On GitHub-hosted runners the anonymous limit (100 pulls / 6h) is enforced **per egress IP**, which is shared across many Actions tenants — so our handful of base-image pulls land in a bucket strangers may have already drained, independent of our own low volume.

## Approach

Route only `docker.io` pulls through Google's pull-through cache (`mirror.gcr.io`), cache buildx layers in GHCR, and keep an authenticated Docker Hub fallback. No Dockerfile changes; explicitly-qualified registries such as `ghcr.io` are never matched by either mirror and continue to pull/push direct.

## Changes (`release.yml` only)

- **Route Docker Hub pulls through `mirror.gcr.io`** at two levels, since the release builds images two ways:
  - **Docker daemon** (`/etc/docker/daemon.json` `registry-mirrors`) — covers the fabric8 `docker-maven-plugin` build during `mvn deploy`. Merges via `jq` if a config already exists.
  - **BuildKit** (`buildkitd.toml` scoped to `[registry."docker.io"]`) — the `docker-container` driver does not inherit daemon mirror settings, so the multi-arch publish needs its own config.
- **Cache multi-arch build layers in GHCR** — added `cache-from`/`cache-to` (`type=registry`, `mode=max`) to both publish steps so BuildKit pulls base layers from GHCR instead of Docker Hub on subsequent releases. The arm64 path previously fetched every release because the daemon's image store is invisible to the `docker-container` BuildKit instance. The two image variants use distinct cache refs (`buildcache` / `buildcache-alpine`) to avoid clobbering.
- **Dropped the redundant `base-images.tar` cache** (restore/load/save/save-cache) — it only warmed the amd64 fabric8 path and was subject to 7-day GitHub Actions eviction, making it unreliable for an infrequent manual release. The mirror plus GHCR cache supersede it.

## Resulting layers of defense

| Layer | Covers | Persists across infrequent releases? | Touches Docker Hub? |
|---|---|---|---|
| GHCR registry cache | buildx multi-arch (amd64 + arm64) | Yes — lives in GHCR, no 7-day eviction | No |
| `mirror.gcr.io` | everything not already cached | Yes — Google keeps it warm | No (pull-through) |
| Docker Hub login | authenticated direct fallback | n/a | Only on mirror miss |

The Docker Hub login is retained as a safety net: on a mirror miss or `mirror.gcr.io` outage, pulls fall back to `docker.io` and the login keeps that on our own authenticated account bucket rather than the shared-IP anonymous bucket.

## Notes

- **The first release after merge is a cold start** — GHCR has no `buildcache` tags yet, so that run still fetches base layers (via the mirror) and populates the cache. The benefit appears on the release after.
- `build.yml` is intentionally untouched. It is the larger account-wide Docker Hub consumer (runs on every push/PR plus the example-testing matrix); applying the daemon mirror there is a sensible follow-up if this proves out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrbM9duwxag4RXoBjHQbxd

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrbM9duwxag4RXoBjHQbxd)_