### PR TITLE
ci: declare Maven Central first to avoid slow aklivity-repo misses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,32 @@
 
   <repositories>
     <repository>
+      <id>central</id>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
       <id>github</id>
       <url>https://maven.packages.aklivity.io/</url>
     </repository>
   </repositories>
 
   <pluginRepositories>
+    <pluginRepository>
+      <id>central</id>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
     <pluginRepository>
       <id>github</id>
       <url>https://maven.packages.aklivity.io/</url>


### PR DESCRIPTION
## Problem

The root `pom.xml` declared only the aklivity repository (`maven.packages.aklivity.io`) under `<repositories>`/`<pluginRepositories>`, with no explicit Maven Central — so Central was inherited from the super-POM and consulted **after** the aklivity repo.

On a cold `~/.m2`, every fresh Central artifact is therefore queried against the aklivity repo first. That repo stalls ~**40s per artifact** on a miss before resolution falls back to Central (which is then fast). Across hundreds of fresh artifacts this makes cold builds crawl.

This is most visible in the release workflow's **`prepare`** job, which runs `./mvnw versions:set` and has **no `~/.m2` cache** (only Homebrew is cached there; the `~/.m2` cache lives only in the later `deploy` job). A recent release run sat on "Update POM versions" for over an hour for this reason.

## Fix

Declare Maven Central explicitly as the **first** entry in both `<repositories>` and `<pluginRepositories>`:

- Central artifacts resolve directly from Central (fast), so the aklivity repo is never queried for them.
- The aklivity repo is consulted only for zilla-hosted artifacts, where Central returns a fast 404.
- Central has `<snapshots><enabled>false</enabled></snapshots>` (matching the super-POM), so `-SNAPSHOT` resolution skips Central entirely and goes straight to the aklivity repo.

## Follow-up (not in this PR)

The release `prepare` job could also cache `~/.m2` (like `deploy` does) so `versions:set` doesn't run fully cold. Happy to add that separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gc1pqiKy9VonUJymCZ8HFW)_