### PR TITLE
fix(common-json): preserve document trailing bytes on the verbatim-forward path

### DIFF
--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonStep.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonStep.java
@@ -25,11 +25,15 @@ package io.aklivity.zilla.runtime.common.json;
  * copying bytes never needs a scalar's type, only that a value occupies a slot. {@link #SEPARATOR} marks a
  * value separator present in the block's bytes; only a block's leading/trailing separator is consulted (to
  * stitch an injected value at a block seam without doubling or dropping a comma), interior separators ride in
- * the bytes and move no state. There is no {@code START_DOCUMENT}/{@code END_DOCUMENT} — framing is not part of
- * a spliced run.
+ * the bytes and move no state. {@link #START_DOCUMENT} and {@link #END_DOCUMENT} are structurally inert framing
+ * steps — they open or close no container and move no depth or member state — present so a verbatim block can
+ * carry a document's leading/trailing insignificant bytes (e.g. a trailing newline) as the byte range
+ * associated with the framing step rather than through a separate sink path.
  */
 public enum JsonStep
 {
+    START_DOCUMENT,
+    END_DOCUMENT,
     START_OBJECT,
     END_OBJECT,
     START_ARRAY,

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -599,6 +599,9 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         case VALUE:
             markValueStart();
             break;
+        case START_DOCUMENT:
+        case END_DOCUMENT:
+            break;
         default:
             break;
         }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -74,6 +74,9 @@ public final class JsonParserImpl implements JsonParserEx
     private int segmentConsumed;
     private int segmentDepth;
     private boolean armNextValue;
+    // whether the current window is the final one of the feed; END_DOCUMENT is held until this is known so a
+    // non-final window starves before the boundary rather than swallowing a following document's leading bytes
+    private boolean windowLast = true;
     // running char cursor into the decoded chars of the current canonical value-string: getStringView()
     // exposes the unconsumed remainder from here and consumed() advances it, so a resumed bounded write
     // continues where the output bound left off
@@ -163,6 +166,7 @@ public final class JsonParserImpl implements JsonParserEx
         frameBaseStreamOffset = tokenizer.streamOffset();
         tokenizer.window(limit - offset);
         ownedInput.wrap(buffer, offset, limit - offset);
+        windowLast = true;
         return this;
     }
 
@@ -177,7 +181,9 @@ public final class JsonParserImpl implements JsonParserEx
         boolean last)
     {
         tokenizer.terminal(last);
-        return wrap(buffer, offset, limit);
+        wrap(buffer, offset, limit);
+        windowLast = last;
+        return this;
     }
 
     @Override
@@ -194,6 +200,7 @@ public final class JsonParserImpl implements JsonParserEx
         segmentDepth = 0;
         segmentConsumed = 0;
         armNextValue = false;
+        windowLast = true;
         stringViewOffset = 0;
         verbatimCursor = 0;
         trimLeadingSeparator = false;
@@ -310,7 +317,7 @@ public final class JsonParserImpl implements JsonParserEx
             docState = DocState.STARTED;
             event = JsonEvent.START_DOCUMENT;
         }
-        else if (segmentState == SegmentState.NONE && !tokenizerHasNext() && tokenizer.done())
+        else if (segmentState == SegmentState.NONE && !tokenizerHasNext() && tokenizer.done() && windowLast)
         {
             docState = DocState.ENDED;
             final long documentEnd = tokenizer.documentEndOffset();
@@ -332,9 +339,20 @@ public final class JsonParserImpl implements JsonParserEx
             currentEvent = toEvent(event);
             if (isBodyEvent(event))
             {
-                // record the run's structural step for getVerbatim(); framing and
-                // segment events are not verbatim steps, and skipValue()'s internal next() never reaches here
+                // record the run's structural step for getVerbatim(); segment events are not verbatim steps,
+                // and skipValue()'s internal next() never reaches here
                 appendStep(event);
+            }
+            else if (mode == Mode.SEGMENTED && event == JsonEvent.START_DOCUMENT)
+            {
+                appendFraming(toStep(event));
+            }
+            else if (event == JsonEvent.END_DOCUMENT)
+            {
+                // align the verbatim cursor to the top-level close so the END_DOCUMENT block is exactly the
+                // trailing [documentEnd, frontier) range whether the body rode as VERBATIM or as a SEGMENT run
+                verbatimCursor = Math.max(verbatimCursor, tokenizer.documentEndOffset());
+                appendFraming(toStep(event));
             }
         }
         return event;
