### PR TITLE
test(binding-mcp-http): cover config adapters and prune dead McpHttpState helpers

### DIFF
--- a/runtime/binding-mcp-http/pom.xml
+++ b/runtime/binding-mcp-http/pom.xml
@@ -24,8 +24,8 @@
   </licenses>
 
   <properties>
-    <jacoco.coverage.ratio>0.00</jacoco.coverage.ratio>
-    <jacoco.missed.count>500</jacoco.missed.count>
+    <jacoco.coverage.ratio>0.90</jacoco.coverage.ratio>
+    <jacoco.missed.count>0</jacoco.missed.count>
   </properties>
 
   <dependencies>

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpState.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpState.java
@@ -37,12 +37,6 @@ final class McpHttpState
         return state | INITIAL_OPENING | INITIAL_OPENED;
     }
 
-    static int closingInitial(
-        int state)
-    {
-        return state | INITIAL_CLOSING;
-    }
-
     static int closedInitial(
         int state)
     {
@@ -55,22 +49,10 @@ final class McpHttpState
         return (state & INITIAL_OPENING) != 0;
     }
 
-    static boolean initialOpened(
-        int state)
-    {
-        return (state & INITIAL_OPENED) != 0;
-    }
-
     static boolean initialClosed(
         int state)
     {
         return (state & INITIAL_CLOSED) != 0;
-    }
-
-    static int openingReply(
-        int state)
-    {
-        return state | REPLY_OPENING;
     }
 
     static int openedReply(
@@ -79,22 +61,10 @@ final class McpHttpState
         return state | REPLY_OPENING | REPLY_OPENED;
     }
 
