### PR TITLE
ci(build): route Docker Hub pulls through mirror.gcr.io and make PR builds uniform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,19 @@ jobs:
         path: manager/target/zpm/cache
         key: zpm-${{ runner.os }}-${{ hashFiles('manager/src/conf/install/zpm.json') }}
         restore-keys: zpm-${{ runner.os }}-
+    - name: Route Docker Hub pulls through mirror.gcr.io
+      run: |
+        sudo mkdir -p /etc/docker
+        if [ -f /etc/docker/daemon.json ]; then
+          sudo jq '. + {"registry-mirrors": ["https://mirror.gcr.io"]}' /etc/docker/daemon.json > /tmp/daemon.json
+        else
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' > /tmp/daemon.json
+        fi
+        sudo mv /tmp/daemon.json /etc/docker/daemon.json
+        sudo systemctl restart docker
+        timeout 30 sh -c 'until docker info >/dev/null 2>&1; do sleep 1; done'
     - name: Login to Docker Hub
+      if: ${{ github.event_name != 'pull_request' }}
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -145,7 +157,20 @@ jobs:
         with:
           sparse-checkout: examples/${{ matrix.dir }}
 
+      - name: Route Docker Hub pulls through mirror.gcr.io
+        run: |
+          sudo mkdir -p /etc/docker
+          if [ -f /etc/docker/daemon.json ]; then
+            sudo jq '. + {"registry-mirrors": ["https://mirror.gcr.io"]}' /etc/docker/daemon.json > /tmp/daemon.json
+          else
+            echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' > /tmp/daemon.json
+          fi
+          sudo mv /tmp/daemon.json /etc/docker/daemon.json
+          sudo systemctl restart docker
+          timeout 30 sh -c 'until docker info >/dev/null 2>&1; do sleep 1; done'
+
       - name: Login to Docker Hub
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## Problem

The `build` workflow gets throttled by Docker Hub pull limits, and PRs from forks fail outright: forks do not receive repository secrets, so `docker/login-action` runs with empty credentials and hard-fails the job before it can pull anything.

Gating the login on secret availability would also split PR builds into two paths — same-organization PRs (Claude/Codex driven, secrets present) would authenticate while fork PRs would not — so two PRs to the same code could fail differently, and a maintainer could not reproduce a contributor's fork failure on an org PR.

## Changes (`build.yml`)

- **Route `docker.io` pulls through `mirror.gcr.io`** at the daemon level (`/etc/docker/daemon.json` `registry-mirrors`, merged via `jq` if a config exists) in **both** jobs:
  - `build` — base-image pulls during the fabric8 `mvn install`
  - `testing` — compose pulls (`apache/kafka`, `eclipse-mosquitto`, `nginx`, etc.)

  `build.yml` uses the fabric8/daemon build, not buildx, so no `buildkitd.toml` is needed.
- **Gate the Docker Hub login on `github.event_name != 'pull_request'`** in both jobs. Every PR build now takes the identical mirror-only path regardless of origin, while pushes to `develop`/`feature` and `workflow_dispatch` keep the authenticated direct fallback for mirror misses.

Only `docker.io` is routed through the mirror; `ghcr.io` images (`ghcr.io/aklivity/*`, `ghcr.io/kafbat/*`, `ghcr.io/aiven-open/*`) pull direct.

## Resulting behavior

| Trigger | Login | Path |
|---|---|---|
| PR from org (Claude/Codex) | No | mirror-only |
| PR from fork (contributors) | No | mirror-only — *identical* |
| Push to `develop`/`feature` | Yes | mirror + authenticated fallback |
| `workflow_dispatch` | Yes | mirror + authenticated fallback |

This is the `build.yml` companion to #1940, which applied the same mirror approach (plus a GHCR layer cache) to the release workflow.

## Notes

- The pre-existing `base-images.tar` cache is left in place — `build.yml` runs frequently enough that the 7-day GitHub Actions eviction window is rarely hit, so it remains complementary to the mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrbM9duwxag4RXoBjHQbxd

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrbM9duwxag4RXoBjHQbxd)_