@@ -381,7 +399,9 @@ public final class JsonParserImpl implements JsonParserEx
         }
         else
         {
-            result = tokenizer.done();
+            // a completed document yields END_DOCUMENT only once the boundary is known; on a non-terminal window
+            // the trailing bytes are still ambiguous, so starve until the boundary is decidable
+            result = tokenizer.done() && windowLast;
         }
         return result;
     }
@@ -763,6 +783,19 @@ public final class JsonParserImpl implements JsonParserEx
         append(toStep(kind), end);
     }
 
+    // records a framing step (no separator, no occupancy) at the current frontier; for END_DOCUMENT this makes
+    // its byte range the document's trailing bytes, for START_DOCUMENT a zero-width step getVerbatim() bounds
+    private void appendFraming(
+        JsonStep step)
+    {
+        if (stepHead == stepCount)
+        {
+            stepCount = 0;
+            stepHead = 0;
+        }
+        append(step, tokenizer.streamOffset());
+    }
+
     private void append(
         JsonStep step,
         long end)
@@ -782,6 +815,8 @@ public final class JsonParserImpl implements JsonParserEx
     {
         return switch (kind)
         {
+        case START_DOCUMENT -> JsonStep.START_DOCUMENT;
+        case END_DOCUMENT -> JsonStep.END_DOCUMENT;
         case START_OBJECT -> JsonStep.START_OBJECT;
         case END_OBJECT -> JsonStep.END_OBJECT;
         case START_ARRAY -> JsonStep.START_ARRAY;

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSinkImpl.java
@@ -48,7 +48,6 @@ public final class JsonSinkImpl implements JsonSink
     // whether a VERBATIM event has been copied this document: gates flush() so a segment-mode sink (whose
     // verbatim cursor never advanced) does not re-emit the whole input from cursor zero
     private boolean verbatimSeen;
-    private boolean documentReplayed;
 
     public JsonSinkImpl(
         JsonGeneratorEx generator)
@@ -129,7 +128,7 @@ public final class JsonSinkImpl implements JsonSink
             }
             break;
         case END_DOCUMENT:
-            status = writeTrailing(control, source);
+            status = writeDocumentEnd(source);
             break;
         default:
             break;
@@ -147,7 +146,7 @@ public final class JsonSinkImpl implements JsonSink
         Status status;
         if (event == JsonEvent.END_DOCUMENT)
         {
-            status = writeTrailing(control, source);
+            status = writeDocumentEnd(source);
         }
         else if (event != null && event.isVerbatim())
         {
@@ -184,7 +183,6 @@ public final class JsonSinkImpl implements JsonSink
     {
         depth = 0;
         verbatimSeen = false;
-        documentReplayed = false;
         generator.reset();
     }
 
@@ -333,7 +331,6 @@ public final class JsonSinkImpl implements JsonSink
         }
         else
         {
-            documentReplayed = depth == 0;
             status = scalarStatus();
         }
         return status;
@@ -364,25 +361,12 @@ public final class JsonSinkImpl implements JsonSink
         return length < free ? Status.ADVANCED : Status.SUSPENDED;
     }
 
