### PR TITLE
test(examples): make smoke-test CI deterministic with readiness gating

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,7 +200,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          sparse-checkout: examples/${{ matrix.dir }}
+          sparse-checkout: |
+            examples/.github
+            examples/${{ matrix.dir }}
 
       - name: Route Docker Hub pulls through mirror.gcr.io
         run: |

--- a/examples/.github/test-lib.sh
+++ b/examples/.github/test-lib.sh
@@ -1,0 +1,52 @@
+# shellcheck shell=sh
+# Shared readiness/retry helpers for the example smoke tests run by the
+# "testing" job in .github/workflows/build.yml.
+#
+# Why this exists: `docker compose up -d --wait` only blocks on container
+# healthchecks. Every example's Zilla healthcheck is a TCP-port probe
+# (`echo -n '' > /dev/tcp/...`), which confirms the listener is bound but not
+# that the data plane is ready -- the Kafka topic may not yet hold the produced
+# record, a consumer group may not have joined, or a route may still be warming
+# up. Asserting on the first call therefore races, which is the dominant cause
+# of intermittent failures (empty OUTPUT, `OUTPUT=[]` before a record is
+# fetchable, or a `timeout` firing before a streamed response arrives).
+#
+# These helpers gate WHEN an assertion runs without changing WHAT it asserts:
+# the data-plane call is re-run until it produces the expected result or a
+# bounded number of attempts elapse. The existing comparison block is left
+# unchanged and remains the authority on pass/fail.
+#
+# Source it from an example's .github/test.sh, resolving the path relative to
+# the script rather than the working directory so it also works when the script
+# is run by hand from the example directory:
+#
+#   . "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
+# retry_until <attempts> <delay_seconds> <command...>
+#
+# Run <command> repeatedly until it exits 0, up to <attempts> times, sleeping
+# <delay_seconds> between attempts. Returns the command's final exit status, so
+# the caller can fall through to its normal assertion on the last result.
+#
+# <command> is typically a shell function defined by the caller that performs
+# the call and assigns OUTPUT / RESULT. Because the function runs in the current
+# shell -- not a subshell -- the variables it sets remain visible afterwards, so
+# the example's existing `echo OUTPUT` / comparison block runs unchanged once
+# the gate succeeds or the attempts are exhausted.
+retry_until() {
+  _attempts=$1
+  _delay=$2
+  shift 2
+
+  _attempt=1
+  until "$@"
+  do
+    _status=$?
+    if [ "$_attempt" -ge "$_attempts" ]
+    then
+      return "$_status"
+    fi
+    _attempt=$((_attempt + 1))
+    sleep "$_delay"
+  done
+}

--- a/examples/grpc.echo/.github/test.sh
+++ b/examples/grpc.echo/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 
 # GIVEN
@@ -16,7 +18,11 @@ echo EXPECTED="$EXPECTED"
 echo
 
 # WHEN
