### PR TITLE
Migrate tshark Docker image to ghcr.io/aklivity registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
         mkdir -p ~/docker-base-cache
         imgs=$(docker images --format '{{.Repository}}:{{.Tag}}' \
           | grep -Ev '<none>|ghcr.io/aklivity/zilla' \
-          | grep -E '^(eclipse-temurin|ubuntu|alpine|kreinerattila/tshark):')
+          | grep -E '^(eclipse-temurin|ubuntu|alpine|ghcr\.io/aklivity/tshark):')
         if [ -n "$imgs" ]; then
           docker save -o ~/docker-base-cache/base-images.tar $imgs
         fi

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/test/TsharkRunner.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/test/TsharkRunner.java
@@ -34,7 +34,7 @@ import io.aklivity.zilla.runtime.command.dump.internal.airline.ZillaDumpDissecto
 
 class TsharkRunner
 {
-    private static final String TSHARK_DOCKER_IMAGE = "kreinerattila/tshark:4.2.0";
+    private static final String TSHARK_DOCKER_IMAGE = "ghcr.io/aklivity/tshark:4.2.0";
     private static final String COMMAND = "sleep infinity";
     private static final WaitStrategy WAIT_STRATEGY = Wait.forSuccessfulCommand("echo 42");
 


### PR DESCRIPTION
## Description

Updates the tshark Docker image reference from the third-party `kreinerattila/tshark` registry to the official Aklivity registry at `ghcr.io/aklivity/tshark`.

### Changes

- Updated the tshark Docker image constant in `TsharkRunner.java` from `kreinerattila/tshark:4.2.0` to `ghcr.io/aklivity/tshark:4.2.0`
- Updated the Docker image caching filter in the build workflow to recognize the new registry path instead of the old third-party image

### Motivation

This change consolidates Docker image dependencies under the official Aklivity registry, improving maintainability and reducing reliance on third-party image sources.

### Testing

Existing tests in `TsharkRunner` will validate the image reference. CI workflow will verify the updated image caching logic.

https://claude.ai/code/session_01MeGftVAbBfoGCRyfSobqDZ