### PR TITLE
test(engine): make store watch assertion deterministic via reply flush

### DIFF
--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
@@ -320,6 +320,7 @@ final class TestBindingFactory implements BindingHandler
         private TestTarget target;
         private boolean pendingBegin;
         private long pendingTraceId;
+        private boolean storeAssertionsStarted;
 
         private TestSource(
             MessageConsumer source,
@@ -620,8 +621,6 @@ final class TestBindingFactory implements BindingHandler
                 doInitialReset(traceId);
             }
 
-            runStoreAssertions(traceId);
-
             while (events != null && eventIndex < events.size())
             {
                 Event e = events.get(eventIndex);
@@ -633,10 +632,11 @@ final class TestBindingFactory implements BindingHandler
         private void runStoreAssertions(
             long traceId)
         {
-            if (store == null || storeAssertions == null || storeAssertions.isEmpty())
+            if (storeAssertionsStarted || store == null || storeAssertions == null || storeAssertions.isEmpty())
             {
                 return;
             }
+            storeAssertionsStarted = true;
             runStoreAssertion(traceId, 0);
         }
 
@@ -823,22 +823,37 @@ final class TestBindingFactory implements BindingHandler
                 returned.value = true;
                 break;
             case "watch":
-                // registration is synchronous; listener fires async on mutations
-                store.watch(a.key, (k, v) ->
-                {
-                    if (Thread.currentThread() != dispatchThread ||
-                        a.hasExpect && !Objects.equals(v, a.expect))
-                    {
-                        doInitialReset(traceId);
-                    }
-                });
-                next.run();
+                runWatchAssertion(traceId, a, dispatchThread, next);
                 break;
             default:
                 doInitialReset(traceId);
                 next.run();
                 break;
             }
+        }
+
+        private void runWatchAssertion(
+            long traceId,
+            StoreAssertion a,
+            Thread dispatchThread,
+            Runnable next)
+        {
+            // registration is synchronous; listener fires async on mutations. emit an observable
+            // reply flush per notification so the script can gate on the callback having fired on
+            // the dispatch thread, making the watch deterministic
+            store.watch(a.key, (k, v) ->
+            {
+                if (Thread.currentThread() != dispatchThread ||
+                    a.hasExpect && !Objects.equals(v, a.expect))
+                {
+                    doInitialReset(traceId);
+                }
+                else
+                {
+                    doReplyFlush(traceId, 0);
+                }
+            });
+            next.run();
         }
 
         private String resolveToken(
@@ -916,6 +931,10 @@ final class TestBindingFactory implements BindingHandler
             replyCap = window.capabilities();
 
             target.doReplyWindow(traceId, replyAck, replyMax, replyBud, replyPad, replyCap);
+
+            // defer store assertions until the reply stream is established and credited, so any
+            // notification (e.g. watch) can emit an observable reply frame the script gates on
+            runStoreAssertions(traceId);
         }
 
         private void onReplyChallenge(

--- a/runtime/store-memory/src/test/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStoreHandlerIT.java
+++ b/runtime/store-memory/src/test/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStoreHandlerIT.java
@@ -89,8 +89,8 @@ public class MemoryStoreHandlerIT
     @Test
     @Configuration("store.watch.yaml")
     @Specification({
-        "${net}/handshake/client",
-        "${app}/handshake/server"})
+        "${net}/store.watch/client",
+        "${app}/store.watch/server"})
     public void shouldWatchKey() throws Exception
     {
         k3po.finish();

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/store.watch/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/store.watch/server.rpt
@@ -1,0 +1,22 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/app0"
+       option zilla:transmission "duplex"
+       option zilla:window 8192
+
+accepted
+connected

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/store.watch/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/store.watch/client.rpt
@@ -1,0 +1,22 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/net0"
+        option zilla:transmission "duplex"
+        option zilla:window 8192
+connected
+
+read advised zilla:flush


### PR DESCRIPTION
## Problem

The `test` binding's `watch` store-assertion registered the listener and then
proceeded immediately, so nothing gated the k3po script on the asynchronous
watch notification. Whether the listener callback executed before test teardown
was a race between event delivery and test completion, leaving the watch-listener
code paths covered only intermittently — flaky store-watch coverage.

Every other store op (`get`/`put`/`lock`/`unlock`/`renew`/...) chains the next
step from inside its own async completion callback, so the assertion chain
naturally blocks on each completion. `watch` returns a `Closeable` rather than a
completion, so it alone had no synchronization point.

## Change

- Emit an observable advisory reply **FLUSH** from the watch callback when the
  notification arrives on the dispatch thread and matches the expectation. The
  new `engine.spec` `store.watch` scripts gate the script on
  `read advised zilla:flush`, so `k3po.finish()` blocks until the notification
  has actually fired — the determinism is now structural, not timing-based. This
  also upgrades the test from "passes unless a reset shows up" to a real positive
  assertion that the notification was observed.
- A reply FLUSH is only valid after the reply stream is established, so store
  assertions are now deferred until the reply stream is open and credited (run
  once from `onReplyWindow` instead of on initial begin). All other ops are
  unaffected beyond running one worker turn later.
- Repoint `MemoryStoreHandlerIT.shouldWatchKey` at the new gating scripts.

## Testing

Test-first: the repointed IT fails with a k3po flush-timeout against the current
code (no flush emitted), and passes after the change. The full
`MemoryStoreHandlerIT` (all store ops) passes and coverage checks are met;
checkstyle is clean. Only `store-memory` consumes store assertions in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gc1pqiKy9VonUJymCZ8HFW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gc1pqiKy9VonUJymCZ8HFW)_