-    private Status writeTrailing(
-        JsonController control,
+    // a byte-preserving sink splices the END_DOCUMENT verbatim block (the document's trailing bytes) through
+    // writeVerbatim; a canonical sink re-rendered every value and writes nothing here, dropping the trailing bytes
+    private Status writeDocumentEnd(
         JsonSource source)
     {
-        Status status = Status.ADVANCED;
-        if (documentReplayed)
-        {
-            final DirectBuffer trailing = source.getSegment();
-            final int available = trailing.capacity();
-            if (available > 0)
-            {
-                final int before = generator.consumed();
-                generator.writeSegment(trailing, 0, available);
-                final int consumed = generator.consumed() - before;
-                control.consumed(consumed);
-                status = available - consumed > 0 ? Status.SUSPENDED : Status.ADVANCED;
-            }
-        }
-        return status;
+        return canonical ? Status.ADVANCED : writeVerbatim(source);
     }
 
     // Suspends at an event boundary once the bounded output nears its limit, so the next event's write

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonInjectTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonInjectTest.java
@@ -38,14 +38,14 @@ class JsonInjectTest
     @Test
     void shouldInjectMemberBetweenVerbatimRuns()
     {
-        assertEquals("{\"a\": 1, \"b\": 2,\"x\":9, \"c\": 3}",
+        assertEquals("{\"a\": 1, \"b\": 2,\"x\":9, \"c\": 3} ",
             inject("c", "x", "9", "{\"a\": 1, \"b\": 2, \"c\": 3}"));
     }
 
     @Test
     void shouldInjectStringMemberBetweenVerbatimRuns()
     {
-        assertEquals("{\"a\": 1,\"tag\":\"new\", \"b\": 2}",
+        assertEquals("{\"a\": 1,\"tag\":\"new\", \"b\": 2} ",
             inject("b", "tag", JsonEvent.VALUE_STRING, "new", "{\"a\": 1, \"b\": 2}"));
     }
 
@@ -54,14 +54,14 @@ class JsonInjectTest
     {
         // injecting before a container's first member displaces it to non-first: the seeded generator
         // synthesizes the separator the displaced member's verbatim bytes do not carry
-        assertEquals("{\"x\":9,\"a\": 1}",
+        assertEquals("{\"x\":9,\"a\": 1} ",
             inject("a", "x", "9", "{\"a\": 1}"));
     }
 
     @Test
     void shouldInjectMemberBeforeFirstOfManyFields()
     {
-        assertEquals("{\"x\":9,\"a\": 1, \"b\": 2}",
+        assertEquals("{\"x\":9,\"a\": 1, \"b\": 2} ",
             inject("a", "x", "9", "{\"a\": 1, \"b\": 2}"));
     }
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentHardeningTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentHardeningTest.java
@@ -41,7 +41,7 @@ class JsonProjectorSegmentHardeningTest
         Status status = run(pipeline, "{\"a\":{ \"b\" : { \"c\" : [1, {\"d\": 2}] } },\"z\":9} ");
 
         assertEquals(Status.COMPLETED, status);
-        assertEquals("{\"a\":{ \"b\" : { \"c\" : [1, {\"d\": 2}] } }}", output(gen));
+        assertEquals("{\"a\":{ \"b\" : { \"c\" : [1, {\"d\": 2}] } }} ", output(gen));
     }
 
     @Test
@@ -54,11 +54,11 @@ class JsonProjectorSegmentHardeningTest
 
         gen.wrap(buffer, 0, buffer.capacity());
         run(pipeline, "{\"x\":{ \"v\" : 1 },\"y\":2} ");
-        assertEquals("{\"x\":{ \"v\" : 1 }}", output(gen));
+        assertEquals("{\"x\":{ \"v\" : 1 }} ", output(gen));
 
         gen.wrap(buffer, 0, buffer.capacity());
         run(pipeline, "{\"x\":[9 ,8]} ");
-        assertEquals("{\"x\":[9 ,8]}", output(gen));
+        assertEquals("{\"x\":[9 ,8]} ", output(gen));
     }
 
     @Test

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorSegmentTest.java
@@ -44,7 +44,7 @@ class JsonProjectorSegmentTest
         Status status = run(pipeline, "{\"a\":{ \"b\" : 1 },\"z\":9} ");
 
         assertEquals(Status.COMPLETED, status);
-        assertEquals("{\"a\":{ \"b\" : 1 }}", output(gen));
+        assertEquals("{\"a\":{ \"b\" : 1 }} ", output(gen));
     }
 
     @Test
@@ -120,7 +120,7 @@ class JsonProjectorSegmentTest
         Status status = run(pipeline, "{\"a\":{ \"b\" : 1 },\"z\":9} ");
 
         assertEquals(Status.COMPLETED, status);
-        assertEquals("{\"a\":{\"b\":1}}", output(gen));
+        assertEquals("{\"a\":{\"b\":1}} ", output(gen));
     }
 
     @Test
@@ -134,7 +134,7 @@ class JsonProjectorSegmentTest
         Status status = run(pipeline, "{\"items\":[{ \"id\" : 1 },{\"id\":2}]} ");
 
         assertEquals(Status.COMPLETED, status);
-        assertEquals("{\"items\":[{ \"id\" : 1 }]}", output(gen));
+        assertEquals("{\"items\":[{ \"id\" : 1 }]} ", output(gen));
     }
 
     @Test