-    static int closingReply(
-        int state)
-    {
-        return state | REPLY_CLOSING;
-    }
-
     static int closedReply(
         int state)
     {
         return state | REPLY_CLOSING | REPLY_CLOSED;
-    }
-
-    static boolean replyOpening(
-        int state)
-    {
-        return (state & REPLY_OPENING) != 0;
     }
 
     static boolean replyOpened(
@@ -107,12 +77,6 @@ final class McpHttpState
         int state)
     {
         return (state & REPLY_CLOSED) != 0;
-    }
-
-    static boolean closed(
-        int state)
-    {
-        return initialClosed(state) && replyClosed(state);
     }
 
     private McpHttpState()

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpConditionConfigAdapterTest.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpConditionConfigAdapterTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.http.internal.config;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.JsonbConfig;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpConditionConfig;
+
+public class McpHttpConditionConfigAdapterTest
+{
+    private Jsonb jsonb;
+
+    @Before
+    public void initJson()
+    {
+        JsonbConfig config = new JsonbConfig()
+                .withAdapters(new McpHttpConditionConfigAdapter());
+        jsonb = JsonbBuilder.create(config);
+    }
+
+    @Test
+    public void shouldReadConditionWithTool()
+    {
+        String text =
+                "{" +
+                    "\"tool\": \"create_pr\"" +
+                "}";
+
+        McpHttpConditionConfig condition = jsonb.fromJson(text, McpHttpConditionConfig.class);
+
+        assertThat(condition, not(nullValue()));
+        assertThat(condition.tool, equalTo("create_pr"));
+        assertThat(condition.resource, nullValue());
+    }
+
+    @Test
+    public void shouldReadConditionWithResource()
+    {
+        String text =
+                "{" +
+                    "\"resource\": \"order\"" +
+                "}";
+
+        McpHttpConditionConfig condition = jsonb.fromJson(text, McpHttpConditionConfig.class);
+
+        assertThat(condition, not(nullValue()));
+        assertThat(condition.tool, nullValue());
+        assertThat(condition.resource, equalTo("order"));
+    }
+
+    @Test
+    public void shouldWriteConditionWithTool()
+    {
+        McpHttpConditionConfig condition = new McpHttpConditionConfig("create_pr", null);
+
+        String text = jsonb.toJson(condition);
+
+        assertThat(text, not(nullValue()));
+        assertThat(text, equalTo("{\"tool\":\"create_pr\"}"));
+    }
+
+    @Test
+    public void shouldWriteConditionWithResource()
+    {
+        McpHttpConditionConfig condition = new McpHttpConditionConfig(null, "order");
+
+        String text = jsonb.toJson(condition);
+
+        assertThat(text, not(nullValue()));
+        assertThat(text, equalTo("{\"resource\":\"order\"}"));
+    }
+}

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpOptionsConfigAdapterTest.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpOptionsConfigAdapterTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.http.internal.config;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.JsonbConfig;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpOptionsConfig;
+import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpPromptConfig;
+import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpResourceConfig;
+import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpToolConfig;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
+
+public class McpHttpOptionsConfigAdapterTest
+{
+    private Jsonb jsonb;
+
+    @Before
+    public void initJson()
+    {
+        JsonbConfig config = new JsonbConfig()
+                .withAdapters(new McpHttpOptionsConfigAdapter());
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
+    }
+
+    @Test
+    public void shouldReadOptions()
+    {
+        String yaml =
+                """
+                authorization:
+                  github0:
+                    credentials:
+                      headers:
+                        authorization: "Bearer ${credentials}"
+                tools:
+                  create_pr:
+                    description: Create a pull request
+                    summary: "Created pull request #${result.number}"
+                    schemas:
+                      input:
+                        model: test
+                      output:
+                        model: test
+                resources:
+                  order:
+                    uri: "order://{orderId}"
+                    description: Customer order by identifier
+                    mimeType: application/json
+                    schemas:
+                      output:
+                        model: test
+                prompts:
+                  summarize:
+                    description: Summarize a document about a topic
+                    arguments:
+                      - name: topic
+                        description: The topic to summarize
+                        required: true
+                    messages:
+                      - role: user
+                        text: "Please summarize the document about ${args.topic}."
+                """;
+
+        McpHttpOptionsConfig options = jsonb.fromJson(yaml, McpHttpOptionsConfig.class);
+
+        assertThat(options, not(nullValue()));
+
+        assertThat(options.authorization, not(nullValue()));
+        assertThat(options.authorization.name, equalTo("github0"));
+        assertThat(options.authorization.headers.get("authorization"), equalTo("Bearer ${credentials}"));
+
+        assertThat(options.tools, hasSize(1));
+        McpHttpToolConfig tool = options.tools.get(0);
+        assertThat(tool.name, equalTo("create_pr"));
+        assertThat(tool.description, equalTo("Create a pull request"));
+        assertThat(tool.summary, equalTo("Created pull request #${result.number}"));
+        assertThat(tool.input, not(nullValue()));
+        assertThat(tool.output, not(nullValue()));
+
+        assertThat(options.resources, hasSize(1));
+        McpHttpResourceConfig resource = options.resources.get(0);
+        assertThat(resource.name, equalTo("order"));
+        assertThat(resource.uri, equalTo("order://{orderId}"));
+        assertThat(resource.description, equalTo("Customer order by identifier"));
+        assertThat(resource.mimeType, equalTo("application/json"));
+        assertThat(resource.output, not(nullValue()));
+
+        assertThat(options.prompts, hasSize(1));
+        McpHttpPromptConfig prompt = options.prompts.get(0);
+        assertThat(prompt.name, equalTo("summarize"));
+        assertThat(prompt.description, equalTo("Summarize a document about a topic"));
+        assertThat(prompt.arguments, hasSize(1));
+        assertThat(prompt.arguments.get(0).name, equalTo("topic"));
+        assertThat(prompt.arguments.get(0).description, equalTo("The topic to summarize"));
+        assertThat(prompt.arguments.get(0).required, equalTo(true));
+        assertThat(prompt.messages, hasSize(1));
+        assertThat(prompt.messages.get(0).role, equalTo("user"));
+        assertThat(prompt.messages.get(0).text, equalTo("Please summarize the document about ${args.topic}."));
+    }
+
+    @Test
+    public void shouldWriteOptions()
+    {
+        String yaml =
+                """
+                authorization:
+                  github0:
+                    credentials:
+                      headers:
+                        authorization: "Bearer ${credentials}"
+                tools:
+                  create_pr:
+                    description: Create a pull request
+                    summary: "Created pull request #${result.number}"
+                    schemas:
+                      input:
+                        model: test
+                      output:
+                        model: test
+                resources:
+                  order:
+                    uri: "order://{orderId}"
+                    description: Customer order by identifier
+                    mimeType: application/json
+                    schemas:
+                      output:
+                        model: test
+                prompts:
+                  summarize:
+                    description: Summarize a document about a topic
+                    arguments:
+                      - name: topic
+                        description: The topic to summarize
+                        required: true
+                    messages:
+                      - role: user
+                        text: "Please summarize the document about ${args.topic}."
+                """;
+
+        McpHttpOptionsConfig options = jsonb.fromJson(yaml, McpHttpOptionsConfig.class);
+
+        String text = jsonb.toJson(options);
+
+        assertThat(text, not(nullValue()));
+        assertThat(text, containsString("authorization:"));
+        assertThat(text, containsString("github0:"));
+        assertThat(text, containsString("tools:"));
+        assertThat(text, containsString("create_pr:"));
+        assertThat(text, containsString("summary:"));
+        assertThat(text, containsString("Created pull request #${result.number}"));
+        assertThat(text, containsString("input:"));
+        assertThat(text, containsString("output:"));
+        assertThat(text, containsString("resources:"));
+        assertThat(text, containsString("order:"));
+        assertThat(text, containsString("uri:"));
+        assertThat(text, containsString("order://{orderId}"));
+        assertThat(text, containsString("mimeType:"));
+        assertThat(text, containsString("application/json"));
+        assertThat(text, containsString("prompts:"));
+        assertThat(text, containsString("summarize:"));
+        assertThat(text, containsString("arguments:"));
+        assertThat(text, containsString("messages:"));
+    }
+
+    @Test
+    public void shouldReadAndWriteMinimalOptions()
+    {
+        String yaml =
+                """
+                authorization:
+                  github0: {}
+                tools:
+                  ping: {}
+                resources:
+                  ping_resource: {}
+                prompts:
+                  greet:
+                    arguments:
+                      - name: who
+                    messages:
+                      - role: user
+                        text: hi
+                  farewell:
+                    messages:
+                      - role: user
+                        text: bye
+                """;
+
+        McpHttpOptionsConfig options = jsonb.fromJson(yaml, McpHttpOptionsConfig.class);
+
+        assertThat(options, not(nullValue()));
+
+        assertThat(options.authorization, not(nullValue()));
+        assertThat(options.authorization.name, equalTo("github0"));
+        assertThat(options.authorization.headers.isEmpty(), equalTo(true));
+
+        assertThat(options.tools, hasSize(1));
+        McpHttpToolConfig tool = options.tools.get(0);
+        assertThat(tool.name, equalTo("ping"));
+        assertThat(tool.description, nullValue());
+        assertThat(tool.summary, nullValue());
+        assertThat(tool.input, nullValue());
+        assertThat(tool.output, nullValue());
+
+        assertThat(options.resources, hasSize(1));
+        McpHttpResourceConfig resource = options.resources.get(0);
+        assertThat(resource.name, equalTo("ping_resource"));
+        assertThat(resource.uri, nullValue());
+        assertThat(resource.description, nullValue());
+        assertThat(resource.mimeType, nullValue());
+        assertThat(resource.output, nullValue());
+
+        assertThat(options.prompts, hasSize(2));
+        McpHttpPromptConfig greet = options.prompts.get(0);
+        assertThat(greet.name, equalTo("greet"));
+        assertThat(greet.description, nullValue());
+        assertThat(greet.arguments, hasSize(1));
+        assertThat(greet.arguments.get(0).name, equalTo("who"));
+        assertThat(greet.arguments.get(0).description, nullValue());
+        assertThat(greet.arguments.get(0).required, equalTo(false));
+        McpHttpPromptConfig farewell = options.prompts.get(1);
+        assertThat(farewell.name, equalTo("farewell"));
+        assertThat(farewell.arguments, nullValue());
+
+        String text = jsonb.toJson(options);
+
+        assertThat(text, not(nullValue()));
+        assertThat(text, containsString("github0:"));
+        assertThat(text, containsString("ping:"));
+        assertThat(text, containsString("ping_resource:"));
+        assertThat(text, containsString("greet:"));
+        assertThat(text, containsString("farewell:"));
+    }
+
+    @Test
+    public void shouldReadAndWriteEmptyOptions()
+    {
+        McpHttpOptionsConfig options = jsonb.fromJson("{}", McpHttpOptionsConfig.class);
+
+        assertThat(options, not(nullValue()));
+        assertThat(options.authorization, nullValue());
+        assertThat(options.tools, nullValue());
+        assertThat(options.resources, nullValue());
+        assertThat(options.prompts, nullValue());
+
+        String text = jsonb.toJson(options);
+
+        assertThat(text, not(nullValue()));
+        assertThat(text, not(containsString("authorization")));
+        assertThat(text, not(containsString("tools")));
+        assertThat(text, not(containsString("resources")));
+        assertThat(text, not(containsString("prompts")));
+    }
+}

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpWithConfigAdapterTest.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpWithConfigAdapterTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.http.internal.config;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.JsonbConfig;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpWithConfig;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
+
+public class McpHttpWithConfigAdapterTest
+{
+    private Jsonb jsonb;
+
+    @Before
+    public void initJson()
+    {
+        JsonbConfig config = new JsonbConfig()
+                .withAdapters(new McpHttpWithConfigAdapter());
+        jsonb = JsonbBuilder.newBuilder()
+                .withProvider(YamlJson.provider())
+                .withConfig(config)
+                .build();
+    }
+
+    @Test
+    public void shouldReadWithHeadersAndBodyTemplate()
+    {
+        String yaml =
+                """
+                headers:
+                  ":method": POST
+                  ":path": /repos/owner/repo/pulls
+                body:
+                  template:
+                    title: "${args.title}"
+                """;
+
+        McpHttpWithConfig with = jsonb.fromJson(yaml, McpHttpWithConfig.class);
+
+        assertThat(with, not(nullValue()));
+        assertThat(with.headers, not(nullValue()));
+        assertThat(with.headers.get(":method"), equalTo("POST"));
+        assertThat(with.headers.get(":path"), equalTo("/repos/owner/repo/pulls"));
+        assertThat(with.bodyTemplate, not(nullValue()));
+        assertThat(with.bodyTemplate.get("title"), equalTo("${args.title}"));
+        assertThat(with.body, nullValue());
+        assertThat(with.query, nullValue());
+    }
+
+    @Test
+    public void shouldReadWithQueryAndBody()
+    {
+        String yaml =
+                """
+                query:
+                  model: test
+                body:
+                  model: test
+                """;
+
+        McpHttpWithConfig with = jsonb.fromJson(yaml, McpHttpWithConfig.class);
+
+        assertThat(with, not(nullValue()));
+        assertThat(with.query, not(nullValue()));
+        assertThat(with.body, not(nullValue()));
+        assertThat(with.bodyTemplate, nullValue());
+        assertThat(with.headers, nullValue());
+    }
+
+    @Test
+    public void shouldWriteWithHeadersAndBodyTemplate()
+    {
+        String yaml =
+                """
+                headers:
+                  ":method": POST
+                body:
+                  template:
+                    title: "${args.title}"
+                """;
+
+        McpHttpWithConfig with = jsonb.fromJson(yaml, McpHttpWithConfig.class);
+
+        String text = jsonb.toJson(with);
+
+        assertThat(text, not(nullValue()));
+        assertThat(text, containsString("headers:"));
+        assertThat(text, containsString(":method"));
+        assertThat(text, containsString("POST"));
+        assertThat(text, containsString("body:"));
+        assertThat(text, containsString("template:"));
+        assertThat(text, containsString("title:"));
+        assertThat(text, containsString("${args.title}"));
+    }
+
+    @Test
+    public void shouldWriteWithQueryAndBody()
+    {
+        String yaml =
+                """
+                query:
+                  model: test
+                body:
+                  model: test
+                """;
+
+        McpHttpWithConfig with = jsonb.fromJson(yaml, McpHttpWithConfig.class);
+
+        String text = jsonb.toJson(with);
+
+        assertThat(text, not(nullValue()));
+        assertThat(text, containsString("query:"));
+        assertThat(text, containsString("body:"));
+    }
+}

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyIT.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyIT.java
@@ -114,6 +114,16 @@ public class McpHttpProxyIT
     @Test
     @Configuration("proxy.yaml")
     @Specification({
+        "${mcp}/create.pr.rich/client",
+        "${http}/create.pr.rich/server"})
+    public void shouldCallToolCreatePrWithStructuredArguments() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
         "${mcp}/read.order.10k/client",
         "${http}/read.order.10k/server"})
     public void shouldReadResourceOrder10k() throws Exception

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/http/create.pr.rich/client.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/http/create.pr.rich/client.rpt
@@ -1,0 +1,45 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/http0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "POST")
+                            .header(":scheme", "https")
+                            .header(":authority", "api.github.com")
+                            .header(":path", "/repos/acme/widget/pulls")
+                            .header("content-type", "application/json")
+                            .build()}
+
+connected
+
+write '{"title":"Add feature","head":"feature","base":"main","body":"'
+write ${core:randomBase64(10000)}
+write '"}'
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":status", "201")
+                           .header("content-type", "application/json")
+                           .build()}
+
+read  '{"number":42,"html_url":"https://github.com/acme/widget/pull/42","state":"open","title":"Add feature",'
+      '"body":"please review","draft":false,"merged":false,"user":{"login":"acme-bot"}}'
+read closed
+
+write close

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/http/create.pr.rich/server.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/http/create.pr.rich/server.rpt
@@ -1,0 +1,52 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/http0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":scheme", "https")
+                           .header(":authority", "api.github.com")
+                           .header(":path", "/repos/acme/widget/pulls")
+                           .header("content-type", "application/json")
+                           .build()}
+
+connected
+
+read '{"title":"Add feature","head":"feature","base":"main","body":"'
+read ${core:randomBase64(10000)}
+read '"}'
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "201")
+                            .header("content-type", "application/json")
+                            .build()}
+write flush
+
+write '{"number":42,"html_url":"https://github.com/acme/widget/pull/42","state":"open","title":"Add feature",'
+      '"body":"please review","draft":false,"merged":false,"user":{"login":"acme-bot"}}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/create.pr.rich/client.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/create.pr.rich/client.rpt
@@ -1,0 +1,64 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsCall()
+                               .sessionId("session-1")
+                               .name("create_pr")
+                               .contentLength(13592)
+                               .build()
+                           .build()}
+
+connected
+
+write '{"name":"create_pr","_meta":{"trace":"t1","tags":["a","b"]},"arguments":{"owner":"acme","repo":"widget","title":"Add feature","head":"feature","base":"main","reviewers":2,"approved":true,"labels":["bug","urgent"],"meta":{"priority":1,"tag":"x"},"body":"'
+write ${core:randomBase64(10000)}
+write '"}}'
+
+read  '{'
+        '"content":[{"type":"text","text":"Created pull request #42"}],'
+        '"structuredContent":{"number":42,"html_url":"https://github.com/acme/widget/pull/42","state":"open","title":"Add feature"},'
+        '"isError":false'
+      '}'
+read closed
+
+write close

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/create.pr.rich/server.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/create.pr.rich/server.rpt
@@ -1,0 +1,68 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                            .typeId(zilla:id("mcp"))
+                            .lifecycle()
+                                .sessionId("session-1")
+                                .build()
+                            .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsCall()
+                              .sessionId("session-1")
+                              .name("create_pr")
+                              .contentLength(13592)
+                              .build()
+                          .build()}
+
+connected
+
+read '{"name":"create_pr","_meta":{"trace":"t1","tags":["a","b"]},"arguments":{"owner":"acme","repo":"widget","title":"Add feature","head":"feature","base":"main","reviewers":2,"approved":true,"labels":["bug","urgent"],"meta":{"priority":1,"tag":"x"},"body":"'
+read ${core:randomBase64(10000)}
+read '"}}'
+
+write flush
+
+write '{'
+        '"content":[{"type":"text","text":"Created pull request #42"}],'
+        '"structuredContent":{"number":42,"html_url":"https://github.com/acme/widget/pull/42","state":"open","title":"Add feature"},'
+        '"isError":false'
+      '}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp-http.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/http/streams/HttpClientIT.java
+++ b/specs/binding-mcp-http.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/http/streams/HttpClientIT.java
@@ -74,6 +74,15 @@ public class HttpClientIT
 
     @Test
     @Specification({
+        "${http}/create.pr.rich/client",
+        "${http}/create.pr.rich/server"})
+    public void shouldProxyCreatePrWithStructuredArgumentsToHttp() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${http}/read.order.10k/client",
         "${http}/read.order.10k/server"})
     public void shouldProxyReadOrder10kToHttp() throws Exception

--- a/specs/binding-mcp-http.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/http/streams/McpServerIT.java
+++ b/specs/binding-mcp-http.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/http/streams/McpServerIT.java
@@ -110,6 +110,15 @@ public class McpServerIT
 
     @Test
     @Specification({
+        "${mcp}/create.pr.rich/client",
+        "${mcp}/create.pr.rich/server"})
+    public void shouldCallToolCreatePrWithStructuredArguments() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${mcp}/read.order.10k/client",
         "${mcp}/read.order.10k/server"})
     public void shouldReadResourceOrder10k() throws Exception


### PR DESCRIPTION
Add JsonbAdapter round-trip unit tests for the condition, with, and options
config adapters, covering both present and absent optional-field branches.
Remove six unused McpHttpState helpers (closingInitial, initialOpened,
openingReply, closingReply, replyOpening, closed) that the proxy never calls
— the implementation guards each direction independently, so the combined
and CLOSING-only helpers were dead code rather than a coverage gap.

Raise the module jacoco threshold from the effectively-disabled 0.00/500 to
0.90 instruction ratio with 0 fully-uncovered classes, consistent with sibling
*-kafka bindings.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015PHvCvEmccBEqDd6YnQ9Qu