### PR TITLE
Enforce store requirement for MQTT server bindings

### DIFF
--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionFactory.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionFactory.java
@@ -1341,7 +1341,7 @@ public class MqttKafkaSessionFactory implements MqttKafkaStreamFactory
                 offsetCommitSeeded = false;
                 doCreateSessionStream(traceId, authorization);
             }
-            else
+            else if (!unackedPacketIds.isEmpty())
             {
                 final int packetId = unackedPacketIds.remove();
                 if (metadata.partitions.containsKey(packetId))


### PR DESCRIPTION
## Description

This change makes the `store` option mandatory for MQTT server bindings by enforcing it at the schema validation level, rather than relying on runtime warnings.

### Changes

**Schema & Validation:**
- Updated `mqtt.schema.patch.json` to require `options` with a `store` property for server bindings
- Added `server.without.store.yaml` test configuration to verify that configurations without a store are rejected
- Added schema validation test `shouldRejectServerWithoutStore()` to ensure the requirement is enforced

**Code Cleanup:**
- Removed the deprecated runtime warning logic from `MqttServerFactory.attach()` that warned about missing store configuration
- Removed the `warnSessionOwnershipDeprecated()` method that is no longer needed

**Configuration Updates:**
- Updated all MQTT server test configurations to include explicit store definitions
- Updated example configurations (`mqtt.kafka.proxy`, `mqtt.proxy.jwt`) to include store setup
- Updated AsyncAPI server generator to automatically inject a memory store when MQTT options are configured

**Bug Fix:**
- Fixed condition in `MqttKafkaSessionFactory` to only process unacked packet IDs when the queue is not empty, preventing unnecessary stream creation

### Rationale

By moving the store requirement from a runtime warning to a schema-level constraint, configurations are validated at load time rather than runtime. This ensures all MQTT server bindings have proper session storage configured before the application starts, improving reliability and preventing runtime surprises.

### Test Plan

Existing schema validation tests pass, including the new test that verifies rejection of server configurations without a store. All updated example and test configurations now include proper store configuration.

https://claude.ai/code/session_01Vx4B6SkggrTs8EEEenxPtp