### PR TITLE
Remove Docker Hub authentication from CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,12 +48,6 @@ jobs:
         sudo mv /tmp/daemon.json /etc/docker/daemon.json
         sudo systemctl restart docker
         timeout 30 sh -c 'until docker info >/dev/null 2>&1; do sleep 1; done'
-    - name: Login to Docker Hub
-      if: ${{ github.event_name != 'pull_request' }}
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Restore base image cache
       uses: actions/cache/restore@v5
       with:
@@ -169,13 +163,6 @@ jobs:
           sudo mv /tmp/daemon.json /etc/docker/daemon.json
           sudo systemctl restart docker
           timeout 30 sh -c 'until docker info >/dev/null 2>&1; do sleep 1; done'
-
-      - name: Login to Docker Hub
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Download Docker image
         uses: actions/download-artifact@v7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -76,11 +76,17 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
 
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Route Docker Hub pulls through mirror.gcr.io
+      run: |
+        sudo mkdir -p /etc/docker
+        if [ -f /etc/docker/daemon.json ]; then
+          sudo jq '. + {"registry-mirrors": ["https://mirror.gcr.io"]}' /etc/docker/daemon.json > /tmp/daemon.json
+        else
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' > /tmp/daemon.json
+        fi
+        sudo mv /tmp/daemon.json /etc/docker/daemon.json
+        sudo systemctl restart docker
+        timeout 30 sh -c 'until docker info >/dev/null 2>&1; do sleep 1; done'
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,12 +155,6 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Login to Docker Hub
-      uses: docker/login-action@v4
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
     - name: Determine docker tag
       id: tag
       run: |


### PR DESCRIPTION
## Description

Removes Docker Hub login steps from GitHub Actions workflows and replaces them with Docker registry mirror configuration to route pulls through `mirror.gcr.io`. This change:

- Eliminates dependency on `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets across three workflows (codeql.yml, build.yml, release.yml)
- Implements registry mirror configuration in codeql.yml and build.yml to improve pull reliability and reduce rate limiting issues
- Simplifies authentication requirements while maintaining Docker image pull capabilities

The registry mirror approach provides a more resilient solution for pulling Docker images in CI environments without requiring explicit Docker Hub credentials.

## Changes

- **codeql.yml**: Replaced Docker Hub login with registry mirror configuration
- **build.yml**: Removed Docker Hub login steps (mirror already configured earlier in workflow)
- **release.yml**: Removed Docker Hub login step (GitHub Container Registry login remains for pushing)

Fixes #(issue)

https://claude.ai/code/session_01DVcVze75SWkKpt4YbcH7cy