-OUTPUT=$(docker compose run --rm grpcurl -plaintext -proto echo.proto  -d "$INPUT" zilla.examples.dev:$PORT example.EchoService.EchoUnary)
+echo_unary() {
+  OUTPUT=$(docker compose run --rm grpcurl -plaintext -proto echo.proto  -d "$INPUT" zilla.examples.dev:$PORT example.EchoService.EchoUnary)
+  [ $? -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 10 3 echo_unary
 RESULT=$?
 echo RESULT="$RESULT"
 # THEN
@@ -43,7 +49,11 @@ echo EXPECTED="$EXPECTED"
 echo
 
 # WHEN
-OUTPUT=$(docker compose run --rm grpcurl -plaintext -proto echo.proto  -d "$INPUT" zilla.examples.dev:$PORT example.EchoService.EchoBidiStream)
+echo_bidi() {
+  OUTPUT=$(docker compose run --rm grpcurl -plaintext -proto echo.proto  -d "$INPUT" zilla.examples.dev:$PORT example.EchoService.EchoBidiStream)
+  [ $? -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 10 3 echo_bidi
 RESULT=$?
 echo RESULT="$RESULT"
 # THEN

--- a/examples/grpc.kafka.echo/.github/test.sh
+++ b/examples/grpc.kafka.echo/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 
 # GIVEN
@@ -16,7 +18,12 @@ echo EXPECTED="$EXPECTED"
 echo
 
 # WHEN
-OUTPUT=$(docker compose run --rm grpcurl -plaintext -proto echo.proto  -d "$INPUT" zilla.examples.dev:$PORT grpc.examples.echo.Echo.UnaryEcho)
+# retry until the grpc-kafka route is live and echoes the request back
+echo_unary() {
+  OUTPUT=$(docker compose run --rm grpcurl -plaintext -proto echo.proto  -d "$INPUT" zilla.examples.dev:$PORT grpc.examples.echo.Echo.UnaryEcho)
+  [ $? -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 10 3 echo_unary
 RESULT=$?
 echo RESULT="$RESULT"
 
@@ -44,7 +51,11 @@ echo EXPECTED="$EXPECTED"
 echo
 
 # WHEN
-OUTPUT=$(docker compose run --rm grpcurl -plaintext -proto echo.proto  -d "$INPUT" zilla.examples.dev:$PORT grpc.examples.echo.Echo.BidirectionalStreamingEcho)
+echo_bidi() {
+  OUTPUT=$(docker compose run --rm grpcurl -plaintext -proto echo.proto  -d "$INPUT" zilla.examples.dev:$PORT grpc.examples.echo.Echo.BidirectionalStreamingEcho)
+  [ $? -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 10 3 echo_bidi
 RESULT=$?
 echo RESULT="$RESULT"
 

--- a/examples/grpc.kafka.fanout/.github/test.sh
+++ b/examples/grpc.kafka.fanout/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 
 # GIVEN
@@ -17,11 +19,17 @@ echo
 
 # WHEN
 
-sleep 10
+# produce the record once; the fanout stream replays it from the topic on every
+# connection, so re-reading below is safe and must not re-produce
+docker compose -p zilla-grpc-kafka-fanout exec kafkacat kafkacat -P -b kafka.examples.dev:29092 -t messages -k -e /tmp/binary.data
 
-(docker compose -p zilla-grpc-kafka-fanout exec kafkacat kafkacat -P -b kafka.examples.dev:29092 -t messages -k -e /tmp/binary.data)
-
-OUTPUT=$(echo "EXIT" | timeout 3s docker compose run --rm grpcurl -plaintext -proto fanout.proto  -d '' zilla.examples.dev:$PORT example.FanoutService.FanoutServerStream)
+# the grpc-kafka route warms up after the TCP healthcheck passes; retry the
+# streamed read until it returns the produced record or attempts are exhausted
+read_fanout() {
+  OUTPUT=$(echo "EXIT" | timeout 3s docker compose run --rm grpcurl -plaintext -proto fanout.proto  -d '' zilla.examples.dev:$PORT example.FanoutService.FanoutServerStream)
+  [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 10 3 read_fanout
 RESULT=$?
 echo RESULT="$RESULT"
 # THEN

--- a/examples/grpc.kafka.proxy/.github/test.sh
+++ b/examples/grpc.kafka.proxy/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 
 # GIVEN
@@ -16,7 +18,11 @@ echo EXPECTED="$EXPECTED"
 echo
 
 # WHEN
-OUTPUT=$(docker compose run --rm grpcurl -plaintext -max-time 10 -proto echo.proto  -d "$INPUT" zilla.examples.dev:$PORT grpc.examples.echo.Echo.UnaryEcho)
+echo_unary() {
+  OUTPUT=$(docker compose run --rm grpcurl -plaintext -max-time 10 -proto echo.proto  -d "$INPUT" zilla.examples.dev:$PORT grpc.examples.echo.Echo.UnaryEcho)
+  [ $? -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 10 3 echo_unary
 RESULT=$?
 echo RESULT="$RESULT"
 # THEN
@@ -70,7 +76,11 @@ echo EXPECTED="$EXPECTED"
 echo
 
 # WHEN
-OUTPUT=$(docker compose run --rm grpcurl -plaintext -max-time 10 -proto echo.proto  -d "$INPUT" zilla.examples.dev:$PORT grpc.examples.echo.Echo.ServerStreamingEcho)
+echo_server_streaming() {
+  OUTPUT=$(docker compose run --rm grpcurl -plaintext -max-time 10 -proto echo.proto  -d "$INPUT" zilla.examples.dev:$PORT grpc.examples.echo.Echo.ServerStreamingEcho)
+  [ $? -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 10 3 echo_server_streaming
 RESULT=$?
 echo RESULT="$RESULT"
 # THEN
@@ -98,7 +108,11 @@ echo EXPECTED="$EXPECTED"
 echo
 
 # WHEN
-OUTPUT=$(docker compose run --rm grpcurl -plaintext -max-time 10 -proto echo.proto  -d "$INPUT" zilla.examples.dev:$PORT grpc.examples.echo.Echo.BidirectionalStreamingEcho)
+echo_bidi() {
+  OUTPUT=$(docker compose run --rm grpcurl -plaintext -max-time 10 -proto echo.proto  -d "$INPUT" zilla.examples.dev:$PORT grpc.examples.echo.Echo.BidirectionalStreamingEcho)
+  [ $? -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 10 3 echo_bidi
 RESULT=$?
 echo RESULT="$RESULT"
 # THEN

--- a/examples/grpc.proxy/.github/test.sh
+++ b/examples/grpc.proxy/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 
 # GIVEN
@@ -16,7 +18,11 @@ echo EXPECTED="$EXPECTED"
 echo
 
 # WHEN
-OUTPUT=$(docker compose run --rm grpcurl -insecure -proto echo.proto  -d "$INPUT" zilla.examples.dev:$PORT grpc.examples.echo.Echo.UnaryEcho)
+echo_unary() {
+  OUTPUT=$(docker compose run --rm grpcurl -insecure -proto echo.proto  -d "$INPUT" zilla.examples.dev:$PORT grpc.examples.echo.Echo.UnaryEcho)
+  [ $? -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 10 3 echo_unary
 RESULT=$?
 echo RESULT="$RESULT"
 # THEN
@@ -70,7 +76,11 @@ echo EXPECTED="$EXPECTED"
 echo
 
 # WHEN
-OUTPUT=$(docker compose run --rm grpcurl -insecure -proto echo.proto  -d "$INPUT" zilla.examples.dev:$PORT grpc.examples.echo.Echo.ServerStreamingEcho)
+echo_server_streaming() {
+  OUTPUT=$(docker compose run --rm grpcurl -insecure -proto echo.proto  -d "$INPUT" zilla.examples.dev:$PORT grpc.examples.echo.Echo.ServerStreamingEcho)
+  [ $? -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 10 3 echo_server_streaming
 RESULT=$?
 echo RESULT="$RESULT"
 # THEN

--- a/examples/http.filesystem/.github/test.sh
+++ b/examples/http.filesystem/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 
 # GIVEN
@@ -19,7 +21,11 @@ echo EXPECTED="$EXPECTED"
 echo
 
 # WHEN
-OUTPUT=$(curl http://localhost:$PORT/index.html)
+get_index() {
+  OUTPUT=$(curl http://localhost:$PORT/index.html)
+  [ $? -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 5 2 get_index
 RESULT=$?
 echo RESULT="$RESULT"
 

--- a/examples/http.json.schema/.github/test.sh
+++ b/examples/http.json.schema/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 
 # GIVEN
@@ -15,7 +17,11 @@ echo EXPECTED="$EXPECTED"
 echo
 
 # WHEN
-OUTPUT=$(curl http://localhost:$PORT/valid.json)
+get_valid() {
+  OUTPUT=$(curl http://localhost:$PORT/valid.json)
+  [ $? -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 5 2 get_valid
 RESULT=$?
 echo RESULT="$RESULT"
 
@@ -39,8 +45,12 @@ echo PORT="$PORT"
 echo
 
 # WHEN
-OUTPUT=$(curl http://localhost:$PORT/invalid.json)
-RESULT=$?
+get_invalid() {
+  OUTPUT=$(curl http://localhost:$PORT/invalid.json)
+  RESULT=$?
+  [ "$RESULT" -eq 18 ]
+}
+retry_until 5 2 get_invalid
 echo RESULT="$RESULT"
 
 # THEN

--- a/examples/http.kafka.avro.json/.github/test.sh
+++ b/examples/http.kafka.avro.json/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 
 # create schema
@@ -28,11 +30,16 @@ echo INPUT="$INPUT"
 echo EXPECTED="$EXPECTED"
 echo
 
-# send message
-curl -k http://localhost:7114/items -H 'Idempotency-Key: 1'  -H 'Content-Type: application/json' -d "$INPUT"
-
 # WHEN
-OUTPUT=$(curl -k http://localhost:$PORT/items/1)
+# the producing POST goes through Zilla and can race a cold route; retry the
+# send+read together. The Idempotency-Key makes re-posting collapse to a single
+# record.
+send_then_fetch_valid() {
+  curl -k http://localhost:7114/items -H 'Idempotency-Key: 1'  -H 'Content-Type: application/json' -d "$INPUT"
+  OUTPUT=$(curl -k http://localhost:$PORT/items/1)
+  [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 10 3 send_then_fetch_valid
 RESULT=$?
 echo RESULT="$RESULT"
 
@@ -61,7 +68,11 @@ echo
 curl -k http://localhost:7114/items -H 'Idempotency-Key: 2'  -H 'Content-Type: application/json' -d "$INPUT"
 
 # WHEN
-OUTPUT=$(curl -w "%{http_code}" http://localhost:$PORT/items/2)
+fetch_invalid() {
+  OUTPUT=$(curl -w "%{http_code}" http://localhost:$PORT/items/2)
+  [ $? -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 10 3 fetch_invalid
 RESULT=$?
 echo RESULT="$RESULT"
 

--- a/examples/http.kafka.cache/.github/test.sh
+++ b/examples/http.kafka.cache/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 
 # GIVEN
@@ -13,7 +15,11 @@ echo EXPECTED="$EXPECTED"
 echo
 
 # WHEN
-OUTPUT=$(curl http://localhost:$PORT/items)
+fetch_empty() {
+  OUTPUT=$(curl http://localhost:$PORT/items)
+  [ $? -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 10 3 fetch_empty
 RESULT=$?
 echo RESULT="$RESULT"
 
@@ -47,7 +53,11 @@ echo "$INPUT" | docker compose -p zilla-http-kafka-cache exec -T kafkacat \
     -H "content-type=application/json"
 
 # WHEN
-OUTPUT=$(curl http://localhost:$PORT/items)
+fetch_item() {
+  OUTPUT=$(curl http://localhost:$PORT/items)
+  [ $? -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 10 3 fetch_item
 RESULT=$?
 echo RESULT="$RESULT"
 

--- a/examples/http.kafka.crud/.github/test.sh
+++ b/examples/http.kafka.crud/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 
 # GIVEN
@@ -13,10 +15,15 @@ echo INPUT="$INPUT"
 echo EXPECTED="$EXPECTED"
 echo
 
-curl -k -v -X POST http://localhost:$PORT/items -H 'Idempotency-Key: 1'  -H 'Content-Type: application/json' -d "$INPUT"
-
 # WHEN
-OUTPUT=$(curl -k http://localhost:$PORT/items/1)
+# the POST goes through Zilla and can race a cold route; retry the create+read
+# together. The Idempotency-Key makes re-posting collapse to a single record.
+create_then_fetch() {
+  curl -k -v -X POST http://localhost:$PORT/items -H 'Idempotency-Key: 1'  -H 'Content-Type: application/json' -d "$INPUT"
+  OUTPUT=$(curl -k http://localhost:$PORT/items/1)
+  [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 10 3 create_then_fetch
 RESULT=$?
 echo RESULT="$RESULT"
 

--- a/examples/http.kafka.oneway.oauthbearer/.github/test.sh
+++ b/examples/http.kafka.oneway.oauthbearer/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 
 PORT="7114"
@@ -10,10 +12,14 @@ echo "# Testing http.kafka.oneway.oauthbearer"
 echo "PORT=$PORT"
 
 # Test POST without Authorization header - expect 204 (HTTP is open, Kafka uses service account)
-RESULT=$(curl -s -o /dev/null -w "%{http_code}" \
-    http://localhost:$PORT/events \
-    -H "Content-Type: application/json" \
-    -d "$MESSAGE")
+post_events() {
+  RESULT=$(curl -s -o /dev/null -w "%{http_code}" \
+      http://localhost:$PORT/events \
+      -H "Content-Type: application/json" \
+      -d "$MESSAGE")
+  [ "$RESULT" = "204" ]
+}
+retry_until 5 2 post_events
 if [ "$RESULT" = "204" ]; then
   echo ✅
 else

--- a/examples/http.kafka.oneway/.github/test.sh
+++ b/examples/http.kafka.oneway/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 
 # GIVEN
@@ -14,8 +16,12 @@ echo EXPECTED="$EXPECTED"
 echo
 
 # WHEN
-OUTPUT=$(curl -w "%{http_code}" http://localhost:$PORT/events -H "Content-Type: application/json" -d "$INPUT")
-RESULT=$?
+post_events() {
+  OUTPUT=$(curl -w "%{http_code}" http://localhost:$PORT/events -H "Content-Type: application/json" -d "$INPUT")
+  RESULT=$?
+  [ "$RESULT" -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 5 2 post_events
 echo RESULT="$RESULT"
 
 # THEN

--- a/examples/http.kafka.proto.json/.github/test.sh
+++ b/examples/http.kafka.proto.json/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 
 # GIVEN
@@ -14,8 +16,12 @@ echo EXPECTED="$EXPECTED"
 echo
 
 # WHEN
-OUTPUT=$(curl -w "%{http_code}" http://localhost:$PORT/requests -H "Content-Type: application/json" -d "$INPUT")
-RESULT=$?
+post_valid() {
+  OUTPUT=$(curl -w "%{http_code}" http://localhost:$PORT/requests -H "Content-Type: application/json" -d "$INPUT")
+  RESULT=$?
+  [ "$RESULT" -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 5 2 post_valid
 echo RESULT="$RESULT"
 
 # THEN
@@ -40,8 +46,12 @@ echo EXPECTED="$EXPECTED"
 echo
 
 # WHEN
-OUTPUT=$(curl -w "%{http_code}" http://localhost:$PORT/requests -H "Content-Type: application/json" -d "$INPUT")
-RESULT=$?
+post_invalid() {
+  OUTPUT=$(curl -w "%{http_code}" http://localhost:$PORT/requests -H "Content-Type: application/json" -d "$INPUT")
+  RESULT=$?
+  [ "$RESULT" -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 5 2 post_invalid
 echo RESULT="$RESULT"
 
 # THEN

--- a/examples/http.kafka.proto.oneway/.github/test.sh
+++ b/examples/http.kafka.proto.oneway/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 
 # GIVEN
@@ -22,10 +24,14 @@ if [ ! -f "$ENCODED_FILE" ]; then
 fi
 
 # WHEN
-OUTPUT=$(curl -w "%{http_code}" -s --request POST http://localhost:$PORT/requests \
-  --header "Content-Type: application/protobuf" \
-  --data-binary @"$ENCODED_FILE")
-RESULT=$?
+post_requests() {
+  OUTPUT=$(curl -w "%{http_code}" -s --request POST http://localhost:$PORT/requests \
+    --header "Content-Type: application/protobuf" \
+    --data-binary @"$ENCODED_FILE")
+  RESULT=$?
+  [ "$RESULT" -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 5 2 post_requests
 echo RESULT="$RESULT"
 
 # THEN

--- a/examples/http.metrics/.github/test.sh
+++ b/examples/http.metrics/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 
 # GIVEN
@@ -15,7 +17,11 @@ echo EXPECTED="$EXPECTED"
 echo
 
 # WHEN
-OUTPUT=$(curl -sf -d "$INPUT" http://localhost:$PORT/items)
+post_items() {
+  OUTPUT=$(curl -sf -d "$INPUT" http://localhost:$PORT/items)
+  [ $? -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 5 2 post_items
 RESULT=$?
 echo RESULT="$RESULT"
 
@@ -31,8 +37,12 @@ else
 fi
 
 # Verify metrics endpoint responds
-METRICS=$(curl -sf http://localhost:$METRICS_PORT/metrics)
-RESULT=$?
+get_metrics() {
+  METRICS=$(curl -sf http://localhost:$METRICS_PORT/metrics)
+  RESULT=$?
+  [ "$RESULT" -eq 0 ]
+}
+retry_until 5 2 get_metrics
 echo METRICS_RESULT="$RESULT"
 if [ "$RESULT" -ne 0 ]; then
   echo ❌ Metrics endpoint failed

--- a/examples/http.proxy.jwt/.github/test.sh
+++ b/examples/http.proxy.jwt/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 PORT="7114"
 MESSAGE="Hello, world"
@@ -19,10 +21,14 @@ JWT_TOKEN_NO_SCOPE=$(docker compose run --rm \
     --no-iat \
     --secret @/private.pem | tr -d '\r\n')
 
-UNAUTHORIZED_RESPONSE=$(curl -w "%{http_code}" http://localhost:$PORT/ \
-    -H "Authorization: Bearer $JWT_TOKEN_NO_SCOPE" \
-    -H "Content-Type: text/plain" \
-    -d "$MESSAGE")
+get_unauthorized() {
+  UNAUTHORIZED_RESPONSE=$(curl -w "%{http_code}" http://localhost:$PORT/ \
+      -H "Authorization: Bearer $JWT_TOKEN_NO_SCOPE" \
+      -H "Content-Type: text/plain" \
+      -d "$MESSAGE")
+  [ "$UNAUTHORIZED_RESPONSE" = "404" ]
+}
+retry_until 5 2 get_unauthorized
 
 if [ "$UNAUTHORIZED_RESPONSE" = "404" ]; then
   echo ✅
@@ -43,10 +49,14 @@ JWT_TOKEN_WITH_SCOPE=$(docker compose run --rm \
     --payload "scope=echo:stream" \
     --secret @/private.pem | tr -d '\r\n')
 
-AUTHORIZED_RESPONSE=$(curl "http://localhost:$PORT/" \
-    -H "Authorization: Bearer $JWT_TOKEN_WITH_SCOPE" \
-    -H "Content-Type: text/plain" \
-    -d "$MESSAGE")
+get_authorized() {
+  AUTHORIZED_RESPONSE=$(curl "http://localhost:$PORT/" \
+      -H "Authorization: Bearer $JWT_TOKEN_WITH_SCOPE" \
+      -H "Content-Type: text/plain" \
+      -d "$MESSAGE")
+  [ "$AUTHORIZED_RESPONSE" = "$MESSAGE" ]
+}
+retry_until 5 2 get_authorized
 
 if [ "$AUTHORIZED_RESPONSE" = "$MESSAGE" ]; then
   echo ✅

--- a/examples/http.proxy/.github/test.sh
+++ b/examples/http.proxy/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 
 # GIVEN
@@ -21,7 +23,11 @@ echo EXPECTED="$EXPECTED"
 echo
 
 # WHEN
-OUTPUT=$(docker compose -p zilla-http-proxy exec nghttp nghttp --no-verify https://zilla.examples.dev:$PORT/demo.html)
+get_demo() {
+  OUTPUT=$(docker compose -p zilla-http-proxy exec nghttp nghttp --no-verify https://zilla.examples.dev:$PORT/demo.html)
+  [ $? -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 5 2 get_demo
 RESULT=$?
 echo RESULT="$RESULT"
 

--- a/examples/mcp.proxy/.github/test.sh
+++ b/examples/mcp.proxy/.github/test.sh
@@ -10,6 +10,8 @@
 # streamed body / client output rather than asserting exact-string equality.
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 PORT="7114"
 INITIALIZE='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{"elicitation":{"url":{}}},"clientInfo":{"name":"zilla-mcp-proxy-test","version":"0.0.1"}}}'
@@ -19,11 +21,16 @@ echo "PORT=$PORT"
 
 # WHEN: a url-elicitation-capable client initializes against the gateway
 # THEN: the gateway negotiates protocol version 2025-11-25 in the response
-INIT_BODY=$(curl -sS -N --max-time 10 \
-    -X POST "http://localhost:$PORT/mcp" \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -d "$INITIALIZE")
+# retry until the mcp route is live and negotiates the protocol version
+initialize_mcp() {
+  INIT_BODY=$(curl -sS -N --max-time 10 \
+      -X POST "http://localhost:$PORT/mcp" \
+      -H "Content-Type: application/json" \
+      -H "Accept: application/json, text/event-stream" \
+      -d "$INITIALIZE")
+  echo "$INIT_BODY" | grep -q '"protocolVersion":"2025-11-25"'
+}
+retry_until 10 3 initialize_mcp
 echo INIT_BODY="$INIT_BODY"
 if echo "$INIT_BODY" | grep -q '"protocolVersion":"2025-11-25"'; then
   echo ✅ initialize negotiated 2025-11-25
@@ -36,9 +43,13 @@ fi
 #       calls the urlelicit toolkit's authorize tool through the gateway
 # THEN: Zilla relays the mode:url elicitation/create request and the subsequent
 #       notifications/elicitation/complete back to the client
-ELICIT_OUT=$(docker compose run --rm --no-deps \
-    -e MCP_URL="http://zilla:$PORT/mcp" \
-    urlelicit-client 2>&1)
+relay_elicitation() {
+  ELICIT_OUT=$(docker compose run --rm --no-deps \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      urlelicit-client 2>&1)
+  echo "$ELICIT_OUT" | grep -q 'OK url-mode elicitation relayed end-to-end'
+}
+retry_until 10 3 relay_elicitation
 echo "$ELICIT_OUT"
 if echo "$ELICIT_OUT" | grep -q 'OK url-mode elicitation relayed end-to-end'; then
   echo ✅ url-mode elicitation relayed end-to-end

--- a/examples/openapi.asyncapi.kakfa.proxy/.github/test.sh
+++ b/examples/openapi.asyncapi.kakfa.proxy/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 
 # GIVEN
@@ -13,10 +15,17 @@ echo INPUT="$INPUT"
 echo EXPECTED="$EXPECTED"
 echo
 
-curl "http://localhost:$PORT/pets" --header 'Content-Type: application/json' --header 'Idempotency-Key: 1' --data "$INPUT"
-
 # WHEN
-OUTPUT=$(curl "http://localhost:$PORT/pets")
+# the GET races the POST->produce->fetch round-trip, so a single read can return
+# [] before the record is fetchable; retry until the produced pet is listed. The
+# POST carries an Idempotency-Key and the topic is compacted by id, so re-posting
+# across attempts collapses to a single entry and is safe to repeat.
+post_then_get() {
+  curl "http://localhost:$PORT/pets" --header 'Content-Type: application/json' --header 'Idempotency-Key: 1' --data "$INPUT"
+  OUTPUT=$(curl "http://localhost:$PORT/pets")
+  [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 10 3 post_then_get
 RESULT=$?
 echo RESULT="$RESULT"
 

--- a/examples/openapi.proxy/.github/test.sh
+++ b/examples/openapi.proxy/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 
 # GIVEN
@@ -12,7 +14,11 @@ echo EXPECTED="$EXPECTED"
 echo
 
 # WHEN
-OUTPUT=$(curl --silent --location "http://localhost:$PORT/pets" --header 'Accept: application/json')
+get_pets() {
+  OUTPUT=$(curl --silent --location "http://localhost:$PORT/pets" --header 'Accept: application/json')
+  [ $? -eq 0 ] && [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 5 2 get_pets
 RESULT=$?
 echo RESULT="$RESULT"
 

--- a/examples/sse.kafka.fanout.jwt/.github/test.sh
+++ b/examples/sse.kafka.fanout.jwt/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 
 # GIVEN
@@ -40,9 +42,12 @@ echo "$INPUT" |
     -t events \
     -k "1"
 
-sleep 5
 # send request to zilla
-OUTPUT=$(timeout 3s curl --cacert test-ca.crt -N --http2 -H "Accept:text/event-stream" "https://localhost:$PORT/events?access_token=${JWT_TOKEN}" | grep "^data:")
+stream_events() {
+  OUTPUT=$(timeout 3s curl --cacert test-ca.crt -N --http2 -H "Accept:text/event-stream" "https://localhost:$PORT/events?access_token=${JWT_TOKEN}" | grep "^data:")
+  [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 10 3 stream_events
 
 # THEN
 echo OUTPUT="$OUTPUT"

--- a/examples/sse.kafka.fanout/.github/test.sh
+++ b/examples/sse.kafka.fanout/.github/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+. "$(CDPATH= cd -- "$(dirname -- "$0")/../../.github" && pwd)/test-lib.sh"
+
 EXIT=0
 
 # GIVEN
@@ -30,9 +32,12 @@ echo "$INPUT" |
     -k "1" \
     -H "tag=abc"
 
-sleep 5
 # send request to zilla
-OUTPUT=$(timeout 3s curl -N --http2 -H "Accept:text/event-stream" "http://localhost:$PORT/events/1/abc" | grep "^data:")
+stream_events() {
+  OUTPUT=$(timeout 3s curl -N --http2 -H "Accept:text/event-stream" "http://localhost:$PORT/events/1/abc" | grep "^data:")
+  [ "$OUTPUT" = "$EXPECTED" ]
+}
+retry_until 10 3 stream_events
 
 # THEN
 echo OUTPUT="$OUTPUT"


### PR DESCRIPTION
## Problem

The `testing` matrix in `.github/workflows/build.yml` runs every `examples/<dir>` as a black-box smoke test. Several jobs fail intermittently for environmental/timing reasons, not code reasons (one even fired on a comment-only commit). Observed modes:

| Example | Symptom | Class |
|---|---|---|
| `openapi.asyncapi.kakfa.proxy` | `OUTPUT=[]` vs non-empty `EXPECTED` | POST→immediate-GET race |
| `grpc.kafka.fanout` | `RESULT=124`, empty `OUTPUT` | `timeout` fired before stream arrived |
| `grpc.kafka.echo` | stall during compose up | cold route / registry |

**Root cause:** `docker compose up -d --wait` only waits on container healthchecks, and every Zilla healthcheck is a TCP-port-only probe (`echo -n '' > /dev/tcp/...`). It confirms the listener is bound but **not** that the data plane is ready — Kafka topic populated, consumer group joined, route warmed up. Asserting on the first call therefore races.

## Fix

Add a shared `examples/.github/test-lib.sh` exposing `retry_until <attempts> <delay> <cmd…>`. Each affected `test.sh` sources it and re-runs the data-plane call (via a probe function that sets `OUTPUT`/`RESULT` in the current shell — not a subshell) until the expected condition holds or a bounded number of attempts elapse.

**Assertions are unchanged — only *when* they run is gated.** The existing `# THEN` comparison block stays the authority on pass/fail.

- The 3 observed flakes are fixed with care: `grpc.kafka.fanout` produces once then retries the streamed read; `openapi.asyncapi.kakfa.proxy` retries an idempotency-keyed POST+GET together.
- Swept all single-shot-assert scripts that depend on async readiness (Kafka / gRPC / SSE / HTTP-route fronting an upstream).
- **Produce-once discipline:** direct kafkacat→Kafka produces stay outside the retry; POSTs that go *through Zilla* (`http.kafka.crud`, `http.kafka.avro.json`) carry an `Idempotency-Key` so they are retried safely inside the gate.
- The `testing` job's sparse-checkout now also fetches `examples/.github` so the helper is present (`.github` is already in the matrix omit list).

Left untouched: pure layer-4 echo tests (`tcp/tls/ws.echo`, `amqp.reflect`) where the TCP healthcheck already implies readiness, and scripts that already gate with equivalent retry loops (`mqtt.*`, `http.kafka.async/sync`, `*.reflect`).

## Verification

- `sh -n` passes on all changed scripts and the helper (dash).
- `retry_until` unit-tested under dash: succeed-on-Nth-attempt, bounded-failure, variable propagation across the function boundary, first-attempt early return.
- Helper sourcing resolves correctly when invoked as CI does (`./.github/test.sh` with `working-directory: examples/<dir>`).
- `build.yml` validates as YAML.

Determinism should be confirmed by looping the three reproducers (`grpc.kafka.fanout`, `grpc.kafka.echo`, `openapi.asyncapi.kakfa.proxy`) in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FevdLGtjAvdDjESEu4yNMY

---
_Generated by [Claude Code](https://claude.ai/code/session_01FevdLGtjAvdDjESEu4yNMY)_