### PR TITLE
test(engine): emit reply flush when store assertion chain completes

### DIFF
--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
@@ -646,6 +646,10 @@ final class TestBindingFactory implements BindingHandler
         {
             if (index >= storeAssertions.size())
             {
+                // the chain advances only from inside each op's async completion, so reaching the
+                // end means every completion has fired; emit an observable reply flush so the
+                // script can gate on the whole chain having completed on the dispatch thread
+                doReplyFlush(traceId, 0);
                 return;
             }
 

--- a/runtime/store-memory/src/test/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStoreHandlerIT.java
+++ b/runtime/store-memory/src/test/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStoreHandlerIT.java
@@ -59,8 +59,8 @@ public class MemoryStoreHandlerIT
     @Test
     @Configuration("store.lock.yaml")
     @Specification({
-        "${net}/handshake/client",
-        "${app}/handshake/server"})
+        "${net}/store.assert/client",
+        "${app}/store.assert/server"})
     public void shouldLockResource() throws Exception
     {
         k3po.finish();
@@ -69,8 +69,8 @@ public class MemoryStoreHandlerIT
     @Test
     @Configuration("store.unlock.yaml")
     @Specification({
-        "${net}/handshake/client",
-        "${app}/handshake/server"})
+        "${net}/store.assert/client",
+        "${app}/store.assert/server"})
     public void shouldUnlockAbsentResource() throws Exception
     {
         k3po.finish();
@@ -79,8 +79,8 @@ public class MemoryStoreHandlerIT
     @Test
     @Configuration("store.renew.yaml")
     @Specification({
-        "${net}/handshake/client",
-        "${app}/handshake/server"})
+        "${net}/store.assert/client",
+        "${app}/store.assert/server"})
     public void shouldRenewOwnedLock() throws Exception
     {
         k3po.finish();

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/store.assert/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/store.assert/server.rpt
@@ -14,10 +14,9 @@
 # under the License.
 #
 
-connect "zilla://streams/net0"
-        option zilla:transmission "duplex"
-        option zilla:window 8192
-connected
+accept "zilla://streams/app0"
+       option zilla:transmission "duplex"
+       option zilla:window 8192
 
-read advised zilla:flush
-read advised zilla:flush
+accepted
+connected

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/store.assert/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/store.assert/client.rpt
@@ -20,4 +20,3 @@ connect "zilla://streams/net0"
 connected
 
 read advised zilla:flush
-read advised zilla:flush


### PR DESCRIPTION
## Problem

Store-assertion completions in the `test` binding are dispatched asynchronously, and the assertion chain only advances from inside each op's completion callback (`next.run()` runs *inside* the callback). With the non-gating `handshake` scripts, `k3po.finish()` returns at "connected" and the engine tears down before the slower completions (e.g. `lock`, `renew`) run — so those paths are only covered when they win the race against teardown, leaving them intermittently uncovered.

This generalizes the `watch` determinism fix (#1946) to the rest of the store ops.

## Change

- Emit an observable reply **FLUSH** when `runStoreAssertion` reaches the end of the chain. Reaching the end means every completion has fired (the chain advances only through completions), so gating the script on `read advised zilla:flush` makes the whole chain deterministic.
- Add `store.assert` engine.spec scripts that read one flush — for non-watch chains.
- A `watch` chain emits its per-notification flush(es) **plus** the chain-complete flush, so `store.watch` now reads two flushes (notification + chain-complete).
- Repoint `MemoryStoreHandlerIT` `shouldLockResource` / `shouldUnlockAbsentResource` / `shouldRenewOwnedLock` at `store.assert`.

## Testing

Full `MemoryStoreHandlerIT` (handshake, lock, unlock, renew, watch) passes deterministically. The flush is only valid once the reply stream is open, which already holds since store assertions run from `onReplyWindow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gc1pqiKy9VonUJymCZ8HFW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gc1pqiKy9VonUJymCZ8HFW)_