### PR TITLE
ci: share one cached image set across examples tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,6 +136,55 @@ jobs:
             ^http.echo$
             ^grpc.kafka.proxy$
 
+  cache-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Route Docker Hub pulls through mirror.gcr.io
+        run: |
+          sudo mkdir -p /etc/docker
+          if [ -f /etc/docker/daemon.json ]; then
+            sudo jq '. + {"registry-mirrors": ["https://mirror.gcr.io"]}' /etc/docker/daemon.json > /tmp/daemon.json
+          else
+            echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' > /tmp/daemon.json
+          fi
+          sudo mv /tmp/daemon.json /etc/docker/daemon.json
+          sudo systemctl restart docker
+          timeout 30 sh -c 'until docker info >/dev/null 2>&1; do sleep 1; done'
+
+      - name: Restore shared example image cache
+        id: cache
+        uses: actions/cache@v5
+        with:
+          path: ~/docker-images-cache/images.tar
+          key: example-images-${{ runner.os }}-${{ hashFiles('examples/**/compose.yaml') }}
+          restore-keys: |
+            example-images-${{ runner.os }}-
+
+      - name: Pull example images and refresh shared cache
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        run: |
+          mkdir -p ~/docker-images-cache
+          if [ -f ~/docker-images-cache/images.tar ]; then
+            docker load -i ~/docker-images-cache/images.tar || true
+          fi
+          images=$(grep -rhE '^[[:space:]]*image:' examples/*/compose.yaml \
+            | sed -E 's/^[[:space:]]*image:[[:space:]]*//' \
+            | tr -d "\"'" \
+            | sed -E 's/[[:space:]]*#.*$//; s/[[:space:]]+$//' \
+            | grep -v '\$' \
+            | grep -v 'ghcr.io/aklivity/zilla' \
+            | sort -u)
+          echo "Ensuring the following example images are present:"
+          echo "$images"
+          for img in $images; do
+            docker pull "$img" || echo "::warning::failed to pull $img"
+          done
+          present=$(for img in $images; do docker image inspect "$img" >/dev/null 2>&1 && echo "$img"; done)
+          docker save -o ~/docker-images-cache/images.tar $present
+
   testing:
     strategy:
       matrix:
@@ -143,6 +192,7 @@ jobs:
       fail-fast: false
     needs:
       - setup-examples
+      - cache-images
     runs-on: ubuntu-latest
     env:
       ZILLA_VERSION: develop-SNAPSHOT
@@ -174,11 +224,19 @@ jobs:
         run: |
           docker load -i ~/docker-cache/docker.tar
 
-      - name: Cache Docker images
-        if: ${{ hashFiles(format('examples/{0}/compose.yaml', matrix.dir)) != '' }}
-        uses: ScribeMD/docker-cache@0.5.0
+      - name: Restore shared example image cache
+        uses: actions/cache/restore@v5
         with:
-          key: docker-${{ runner.os }}-${{ matrix.dir }}-${{ hashFiles(format('examples/{0}/compose.yaml', matrix.dir)) }}
+          path: ~/docker-images-cache/images.tar
+          key: example-images-${{ runner.os }}-${{ hashFiles('examples/**/compose.yaml') }}
+          restore-keys: |
+            example-images-${{ runner.os }}-
+
+      - name: Load shared example images
+        run: |
+          if [ -f ~/docker-images-cache/images.tar ]; then
+            docker load -i ~/docker-images-cache/images.tar || true
+          fi
 
       - name: Start Zilla and wait for it to be healthy
         working-directory: examples/${{ matrix.dir }}


### PR DESCRIPTION
## Problem

Each examples `testing` matrix leg cached its Docker images under a per-example key:

```
docker-<os>-<dir>-<hash of that example's compose.yaml>
```

via `ScribeMD/docker-cache`. Because every example got its own cache entry, common images were duplicated across dozens of entries — `apache/kafka:4.1.1` alone appears in 36 examples, so it was stored 36 times. The combined size blows past GitHub Actions' 10 GB per-repo cache limit, triggering constant LRU eviction. Evicted entries miss on the next PR build and re-pull, which is the "repeated downloads per PR build" symptom. `ScribeMD/docker-cache` also does not support `restore-keys`, so any edit to a `compose.yaml` is a full cold pull for that example with no partial fallback.

## Change

Replace the per-example caches with a single shared image cache:

- New **`cache-images`** job (runs in parallel with `build`) computes the union of third-party `image:` refs across all `examples/*/compose.yaml` — excluding the freshly-built `ghcr.io/aklivity/zilla` image and any `${...}` var-substituted refs — pulls them through the existing `mirror.gcr.io` route, and saves a single tarball. Keyed on the hash of all example compose files, with an `example-images-<os>-` `restore-keys` prefix for partial reuse when one compose file changes. On an exact-key hit it does nothing (no pulls, no re-save).
- The **`testing`** job now `needs: cache-images` and restores that one tarball read-only (`actions/cache/restore@v5`) and `docker load`s it before `docker compose up`. The `restore-keys` prefix lets each sparse-checkout leg find the single shared cache despite seeing only its own compose file.

Each image is now stored **once** per run instead of once per example, which keeps the cache under quota, stops the eviction churn, and lets PRs warm-start from the `develop`-branch cache.

## Notes

- CI-only change; no runtime code or test coverage affected. Validation is a green build on this PR.
- The per-leg step ordering (load zilla image, then restore shared cache) is preserved and remains correct: `ScribeMD` only ever cached images pulled *after* it ran, and the shared cache likewise excludes the zilla image, so the freshly-built image is never shadowed by a stale cached copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URjAMEEeyTwwdPpZigRibg

---
_Generated by [Claude Code](https://claude.ai/code/session_01URjAMEEeyTwwdPpZigRibg)_