@@ -252,7 +252,7 @@ class JsonProjectorSegmentTest
         String whole = driveMulti(json, 4096, 4096);
 
         assertEquals(whole, escaped);
-        assertEquals("{\"id\":\"12345\",\"status\":\"" + status + "\",\"total\":42.5}",
+        assertEquals("{\"id\":\"12345\",\"status\":\"" + status + "\",\"total\":42.5} ",
             decodeJsonString(escaped));
     }
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
@@ -127,7 +127,7 @@ class JsonProjectorTest
         assertEquals(Status.COMPLETED, status);
         byte[] out = new byte[gen.length()];
         buffer.getBytes(0, out);
-        assertEquals("{\"a\":1,\"c\":3}", new String(out, UTF_8));
+        assertEquals("{\"a\":1,\"c\":3} ", new String(out, UTF_8));
     }
 
     @Test
@@ -143,13 +143,13 @@ class JsonProjectorTest
         feed(pipeline, "{\"x\":1,\"y\":2} ");
         byte[] out1 = new byte[gen.length()];
         buffer.getBytes(0, out1);
-        assertEquals("{\"x\":1}", new String(out1, UTF_8));
+        assertEquals("{\"x\":1} ", new String(out1, UTF_8));
 
         gen.wrap(buffer, 0, buffer.capacity());
         feed(pipeline, "{\"x\":\"two\"} ");
         byte[] out2 = new byte[gen.length()];
         buffer.getBytes(0, out2);
-        assertEquals("{\"x\":\"two\"}", new String(out2, UTF_8));
+        assertEquals("{\"x\":\"two\"} ", new String(out2, UTF_8));
     }
 
     @Test
@@ -192,7 +192,7 @@ class JsonProjectorTest
     {
         // kept keys are forwarded live at the key event, so a key write can land on an output-bound
         // boundary and suspend; the drain/resume must advance to the value without re-emitting the key
-        assertEquals("{\"alpha\":1,\"gamma\":3,\"epsilon\":5}",
+        assertEquals("{\"alpha\":1,\"gamma\":3,\"epsilon\":5} ",
             projectBounded(List.of("/alpha", "/gamma", "/epsilon"),
                 "{\"alpha\":1,\"beta\":2,\"gamma\":3,\"delta\":4,\"epsilon\":5}", 12));
     }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSkipTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSkipTest.java
@@ -32,32 +32,32 @@ class JsonSkipTest
     @Test
     void shouldDropMiddleFieldPreservingWhitespace()
     {
-        assertEquals("{ \"a\" : 1, \"c\" : 3 }", skip("b", "{ \"a\" : 1, \"b\" : 2, \"c\" : 3 }"));
+        assertEquals("{ \"a\" : 1, \"c\" : 3 } ", skip("b", "{ \"a\" : 1, \"b\" : 2, \"c\" : 3 }"));
     }
 
     @Test
     void shouldDropLastFieldPreservingWhitespace()
     {
-        assertEquals("{ \"a\" : 1 }", skip("b", "{ \"a\" : 1, \"b\" : 2 }"));
+        assertEquals("{ \"a\" : 1 } ", skip("b", "{ \"a\" : 1, \"b\" : 2 }"));
     }
 
     @Test
     void shouldDropFirstFieldPreservingWhitespace()
     {
-        assertEquals("{ \"b\" : 2 }", skip("a", "{ \"a\" : 1, \"b\" : 2 }"));
+        assertEquals("{ \"b\" : 2 } ", skip("a", "{ \"a\" : 1, \"b\" : 2 }"));
     }
 
     @Test
     void shouldDropFieldWithObjectValue()
     {
-        assertEquals("{ \"a\" : 1, \"c\" : 3 }",
+        assertEquals("{ \"a\" : 1, \"c\" : 3 } ",
             skip("b", "{ \"a\" : 1, \"b\" : { \"x\" : [1, 2] }, \"c\" : 3 }"));
     }
 
     @Test
     void shouldDropOnlyField()
     {
-        assertEquals("{}", skip("a", "{ \"a\" : 1 }"));
+        assertEquals("{} ", skip("a", "{ \"a\" : 1 }"));
     }
 
     private static String skip(

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorChainTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorChainTest.java
@@ -51,7 +51,7 @@ class JsonValidatorChainTest
         Status status = run(pipeline, "{\"id\":1,\"name\":\"x\"} ");
 
         assertEquals(Status.COMPLETED, status);
-        assertEquals("{\"id\":1,\"name\":\"x\"}", output(gen));
+        assertEquals("{\"id\":1,\"name\":\"x\"} ", output(gen));
     }
 
     @Test
@@ -122,7 +122,7 @@ class JsonValidatorChainTest
         Status status = run(pipeline, "{\"id\":1,\"name\":\"x\"} ");
 
         assertEquals(Status.COMPLETED, status);
-        assertEquals("{\"id\":1}", output(gen));
+        assertEquals("{\"id\":1} ", output(gen));
     }
 
     @Test
@@ -172,7 +172,7 @@ class JsonValidatorChainTest
         Status status = pipeline.transform(in, 8, bytes.length);
 
         assertEquals(Status.COMPLETED, status);
-        assertEquals("{\"id\":1,\"name\":\"x\"}", output(gen));
+        assertEquals("{\"id\":1,\"name\":\"x\"} ", output(gen));
     }
 
     @Test
