### PR TITLE
fix(catalog-schema-registry): strip framing prefix on ModelPipeline read path

### DIFF
--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/handler/SchemaRegistryCatalogHandler.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/handler/SchemaRegistryCatalogHandler.java
@@ -424,6 +424,20 @@ public class SchemaRegistryCatalogHandler implements CatalogHandler
     }
 
     @Override
+    public int decodePadding(
+        DirectBuffer data,
+        int index,
+        int length)
+    {
+        int padding = 0;
+        if (length >= BitUtil.SIZE_OF_BYTE && data.getByte(index) == MAGIC_BYTE)
+        {
+            padding = MAX_PADDING_LENGTH;
+        }
+        return padding;
+    }
+
+    @Override
     public boolean validate(
         long traceId,
         long bindingId,

--- a/runtime/catalog-schema-registry/src/test/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/SchemaRegistryCatalogHandlerTest.java
+++ b/runtime/catalog-schema-registry/src/test/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/SchemaRegistryCatalogHandlerTest.java
@@ -65,6 +65,22 @@ public class SchemaRegistryCatalogHandlerTest
     }
 
     @Test
+    public void shouldDecodePaddingForFramedData()
+    {
+        SchemaRegistryCatalogHandler catalog = new SchemaRegistryCatalogHandler(config, catalogConfig, context);
+
+        DirectBuffer framed = new UnsafeBuffer();
+        byte[] framedBytes = {0x00, 0x00, 0x00, 0x00, 0x09, 0x06, 0x69, 0x64};
+        framed.wrap(framedBytes, 0, framedBytes.length);
+        assertEquals(5, catalog.decodePadding(framed, 0, framed.capacity()));
+
+        DirectBuffer unframed = new UnsafeBuffer();
+        byte[] unframedBytes = {0x06, 0x69, 0x64};
+        unframed.wrap(unframedBytes, 0, unframedBytes.length);
+        assertEquals(0, catalog.decodePadding(unframed, 0, unframed.capacity()));
+    }
+
+    @Test
     public void shouldVerifyEncodedData()
     {
         SchemaRegistryCatalogHandler catalog = new SchemaRegistryCatalogHandler(config, catalogConfig, context);


### PR DESCRIPTION
## Problem

The `http.kafka.avro.json` example returns `{"id":"","status":""}` instead of `{"id":"123","status":"OK"}` — the JSON structure round-trips but every string value is emptied.

## Root cause

`#1933` moved the schema-registry framing-prefix strip on the read path onto `CatalogHandler.decodePadding()` (the new per-stream `ModelPipeline` calls `handler.prefix()` → `decodePadding()` before parsing). But `SchemaRegistryCatalogHandler` implements only the symmetric `encode()` / `encodePadding()` / `decode()` and **never overrode `decodePadding()`**, so the engine default (`0`) left the 5-byte Karapace/Confluent prefix (magic byte + big-endian schema id) in the parse window. The Avro decoder then read the magic byte (`0x00`) as the first field's length (`0`), collapsing every string field — including the first — to `""`. The value parses "successfully", so no error surfaces, just empty content.

The legacy `AvroReadConverterHandler` still strips correctly via `decode()`; only the `ModelPipeline` read path (which relies on `decodePadding()`) was affected. Non-framing catalogs (`filesystem`, `inline`) correctly return `0`, which is why `http.kafka.proto.json` and `http.json.schema` were unaffected.

## Change

Implement `decodePadding` on `SchemaRegistryCatalogHandler` to report the framing length when the magic byte is present (mirroring `decode()` / `encodePadding()`), so the read pipeline skips the prefix before parsing.

## Testing

Add `SchemaRegistryCatalogHandlerTest.shouldDecodePaddingForFramedData` (framed → 5, unframed → 0) — the symmetric coverage the suite lacked because its existing decode tests already pass through `decode()` rather than the new `decodePadding()` path. `catalog-schema-registry` suite green (12 tests); checkstyle clean. Fixes the `http.kafka.avro.json` example.

Split out of #1951 (which covers the separate bounded-output byte-fidelity fixes in `common-json`/`common-avro`/`common-protobuf`); the two are complementary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gc1pqiKy9VonUJymCZ8HFW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gc1pqiKy9VonUJymCZ8HFW)_