### PR TITLE
Remove Maven Central repository, use Aklivity packages only

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Daether.remoteRepositoryFilter.groupId=true
+-Daether.remoteRepositoryFilter.filterBasedir=${session.rootDirectory}/.mvn/rrf

--- a/.mvn/rrf/groupId-github.txt
+++ b/.mvn/rrf/groupId-github.txt
@@ -1,0 +1,1 @@
+io.aklivity

--- a/pom.xml
+++ b/pom.xml
@@ -34,32 +34,12 @@
 
   <repositories>
     <repository>
-      <id>central</id>
-      <url>https://repo.maven.apache.org/maven2</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
       <id>github</id>
       <url>https://maven.packages.aklivity.io/</url>
     </repository>
   </repositories>
 
   <pluginRepositories>
-    <pluginRepository>
-      <id>central</id>
-      <url>https://repo.maven.apache.org/maven2</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>
     <pluginRepository>
       <id>github</id>
       <url>https://maven.packages.aklivity.io/</url>


### PR DESCRIPTION
## Description

This change removes the Maven Central repository configuration from both `<repositories>` and `<pluginRepositories>` sections in pom.xml, consolidating dependency resolution to use only the Aklivity GitHub Packages repository.

To support this transition, Maven's remote repository filtering is configured via `.mvn/maven.config` to restrict the GitHub Packages repository to Aklivity group IDs only, as specified in `.mvn/rrf/groupId-github.txt`.

### Changes:
- Removed Maven Central repository and plugin repository declarations from pom.xml
- Added Maven configuration file (`.mvn/maven.config`) to enable remote repository filtering
- Added repository filter rules file (`.mvn/rrf/groupId-github.txt`) to limit GitHub Packages access to `io.aklivity` group ID

This ensures all dependencies are sourced from the Aklivity GitHub Packages repository while maintaining proper filtering to prevent unintended artifact resolution.

### Test Plan
Verify that Maven builds successfully and resolves all dependencies from the configured Aklivity repository. Existing CI/CD pipeline tests will validate the build integrity.

https://claude.ai/code/session_01EA29Pgv9aBSyB9JsZCi27G