@@ -186,7 +186,7 @@ class JsonValidatorChainTest
 
         gen.wrap(buffer, 0, buffer.capacity());
         assertEquals(Status.COMPLETED, run(pipeline, "{\"id\":1,\"name\":\"a\"} "));
-        assertEquals("{\"id\":1,\"name\":\"a\"}", output(gen));
+        assertEquals("{\"id\":1,\"name\":\"a\"} ", output(gen));
 
         gen.wrap(buffer, 0, buffer.capacity());
         assertEquals(Status.REJECTED, run(pipeline, "{\"id\":2} "));

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorVerbatimTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorVerbatimTest.java
@@ -67,7 +67,73 @@ class JsonValidatorVerbatimTest
         Status status = pipeline.transform(new UnsafeBuffer(second), 0, second.length);
 
         assertEquals(Status.COMPLETED, status);
-        assertEquals("{\"id\": \"123\", \"n\": 2}", output(gen, buffer));
+        assertEquals("{\"id\": \"123\", \"n\": 2} ", output(gen, buffer));
+    }
+
+    @Test
+    void shouldForwardTrailingNewlineVerbatim()
+    {
+        JsonGeneratorEx gen = JsonEx.createGenerator();
+        MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
+        gen.wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonSchema.of(SCHEMA).validator())
+            .into(JsonEx.createSink(gen));
+
+        String json = "{\n    \"id\": \"123\"\n}\n";
+        byte[] bytes = json.getBytes(UTF_8);
+        pipeline.reset();
+        Status status = pipeline.transform(new UnsafeBuffer(bytes), 0, bytes.length);
+
+        assertEquals(Status.COMPLETED, status);
+        assertEquals(json, output(gen, buffer));
+    }
+
+    @Test
+    void shouldForwardTrailingNewlineThroughBoundedOutput()
+    {
+        JsonGeneratorEx gen = JsonEx.createGenerator();
+        MutableDirectBuffer output = new UnsafeBuffer(new byte[256]);
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonSchema.of(SCHEMA).validator())
+            .into(JsonEx.createSink(gen));
+
+        // the trailing run fits a fresh output window but not the space left after the body, so the pipeline
+        // must report SUSPENDED (never COMPLETED with trailing pending), let the caller drain, then complete the
+        // trailing splice against a fresh window
+        String json = "{ \"id\" : \"123\" }\n\n\n";
+        assertEquals(json, bounded(pipeline, gen, output, json, 16));
+    }
+
+    @Test
+    void shouldForwardMultipleDocumentsVerbatimPreservingInterDocumentBytes()
+    {
+        JsonGeneratorEx gen = JsonEx.createGenerator();
+        MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
+        gen.wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonSchema.of(SCHEMA).validator())
+            .into(JsonEx.createSink(gen));
+
+        String first = "{ \"id\" : \"1\" }\n";
+        String second = "{ \"id\" : \"2\" }\n";
+
+        byte[] firstBytes = first.getBytes(UTF_8);
+        byte[] secondBytes = second.getBytes(UTF_8);
+
+        pipeline.reset();
+        Status one = pipeline.transform(new UnsafeBuffer(firstBytes), 0, firstBytes.length);
+        assertEquals(Status.COMPLETED, one);
+        String oneOut = output(gen, buffer);
+
+        pipeline.reset();
+        gen.wrap(buffer, 0, buffer.capacity());
+        Status two = pipeline.transform(new UnsafeBuffer(secondBytes), 0, secondBytes.length);
+        assertEquals(Status.COMPLETED, two);
+        String twoOut = output(gen, buffer);
+
+        assertEquals(first, oneOut);
+        assertEquals(second, twoOut);
     }
 
     @Test
