### PR TITLE
ci: pass docker image between build jobs via artifact instead of cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,12 +95,13 @@ jobs:
         mkdir -p ~/docker-cache
         docker save -o ~/docker-cache/docker.tar $(docker images --format "{{.Repository}}" | grep "zilla")
 
-    - name: Cache Docker image
-      uses: actions/cache@v5
+    - name: Upload Docker image
+      uses: actions/upload-artifact@v7
       if: success()
       with:
+        name: zilla-image
         path: ~/docker-cache/docker.tar
-        key: zilla-develop-SNAPSHOT-${{ github.run_id }}
+        retention-days: 1
 
     - name: Conditional Artifact Upload
       uses: actions/upload-artifact@v7
@@ -176,13 +177,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Restore cached Docker images
-        uses: actions/cache@v5
+      - name: Download Docker image
+        uses: actions/download-artifact@v7
         with:
-          path: ~/docker-cache/docker.tar
-          key: zilla-develop-SNAPSHOT-${{ github.run_id }}
+          name: zilla-image
+          path: ~/docker-cache
 
-      - name: Load cached Docker image
+      - name: Load Docker image
         run: |
           docker load -i ~/docker-cache/docker.tar
 
@@ -221,3 +222,28 @@ jobs:
         if: ${{ always() && hashFiles(format('examples/{0}/teardown.sh', matrix.dir)) != '' }}
         working-directory: examples/${{ matrix.dir }}
         run: docker compose down --remove-orphans
+
+  cleanup:
+    if: always()
+    needs:
+      - testing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete Docker image artifact
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });
+            for (const artifact of artifacts.data.artifacts) {
+              if (artifact.name === 'zilla-image') {
+                await github.rest.actions.deleteArtifact({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  artifact_id: artifact.id,
+                });
+              }
+            }


### PR DESCRIPTION
## Problem

The `build` job saves the docker image to `actions/cache` keyed `zilla-develop-SNAPSHOT-${run_id}`, and the parallel `testing` matrix jobs each restore it before `docker load`. `actions/cache` is eventually consistent, so when the `testing` jobs start simultaneously some get a cache hit and some get "Cache not found" for the same key, failing at the `docker load` step before any example runs. Which jobs lose the race is effectively random.

(Same root cause and fix as the zilla-plus build workflow.)

## Change

- `build`: upload the docker image as an artifact (`zilla-image`) instead of caching it.
- `testing`: download the artifact and load it, instead of restoring from cache.
- Add a `cleanup` job (`needs: testing`, `if: always()`) that deletes the transient `zilla-image` artifact once the matrix completes — it is purely an intra-run transport, not a deliverable.

Artifacts are strongly consistent within a run and gated by the `needs` chain, so every example job gets the image deterministically. The Maven-packages, ZPM, and base-image caches are unchanged (those are legitimate cross-run caches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gc1pqiKy9VonUJymCZ8HFW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gc1pqiKy9VonUJymCZ8HFW)_