### PR TITLE
fix(binding-http): skip HTTP/1.1 response decode when no exchange is outstanding

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -738,6 +738,14 @@ public final class HttpClientFactory implements HttpStreamFactory
         int offset,
         int limit)
     {
+        // a response is only valid for an outstanding request; on a keep-alive connection the next
+        // response's buffered bytes can be seen here after the prior exchange closed but before the
+        // next exchange is established, so leave them buffered until there is a current exchange
+        if (client.exchange == null)
+        {
+            return offset;
+        }
+
         int progress = offset;
 
         final int endOfHeadersAt = limitOfBytes(buffer, offset, limit, CRLFCRLF_BYTES);


### PR DESCRIPTION
## Summary

Gate `decodeHttp11Headers` on a current `client.exchange` so HTTP response bytes that arrive while no exchange is outstanding stay buffered until one exists, instead of being parsed into a null exchange and crashing the worker.

## Problem

A response is only valid for an outstanding request. On a keep-alive `HttpClient` connection, `decodeHttp11Headers` could be reached for bytes that arrive after the prior exchange closed — for example a `400 Bad Request` with `Connection: close` whose exchange already closed, or the next response's bytes before the next exchange is established. `onDecodeHttp11Headers` then dereferenced a null `client.exchange`, throwing `NullPointerException` on the worker thread and crashing it via `AgentTerminationException`:

```
java.lang.NullPointerException: Cannot invoke
  "HttpClientFactory$HttpExchange.resolveResponse(HttpBeginExFW)"
  because "this.exchange" is null
  at HttpClientFactory$HttpClient.onDecodeHttp11Headers(HttpClientFactory.java:2921)
```

Every other access site for `exchange` in this file already guards on `exchange != null` (lines 2515, 2896, 3247, 3333, 3348, 3463, 3608) — this decode path was the one missing the guard.

## Fix

When `client.exchange` is null on entry to `decodeHttp11Headers`, return without progress or decoder transition, leaving the bytes buffered until an exchange exists. This preserves the keep-alive connection — a `cleanupNetwork`-style guard at `onDecodeHttp11Headers` would have torn the connection down after parsing a phantom response.

## Test plan

- [ ] `./mvnw verify -pl runtime/binding-http` green
- [ ] No regressions on the existing rfc7230 client ITs (`ConnectionManagementIT`, `MessageFormatIT`, etc.)
- [ ] Manually verified that a `400 Bad Request` with `Connection: close` on a keep-alive client no longer crashes the worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0184bhWpuAK8AdyQrSFgGQtc)_