@@ -100,7 +166,7 @@ class JsonValidatorVerbatimTest
         // a validated document whose verbatim form far exceeds the output bound: the run drains in pieces via
         // SUSPENDED/resume through the validator, reassembling byte-identical with whitespace preserved
         String json = "{ \"id\" : \"123\", \"items\" : [ \"aaaaaaaa\", \"bbbbbbbb\", \"cccccccc\" ], \"ok\" : true }";
-        assertEquals(json, chunked(pipeline, gen, output, json, 16));
+        assertEquals(json + " ", chunked(pipeline, gen, output, json, 16));
     }
 
     private static String output(
@@ -110,6 +176,40 @@ class JsonValidatorVerbatimTest
         byte[] out = new byte[gen.length()];
         buffer.getBytes(0, out);
         return new String(out, UTF_8);
+    }
+
+    private static String bounded(
+        JsonPipeline pipeline,
+        JsonGeneratorEx gen,
+        MutableDirectBuffer output,
+        String json,
+        int bound)
+    {
+        byte[] bytes = json.getBytes(UTF_8);
+        UnsafeBuffer in = new UnsafeBuffer(bytes);
+        StringBuilder result = new StringBuilder();
+        pipeline.reset();
+        gen.wrap(output, 0, bound);
+        int suspends = 0;
+        int guard = 0;
+        Status status;
+        do
+        {
+            status = pipeline.transform(in, 0, bytes.length);
+            byte[] chunk = new byte[gen.length()];
+            output.getBytes(0, chunk);
+            result.append(new String(chunk, UTF_8));
+            if (status == Status.SUSPENDED)
+            {
+                suspends++;
+                gen.wrap(output, 0, bound);
+            }
+            guard++;
+        }
+        while (status == Status.SUSPENDED && guard < 10_000);
+        assertEquals(Status.COMPLETED, status);
+        assertTrue(suspends >= 1, "expected at least one SUSPENDED chunk boundary");
+        return result.toString();
     }
 
     private static String chunked(

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserDocumentTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserDocumentTest.java
@@ -81,6 +81,30 @@ public class JsonParserDocumentTest
         assertFalse(parser.hasNextEvent());
     }
 
+    @Test
+    public void shouldDeferEndDocumentUntilBoundaryKnownOnNonTerminalWindow()
+    {
+        final JsonParserImpl parser = new JsonParserImpl();
+        final byte[] bytes = "{\"a\":1}".getBytes(UTF_8);
+        final UnsafeBuffer buffer = new UnsafeBuffer(bytes);
+
+        // a non-terminal window: the top-level value closes but the trailing bytes are still ambiguous (this
+        // document's trailing whitespace, or the next document's leading bytes), so END_DOCUMENT must not be
+        // emitted yet — it would risk swallowing a following document's start
+        parser.wrap(buffer, 0, bytes.length, false);
+        assertEquals(JsonEvent.START_DOCUMENT, parser.nextEvent());
+        assertEquals(JsonEvent.START_OBJECT, parser.nextEvent());
+        assertEquals(JsonEvent.KEY_NAME, parser.nextEvent());
+        assertEquals(JsonEvent.VALUE_NUMBER, parser.nextEvent());
+        assertEquals(JsonEvent.END_OBJECT, parser.nextEvent());
+        assertFalse(parser.hasNextEvent());
+
+        // the terminal window resolves the boundary; END_DOCUMENT now follows
+        parser.wrap(buffer, bytes.length, bytes.length, true);
+        assertEquals(JsonEvent.END_DOCUMENT, parser.nextEvent());
+        assertFalse(parser.hasNextEvent());
+    }
+
     private static void wrap(
         JsonParserImpl parser,
         String json)

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -88,7 +88,7 @@ class JsonPipelineChunkingTest
             .into(JsonEx.createSink(generator));
 
         String json = "{\"k0\":0,\"k1\":1,\"k2\":2,\"k3\":3,\"k4\":4,\"k5\":5,\"k6\":6,\"k7\":7,\"k8\":8,\"k9\":9}";
-        assertEquals(json, chunked(pipeline, generator, output, json));
+        assertEquals(json + " ", chunked(pipeline, generator, output, json));
     }
 
     @Test

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaPathsTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaPathsTest.java
@@ -119,7 +119,7 @@ class JsonSchemaPathsTest
         pipeline.transform(new UnsafeBuffer(bytes), 0, bytes.length);
         byte[] out = new byte[gen.length()];
         buffer.getBytes(0, out);
-        assertEquals("{\"items\":[{\"id\":1},{\"id\":2}]}", new String(out, UTF_8));
+        assertEquals("{\"items\":[{\"id\":1},{\"id\":2}]} ", new String(out, UTF_8));
     }
 
     private static List<String> retained(


### PR DESCRIPTION
## Problem

A validate-and-forward JSON pipeline (parser → validator → sink, no member-modifying transform) dropped a document's trailing insignificant bytes — e.g. a trailing newline. The HTTP response body then came up one byte short of its upstream `Content-Length` (40 of 41 bytes for the `http.json.schema` example), and the client hung waiting for the byte that never arrived.

Reproduced with the `http.json.schema` example: `GET /valid.json` returns a pretty-printed document whose `www/valid.json` source ends in `\n`. The validator forwarded the document body but not the trailing newline, truncating the response by one byte.

## Fix

Model document framing as verbatim steps rather than a bespoke sink path.

- `START_DOCUMENT` and `END_DOCUMENT` join `JsonStep` as **structurally inert** framing steps: they open or close no container and move no depth or member state.
- The parser aligns the verbatim cursor to the top-level close and tags the `END_DOCUMENT` step with the parse frontier, so its byte range is exactly the document's trailing `[documentEnd, frontier)` run — whether the body rode as `VERBATIM` or as a `SEGMENT` run.
- A byte-preserving sink splices that block through the same `writeVerbatim` path as any other run, suspending and resuming under a bounded output until the trailing bytes drain. A canonical (re-rendering) sink writes nothing here and drops the trailing bytes, as before.
- This replaces the `documentReplayed` flag and the bespoke `writeTrailing` path in `JsonSinkImpl`.

### Multi-document correctness

`END_DOCUMENT` is now held until the document boundary is known. On a non-terminal window the trailing bytes are still ambiguous (more could follow, or another document), so the parser starves before the boundary rather than emitting a premature `END_DOCUMENT` that could swallow a following document's leading bytes. On the terminal window (`last == true`) the boundary is decidable and `END_DOCUMENT` is emitted with the full trailing run.

## Tests

- `JsonValidatorVerbatimTest` — forwards a trailing newline verbatim, through a 16-byte bounded output, and across multiple documents preserving inter-document bytes.
- `JsonParserDocumentTest` — defers `END_DOCUMENT` until the boundary is known on a non-terminal window.
- Existing projector/inject/skip/validator-chain tests updated to expect trailing-byte preservation on pure-forward paths.
- Full `runtime/common-json` suite green (4831 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gc1pqiKy9VonUJymCZ8HFW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gc1pqiKy9VonUJymCZ8HFW)_