### PR TITLE
Replace Unsafe with Foreign Function & Memory API in UnsafeBufferEx

### DIFF
--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Array16FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Array16FWTest.java
@@ -41,13 +41,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class Array16FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(150000))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(150000));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final Array16FW<VariantEnumKindOfStringFW> flyweightRO =
         new Array16FW<>(new VariantEnumKindOfStringFW());

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Array32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Array32FWTest.java
@@ -39,13 +39,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class Array32FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(150000))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(150000));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final Array32FW<VariantEnumKindOfStringFW> flyweightRO =
         new Array32FW<>(new VariantEnumKindOfStringFW());

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Array8FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Array8FWTest.java
@@ -39,13 +39,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class Array8FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final Array8FW<VariantEnumKindOfStringFW> flyweightRO =
         new Array8FW<>(new VariantEnumKindOfStringFW());

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/BoundedOctets16FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/BoundedOctets16FWTest.java
@@ -33,13 +33,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class BoundedOctets16FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final BoundedOctets16FW.Builder flyweightRW = new BoundedOctets16FW.Builder();
 

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/BoundedOctets32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/BoundedOctets32FWTest.java
@@ -33,13 +33,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class BoundedOctets32FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final BoundedOctets32FW.Builder flyweightRW = new BoundedOctets32FW.Builder();
 

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/BoundedOctets8FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/BoundedOctets8FWTest.java
@@ -33,13 +33,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class BoundedOctets8FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final BoundedOctets8FW.Builder flyweightRW = new BoundedOctets8FW.Builder();
 

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ConstrainedMapFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ConstrainedMapFWTest.java
@@ -40,13 +40,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class ConstrainedMapFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final ConstrainedMapFW.Builder<VariantWithoutOfFW, VariantWithoutOfFW.Builder> flyweightRW =
         new ConstrainedMapFW.Builder<>(new VariantEnumKindOfStringFW(), new VariantWithoutOfFW(),

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ContiguousSizeFieldsFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ContiguousSizeFieldsFWTest.java
@@ -37,11 +37,8 @@ public class ContiguousSizeFieldsFWTest
     private final MutableDirectBufferEx expected = new UnsafeBufferEx(new byte[100]);
 
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            buffer.setMemory(0, buffer.capacity(), (byte) 0xab);
-            expected.setMemory(0, expected.capacity(), (byte) 0xab);
-        }
+        buffer.setMemory(0, buffer.capacity(), (byte) 0xab);
+        expected.setMemory(0, expected.capacity(), (byte) 0xab);
     }
 
     private final ContiguousSizeFieldsFW.Builder builder = new ContiguousSizeFieldsFW.Builder();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithInt16FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithInt16FWTest.java
@@ -33,21 +33,19 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class EnumWithInt16FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx expected;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
 
     private final EnumWithInt16FW.Builder flyweightRW = new EnumWithInt16FW.Builder();
     private final EnumWithInt16FW flyweightRO = new EnumWithInt16FW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithInt32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithInt32FWTest.java
@@ -33,21 +33,19 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class EnumWithInt32FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx expected;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
 
     private final EnumWithInt32FW.Builder flyweightRW = new EnumWithInt32FW.Builder();
     private final EnumWithInt32FW flyweightRO = new EnumWithInt32FW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithInt64FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithInt64FWTest.java
@@ -33,13 +33,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class EnumWithInt64FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final EnumWithInt64FW.Builder flyweightRW = new EnumWithInt64FW.Builder();
     private final EnumWithInt64FW flyweightRO = new EnumWithInt64FW();
@@ -59,20 +58,10 @@ public class EnumWithInt64FWTest
     @Test
     public void shouldSetUsingEnum()
     {
-        MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(8))
-        {
-            {
-                // Make sure the code is not secretly relying upon memory being initialized to 0
-                setMemory(0, capacity(), (byte) 0xab);
-            }
-        };
-        MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(8))
-        {
-            {
-                // Make sure the code is not secretly relying upon memory being initialized to 0
-                setMemory(0, capacity(), (byte) 0xab);
-            }
-        };
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(8));
+        buffer.setMemory(0, buffer.capacity(), (byte) 0xab);
+        MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(8));
+        expected.setMemory(0, expected.capacity(), (byte) 0xab);
         int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
                                .set(EnumWithInt64.TWELVE)
                                .build()
@@ -85,13 +74,8 @@ public class EnumWithInt64FWTest
     @Test
     public void shouldNotTryWrapWhenIncomplete()
     {
-        MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(10 + SIZE_OF_LONG))
-        {
-            {
-                // Make sure the code is not secretly relying upon memory being initialized to 0
-                setMemory(0, capacity(), (byte) 0xab);
-            }
-        };
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(10 + SIZE_OF_LONG));
+        buffer.setMemory(0, buffer.capacity(), (byte) 0xab);
         int size = setAllTestValues(buffer, 10);
         for (int maxLimit = 10; maxLimit < 10 + size; maxLimit++)
         {
@@ -102,13 +86,8 @@ public class EnumWithInt64FWTest
     @Test
     public void shouldNotWrapWhenIncomplete()
     {
-        MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(10 + SIZE_OF_LONG))
-        {
-            {
-                // Make sure the code is not secretly relying upon memory being initialized to 0
-                setMemory(0, capacity(), (byte) 0xab);
-            }
-        };
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(10 + SIZE_OF_LONG));
+        buffer.setMemory(0, buffer.capacity(), (byte) 0xab);
         int size = setAllTestValues(buffer, 10);
         for (int maxLimit = 10; maxLimit < 10 + size; maxLimit++)
         {
@@ -131,13 +110,8 @@ public class EnumWithInt64FWTest
     public void shouldTryWrapAndReadAllValues() throws Exception
     {
         final int offset = 1;
-        MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(offset + SIZE_OF_LONG))
-        {
-            {
-                // Make sure the code is not secretly relying upon memory being initialized to 0
-                setMemory(0, capacity(), (byte) 0xab);
-            }
-        };
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(offset + SIZE_OF_LONG));
+        buffer.setMemory(0, buffer.capacity(), (byte) 0xab);
         setAllTestValues(buffer, offset);
         assertNotNull(flyweightRO.tryWrap(buffer, offset, buffer.capacity()));
         assertAllTestValuesRead(flyweightRO);
@@ -147,13 +121,8 @@ public class EnumWithInt64FWTest
     public void shouldWrapAndReadAllValues() throws Exception
     {
         final int offset = 10;
-        MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(offset + SIZE_OF_LONG))
-        {
-            {
-                // Make sure the code is not secretly relying upon memory being initialized to 0
-                setMemory(0, capacity(), (byte) 0xab);
-            }
-        };
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(offset + SIZE_OF_LONG));
+        buffer.setMemory(0, buffer.capacity(), (byte) 0xab);
         int size = setAllTestValues(buffer, offset);
         int limit = flyweightRO.wrap(buffer,  offset,  buffer.capacity()).limit();
         assertEquals(offset + size, limit);
@@ -164,13 +133,8 @@ public class EnumWithInt64FWTest
     public void shouldNotTryWrapAndReadInvalidValue() throws Exception
     {
         final int offset = 12;
-        MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(offset + SIZE_OF_LONG))
-        {
-            {
-                // Make sure the code is not secretly relying upon memory being initialized to 0
-                setMemory(0, capacity(), (byte) 0xab);
-            }
-        };
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(offset + SIZE_OF_LONG));
+        buffer.setMemory(0, buffer.capacity(), (byte) 0xab);
         buffer.putLong(offset, -2L);
         assertNotNull(flyweightRO.tryWrap(buffer, offset, buffer.capacity()));
         assertNull(flyweightRO.get());
@@ -180,13 +144,8 @@ public class EnumWithInt64FWTest
     public void shouldNotWrapAndReadInvalidValue() throws Exception
     {
         final int offset = 12;
-        MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(offset + SIZE_OF_LONG))
-        {
-            {
-                // Make sure the code is not secretly relying upon memory being initialized to 0
-                setMemory(0, capacity(), (byte) 0xab);
-            }
-        };
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(offset + SIZE_OF_LONG));
+        buffer.setMemory(0, buffer.capacity(), (byte) 0xab);
         buffer.putLong(offset, -2L);
         flyweightRO.wrap(buffer, offset, buffer.capacity()).limit();
         assertNull(flyweightRO.get());
@@ -196,13 +155,8 @@ public class EnumWithInt64FWTest
     public void shouldSetUsingEnumWithInt64FW()
     {
         int offset = 10;
-        MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(offset + SIZE_OF_LONG))
-        {
-            {
-                // Make sure the code is not secretly relying upon memory being initialized to 0
-                setMemory(0, capacity(), (byte) 0xab);
-            }
-        };
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(offset + SIZE_OF_LONG));
+        buffer.setMemory(0, buffer.capacity(), (byte) 0xab);
         EnumWithInt64FW bigNumber = new EnumWithInt64FW().wrap(asBuffer(0x10L), 0, SIZE_OF_LONG);
 
         int limit = flyweightRW.wrap(buffer, offset, offset + SIZE_OF_LONG)

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithInt8FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithInt8FWTest.java
@@ -32,21 +32,19 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class EnumWithInt8FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx expected;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
 
     private final EnumWithInt8FW.Builder flyweightRW = new EnumWithInt8FW.Builder();
     private final EnumWithInt8FW flyweightRO = new EnumWithInt8FW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithString16FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithString16FWTest.java
@@ -34,20 +34,18 @@ public class EnumWithString16FWTest
 {
     private static final int LENGTH_SIZE = 2;
 
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100000))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(100000))
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100000));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
+    private final MutableDirectBufferEx expected;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100000));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
     private final EnumWithString16FW.Builder flyweightRW = new EnumWithString16FW.Builder();
     private final EnumWithString16FW flyweightRO = new EnumWithString16FW();
 

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithString32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithString32FWTest.java
@@ -34,20 +34,18 @@ public class EnumWithString32FWTest
 {
     private static final int LENGTH_SIZE = 4;
 
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(1000000))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(1000000))
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(1000000));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
+    private final MutableDirectBufferEx expected;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(1000000));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
     private final EnumWithString32FW.Builder flyweightRW = new EnumWithString32FW.Builder();
     private final EnumWithString32FW flyweightRO = new EnumWithString32FW();
 

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithString8FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithString8FWTest.java
@@ -35,20 +35,18 @@ public class EnumWithString8FWTest
 {
     private static final int LENGTH_SIZE = BitUtil.SIZE_OF_BYTE;
 
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(100))
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
+    private final MutableDirectBufferEx expected;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
     private final EnumWithStringFW.Builder flyweightRW = new EnumWithStringFW.Builder();
     private final EnumWithStringFW flyweightRO = new EnumWithStringFW();
 

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithUint16FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithUint16FWTest.java
@@ -33,21 +33,19 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class EnumWithUint16FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx expected;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
 
     private final EnumWithUint16FW.Builder flyweightRW = new EnumWithUint16FW.Builder();
     private final EnumWithUint16FW flyweightRO = new EnumWithUint16FW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithUint32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithUint32FWTest.java
@@ -33,21 +33,19 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class EnumWithUint32FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx expected;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
 
     private final EnumWithUint32FW.Builder flyweightRW = new EnumWithUint32FW.Builder();
     private final EnumWithUint32FW flyweightRO = new EnumWithUint32FW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithUint64FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithUint64FWTest.java
@@ -33,21 +33,19 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class EnumWithUint64FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx expected;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
 
     private final EnumWithUint64FW.Builder flyweightRW = new EnumWithUint64FW.Builder();
     private final EnumWithUint64FW flyweightRO = new EnumWithUint64FW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithUint8FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithUint8FWTest.java
@@ -33,21 +33,19 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class EnumWithUint8FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx expected;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
 
     private final EnumWithUint8FW.Builder flyweightRW = new EnumWithUint8FW.Builder();
     private final EnumWithUint8FW flyweightRO = new EnumWithUint8FW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithVariantOfUint64FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithVariantOfUint64FWTest.java
@@ -32,13 +32,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class EnumWithVariantOfUint64FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final EnumWithVariantOfUint64FW.Builder flyweightRW = new EnumWithVariantOfUint64FW.Builder();
     private final EnumWithVariantOfUint64FW flyweightRO = new EnumWithVariantOfUint64FW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/FlatFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/FlatFWTest.java
@@ -34,20 +34,18 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class FlatFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(100))
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
+    private final MutableDirectBufferEx expected;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
     private final FlatFW.Builder flatRW = new FlatFW.Builder();
     private final FlatFW flatRO = new FlatFW();
     private final String8FW.Builder stringRW = new String8FW.Builder();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/FlatWithArrayFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/FlatWithArrayFWTest.java
@@ -37,20 +37,18 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class FlatWithArrayFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(100))
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
+    private final MutableDirectBufferEx expected;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
     private final FlatWithArrayFW.Builder flatRW = new FlatWithArrayFW.Builder();
     private final FlatWithArrayFW flyweightRO = new FlatWithArrayFW();
     private final String8FW.Builder stringRW = new String8FW.Builder();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/FlatWithOctetsFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/FlatWithOctetsFWTest.java
@@ -37,13 +37,12 @@ public class FlatWithOctetsFWTest
 {
     private static final int MEDIUM_INT_BYTES = 3;
 
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
     private final FlatWithOctetsFW.Builder flatWithOctetsRW = new FlatWithOctetsFW.Builder();
     private final FlatWithOctetsFW flatWithOctetsRO = new FlatWithOctetsFW();
 

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/FlyweightTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/FlyweightTest.java
@@ -35,13 +35,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class FlyweightTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(150))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(150));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final class TestFlyweight extends Flyweight
     {

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/IntegerFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/IntegerFWTest.java
@@ -27,13 +27,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class IntegerFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
     private final IntegersFW.Builder integersRW = new IntegersFW.Builder();
     private final IntegersFW integersRO = new IntegersFW();
 

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/IntegerFixedArraysFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/IntegerFixedArraysFWTest.java
@@ -37,19 +37,18 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class IntegerFixedArraysFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(199))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xFF);
-        }
-    };
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(199))
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(199));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xFF);
+        buffer = unsafe;
+    }
+    private final MutableDirectBufferEx expected;
     {
-        {
-            setMemory(0, capacity(), (byte) 0xFF);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(199));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xFF);
+        expected = unsafe;
+    }
     private final IntegerFixedArraysFW.Builder flyweightRW = new IntegerFixedArraysFW.Builder();
     private final IntegerFixedArraysFW flyweightRO = new IntegerFixedArraysFW();
 

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/IntegerVariableArraysFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/IntegerVariableArraysFWTest.java
@@ -38,19 +38,18 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class IntegerVariableArraysFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(100))
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
+    private final MutableDirectBufferEx expected;
     {
-        {
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
     private final IntegerVariableArraysFW.Builder flyweightRW = new IntegerVariableArraysFW.Builder();
     private final IntegerVariableArraysFW flyweightRO = new IntegerVariableArraysFW();
 

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/List0FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/List0FWTest.java
@@ -29,13 +29,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class List0FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final List0FW list0RO = new List0FW();
 

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/List32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/List32FWTest.java
@@ -37,13 +37,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class List32FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final List32FW.Builder list32RW = new List32FW.Builder();
     private final List32FW list32RO = new List32FW();
@@ -147,13 +146,8 @@ public class List32FWTest
     @Test
     public void shouldSetFieldsUsingFieldsMethodWithDirectBuffer() throws Exception
     {
-        final MutableDirectBufferEx listBuffer = new UnsafeBufferEx(allocateDirect(100))
-        {
-            {
-                // Make sure the code is not secretly relying upon memory being initialized to 0
-                setMemory(0, capacity(), (byte) 0xab);
-            }
-        };
+        final MutableDirectBufferEx listBuffer = new UnsafeBufferEx(allocateDirect(100));
+        listBuffer.setMemory(0, listBuffer.capacity(), (byte) 0xab);
         VariantEnumKindOfStringFW.Builder field1RW = new VariantEnumKindOfStringFW.Builder();
         VariantEnumKindOfUint32FW.Builder field2RW = new VariantEnumKindOfUint32FW.Builder();
         ListFW.Builder<List32FW> listRW = new List32FW.Builder()
@@ -176,13 +170,8 @@ public class List32FWTest
     @Test
     public void shouldSetFieldsUsingFieldsMethodWithVisitor() throws Exception
     {
-        final MutableDirectBufferEx listBuffer = new UnsafeBufferEx(allocateDirect(100))
-        {
-            {
-                // Make sure the code is not secretly relying upon memory being initialized to 0
-                setMemory(0, capacity(), (byte) 0xab);
-            }
-        };
+        final MutableDirectBufferEx listBuffer = new UnsafeBufferEx(allocateDirect(100));
+        listBuffer.setMemory(0, listBuffer.capacity(), (byte) 0xab);
         VariantEnumKindOfStringFW.Builder field1RW = new VariantEnumKindOfStringFW.Builder();
         VariantEnumKindOfUint32FW.Builder field2RW = new VariantEnumKindOfUint32FW.Builder();
         ListFW.Builder<List32FW> listRW = new List32FW.Builder()

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/List8FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/List8FWTest.java
@@ -37,13 +37,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class List8FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final List8FW.Builder list8RW = new List8FW.Builder();
     private final List8FW list8RO = new List8FW();
@@ -147,13 +146,8 @@ public class List8FWTest
     @Test
     public void shouldSetFieldsUsingFieldsMethodWithDirectBuffer() throws Exception
     {
-        final MutableDirectBufferEx listBuffer = new UnsafeBufferEx(allocateDirect(100))
-        {
-            {
-                // Make sure the code is not secretly relying upon memory being initialized to 0
-                setMemory(0, capacity(), (byte) 0xab);
-            }
-        };
+        final MutableDirectBufferEx listBuffer = new UnsafeBufferEx(allocateDirect(100));
+        listBuffer.setMemory(0, listBuffer.capacity(), (byte) 0xab);
         VariantEnumKindOfStringFW.Builder field1RW = new VariantEnumKindOfStringFW.Builder();
         VariantEnumKindOfUint32FW.Builder field2RW = new VariantEnumKindOfUint32FW.Builder();
         ListFW.Builder<List8FW> listRW = new List8FW.Builder()
@@ -176,13 +170,8 @@ public class List8FWTest
     @Test
     public void shouldSetFieldsUsingFieldsMethodWithVisitor() throws Exception
     {
-        final MutableDirectBufferEx listBuffer = new UnsafeBufferEx(allocateDirect(100))
-        {
-            {
-                // Make sure the code is not secretly relying upon memory being initialized to 0
-                setMemory(0, capacity(), (byte) 0xab);
-            }
-        };
+        final MutableDirectBufferEx listBuffer = new UnsafeBufferEx(allocateDirect(100));
+        listBuffer.setMemory(0, listBuffer.capacity(), (byte) 0xab);
         VariantEnumKindOfStringFW.Builder field1RW = new VariantEnumKindOfStringFW.Builder();
         VariantEnumKindOfUint32FW.Builder field2RW = new VariantEnumKindOfUint32FW.Builder();
         ListFW.Builder<List8FW> listRW = new List8FW.Builder()

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListFromVariantOfListFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListFromVariantOfListFWTest.java
@@ -35,13 +35,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class ListFromVariantOfListFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
     private final ListFromVariantOfListFW.Builder listFromVariantOfListRW = new ListFromVariantOfListFW.Builder();
     private final ListFromVariantOfListFW listFromVariantOfListRO = new ListFromVariantOfListFW();
     private final int lengthSize = Integer.BYTES;

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithArrayFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithArrayFWTest.java
@@ -42,13 +42,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class ListWithArrayFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
     private final ListWithArrayFW.Builder listWithArrayRW = new ListWithArrayFW.Builder();
     private final ListWithArrayFW listWithArrayRO = new ListWithArrayFW();
     private final int lengthSize = Byte.BYTES;

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithArrayOfStructFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithArrayOfStructFWTest.java
@@ -27,13 +27,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class ListWithArrayOfStructFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
     private final ListWithArrayOfStructFW.Builder listWithArrayRW = new ListWithArrayOfStructFW.Builder();
     private final ListWithArrayOfStructFW listWithArrayRO = new ListWithArrayOfStructFW();
 

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithConstrainedMapFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithConstrainedMapFWTest.java
@@ -45,13 +45,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class ListWithConstrainedMapFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final ListWithConstrainedMapFW.Builder flyweightRW = new ListWithConstrainedMapFW.Builder();
     private final ListWithConstrainedMapFW flyweightRO = new ListWithConstrainedMapFW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithEnumAndVariantWithDefaultFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithEnumAndVariantWithDefaultFWTest.java
@@ -35,13 +35,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class ListWithEnumAndVariantWithDefaultFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final ListWithEnumAndVariantWithDefaultFW.Builder listWithEnumAndVariantWithDefaultRW =
         new ListWithEnumAndVariantWithDefaultFW.Builder();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithEnumFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithEnumFWTest.java
@@ -44,13 +44,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class ListWithEnumFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
     private final ListWithEnumFW.Builder listWithEnumRW = new ListWithEnumFW.Builder();
     private final ListWithEnumFW listWithEnumRO = new ListWithEnumFW();
     private final int physicalLengthSize = Byte.BYTES;

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithMapFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithMapFWTest.java
@@ -44,13 +44,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class ListWithMapFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final ListWithMapFW.Builder flyweightRW = new ListWithMapFW.Builder();
     private final ListWithMapFW flyweightRO = new ListWithMapFW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithMissingFieldByteFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithMissingFieldByteFWTest.java
@@ -35,13 +35,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class ListWithMissingFieldByteFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
     private final ListWithMissingFieldByteFW.Builder listWithMissingFieldByteRW = new ListWithMissingFieldByteFW.Builder();
     private final ListWithMissingFieldByteFW listWithMissingFieldByteRO = new ListWithMissingFieldByteFW();
     private final int lengthSize = Integer.BYTES;

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithOctetsFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithOctetsFWTest.java
@@ -34,13 +34,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class ListWithOctetsFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
     private final ListWithOctetsFW.Builder listWithOctetsRW = new ListWithOctetsFW.Builder();
     private final ListWithOctetsFW listWithOctetsRO = new ListWithOctetsFW();
     private final int physicalLengthSize = Byte.BYTES;

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithPhysicalAndLogicalLengthFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithPhysicalAndLogicalLengthFWTest.java
@@ -32,13 +32,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class ListWithPhysicalAndLogicalLengthFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
     private final ListWithPhysicalAndLogicalLengthFW.Builder flyweightRW = new ListWithPhysicalAndLogicalLengthFW.Builder();
     private final ListWithPhysicalAndLogicalLengthFW flyweightRO = new ListWithPhysicalAndLogicalLengthFW();
     private final String8FW.Builder stringRW = new String8FW.Builder();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithTypedefFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithTypedefFWTest.java
@@ -32,13 +32,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class ListWithTypedefFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final ListWithTypedefFW.Builder flyweightRW = new ListWithTypedefFW.Builder();
     private final ListWithTypedefFW flyweightRO = new ListWithTypedefFW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithUnionFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithUnionFWTest.java
@@ -36,13 +36,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 public class ListWithUnionFWTest
 {
     private static final int KIND_SIZE = Byte.BYTES;
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
     private final ListWithUnionFW.Builder listWithUnionRW = new ListWithUnionFW.Builder();
     private final ListWithUnionFW listWithUnionRO = new ListWithUnionFW();
     private final int physicalLengthSize = Byte.BYTES;

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithVariantFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithVariantFWTest.java
@@ -38,13 +38,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class ListWithVariantFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
     private final ListWithVariantFW.Builder listWithVariantOfIntRW = new ListWithVariantFW.Builder();
     private final ListWithVariantFW listWithVariantOfIntRO = new ListWithVariantFW();
     private final int lengthSize = Byte.BYTES;

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Map16FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Map16FWTest.java
@@ -40,13 +40,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class Map16FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final Map16FW.Builder<TypedefStringFW, VariantEnumKindOfStringFW, TypedefStringFW.Builder,
         VariantEnumKindOfStringFW.Builder> flyweightRW =

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Map32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Map32FWTest.java
@@ -40,13 +40,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class Map32FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final Map32FW.Builder<TypedefStringFW, VariantEnumKindOfStringFW, TypedefStringFW.Builder,
         VariantEnumKindOfStringFW.Builder> flyweightRW =

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Map8FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Map8FWTest.java
@@ -40,13 +40,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class Map8FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final Map8FW.Builder<TypedefStringFW, VariantEnumKindOfStringFW, TypedefStringFW.Builder,
         VariantEnumKindOfStringFW.Builder> flyweightRW =

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/NestedFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/NestedFWTest.java
@@ -33,13 +33,12 @@ public class NestedFWTest
 {
     private final NestedFW.Builder nestedRW = new NestedFW.Builder();
     private final NestedFW nestedRO = new NestedFW();
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     static void assertAllTestValuesRead(NestedFW flyweight)
     {

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/OctetsDefaultedNoAnchorFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/OctetsDefaultedNoAnchorFWTest.java
@@ -28,13 +28,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class OctetsDefaultedNoAnchorFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(150))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(150));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
     private final OctetsDefaultedNoAnchorFW octetsDefaultedNoAnchorRO = new OctetsDefaultedNoAnchorFW();
 
     @Test

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/OctetsFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/OctetsFWTest.java
@@ -32,13 +32,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class OctetsFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
     private final OctetsFW.Builder octetsRW = new OctetsFW.Builder();
     private final OctetsFW octetsRO = new OctetsFW();
 

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/PotentialNameConflitsFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/PotentialNameConflitsFWTest.java
@@ -28,13 +28,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class PotentialNameConflitsFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
     private final PotentialNameConflictsFW.Builder potentialNameConflictsRW = new PotentialNameConflictsFW.Builder();
     private final PotentialNameConflictsFW potentialNameConflictsRO = new PotentialNameConflictsFW();
 

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/RollFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/RollFWTest.java
@@ -32,20 +32,18 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class RollFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(100))
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
+    private final MutableDirectBufferEx expected;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
     private final RollFW.Builder flyweightRW = new RollFW.Builder();
     private final RollFW flyweightRO = new RollFW();
 

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/String16FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/String16FWTest.java
@@ -42,13 +42,12 @@ public class String16FWTest
 {
     private static final int LENGTH_SIZE = 2;
 
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100000))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100000));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     @Parameters
     public static Collection<Object[]> values()

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/String32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/String32FWTest.java
@@ -42,13 +42,12 @@ public class String32FWTest
 {
     private static final int LENGTH_SIZE = 4;
 
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(1000000))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(1000000));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     @Parameters
     public static Collection<Object[]> values()

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/String8FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/String8FWTest.java
@@ -32,13 +32,12 @@ public class String8FWTest
 {
     private static final int LENGTH_SIZE = 1;
 
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
     private final String8FW.Builder stringRW = new String8FW.Builder();
     private final String8FW stringRO = new String8FW();
 

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/StructWithNonPrimitiveFieldsFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/StructWithNonPrimitiveFieldsFWTest.java
@@ -40,13 +40,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class StructWithNonPrimitiveFieldsFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final StructWithNonPrimitiveFieldsFW.Builder structWithNonPrimitiveFieldsRW =
         new StructWithNonPrimitiveFieldsFW.Builder();
@@ -173,13 +172,8 @@ public class StructWithNonPrimitiveFieldsFWTest
     @Test
     public void shouldSetFieldsWithFlyweights() throws Exception
     {
-        final MutableDirectBufferEx fieldBuffer = new UnsafeBufferEx(allocateDirect(100))
-        {
-            {
-                // Make sure the code is not secretly relying upon memory being initialized to 0
-                setMemory(0, capacity(), (byte) 0xab);
-            }
-        };
+        final MutableDirectBufferEx fieldBuffer = new UnsafeBufferEx(allocateDirect(100));
+        fieldBuffer.setMemory(0, fieldBuffer.capacity(), (byte) 0xab);
 
         final EnumWithUint8FW enumWithUint8 = enumWithUint8RW.wrap(fieldBuffer, 0, fieldBuffer.capacity())
             .set(EnumWithUint8.ICHI)

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/TypedefFromTypedefFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/TypedefFromTypedefFWTest.java
@@ -33,13 +33,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class TypedefFromTypedefFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final TypedefFromTypedefFW.Builder flyweightRW = new TypedefFromTypedefFW.Builder();
     private final TypedefFromTypedefFW flyweightRO = new TypedefFromTypedefFW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/TypedefUint32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/TypedefUint32FWTest.java
@@ -33,13 +33,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class TypedefUint32FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final TypedefUint32FW.Builder flyweightRW = new TypedefUint32FW.Builder();
     private final TypedefUint32FW flyweightRO = new TypedefUint32FW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/UnionChildFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/UnionChildFWTest.java
@@ -30,13 +30,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class UnionChildFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final UnionChildFW.Builder flyweightRW = new UnionChildFW.Builder();
     private final UnionChildFW flyweightRO = new UnionChildFW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/UnionOctetsFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/UnionOctetsFWTest.java
@@ -33,21 +33,19 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class UnionOctetsFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx expected;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
     private final UnionOctetsFW.Builder flyweightRW = new UnionOctetsFW.Builder();
     private final UnionOctetsFW flyweightRO = new UnionOctetsFW();
 

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/UnionStringFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/UnionStringFWTest.java
@@ -28,21 +28,19 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class UnionStringFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx expected;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
     private final UnionStringFW.Builder flyweightRW = new UnionStringFW.Builder();
     private final UnionStringFW flyweightRO = new UnionStringFW();
 

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/UnionWithEnumFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/UnionWithEnumFWTest.java
@@ -35,13 +35,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class UnionWithEnumFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final UnionWithEnumFW.Builder flyweightRW = new UnionWithEnumFW.Builder();
     private final UnionWithEnumFW flyweightRO = new UnionWithEnumFW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfInt16FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfInt16FWTest.java
@@ -33,13 +33,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class VariantEnumKindOfInt16FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final VariantEnumKindOfInt16FW.Builder flyweightRW = new VariantEnumKindOfInt16FW.Builder();
     private final VariantEnumKindOfInt16FW flyweightRO = new VariantEnumKindOfInt16FW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfInt8FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfInt8FWTest.java
@@ -33,13 +33,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class VariantEnumKindOfInt8FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final VariantEnumKindOfInt8FW.Builder flyweightRW = new VariantEnumKindOfInt8FW.Builder();
     private final VariantEnumKindOfInt8FW flyweightRO = new VariantEnumKindOfInt8FW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfStringFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfStringFWTest.java
@@ -39,13 +39,12 @@ public class VariantEnumKindOfStringFWTest
     private static final int LENGTH_SIZE_STRING32 = 4;
     private static final int KIND_SIZE = 1;
 
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final VariantEnumKindOfStringFW.Builder flyweightRW = new VariantEnumKindOfStringFW.Builder();
     private final VariantEnumKindOfStringFW flyweightRO = new VariantEnumKindOfStringFW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfUint16FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfUint16FWTest.java
@@ -33,13 +33,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class VariantEnumKindOfUint16FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final VariantEnumKindOfUint16FW.Builder flyweightRW = new VariantEnumKindOfUint16FW.Builder();
     private final VariantEnumKindOfUint16FW flyweightRO = new VariantEnumKindOfUint16FW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfUint32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfUint32FWTest.java
@@ -33,13 +33,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class VariantEnumKindOfUint32FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final VariantEnumKindOfUint32FW.Builder flyweightRW = new VariantEnumKindOfUint32FW.Builder();
     private final VariantEnumKindOfUint32FW flyweightRO = new VariantEnumKindOfUint32FW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfUint8FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfUint8FWTest.java
@@ -33,13 +33,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class VariantEnumKindOfUint8FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final VariantEnumKindOfUint8FW.Builder flyweightRW = new VariantEnumKindOfUint8FW.Builder();
     private final VariantEnumKindOfUint8FW flyweightRO = new VariantEnumKindOfUint8FW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindWithInt32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindWithInt32FWTest.java
@@ -33,13 +33,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class VariantEnumKindWithInt32FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final VariantEnumKindWithInt32FW.Builder flyweightRW = new VariantEnumKindWithInt32FW.Builder();
     private final VariantEnumKindWithInt32FW flyweightRO = new VariantEnumKindWithInt32FW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantOfArrayFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantOfArrayFWTest.java
@@ -38,13 +38,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class VariantOfArrayFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final VariantOfArrayFW.Builder<VariantEnumKindOfStringFW.Builder, VariantEnumKindOfStringFW> flyweightRW =
         new VariantOfArrayFW.Builder<>(

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantOfListFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantOfListFWTest.java
@@ -38,13 +38,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class VariantOfListFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
     private final VariantOfListFW.Builder variantOfListRW = new VariantOfListFW.Builder();
     private final VariantOfListFW variantOfListRO = new VariantOfListFW();
     private final int lengthSize = Integer.BYTES;
@@ -197,13 +196,8 @@ public class VariantOfListFWTest
     @Test
     public void shouldSetFieldsUsingFieldsMethodWithVisitor() throws Exception
     {
-        final MutableDirectBufferEx listBuffer = new UnsafeBufferEx(allocateDirect(100))
-        {
-            {
-                // Make sure the code is not secretly relying upon memory being initialized to 0
-                setMemory(0, capacity(), (byte) 0xab);
-            }
-        };
+        final MutableDirectBufferEx listBuffer = new UnsafeBufferEx(allocateDirect(100));
+        listBuffer.setMemory(0, listBuffer.capacity(), (byte) 0xab);
         VariantEnumKindOfStringFW.Builder field1RW = new VariantEnumKindOfStringFW.Builder();
         VariantEnumKindOfUint32FW.Builder field2RW = new VariantEnumKindOfUint32FW.Builder();
         ListFW.Builder<List8FW> listRW = new List8FW.Builder()
@@ -232,13 +226,8 @@ public class VariantOfListFWTest
     @Test
     public void shouldSetFieldsUsingFieldsMethodWithDirectBuffer() throws Exception
     {
-        final MutableDirectBufferEx listBuffer = new UnsafeBufferEx(allocateDirect(100))
-        {
-            {
-                // Make sure the code is not secretly relying upon memory being initialized to 0
-                setMemory(0, capacity(), (byte) 0xab);
-            }
-        };
+        final MutableDirectBufferEx listBuffer = new UnsafeBufferEx(allocateDirect(100));
+        listBuffer.setMemory(0, listBuffer.capacity(), (byte) 0xab);
         VariantEnumKindOfStringFW.Builder field1RW = new VariantEnumKindOfStringFW.Builder();
         VariantEnumKindOfUint32FW.Builder field2RW = new VariantEnumKindOfUint32FW.Builder();
         ListFW.Builder<List8FW> listRW = new List8FW.Builder()

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantOfMapFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantOfMapFWTest.java
@@ -39,13 +39,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class VariantOfMapFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final VariantOfMapFW.Builder<VariantEnumKindOfStringFW, TypedefStringFW, VariantEnumKindOfStringFW.Builder,
         TypedefStringFW.Builder> flyweightRW =

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantOfOctetsFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantOfOctetsFWTest.java
@@ -38,13 +38,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class VariantOfOctetsFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(1000000))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(1000000));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final VariantOfOctetsFW.Builder flyweightRW = new VariantOfOctetsFW.Builder();
     private final VariantOfOctetsFW flyweightRO = new VariantOfOctetsFW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantUint8KindOfUint64FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantUint8KindOfUint64FWTest.java
@@ -32,13 +32,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class VariantUint8KindOfUint64FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final VariantUint8KindOfUint64FW.Builder flyweightRW = new VariantUint8KindOfUint64FW.Builder();
     private final VariantUint8KindOfUint64FW flyweightRO = new VariantUint8KindOfUint64FW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantUint8KindWithInt64TypeFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantUint8KindWithInt64TypeFWTest.java
@@ -32,13 +32,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class VariantUint8KindWithInt64TypeFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final VariantUint8KindWithInt64TypeFW.Builder flyweightRW = new VariantUint8KindWithInt64TypeFW.Builder();
     private final VariantUint8KindWithInt64TypeFW flyweightRO = new VariantUint8KindWithInt64TypeFW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantUint8KindWithString32TypeFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantUint8KindWithString32TypeFWTest.java
@@ -39,13 +39,12 @@ public class VariantUint8KindWithString32TypeFWTest
     private static final int LENGTH_SIZE_STRING32 = 4;
     private static final int KIND_SIZE = 1;
 
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final VariantUint8KindWithString32TypeFW.Builder flyweightRW = new VariantUint8KindWithString32TypeFW.Builder();
     private final VariantUint8KindWithString32TypeFW flyweightRO = new VariantUint8KindWithString32TypeFW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantWithFourTypesFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantWithFourTypesFWTest.java
@@ -40,13 +40,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class VariantWithFourTypesFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final VariantWithFourTypesFW.Builder flyweightRW = new VariantWithFourTypesFW.Builder();
     private final VariantWithFourTypesFW flyweightRO = new VariantWithFourTypesFW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantWithVariantCaseFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantWithVariantCaseFWTest.java
@@ -32,13 +32,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class VariantWithVariantCaseFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final VariantWithVariantCaseFW.Builder flyweightRW = new VariantWithVariantCaseFW.Builder();
     private final VariantWithVariantCaseFW flyweightRO = new VariantWithVariantCaseFW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantWithoutOfFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantWithoutOfFWTest.java
@@ -37,13 +37,12 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class VariantWithoutOfFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
 
     private final VariantWithoutOfFW.Builder flyweightRW = new VariantWithoutOfFW.Builder();
     private final VariantWithoutOfFW flyweightRO = new VariantWithoutOfFW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Varint32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Varint32FWTest.java
@@ -28,20 +28,18 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class Varint32FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(100))
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
+    private final MutableDirectBufferEx expected;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
 
     private final Varint32FW.Builder varint32RW = new Varint32FW.Builder();
     private final Varint32FW varint32RO = new Varint32FW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Varint64FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Varint64FWTest.java
@@ -28,20 +28,18 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class Varint64FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(100))
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
+    private final MutableDirectBufferEx expected;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
 
     private final Varint64FW.Builder varintRW = new Varint64FW.Builder();
     private final Varint64FW varint64RO = new Varint64FW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Varuint32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Varuint32FWTest.java
@@ -28,20 +28,18 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class Varuint32FWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(100))
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
+    private final MutableDirectBufferEx expected;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
 
     private final Varuint32FW.Builder varuint32RW = new Varuint32FW.Builder();
     private final Varuint32FW varuint32RO = new Varuint32FW();

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Varuint32nFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Varuint32nFWTest.java
@@ -28,20 +28,18 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class Varuint32nFWTest
 {
-    private final MutableDirectBufferEx buffer = new UnsafeBufferEx(allocateDirect(100))
+    private final MutableDirectBufferEx buffer;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
-    private final MutableDirectBufferEx expected = new UnsafeBufferEx(allocateDirect(100))
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        buffer = unsafe;
+    }
+    private final MutableDirectBufferEx expected;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(100));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
 
     private final Varuint32nFW.Builder varuint32nRW = new Varuint32nFW.Builder();
     private final Varuint32nFW varuint32nRO = new Varuint32nFW();

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
@@ -759,7 +759,7 @@ public final class ZpmInstall extends ZpmCommand
             "JAVA_OPTIONS=\"$JAVA_OPTIONS -Dzilla.directory=$ZILLA_DIRECTORY\"",
             "JAVA_OPTIONS=\"$JAVA_OPTIONS --add-opens java.base/jdk.internal.misc=ALL-UNNAMED " +
                 "--add-opens java.base/jdk.internal.misc=org.agrona " +
-                "--enable-native-access=ALL-UNNAMED\"",
+                "--enable-native-access=ALL-UNNAMED,io.aklivity.zilla.runtime.common.agrona\"",
             String.format(String.join(" ", Arrays.asList(
                     "exec $ZILLA_DIRECTORY/%s/bin/java",
                     "$JAVA_OPTIONS",

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
@@ -759,7 +759,7 @@ public final class ZpmInstall extends ZpmCommand
             "JAVA_OPTIONS=\"$JAVA_OPTIONS -Dzilla.directory=$ZILLA_DIRECTORY\"",
             "JAVA_OPTIONS=\"$JAVA_OPTIONS --add-opens java.base/jdk.internal.misc=ALL-UNNAMED " +
                 "--add-opens java.base/jdk.internal.misc=org.agrona " +
-                "--enable-native-access=ALL-UNNAMED,io.aklivity.zilla.runtime.common.agrona\"",
+                "--enable-native-access=io.aklivity.zilla.runtime.common.agrona\"",
             String.format(String.join(" ", Arrays.asList(
                     "exec $ZILLA_DIRECTORY/%s/bin/java",
                     "$JAVA_OPTIONS",

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/types/codec/SseEventFWTest.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/types/codec/SseEventFWTest.java
@@ -28,21 +28,19 @@ public class SseEventFWTest
 {
     private static final int BUFFER_SIZE = 1024;
 
-    private final UnsafeBufferEx actual = new UnsafeBufferEx(allocateDirect(BUFFER_SIZE))
+    private final UnsafeBufferEx actual;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(BUFFER_SIZE));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        actual = unsafe;
+    }
 
-    private final UnsafeBufferEx expected = new UnsafeBufferEx(allocateDirect(BUFFER_SIZE))
+    private final UnsafeBufferEx expected;
     {
-        {
-            // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xab);
-        }
-    };
+        UnsafeBufferEx unsafe = new UnsafeBufferEx(allocateDirect(BUFFER_SIZE));
+        unsafe.setMemory(0, unsafe.capacity(), (byte) 0xab);
+        expected = unsafe;
+    }
 
     final int offset = 123;
 

--- a/runtime/common-agrona/pom.xml
+++ b/runtime/common-agrona/pom.xml
@@ -53,6 +53,16 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/runtime/common-agrona/pom.xml
+++ b/runtime/common-agrona/pom.xml
@@ -44,6 +44,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/DirectBufferViewEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/DirectBufferViewEx.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.common.agrona.buffer;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Internal access to a clean {@link ByteBuffer} view over the wrapped buffer,
+ * used to take the intrinsified {@code ByteBuffer.put} bulk-copy fast path
+ * without consulting the wrapped buffer's NIO {@code position}/{@code limit} —
+ * which Agrona treats as scratch state independent of capacity (e.g. left dirty
+ * by {@code CRC32.update}). The view is a cached {@link ByteBuffer#duplicate()}
+ * held permanently at {@code position == 0}, {@code limit == capacity}, so an
+ * absolute indexed {@code put} is always in bounds for any valid copy.
+ * <p>
+ * Sealed to {@link UnsafeBufferEx} and {@link UnsafeBufferEx.Native} so the JIT
+ * can devirtualize the {@code instanceof} check on the copy hot path.
+ */
+sealed interface DirectBufferViewEx permits UnsafeBufferEx, UnsafeBufferEx.Native
+{
+    /**
+     * A clean duplicate of the wrapped {@link ByteBuffer}, or {@code null} when
+     * the buffer is not {@link ByteBuffer}-backed (e.g. wraps a {@code byte[]},
+     * raw address, or {@code MemorySegment}). The returned buffer shares memory
+     * with the wrapped buffer and must only be used for absolute indexed access
+     * — never for relative reads/writes that mutate its cursors.
+     */
+    ByteBuffer byteBufferView();
+}

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/SafeBuffer.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/SafeBuffer.java
@@ -43,7 +43,7 @@ import org.agrona.concurrent.UnsafeBuffer;
  * {@code MemorySegment}, providing the same memory ordering guarantees as
  * {@link UnsafeBuffer} without depending on {@code jdk.unsupported}.
  */
-public class SafeBuffer implements AtomicBufferEx
+public final class SafeBuffer implements AtomicBufferEx
 {
     private static final ValueLayout.OfByte BYTE_LAYOUT = JAVA_BYTE;
     private static final ValueLayout.OfInt INT_LAYOUT = JAVA_INT_UNALIGNED;

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -33,7 +33,6 @@ import java.nio.ByteOrder;
 import org.agrona.BufferUtil;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
-import org.agrona.concurrent.UnsafeBuffer;
 
 /**
  * An {@link AtomicBufferEx} implementation backed by Java's {@link MemorySegment}
@@ -44,6 +43,10 @@ import org.agrona.concurrent.UnsafeBuffer;
  * access whose bounds checks the JIT can elide — matching {@code sun.misc.Unsafe}
  * performance without depending on {@code jdk.unsupported}. For heap memory it
  * falls back to the bounded per-instance segment.
+ * <p>
+ * Native-path bounds checks are enabled when this class is loaded from the class
+ * path (unnamed module), as in unit and integration tests, and disabled when it
+ * is loaded as a named module, as in the packaged production runtime.
  * <p>
  * All atomic operations use {@link VarHandle} access modes on the selected
  * segment, providing the same memory ordering guarantees as an
@@ -58,6 +61,12 @@ import org.agrona.concurrent.UnsafeBuffer;
 public class UnsafeBufferEx implements AtomicBufferEx
 {
     private static final MemorySegment GLOBAL = MemorySegment.NULL.reinterpret(Long.MAX_VALUE);
+
+    // Bounds checks are enabled when this class loads from the class path (unnamed module) — i.e. unit and
+    // integration tests — and disabled when it loads as a named module, which is how the packaged jlink
+    // runtime loads it in production. Tests keep IndexOutOfBoundsException safety; production takes the
+    // unchecked native GLOBAL fast path. Resolved once at class init so the JIT folds the per-access branch.
+    private static final boolean SHOULD_BOUNDS_CHECK = !UnsafeBufferEx.class.getModule().isNamed();
 
     private static final ValueLayout.OfByte BYTE_LAYOUT = JAVA_BYTE;
     private static final ValueLayout.OfInt INT_LAYOUT = JAVA_INT_UNALIGNED;
@@ -486,7 +495,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -501,7 +510,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -516,7 +525,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Short.BYTES);
             }
@@ -531,7 +540,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Byte.BYTES);
             }
@@ -546,7 +555,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -561,7 +570,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -576,7 +585,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Short.BYTES);
             }
@@ -596,7 +605,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -612,7 +621,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -628,7 +637,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Short.BYTES);
             }
@@ -644,7 +653,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -660,7 +669,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -676,7 +685,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Short.BYTES);
             }
@@ -696,7 +705,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -715,7 +724,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -734,7 +743,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Short.BYTES);
             }
@@ -753,7 +762,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Byte.BYTES);
             }
@@ -772,7 +781,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -791,7 +800,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -810,7 +819,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Short.BYTES);
             }
@@ -834,7 +843,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -854,7 +863,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -874,7 +883,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Short.BYTES);
             }
@@ -894,7 +903,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -914,7 +923,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -934,7 +943,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Short.BYTES);
             }
@@ -1176,7 +1185,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -1192,7 +1201,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -1211,7 +1220,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -1230,7 +1239,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -1249,7 +1258,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -1265,7 +1274,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -1281,7 +1290,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -1300,7 +1309,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -1316,7 +1325,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -1335,7 +1344,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -1354,7 +1363,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -1373,7 +1382,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -1389,7 +1398,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -1405,7 +1414,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -1425,7 +1434,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         // No VarHandle for short on MemorySegment; use plain access
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Short.BYTES);
             }
@@ -1441,7 +1450,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Short.BYTES);
             }
@@ -1459,7 +1468,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Short.BYTES);
             }
@@ -1475,7 +1484,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Short.BYTES);
             }
@@ -1493,7 +1502,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Byte.BYTES);
             }
@@ -1509,7 +1518,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Byte.BYTES);
             }
@@ -1531,7 +1540,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -1547,7 +1556,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -1565,7 +1574,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -1581,7 +1590,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -1600,7 +1609,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -1618,7 +1627,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -1637,7 +1646,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Long.BYTES);
             }
@@ -1652,7 +1661,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -1668,7 +1677,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -1686,7 +1695,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -1702,7 +1711,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -1721,7 +1730,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -1739,7 +1748,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }
@@ -1758,7 +1767,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
-            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            if (SHOULD_BOUNDS_CHECK)
             {
                 boundsCheck(index, Integer.BYTES);
             }

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -2417,4 +2417,1029 @@ public class UnsafeBufferEx implements AtomicBufferEx
         }
         return result;
     }
+
+    public Native asNative()
+    {
+        if (!isNative)
+        {
+            throw new IllegalStateException("UnsafeBufferEx.asNative requires a native-backed buffer");
+        }
+        return new Native(segment, byteBuffer);
+    }
+
+    public static final class Native implements AtomicBufferEx
+    {
+        private final MemorySegment segment;
+        private final long addressOffset;
+        private final int capacity;
+        private final ByteBuffer byteBuffer;
+        private final UnsafeBufferEx fallback;
+
+        private Native(
+            MemorySegment segment,
+            ByteBuffer byteBuffer)
+        {
+            assert segment.heapBase().isEmpty()
+                : "UnsafeBufferEx.Native requires a native MemorySegment";
+            this.segment = segment;
+            this.addressOffset = segment.address();
+            this.capacity = (int) segment.byteSize();
+            this.byteBuffer = byteBuffer;
+            this.fallback = new UnsafeBufferEx(segment);
+        }
+
+        private static UnsupportedOperationException cannotReWrap()
+        {
+            return new UnsupportedOperationException("UnsafeBufferEx.Native does not support re-wrap");
+        }
+
+        // -------------------------------------------------------------------
+        // Hot path — final field accessors
+        // -------------------------------------------------------------------
+
+        @Override
+        public int capacity()
+        {
+            return capacity;
+        }
+
+        @Override
+        public long addressOffset()
+        {
+            return addressOffset;
+        }
+
+        @Override
+        public ByteBuffer byteBuffer()
+        {
+            return byteBuffer;
+        }
+
+        @Override
+        public byte[] byteArray()
+        {
+            return null;
+        }
+
+        @Override
+        public int wrapAdjustment()
+        {
+            return 0;
+        }
+
+        @Override
+        public MemorySegment segment()
+        {
+            return segment;
+        }
+
+        // -------------------------------------------------------------------
+        // Hot path — primitive long/int put/get
+        // -------------------------------------------------------------------
+
+        @Override
+        public void putLong(
+            int index,
+            long value)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            GLOBAL.set(LONG_LAYOUT, addressOffset + index, value);
+        }
+
+        @Override
+        public long getLong(
+            int index)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            return GLOBAL.get(LONG_LAYOUT, addressOffset + index);
+        }
+
+        @Override
+        public void putInt(
+            int index,
+            int value)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            GLOBAL.set(INT_LAYOUT, addressOffset + index, value);
+        }
+
+        @Override
+        public int getInt(
+            int index)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            return GLOBAL.get(INT_LAYOUT, addressOffset + index);
+        }
+
+        // -------------------------------------------------------------------
+        // Hot path — ordered / release / acquire / volatile (release-acquire form)
+        // -------------------------------------------------------------------
+
+        @Override
+        public void putLongOrdered(
+            int index,
+            long value)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            if (USE_ALIGNED_ATOMICS)
+            {
+                LONG_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
+            }
+            else
+            {
+                assert ((addressOffset + index) & 0x7) == 0
+                    : "putLongOrdered requires 8-byte aligned address";
+                VarHandle.releaseFence();
+                GLOBAL.set(LONG_LAYOUT, addressOffset + index, value);
+            }
+        }
+
+        @Override
+        public long getLongVolatile(
+            int index)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            final long result;
+            if (USE_ALIGNED_ATOMICS)
+            {
+                result = (long) LONG_HANDLE.getVolatile(GLOBAL, addressOffset + index);
+            }
+            else
+            {
+                assert ((addressOffset + index) & 0x7) == 0
+                    : "getLongVolatile requires 8-byte aligned address";
+                result = GLOBAL.get(LONG_LAYOUT, addressOffset + index);
+                VarHandle.acquireFence();
+            }
+            return result;
+        }
+
+        @Override
+        public void putIntOrdered(
+            int index,
+            int value)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            if (USE_ALIGNED_ATOMICS)
+            {
+                INT_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
+            }
+            else
+            {
+                assert ((addressOffset + index) & 0x3) == 0
+                    : "putIntOrdered requires 4-byte aligned address";
+                VarHandle.releaseFence();
+                GLOBAL.set(INT_LAYOUT, addressOffset + index, value);
+            }
+        }
+
+        @Override
+        public int getIntVolatile(
+            int index)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            final int result;
+            if (USE_ALIGNED_ATOMICS)
+            {
+                result = (int) INT_HANDLE.getVolatile(GLOBAL, addressOffset + index);
+            }
+            else
+            {
+                assert ((addressOffset + index) & 0x3) == 0
+                    : "getIntVolatile requires 4-byte aligned address";
+                result = GLOBAL.get(INT_LAYOUT, addressOffset + index);
+                VarHandle.acquireFence();
+            }
+            return result;
+        }
+
+        @Override
+        public void putLongRelease(
+            int index,
+            long value)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            if (USE_ALIGNED_ATOMICS)
+            {
+                LONG_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
+            }
+            else
+            {
+                assert ((addressOffset + index) & 0x7) == 0
+                    : "putLongRelease requires 8-byte aligned address";
+                VarHandle.releaseFence();
+                GLOBAL.set(LONG_LAYOUT, addressOffset + index, value);
+            }
+        }
+
+        @Override
+        public long getLongAcquire(
+            int index)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            final long result;
+            if (USE_ALIGNED_ATOMICS)
+            {
+                result = (long) LONG_HANDLE.getAcquire(GLOBAL, addressOffset + index);
+            }
+            else
+            {
+                assert ((addressOffset + index) & 0x7) == 0
+                    : "getLongAcquire requires 8-byte aligned address";
+                result = GLOBAL.get(LONG_LAYOUT, addressOffset + index);
+                VarHandle.acquireFence();
+            }
+            return result;
+        }
+
+        @Override
+        public void putIntRelease(
+            int index,
+            int value)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            if (USE_ALIGNED_ATOMICS)
+            {
+                INT_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
+            }
+            else
+            {
+                assert ((addressOffset + index) & 0x3) == 0
+                    : "putIntRelease requires 4-byte aligned address";
+                VarHandle.releaseFence();
+                GLOBAL.set(INT_LAYOUT, addressOffset + index, value);
+            }
+        }
+
+        @Override
+        public int getIntAcquire(
+            int index)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            final int result;
+            if (USE_ALIGNED_ATOMICS)
+            {
+                result = (int) INT_HANDLE.getAcquire(GLOBAL, addressOffset + index);
+            }
+            else
+            {
+                assert ((addressOffset + index) & 0x3) == 0
+                    : "getIntAcquire requires 4-byte aligned address";
+                result = GLOBAL.get(INT_LAYOUT, addressOffset + index);
+                VarHandle.acquireFence();
+            }
+            return result;
+        }
+
+        @Override
+        public boolean compareAndSetInt(
+            int index,
+            int expectedValue,
+            int updateValue)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            return INT_HANDLE.compareAndSet(GLOBAL, addressOffset + index, expectedValue, updateValue);
+        }
+
+        @Override
+        public boolean compareAndSetLong(
+            int index,
+            long expectedValue,
+            long updateValue)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            return LONG_HANDLE.compareAndSet(GLOBAL, addressOffset + index, expectedValue, updateValue);
+        }
+
+        // -------------------------------------------------------------------
+        // Hot path — bulk copy / fill
+        // -------------------------------------------------------------------
+
+        @Override
+        public void putBytes(
+            int index,
+            DirectBuffer srcBuffer,
+            int srcIndex,
+            int length)
+        {
+            if (srcBuffer instanceof DirectBufferEx ex)
+            {
+                MemorySegment.copy(ex.segment(), ex.wrapAdjustment() + srcIndex, segment, index, length);
+            }
+            else
+            {
+                fallback.putBytes(index, srcBuffer, srcIndex, length);
+            }
+        }
+
+        @Override
+        public void setMemory(
+            int index,
+            int length,
+            byte value)
+        {
+            segment.asSlice(index, length).fill(value);
+        }
+
+        // -------------------------------------------------------------------
+        // wrap — all overloads unsupported
+        // -------------------------------------------------------------------
+
+        @Override
+        public void wrap(
+            byte[] buffer)
+        {
+            throw cannotReWrap();
+        }
+
+        @Override
+        public void wrap(
+            byte[] buffer,
+            int offset,
+            int length)
+        {
+            throw cannotReWrap();
+        }
+
+        @Override
+        public void wrap(
+            ByteBuffer buffer)
+        {
+            throw cannotReWrap();
+        }
+
+        @Override
+        public void wrap(
+            ByteBuffer buffer,
+            int offset,
+            int length)
+        {
+            throw cannotReWrap();
+        }
+
+        @Override
+        public void wrap(
+            DirectBuffer buffer)
+        {
+            throw cannotReWrap();
+        }
+
+        @Override
+        public void wrap(
+            DirectBuffer buffer,
+            int offset,
+            int length)
+        {
+            throw cannotReWrap();
+        }
+
+        @Override
+        public void wrap(
+            DirectBufferEx buffer)
+        {
+            throw cannotReWrap();
+        }
+
+        @Override
+        public void wrap(
+            DirectBufferEx buffer,
+            int offset,
+            int length)
+        {
+            throw cannotReWrap();
+        }
+
+        @Override
+        public void wrap(
+            long address,
+            int length)
+        {
+            throw cannotReWrap();
+        }
+
+        @Override
+        public void wrap(
+            MemorySegment segment)
+        {
+            throw cannotReWrap();
+        }
+
+        @Override
+        public void wrap(
+            MemorySegment segment,
+            int offset,
+            int length)
+        {
+            throw cannotReWrap();
+        }
+
+        // -------------------------------------------------------------------
+        // Cold path — delegate to fallback
+        // -------------------------------------------------------------------
+
+        @Override
+        public boolean isExpandable()
+        {
+            return fallback.isExpandable();
+        }
+        @Override
+        public void checkLimit(int limit)
+        {
+            fallback.checkLimit(limit);
+        }
+        @Override
+        public void boundsCheck(int index, int length)
+        {
+            fallback.boundsCheck(index, length);
+        }
+        @Override
+        public void verifyAlignment()
+        {
+            fallback.verifyAlignment();
+        }
+
+        @Override
+        public short getShort(int index)
+        {
+            return fallback.getShort(index);
+        }
+        @Override
+        public byte getByte(int index)
+        {
+            return fallback.getByte(index);
+        }
+        @Override
+        public double getDouble(int index)
+        {
+            return fallback.getDouble(index);
+        }
+        @Override
+        public float getFloat(int index)
+        {
+            return fallback.getFloat(index);
+        }
+        @Override
+        public char getChar(int index)
+        {
+            return fallback.getChar(index);
+        }
+
+        @Override
+        public long getLong(int index, ByteOrder byteOrder)
+        {
+            return fallback.getLong(index, byteOrder);
+        }
+        @Override
+        public int getInt(int index, ByteOrder byteOrder)
+        {
+            return fallback.getInt(index, byteOrder);
+        }
+        @Override
+        public short getShort(int index, ByteOrder byteOrder)
+        {
+            return fallback.getShort(index, byteOrder);
+        }
+        @Override
+        public double getDouble(int index, ByteOrder byteOrder)
+        {
+            return fallback.getDouble(index, byteOrder);
+        }
+        @Override
+        public float getFloat(int index, ByteOrder byteOrder)
+        {
+            return fallback.getFloat(index, byteOrder);
+        }
+        @Override
+        public char getChar(int index, ByteOrder byteOrder)
+        {
+            return fallback.getChar(index, byteOrder);
+        }
+
+        @Override
+        public void putShort(int index, short value)
+        {
+            fallback.putShort(index, value);
+        }
+        @Override
+        public void putByte(int index, byte value)
+        {
+            fallback.putByte(index, value);
+        }
+        @Override
+        public void putDouble(int index, double value)
+        {
+            fallback.putDouble(index, value);
+        }
+        @Override
+        public void putFloat(int index, float value)
+        {
+            fallback.putFloat(index, value);
+        }
+        @Override
+        public void putChar(int index, char value)
+        {
+            fallback.putChar(index, value);
+        }
+
+        @Override
+        public void putLong(int index, long value, ByteOrder byteOrder)
+        {
+            fallback.putLong(index, value, byteOrder);
+        }
+        @Override
+        public void putInt(int index, int value, ByteOrder byteOrder)
+        {
+            fallback.putInt(index, value, byteOrder);
+        }
+        @Override
+        public void putShort(int index, short value, ByteOrder byteOrder)
+        {
+            fallback.putShort(index, value, byteOrder);
+        }
+        @Override
+        public void putDouble(int index, double value, ByteOrder byteOrder)
+        {
+            fallback.putDouble(index, value, byteOrder);
+        }
+        @Override
+        public void putFloat(int index, float value, ByteOrder byteOrder)
+        {
+            fallback.putFloat(index, value, byteOrder);
+        }
+        @Override
+        public void putChar(int index, char value, ByteOrder byteOrder)
+        {
+            fallback.putChar(index, value, byteOrder);
+        }
+
+        @Override
+        public void getBytes(int index, byte[] dst)
+        {
+            fallback.getBytes(index, dst);
+        }
+        @Override
+        public void getBytes(int index, byte[] dst, int offset, int length)
+        {
+            fallback.getBytes(index, dst, offset, length);
+        }
+        @Override
+        public void getBytes(int index, MutableDirectBuffer dstBuffer, int dstIndex, int length)
+        {
+            fallback.getBytes(index, dstBuffer, dstIndex, length);
+        }
+        @Override
+        public void getBytes(int index, ByteBuffer dstBuffer, int length)
+        {
+            fallback.getBytes(index, dstBuffer, length);
+        }
+        @Override
+        public void getBytes(int index, ByteBuffer dstBuffer, int dstOffset, int length)
+        {
+            fallback.getBytes(index, dstBuffer, dstOffset, length);
+        }
+        @Override
+        public void getBytes(int index, MemorySegment dstSegment, int dstIndex, int length)
+        {
+            fallback.getBytes(index, dstSegment, dstIndex, length);
+        }
+
+        @Override
+        public void putBytes(int index, byte[] src)
+        {
+            fallback.putBytes(index, src);
+        }
+        @Override
+        public void putBytes(int index, byte[] src, int offset, int length)
+        {
+            fallback.putBytes(index, src, offset, length);
+        }
+        @Override
+        public void putBytes(int index, ByteBuffer srcBuffer, int length)
+        {
+            fallback.putBytes(index, srcBuffer, length);
+        }
+        @Override
+        public void putBytes(int index, ByteBuffer srcBuffer, int srcOffset, int length)
+        {
+            fallback.putBytes(index, srcBuffer, srcOffset, length);
+        }
+        @Override
+        public void putBytes(int index, DirectBufferEx srcBuffer, int srcIndex, int length)
+        {
+            fallback.putBytes(index, srcBuffer, srcIndex, length);
+        }
+        @Override
+        public void putBytes(int index, MemorySegment srcSegment, int srcIndex, int length)
+        {
+            fallback.putBytes(index, srcSegment, srcIndex, length);
+        }
+
+        // Atomic — long volatile / ordered / opaque (cold-path remainder)
+        @Override
+        public void putLongVolatile(int index, long value)
+        {
+            fallback.putLongVolatile(index, value);
+        }
+        @Override
+        public long addLongOrdered(int index, long increment)
+        {
+            return fallback.addLongOrdered(index, increment);
+        }
+        @Override
+        public long getAndSetLong(int index, long value)
+        {
+            return fallback.getAndSetLong(index, value);
+        }
+        @Override
+        public long getAndAddLong(int index, long delta)
+        {
+            return fallback.getAndAddLong(index, delta);
+        }
+        @Override
+        public long getLongOpaque(int index)
+        {
+            return fallback.getLongOpaque(index);
+        }
+        @Override
+        public void putLongOpaque(int index, long value)
+        {
+            fallback.putLongOpaque(index, value);
+        }
+        @Override
+        public long addLongRelease(int index, long increment)
+        {
+            return fallback.addLongRelease(index, increment);
+        }
+        @Override
+        public long addLongOpaque(int index, long increment)
+        {
+            return fallback.addLongOpaque(index, increment);
+        }
+        @Override
+        public long compareAndExchangeLong(int index, long expectedValue, long updateValue)
+        {
+            return fallback.compareAndExchangeLong(index, expectedValue, updateValue);
+        }
+
+        // Atomic — int volatile / ordered / opaque (cold-path remainder)
+        @Override
+        public void putIntVolatile(int index, int value)
+        {
+            fallback.putIntVolatile(index, value);
+        }
+        @Override
+        public int addIntOrdered(int index, int increment)
+        {
+            return fallback.addIntOrdered(index, increment);
+        }
+        @Override
+        public int getAndSetInt(int index, int value)
+        {
+            return fallback.getAndSetInt(index, value);
+        }
+        @Override
+        public int getAndAddInt(int index, int delta)
+        {
+            return fallback.getAndAddInt(index, delta);
+        }
+        @Override
+        public int getIntOpaque(int index)
+        {
+            return fallback.getIntOpaque(index);
+        }
+        @Override
+        public void putIntOpaque(int index, int value)
+        {
+            fallback.putIntOpaque(index, value);
+        }
+        @Override
+        public int addIntRelease(int index, int increment)
+        {
+            return fallback.addIntRelease(index, increment);
+        }
+        @Override
+        public int addIntOpaque(int index, int increment)
+        {
+            return fallback.addIntOpaque(index, increment);
+        }
+        @Override
+        public int compareAndExchangeInt(int index, int expectedValue, int updateValue)
+        {
+            return fallback.compareAndExchangeInt(index, expectedValue, updateValue);
+        }
+
+        // Atomic — short / char / byte volatile
+        @Override
+        public short getShortVolatile(int index)
+        {
+            return fallback.getShortVolatile(index);
+        }
+        @Override
+        public void putShortVolatile(int index, short value)
+        {
+            fallback.putShortVolatile(index, value);
+        }
+        @Override
+        public char getCharVolatile(int index)
+        {
+            return fallback.getCharVolatile(index);
+        }
+        @Override
+        public void putCharVolatile(int index, char value)
+        {
+            fallback.putCharVolatile(index, value);
+        }
+        @Override
+        public byte getByteVolatile(int index)
+        {
+            return fallback.getByteVolatile(index);
+        }
+        @Override
+        public void putByteVolatile(int index, byte value)
+        {
+            fallback.putByteVolatile(index, value);
+        }
+
+        // String — ASCII (length-prefixed)
+        @Override
+        public String getStringAscii(int index)
+        {
+            return fallback.getStringAscii(index);
+        }
+        @Override
+        public String getStringAscii(int index, ByteOrder byteOrder)
+        {
+            return fallback.getStringAscii(index, byteOrder);
+        }
+        @Override
+        public String getStringAscii(int index, int length)
+        {
+            return fallback.getStringAscii(index, length);
+        }
+        @Override
+        public int getStringAscii(int index, Appendable appendable)
+        {
+            return fallback.getStringAscii(index, appendable);
+        }
+        @Override
+        public int getStringAscii(int index, Appendable appendable, ByteOrder byteOrder)
+        {
+            return fallback.getStringAscii(index, appendable, byteOrder);
+        }
+        @Override
+        public int getStringAscii(int index, int length, Appendable appendable)
+        {
+            return fallback.getStringAscii(index, length, appendable);
+        }
+
+        // String — ASCII (no length prefix)
+        @Override
+        public String getStringWithoutLengthAscii(int index, int length)
+        {
+            return fallback.getStringWithoutLengthAscii(index, length);
+        }
+        @Override
+        public int getStringWithoutLengthAscii(int index, int length, Appendable appendable)
+        {
+            return fallback.getStringWithoutLengthAscii(index, length, appendable);
+        }
+
+        // String — UTF-8
+        @Override
+        public String getStringUtf8(int index)
+        {
+            return fallback.getStringUtf8(index);
+        }
+        @Override
+        public String getStringUtf8(int index, ByteOrder byteOrder)
+        {
+            return fallback.getStringUtf8(index, byteOrder);
+        }
+        @Override
+        public String getStringUtf8(int index, int length)
+        {
+            return fallback.getStringUtf8(index, length);
+        }
+        @Override
+        public String getStringWithoutLengthUtf8(int index, int length)
+        {
+            return fallback.getStringWithoutLengthUtf8(index, length);
+        }
+
+        // putString — ASCII (length-prefixed)
+        @Override
+        public int putStringAscii(int index, String value)
+        {
+            return fallback.putStringAscii(index, value);
+        }
+        @Override
+        public int putStringAscii(int index, CharSequence value)
+        {
+            return fallback.putStringAscii(index, value);
+        }
+        @Override
+        public int putStringAscii(int index, String value, ByteOrder byteOrder)
+        {
+            return fallback.putStringAscii(index, value, byteOrder);
+        }
+        @Override
+        public int putStringAscii(int index, CharSequence value, ByteOrder byteOrder)
+        {
+            return fallback.putStringAscii(index, value, byteOrder);
+        }
+
+        // putString — ASCII (no length prefix)
+        @Override
+        public int putStringWithoutLengthAscii(int index, String value)
+        {
+            return fallback.putStringWithoutLengthAscii(index, value);
+        }
+        @Override
+        public int putStringWithoutLengthAscii(int index, CharSequence value)
+        {
+            return fallback.putStringWithoutLengthAscii(index, value);
+        }
+        @Override
+        public int putStringWithoutLengthAscii(int index, String value, int valueOffset, int length)
+        {
+            return fallback.putStringWithoutLengthAscii(index, value, valueOffset, length);
+        }
+        @Override
+        public int putStringWithoutLengthAscii(int index, CharSequence value, int valueOffset, int length)
+        {
+            return fallback.putStringWithoutLengthAscii(index, value, valueOffset, length);
+        }
+
+        // putString — UTF-8
+        @Override
+        public int putStringUtf8(int index, String value)
+        {
+            return fallback.putStringUtf8(index, value);
+        }
+        @Override
+        public int putStringUtf8(int index, String value, ByteOrder byteOrder)
+        {
+            return fallback.putStringUtf8(index, value, byteOrder);
+        }
+        @Override
+        public int putStringUtf8(int index, String value, int maxEncodedLength)
+        {
+            return fallback.putStringUtf8(index, value, maxEncodedLength);
+        }
+        @Override
+        public int putStringUtf8(int index, String value, ByteOrder byteOrder, int maxEncodedLength)
+        {
+            return fallback.putStringUtf8(index, value, byteOrder, maxEncodedLength);
+        }
+        @Override
+        public int putStringWithoutLengthUtf8(int index, String value)
+        {
+            return fallback.putStringWithoutLengthUtf8(index, value);
+        }
+
+        // ASCII int/long parsing and encoding
+        @Override
+        public int parseNaturalIntAscii(int index, int length)
+        {
+            return fallback.parseNaturalIntAscii(index, length);
+        }
+        @Override
+        public long parseNaturalLongAscii(int index, int length)
+        {
+            return fallback.parseNaturalLongAscii(index, length);
+        }
+        @Override
+        public int parseIntAscii(int index, int length)
+        {
+            return fallback.parseIntAscii(index, length);
+        }
+        @Override
+        public long parseLongAscii(int index, int length)
+        {
+            return fallback.parseLongAscii(index, length);
+        }
+        @Override
+        public int putIntAscii(int index, int value)
+        {
+            return fallback.putIntAscii(index, value);
+        }
+        @Override
+        public int putNaturalIntAscii(int index, int value)
+        {
+            return fallback.putNaturalIntAscii(index, value);
+        }
+        @Override
+        public void putNaturalPaddedIntAscii(int index, int length, int value)
+        {
+            fallback.putNaturalPaddedIntAscii(index, length, value);
+        }
+        @Override
+        public int putNaturalIntAsciiFromEnd(int value, int endExclusive)
+        {
+            return fallback.putNaturalIntAsciiFromEnd(value, endExclusive);
+        }
+        @Override
+        public int putNaturalLongAscii(int index, long value)
+        {
+            return fallback.putNaturalLongAscii(index, value);
+        }
+        @Override
+        public int putLongAscii(int index, long value)
+        {
+            return fallback.putLongAscii(index, value);
+        }
+
+        // Comparable
+        @Override
+        public int compareTo(DirectBuffer that)
+        {
+            return fallback.compareTo(that);
+        }
+
+        // Object overrides
+        @Override
+        public String toString()
+        {
+            return "UnsafeBufferEx.Native{capacity=" + capacity + "}";
+        }
+
+        @Override
+        public boolean equals(
+            Object obj)
+        {
+            if (this == obj)
+            {
+                return true;
+            }
+            if (!(obj instanceof DirectBuffer that))
+            {
+                return false;
+            }
+            if (this.capacity != that.capacity())
+            {
+                return false;
+            }
+            for (int i = 0; i < capacity; i++)
+            {
+                if (this.getByte(i) != that.getByte(i))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int result = 1;
+            for (int i = 0; i < capacity; i++)
+            {
+                result = 31 * result + getByte(i);
+            }
+            return result;
+        }
+    }
 }

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -1145,8 +1145,20 @@ public class UnsafeBufferEx implements AtomicBufferEx
         int srcIndex,
         int length)
     {
-        MemorySegment.copy(srcBuffer.segment(), srcBuffer.wrapAdjustment() + srcIndex,
-            segment, wrapAdjustment + index, length);
+        final ByteBuffer srcBb = srcBuffer.byteBuffer();
+        final int srcAdjusted = srcBuffer.wrapAdjustment() + srcIndex;
+        // ByteBuffer.put bounds-checks the source against its NIO limit, which Agrona treats as
+        // scratch state independent of capacity (e.g. left dirty by CRC32.update); only take the
+        // intrinsified fast path when limit covers the range, else copy by the buffer's capacity
+        if (byteBuffer != null && srcBb != null && srcBb.limit() >= srcAdjusted + length)
+        {
+            byteBuffer.put(wrapAdjustment + index, srcBb, srcAdjusted, length);
+        }
+        else
+        {
+            MemorySegment.copy(srcBuffer.segment(), srcAdjusted,
+                segment, wrapAdjustment + index, length);
+        }
     }
 
     @Override
@@ -1156,9 +1168,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
         int srcIndex,
         int length)
     {
-        if (srcBuffer instanceof DirectBufferEx safe)
+        final ByteBuffer srcBb = srcBuffer.byteBuffer();
+        final int srcAdjusted = srcBuffer.wrapAdjustment() + srcIndex;
+        if (byteBuffer != null && srcBb != null && srcBb.limit() >= srcAdjusted + length)
         {
-            MemorySegment.copy(safe.segment(), safe.wrapAdjustment() + srcIndex,
+            byteBuffer.put(wrapAdjustment + index, srcBb, srcAdjusted, length);
+        }
+        else if (srcBuffer instanceof DirectBufferEx safe)
+        {
+            MemorySegment.copy(safe.segment(), srcAdjusted,
                 segment, wrapAdjustment + index, length);
         }
         else
@@ -1166,12 +1184,12 @@ public class UnsafeBufferEx implements AtomicBufferEx
             final byte[] srcArray = srcBuffer.byteArray();
             if (byteBuffer != null && srcArray != null)
             {
-                byteBuffer.put(wrapAdjustment + index, srcArray, srcBuffer.wrapAdjustment() + srcIndex, length);
+                byteBuffer.put(wrapAdjustment + index, srcArray, srcAdjusted, length);
             }
             else if (srcArray != null)
             {
                 MemorySegment.copy(
-                    MemorySegment.ofArray(srcArray), BYTE_LAYOUT, srcBuffer.wrapAdjustment() + srcIndex,
+                    MemorySegment.ofArray(srcArray), BYTE_LAYOUT, srcAdjusted,
                     segment, BYTE_LAYOUT, wrapAdjustment + index, length);
             }
             else
@@ -3338,8 +3356,19 @@ public class UnsafeBufferEx implements AtomicBufferEx
             int srcIndex,
             int length)
         {
-            MemorySegment.copy(srcBuffer.segment(), srcBuffer.wrapAdjustment() + srcIndex,
-                segment, index, length);
+            final ByteBuffer srcBb = srcBuffer.byteBuffer();
+            final int srcAdjusted = srcBuffer.wrapAdjustment() + srcIndex;
+            // ByteBuffer.put bounds-checks the source against its NIO limit, which Agrona treats
+            // as scratch state independent of capacity (e.g. left dirty by CRC32.update); only
+            // take the intrinsified fast path when limit covers the range, else copy by capacity
+            if (srcBb != null && srcBb.limit() >= srcAdjusted + length)
+            {
+                byteBuffer.put(index, srcBb, srcAdjusted, length);
+            }
+            else
+            {
+                MemorySegment.copy(srcBuffer.segment(), srcAdjusted, segment, index, length);
+            }
         }
 
         @Override

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -56,14 +56,12 @@ import org.agrona.MutableDirectBuffer;
  * {@code Unsafe}-backed buffer. Release/acquire-only accessors
  * ({@code putLongOrdered}, {@code putIntOrdered}, {@code put*Release},
  * {@code getLongVolatile}, {@code getIntVolatile}, {@code get*Acquire}) lower
- * to plain unaligned access plus a standalone
- * {@link VarHandle#releaseFence}/{@link VarHandle#acquireFence}, recovering the
- * per-access alignment-check cost the aligned {@code VarHandle} carries. This
- * matches the {@code sun.misc.Unsafe} contract (caller is responsible for
- * alignment; misaligned ordered access has no atomicity guarantee). On x86
- * (TSO) the fences emit zero instructions; on aarch64 they emit {@code dmb}
- * and the aligned path may be cheaper. The default is {@code false} on x86 and
- * {@code true} elsewhere; override with {@code zilla.buffer.aligned.atomics}.
+ * by default to plain unaligned access plus a standalone
+ * {@link VarHandle#releaseFence}/{@link VarHandle#acquireFence}, matching the
+ * {@code sun.misc.Unsafe} contract (caller is responsible for alignment;
+ * misaligned ordered access has no atomicity guarantee). Override with
+ * {@code -Dzilla.buffer.aligned.atomics=true} to restore the aligned
+ * {@code VarHandle} path's per-access alignment-check fast-fail.
  * Sequentially-consistent ({@code put*Volatile}), real atomic
  * ({@code compareAndSet}, {@code getAndAdd}, {@code getAndSet},
  * {@code compareAndExchange}), and opaque accessors always use the aligned
@@ -91,24 +89,18 @@ public final class UnsafeBufferEx implements AtomicBufferEx
     // putLongRelease, putIntRelease, getLongVolatile, getIntVolatile, getLongAcquire, getIntAcquire).
     // The aligned path validates the address is naturally aligned on every access, providing a fast-fail
     // for misaligned ordered/volatile use (the JMM provides no atomicity guarantee for misaligned
-    // long/double access). When false, those accessors lower to a standalone VarHandle release/acquire
-    // fence plus an unaligned plain access, matching the sun.misc.Unsafe contract — on x86 (TSO) the
-    // fences emit zero instructions, recovering the per-op alignment-check cost; on aarch64 the aligned
-    // path uses stlr/ldar instructions that may be cheaper than fence emulation. Defaults to false on
-    // x86/amd64, true elsewhere. Override with -Dzilla.buffer.aligned.atomics=true|false. Read once at
-    // class init so the JIT folds the per-access branch. Full setVolatile / getVolatile (sequentially
-    // consistent), compareAndSet / getAndAdd / getAndSet / compareAndExchange (real atomics), and
-    // opaque accessors always use the aligned VarHandle regardless of this setting — they require
-    // alignment for correctness, not just diagnostics.
+    // long/double access). When false (default), those accessors lower to a standalone VarHandle
+    // release/acquire fence plus an unaligned plain access, matching the sun.misc.Unsafe contract — on
+    // x86 (TSO) the fences emit zero instructions, on aarch64 they emit dmb but Apple Silicon and
+    // similar cores elide the barrier into the load-store buffer under contention. BufferBM confirms
+    // false is a strict improvement on both x86 and aarch64 at all measured payload sizes. Override
+    // with -Dzilla.buffer.aligned.atomics=true to restore the per-access alignment-check fast-fail.
+    // Read once at class init so the JIT folds the per-access branch. Full setVolatile / getVolatile
+    // (sequentially consistent), compareAndSet / getAndAdd / getAndSet / compareAndExchange (real
+    // atomics), and opaque accessors always use the aligned VarHandle regardless of this setting —
+    // they require alignment for correctness, not just diagnostics.
     private static final boolean USE_ALIGNED_ATOMICS =
-        Boolean.parseBoolean(System.getProperty("zilla.buffer.aligned.atomics",
-            Boolean.toString(!isX86())));
-
-    private static boolean isX86()
-    {
-        final String arch = System.getProperty("os.arch", "");
-        return "amd64".equals(arch) || "x86_64".equals(arch);
-    }
+        Boolean.parseBoolean(System.getProperty("zilla.buffer.aligned.atomics", "false"));
 
     private static final ValueLayout.OfByte BYTE_LAYOUT = JAVA_BYTE;
     private static final ValueLayout.OfInt INT_LAYOUT = JAVA_INT_UNALIGNED;

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -53,7 +53,21 @@ import org.agrona.MutableDirectBuffer;
  * <p>
  * All atomic operations use {@link VarHandle} access modes on the selected
  * segment, providing the same memory ordering guarantees as an
- * {@code Unsafe}-backed buffer.
+ * {@code Unsafe}-backed buffer. Release/acquire-only accessors
+ * ({@code putLongOrdered}, {@code putIntOrdered}, {@code put*Release},
+ * {@code getLongVolatile}, {@code getIntVolatile}, {@code get*Acquire}) lower
+ * to plain unaligned access plus a standalone
+ * {@link VarHandle#releaseFence}/{@link VarHandle#acquireFence}, recovering the
+ * per-access alignment-check cost the aligned {@code VarHandle} carries. This
+ * matches the {@code sun.misc.Unsafe} contract (caller is responsible for
+ * alignment; misaligned ordered access has no atomicity guarantee). On x86
+ * (TSO) the fences emit zero instructions; on aarch64 they emit {@code dmb}
+ * and the aligned path may be cheaper. The default is {@code false} on x86 and
+ * {@code true} elsewhere; override with {@code zilla.buffer.aligned.atomics}.
+ * Sequentially-consistent ({@code put*Volatile}), real atomic
+ * ({@code compareAndSet}, {@code getAndAdd}, {@code getAndSet},
+ * {@code compareAndExchange}), and opaque accessors always use the aligned
+ * {@code VarHandle}.
  * <p>
  * Atomic operations are supported only on native-backed buffers (direct
  * {@code ByteBuffer}, mapped file, or native {@code MemorySegment}). Heap
@@ -72,6 +86,29 @@ public class UnsafeBufferEx implements AtomicBufferEx
     private static final boolean SHOULD_BOUNDS_CHECK =
         Boolean.parseBoolean(System.getProperty("zilla.buffer.bounds.checks",
             Boolean.toString(!UnsafeBufferEx.class.getModule().isNamed())));
+
+    // Use aligned VarHandle for release/acquire-only accessors (putLongOrdered, putIntOrdered,
+    // putLongRelease, putIntRelease, getLongVolatile, getIntVolatile, getLongAcquire, getIntAcquire).
+    // The aligned path validates the address is naturally aligned on every access, providing a fast-fail
+    // for misaligned ordered/volatile use (the JMM provides no atomicity guarantee for misaligned
+    // long/double access). When false, those accessors lower to a standalone VarHandle release/acquire
+    // fence plus an unaligned plain access, matching the sun.misc.Unsafe contract — on x86 (TSO) the
+    // fences emit zero instructions, recovering the per-op alignment-check cost; on aarch64 the aligned
+    // path uses stlr/ldar instructions that may be cheaper than fence emulation. Defaults to false on
+    // x86/amd64, true elsewhere. Override with -Dzilla.buffer.aligned.atomics=true|false. Read once at
+    // class init so the JIT folds the per-access branch. Full setVolatile / getVolatile (sequentially
+    // consistent), compareAndSet / getAndAdd / getAndSet / compareAndExchange (real atomics), and
+    // opaque accessors always use the aligned VarHandle regardless of this setting — they require
+    // alignment for correctness, not just diagnostics.
+    private static final boolean USE_ALIGNED_ATOMICS =
+        Boolean.parseBoolean(System.getProperty("zilla.buffer.aligned.atomics",
+            Boolean.toString(!isX86())));
+
+    private static boolean isX86()
+    {
+        final String arch = System.getProperty("os.arch", "");
+        return "amd64".equals(arch) || "x86_64".equals(arch);
+    }
 
     private static final ValueLayout.OfByte BYTE_LAYOUT = JAVA_BYTE;
     private static final ValueLayout.OfInt INT_LAYOUT = JAVA_INT_UNALIGNED;
@@ -1189,7 +1226,19 @@ public class UnsafeBufferEx implements AtomicBufferEx
             {
                 Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
-            return (long) LONG_HANDLE.getVolatile(GLOBAL, addressOffset + index);
+            final long result;
+            if (USE_ALIGNED_ATOMICS)
+            {
+                result = (long) LONG_HANDLE.getVolatile(GLOBAL, addressOffset + index);
+            }
+            else
+            {
+                assert ((addressOffset + index) & 0x7) == 0
+                    : "getLongVolatile requires 8-byte aligned address";
+                result = GLOBAL.get(LONG_LAYOUT, addressOffset + index);
+                VarHandle.acquireFence();
+            }
+            return result;
         }
         throw heapAtomicsUnsupported();
     }
@@ -1224,7 +1273,17 @@ public class UnsafeBufferEx implements AtomicBufferEx
             {
                 Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
-            LONG_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
+            if (USE_ALIGNED_ATOMICS)
+            {
+                LONG_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
+            }
+            else
+            {
+                assert ((addressOffset + index) & 0x7) == 0
+                    : "putLongOrdered requires 8-byte aligned address";
+                VarHandle.releaseFence();
+                GLOBAL.set(LONG_LAYOUT, addressOffset + index, value);
+            }
         }
         else
         {
@@ -1313,7 +1372,19 @@ public class UnsafeBufferEx implements AtomicBufferEx
             {
                 Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
-            return (int) INT_HANDLE.getVolatile(GLOBAL, addressOffset + index);
+            final int result;
+            if (USE_ALIGNED_ATOMICS)
+            {
+                result = (int) INT_HANDLE.getVolatile(GLOBAL, addressOffset + index);
+            }
+            else
+            {
+                assert ((addressOffset + index) & 0x3) == 0
+                    : "getIntVolatile requires 4-byte aligned address";
+                result = GLOBAL.get(INT_LAYOUT, addressOffset + index);
+                VarHandle.acquireFence();
+            }
+            return result;
         }
         throw heapAtomicsUnsupported();
     }
@@ -1348,7 +1419,17 @@ public class UnsafeBufferEx implements AtomicBufferEx
             {
                 Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
-            INT_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
+            if (USE_ALIGNED_ATOMICS)
+            {
+                INT_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
+            }
+            else
+            {
+                assert ((addressOffset + index) & 0x3) == 0
+                    : "putIntOrdered requires 4-byte aligned address";
+                VarHandle.releaseFence();
+                GLOBAL.set(INT_LAYOUT, addressOffset + index, value);
+            }
         }
         else
         {
@@ -1544,7 +1625,19 @@ public class UnsafeBufferEx implements AtomicBufferEx
             {
                 Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
-            return (long) LONG_HANDLE.getAcquire(GLOBAL, addressOffset + index);
+            final long result;
+            if (USE_ALIGNED_ATOMICS)
+            {
+                result = (long) LONG_HANDLE.getAcquire(GLOBAL, addressOffset + index);
+            }
+            else
+            {
+                assert ((addressOffset + index) & 0x7) == 0
+                    : "getLongAcquire requires 8-byte aligned address";
+                result = GLOBAL.get(LONG_LAYOUT, addressOffset + index);
+                VarHandle.acquireFence();
+            }
+            return result;
         }
         throw heapAtomicsUnsupported();
     }
@@ -1560,7 +1653,17 @@ public class UnsafeBufferEx implements AtomicBufferEx
             {
                 Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
-            LONG_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
+            if (USE_ALIGNED_ATOMICS)
+            {
+                LONG_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
+            }
+            else
+            {
+                assert ((addressOffset + index) & 0x7) == 0
+                    : "putLongRelease requires 8-byte aligned address";
+                VarHandle.releaseFence();
+                GLOBAL.set(LONG_LAYOUT, addressOffset + index, value);
+            }
         }
         else
         {
@@ -1665,7 +1768,19 @@ public class UnsafeBufferEx implements AtomicBufferEx
             {
                 Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
-            return (int) INT_HANDLE.getAcquire(GLOBAL, addressOffset + index);
+            final int result;
+            if (USE_ALIGNED_ATOMICS)
+            {
+                result = (int) INT_HANDLE.getAcquire(GLOBAL, addressOffset + index);
+            }
+            else
+            {
+                assert ((addressOffset + index) & 0x3) == 0
+                    : "getIntAcquire requires 4-byte aligned address";
+                result = GLOBAL.get(INT_LAYOUT, addressOffset + index);
+                VarHandle.acquireFence();
+            }
+            return result;
         }
         throw heapAtomicsUnsupported();
     }
@@ -1681,7 +1796,17 @@ public class UnsafeBufferEx implements AtomicBufferEx
             {
                 Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
-            INT_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
+            if (USE_ALIGNED_ATOMICS)
+            {
+                INT_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
+            }
+            else
+            {
+                assert ((addressOffset + index) & 0x3) == 0
+                    : "putIntRelease requires 4-byte aligned address";
+                VarHandle.releaseFence();
+                GLOBAL.set(INT_LAYOUT, addressOffset + index, value);
+            }
         }
         else
         {

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -1145,16 +1145,8 @@ public class UnsafeBufferEx implements AtomicBufferEx
         int srcIndex,
         int length)
     {
-        final ByteBuffer srcBb = srcBuffer.byteBuffer();
-        if (byteBuffer != null && srcBb != null)
-        {
-            byteBuffer.put(wrapAdjustment + index, srcBb, srcBuffer.wrapAdjustment() + srcIndex, length);
-        }
-        else
-        {
-            MemorySegment.copy(srcBuffer.segment(), srcBuffer.wrapAdjustment() + srcIndex,
-                segment, wrapAdjustment + index, length);
-        }
+        MemorySegment.copy(srcBuffer.segment(), srcBuffer.wrapAdjustment() + srcIndex,
+            segment, wrapAdjustment + index, length);
     }
 
     @Override
@@ -1164,10 +1156,10 @@ public class UnsafeBufferEx implements AtomicBufferEx
         int srcIndex,
         int length)
     {
-        final ByteBuffer srcBb = srcBuffer.byteBuffer();
-        if (byteBuffer != null && srcBb != null)
+        if (srcBuffer instanceof DirectBufferEx safe)
         {
-            byteBuffer.put(wrapAdjustment + index, srcBb, srcBuffer.wrapAdjustment() + srcIndex, length);
+            MemorySegment.copy(safe.segment(), safe.wrapAdjustment() + srcIndex,
+                segment, wrapAdjustment + index, length);
         }
         else
         {
@@ -1175,11 +1167,6 @@ public class UnsafeBufferEx implements AtomicBufferEx
             if (byteBuffer != null && srcArray != null)
             {
                 byteBuffer.put(wrapAdjustment + index, srcArray, srcBuffer.wrapAdjustment() + srcIndex, length);
-            }
-            else if (srcBuffer instanceof DirectBufferEx safe)
-            {
-                MemorySegment.copy(safe.segment(), safe.wrapAdjustment() + srcIndex,
-                    segment, wrapAdjustment + index, length);
             }
             else if (srcArray != null)
             {
@@ -2775,10 +2762,9 @@ public class UnsafeBufferEx implements AtomicBufferEx
             int srcIndex,
             int length)
         {
-            final ByteBuffer srcBb = srcBuffer.byteBuffer();
-            if (srcBb != null)
+            if (srcBuffer instanceof DirectBufferEx ex)
             {
-                byteBuffer.put(index, srcBb, srcBuffer.wrapAdjustment() + srcIndex, length);
+                MemorySegment.copy(ex.segment(), ex.wrapAdjustment() + srcIndex, segment, index, length);
             }
             else
             {
@@ -2786,10 +2772,6 @@ public class UnsafeBufferEx implements AtomicBufferEx
                 if (srcArray != null)
                 {
                     byteBuffer.put(index, srcArray, srcBuffer.wrapAdjustment() + srcIndex, length);
-                }
-                else if (srcBuffer instanceof DirectBufferEx ex)
-                {
-                    MemorySegment.copy(ex.segment(), ex.wrapAdjustment() + srcIndex, segment, index, length);
                 }
                 else
                 {
@@ -3356,16 +3338,8 @@ public class UnsafeBufferEx implements AtomicBufferEx
             int srcIndex,
             int length)
         {
-            final ByteBuffer srcBb = srcBuffer.byteBuffer();
-            if (srcBb != null)
-            {
-                byteBuffer.put(index, srcBb, srcBuffer.wrapAdjustment() + srcIndex, length);
-            }
-            else
-            {
-                MemorySegment.copy(srcBuffer.segment(), srcBuffer.wrapAdjustment() + srcIndex,
-                    segment, index, length);
-            }
+            MemorySegment.copy(srcBuffer.segment(), srcBuffer.wrapAdjustment() + srcIndex,
+                segment, index, length);
         }
 
         @Override

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -75,7 +75,7 @@ import org.agrona.MutableDirectBuffer;
  * atomics, because the JVM cannot guarantee {@code byte[]} alignment for
  * {@code VarHandle} atomic access.
  */
-public class UnsafeBufferEx implements AtomicBufferEx
+public final class UnsafeBufferEx implements AtomicBufferEx
 {
     private static final MemorySegment GLOBAL = MemorySegment.NULL.reinterpret(Long.MAX_VALUE);
 
@@ -2433,7 +2433,6 @@ public class UnsafeBufferEx implements AtomicBufferEx
         private final long addressOffset;
         private final int capacity;
         private final ByteBuffer byteBuffer;
-        private final UnsafeBufferEx fallback;
 
         private Native(
             MemorySegment segment,
@@ -2445,7 +2444,6 @@ public class UnsafeBufferEx implements AtomicBufferEx
             this.addressOffset = segment.address();
             this.capacity = (int) segment.byteSize();
             this.byteBuffer = byteBuffer;
-            this.fallback = new UnsafeBufferEx(segment);
         }
 
         private static UnsupportedOperationException cannotReWrap()
@@ -2770,7 +2768,33 @@ public class UnsafeBufferEx implements AtomicBufferEx
             }
             else
             {
-                fallback.putBytes(index, srcBuffer, srcIndex, length);
+                final byte[] srcArray = srcBuffer.byteArray();
+                if (srcArray != null)
+                {
+                    final int adjustment = srcBuffer.wrapAdjustment();
+                    MemorySegment.copy(
+                        MemorySegment.ofArray(srcArray), BYTE_LAYOUT, adjustment + srcIndex,
+                        segment, BYTE_LAYOUT, index, length);
+                }
+                else
+                {
+                    final ByteBuffer srcBb = srcBuffer.byteBuffer();
+                    if (srcBb != null)
+                    {
+                        final MemorySegment src = srcBb.isDirect()
+                            ? MemorySegment.ofAddress(BufferUtil.address(srcBb)).reinterpret(srcBb.capacity())
+                            : MemorySegment.ofArray(BufferUtil.array(srcBb));
+                        MemorySegment.copy(src, srcBuffer.wrapAdjustment() + srcIndex,
+                            segment, index, length);
+                    }
+                    else
+                    {
+                        for (int i = 0; i < length; i++)
+                        {
+                            segment.set(BYTE_LAYOUT, index + i, srcBuffer.getByte(srcIndex + i));
+                        }
+                    }
+                }
             }
         }
 
@@ -2876,529 +2900,1236 @@ public class UnsafeBufferEx implements AtomicBufferEx
         }
 
         // -------------------------------------------------------------------
-        // Cold path — delegate to fallback
+        // Cold path — direct implementations on final fields
         // -------------------------------------------------------------------
 
         @Override
         public boolean isExpandable()
         {
-            return fallback.isExpandable();
+            return false;
         }
+
         @Override
-        public void checkLimit(int limit)
+        public void checkLimit(
+            int limit)
         {
-            fallback.checkLimit(limit);
+            if (limit > capacity)
+            {
+                throw new IndexOutOfBoundsException(
+                    String.format("limit=%d is beyond capacity=%d", limit, capacity));
+            }
         }
+
         @Override
-        public void boundsCheck(int index, int length)
+        public void boundsCheck(
+            int index,
+            int length)
         {
-            fallback.boundsCheck(index, length);
+            Objects.checkFromIndexSize(index, length, capacity);
         }
+
         @Override
         public void verifyAlignment()
         {
-            fallback.verifyAlignment();
+            final long address = segment.address();
+            if (0 != (address & 7))
+            {
+                throw new IllegalStateException(
+                    String.format("AtomicBuffer is not correctly aligned: address=%d", address));
+            }
+        }
+
+        // get — primitives (native byte order)
+
+        @Override
+        public short getShort(
+            int index)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
+            }
+            return GLOBAL.get(SHORT_LAYOUT, addressOffset + index);
         }
 
         @Override
-        public short getShort(int index)
+        public byte getByte(
+            int index)
         {
-            return fallback.getShort(index);
-        }
-        @Override
-        public byte getByte(int index)
-        {
-            return fallback.getByte(index);
-        }
-        @Override
-        public double getDouble(int index)
-        {
-            return fallback.getDouble(index);
-        }
-        @Override
-        public float getFloat(int index)
-        {
-            return fallback.getFloat(index);
-        }
-        @Override
-        public char getChar(int index)
-        {
-            return fallback.getChar(index);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Byte.BYTES, capacity);
+            }
+            return GLOBAL.get(BYTE_LAYOUT, addressOffset + index);
         }
 
         @Override
-        public long getLong(int index, ByteOrder byteOrder)
+        public double getDouble(
+            int index)
         {
-            return fallback.getLong(index, byteOrder);
-        }
-        @Override
-        public int getInt(int index, ByteOrder byteOrder)
-        {
-            return fallback.getInt(index, byteOrder);
-        }
-        @Override
-        public short getShort(int index, ByteOrder byteOrder)
-        {
-            return fallback.getShort(index, byteOrder);
-        }
-        @Override
-        public double getDouble(int index, ByteOrder byteOrder)
-        {
-            return fallback.getDouble(index, byteOrder);
-        }
-        @Override
-        public float getFloat(int index, ByteOrder byteOrder)
-        {
-            return fallback.getFloat(index, byteOrder);
-        }
-        @Override
-        public char getChar(int index, ByteOrder byteOrder)
-        {
-            return fallback.getChar(index, byteOrder);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            return Double.longBitsToDouble(GLOBAL.get(LONG_LAYOUT, addressOffset + index));
         }
 
         @Override
-        public void putShort(int index, short value)
+        public float getFloat(
+            int index)
         {
-            fallback.putShort(index, value);
-        }
-        @Override
-        public void putByte(int index, byte value)
-        {
-            fallback.putByte(index, value);
-        }
-        @Override
-        public void putDouble(int index, double value)
-        {
-            fallback.putDouble(index, value);
-        }
-        @Override
-        public void putFloat(int index, float value)
-        {
-            fallback.putFloat(index, value);
-        }
-        @Override
-        public void putChar(int index, char value)
-        {
-            fallback.putChar(index, value);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            return Float.intBitsToFloat(GLOBAL.get(INT_LAYOUT, addressOffset + index));
         }
 
         @Override
-        public void putLong(int index, long value, ByteOrder byteOrder)
+        public char getChar(
+            int index)
         {
-            fallback.putLong(index, value, byteOrder);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
+            }
+            return (char) GLOBAL.get(SHORT_LAYOUT, addressOffset + index);
         }
+
+        // get — primitives (explicit byte order)
+
         @Override
-        public void putInt(int index, int value, ByteOrder byteOrder)
+        public long getLong(
+            int index,
+            ByteOrder byteOrder)
         {
-            fallback.putInt(index, value, byteOrder);
-        }
-        @Override
-        public void putShort(int index, short value, ByteOrder byteOrder)
-        {
-            fallback.putShort(index, value, byteOrder);
-        }
-        @Override
-        public void putDouble(int index, double value, ByteOrder byteOrder)
-        {
-            fallback.putDouble(index, value, byteOrder);
-        }
-        @Override
-        public void putFloat(int index, float value, ByteOrder byteOrder)
-        {
-            fallback.putFloat(index, value, byteOrder);
-        }
-        @Override
-        public void putChar(int index, char value, ByteOrder byteOrder)
-        {
-            fallback.putChar(index, value, byteOrder);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            return GLOBAL.get(longLayout(byteOrder), addressOffset + index);
         }
 
         @Override
-        public void getBytes(int index, byte[] dst)
+        public int getInt(
+            int index,
+            ByteOrder byteOrder)
         {
-            fallback.getBytes(index, dst);
-        }
-        @Override
-        public void getBytes(int index, byte[] dst, int offset, int length)
-        {
-            fallback.getBytes(index, dst, offset, length);
-        }
-        @Override
-        public void getBytes(int index, MutableDirectBuffer dstBuffer, int dstIndex, int length)
-        {
-            fallback.getBytes(index, dstBuffer, dstIndex, length);
-        }
-        @Override
-        public void getBytes(int index, ByteBuffer dstBuffer, int length)
-        {
-            fallback.getBytes(index, dstBuffer, length);
-        }
-        @Override
-        public void getBytes(int index, ByteBuffer dstBuffer, int dstOffset, int length)
-        {
-            fallback.getBytes(index, dstBuffer, dstOffset, length);
-        }
-        @Override
-        public void getBytes(int index, MemorySegment dstSegment, int dstIndex, int length)
-        {
-            fallback.getBytes(index, dstSegment, dstIndex, length);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            return GLOBAL.get(intLayout(byteOrder), addressOffset + index);
         }
 
         @Override
-        public void putBytes(int index, byte[] src)
+        public short getShort(
+            int index,
+            ByteOrder byteOrder)
         {
-            fallback.putBytes(index, src);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
+            }
+            return GLOBAL.get(shortLayout(byteOrder), addressOffset + index);
         }
+
         @Override
-        public void putBytes(int index, byte[] src, int offset, int length)
+        public double getDouble(
+            int index,
+            ByteOrder byteOrder)
         {
-            fallback.putBytes(index, src, offset, length);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            return Double.longBitsToDouble(GLOBAL.get(longLayout(byteOrder), addressOffset + index));
         }
+
         @Override
-        public void putBytes(int index, ByteBuffer srcBuffer, int length)
+        public float getFloat(
+            int index,
+            ByteOrder byteOrder)
         {
-            fallback.putBytes(index, srcBuffer, length);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            return Float.intBitsToFloat(GLOBAL.get(intLayout(byteOrder), addressOffset + index));
         }
+
         @Override
-        public void putBytes(int index, ByteBuffer srcBuffer, int srcOffset, int length)
+        public char getChar(
+            int index,
+            ByteOrder byteOrder)
         {
-            fallback.putBytes(index, srcBuffer, srcOffset, length);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
+            }
+            return (char) GLOBAL.get(shortLayout(byteOrder), addressOffset + index);
         }
+
+        // put — primitives (native byte order)
+
         @Override
-        public void putBytes(int index, DirectBufferEx srcBuffer, int srcIndex, int length)
+        public void putShort(
+            int index,
+            short value)
         {
-            fallback.putBytes(index, srcBuffer, srcIndex, length);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
+            }
+            GLOBAL.set(SHORT_LAYOUT, addressOffset + index, value);
         }
+
         @Override
-        public void putBytes(int index, MemorySegment srcSegment, int srcIndex, int length)
+        public void putByte(
+            int index,
+            byte value)
         {
-            fallback.putBytes(index, srcSegment, srcIndex, length);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Byte.BYTES, capacity);
+            }
+            GLOBAL.set(BYTE_LAYOUT, addressOffset + index, value);
+        }
+
+        @Override
+        public void putDouble(
+            int index,
+            double value)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            GLOBAL.set(LONG_LAYOUT, addressOffset + index, Double.doubleToRawLongBits(value));
+        }
+
+        @Override
+        public void putFloat(
+            int index,
+            float value)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            GLOBAL.set(INT_LAYOUT, addressOffset + index, Float.floatToRawIntBits(value));
+        }
+
+        @Override
+        public void putChar(
+            int index,
+            char value)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
+            }
+            GLOBAL.set(SHORT_LAYOUT, addressOffset + index, (short) value);
+        }
+
+        // put — primitives (explicit byte order)
+
+        @Override
+        public void putLong(
+            int index,
+            long value,
+            ByteOrder byteOrder)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            GLOBAL.set(longLayout(byteOrder), addressOffset + index, value);
+        }
+
+        @Override
+        public void putInt(
+            int index,
+            int value,
+            ByteOrder byteOrder)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            GLOBAL.set(intLayout(byteOrder), addressOffset + index, value);
+        }
+
+        @Override
+        public void putShort(
+            int index,
+            short value,
+            ByteOrder byteOrder)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
+            }
+            GLOBAL.set(shortLayout(byteOrder), addressOffset + index, value);
+        }
+
+        @Override
+        public void putDouble(
+            int index,
+            double value,
+            ByteOrder byteOrder)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            GLOBAL.set(longLayout(byteOrder), addressOffset + index, Double.doubleToRawLongBits(value));
+        }
+
+        @Override
+        public void putFloat(
+            int index,
+            float value,
+            ByteOrder byteOrder)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            GLOBAL.set(intLayout(byteOrder), addressOffset + index, Float.floatToRawIntBits(value));
+        }
+
+        @Override
+        public void putChar(
+            int index,
+            char value,
+            ByteOrder byteOrder)
+        {
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
+            }
+            GLOBAL.set(shortLayout(byteOrder), addressOffset + index, (short) value);
+        }
+
+        // getBytes / putBytes
+
+        @Override
+        public void getBytes(
+            int index,
+            byte[] dst)
+        {
+            getBytes(index, dst, 0, dst.length);
+        }
+
+        @Override
+        public void getBytes(
+            int index,
+            byte[] dst,
+            int offset,
+            int length)
+        {
+            MemorySegment.copy(segment, BYTE_LAYOUT, index,
+                MemorySegment.ofArray(dst), BYTE_LAYOUT, offset, length);
+        }
+
+        @Override
+        public void getBytes(
+            int index,
+            MutableDirectBuffer dstBuffer,
+            int dstIndex,
+            int length)
+        {
+            if (dstBuffer instanceof UnsafeBufferEx safe)
+            {
+                MemorySegment.copy(segment, index, safe.segment, safe.wrapAdjustment + dstIndex, length);
+            }
+            else
+            {
+                final byte[] dstArray = dstBuffer.byteArray();
+                if (dstArray != null)
+                {
+                    final int adjustment = dstBuffer.wrapAdjustment();
+                    MemorySegment.copy(segment, BYTE_LAYOUT, index,
+                        MemorySegment.ofArray(dstArray), BYTE_LAYOUT, adjustment + dstIndex, length);
+                }
+                else
+                {
+                    final ByteBuffer dstBb = dstBuffer.byteBuffer();
+                    if (dstBb != null)
+                    {
+                        final MemorySegment dst = dstBb.isDirect()
+                            ? MemorySegment.ofAddress(BufferUtil.address(dstBb)).reinterpret(dstBb.capacity())
+                            : MemorySegment.ofArray(BufferUtil.array(dstBb));
+                        MemorySegment.copy(segment, index,
+                            dst, dstBuffer.wrapAdjustment() + dstIndex, length);
+                    }
+                    else
+                    {
+                        for (int i = 0; i < length; i++)
+                        {
+                            dstBuffer.putByte(dstIndex + i, getByte(index + i));
+                        }
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void getBytes(
+            int index,
+            ByteBuffer dstBuffer,
+            int length)
+        {
+            getBytes(index, dstBuffer, dstBuffer.position(), length);
+            dstBuffer.position(dstBuffer.position() + length);
+        }
+
+        @Override
+        public void getBytes(
+            int index,
+            ByteBuffer dstBuffer,
+            int dstOffset,
+            int length)
+        {
+            final MemorySegment dst = dstBuffer.isDirect()
+                ? MemorySegment.ofAddress(BufferUtil.address(dstBuffer)).reinterpret(dstBuffer.capacity())
+                : MemorySegment.ofArray(BufferUtil.array(dstBuffer));
+            MemorySegment.copy(segment, index, dst, dstOffset, length);
+        }
+
+        @Override
+        public void getBytes(
+            int index,
+            MemorySegment dstSegment,
+            int dstIndex,
+            int length)
+        {
+            MemorySegment.copy(segment, index, dstSegment, dstIndex, length);
+        }
+
+        @Override
+        public void putBytes(
+            int index,
+            byte[] src)
+        {
+            putBytes(index, src, 0, src.length);
+        }
+
+        @Override
+        public void putBytes(
+            int index,
+            byte[] src,
+            int offset,
+            int length)
+        {
+            MemorySegment.copy(MemorySegment.ofArray(src), BYTE_LAYOUT, offset,
+                segment, BYTE_LAYOUT, index, length);
+        }
+
+        @Override
+        public void putBytes(
+            int index,
+            ByteBuffer srcBuffer,
+            int length)
+        {
+            putBytes(index, srcBuffer, srcBuffer.position(), length);
+            srcBuffer.position(srcBuffer.position() + length);
+        }
+
+        @Override
+        public void putBytes(
+            int index,
+            ByteBuffer srcBuffer,
+            int srcOffset,
+            int length)
+        {
+            final MemorySegment src = srcBuffer.isDirect()
+                ? MemorySegment.ofAddress(BufferUtil.address(srcBuffer)).reinterpret(srcBuffer.capacity())
+                : MemorySegment.ofArray(BufferUtil.array(srcBuffer));
+            MemorySegment.copy(src, srcOffset, segment, index, length);
+        }
+
+        @Override
+        public void putBytes(
+            int index,
+            DirectBufferEx srcBuffer,
+            int srcIndex,
+            int length)
+        {
+            MemorySegment.copy(srcBuffer.segment(), srcBuffer.wrapAdjustment() + srcIndex,
+                segment, index, length);
+        }
+
+        @Override
+        public void putBytes(
+            int index,
+            MemorySegment srcSegment,
+            int srcIndex,
+            int length)
+        {
+            MemorySegment.copy(srcSegment, srcIndex, segment, index, length);
         }
 
         // Atomic — long volatile / ordered / opaque (cold-path remainder)
+
         @Override
-        public void putLongVolatile(int index, long value)
+        public void putLongVolatile(
+            int index,
+            long value)
         {
-            fallback.putLongVolatile(index, value);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            LONG_HANDLE.setVolatile(GLOBAL, addressOffset + index, value);
         }
+
         @Override
-        public long addLongOrdered(int index, long increment)
+        public long addLongOrdered(
+            int index,
+            long increment)
         {
-            return fallback.addLongOrdered(index, increment);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            final long currentValue = (long) LONG_HANDLE.getAcquire(GLOBAL, addressOffset + index);
+            LONG_HANDLE.setRelease(GLOBAL, addressOffset + index, currentValue + increment);
+            return currentValue;
         }
+
         @Override
-        public long getAndSetLong(int index, long value)
+        public long getAndSetLong(
+            int index,
+            long value)
         {
-            return fallback.getAndSetLong(index, value);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            return (long) LONG_HANDLE.getAndSet(GLOBAL, addressOffset + index, value);
         }
+
         @Override
-        public long getAndAddLong(int index, long delta)
+        public long getAndAddLong(
+            int index,
+            long delta)
         {
-            return fallback.getAndAddLong(index, delta);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            return (long) LONG_HANDLE.getAndAdd(GLOBAL, addressOffset + index, delta);
         }
+
         @Override
-        public long getLongOpaque(int index)
+        public long getLongOpaque(
+            int index)
         {
-            return fallback.getLongOpaque(index);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            return (long) LONG_HANDLE.getOpaque(GLOBAL, addressOffset + index);
         }
+
         @Override
-        public void putLongOpaque(int index, long value)
+        public void putLongOpaque(
+            int index,
+            long value)
         {
-            fallback.putLongOpaque(index, value);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            LONG_HANDLE.setOpaque(GLOBAL, addressOffset + index, value);
         }
+
         @Override
-        public long addLongRelease(int index, long increment)
+        public long addLongRelease(
+            int index,
+            long increment)
         {
-            return fallback.addLongRelease(index, increment);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            final long currentValue = (long) LONG_HANDLE.getAcquire(GLOBAL, addressOffset + index);
+            LONG_HANDLE.setRelease(GLOBAL, addressOffset + index, currentValue + increment);
+            return currentValue;
         }
+
         @Override
-        public long addLongOpaque(int index, long increment)
+        public long addLongOpaque(
+            int index,
+            long increment)
         {
-            return fallback.addLongOpaque(index, increment);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            final long currentValue = (long) LONG_HANDLE.getOpaque(GLOBAL, addressOffset + index);
+            LONG_HANDLE.setOpaque(GLOBAL, addressOffset + index, currentValue + increment);
+            return currentValue;
         }
+
         @Override
-        public long compareAndExchangeLong(int index, long expectedValue, long updateValue)
+        public long compareAndExchangeLong(
+            int index,
+            long expectedValue,
+            long updateValue)
         {
-            return fallback.compareAndExchangeLong(index, expectedValue, updateValue);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
+            }
+            return (long) LONG_HANDLE.compareAndExchange(GLOBAL, addressOffset + index, expectedValue, updateValue);
         }
 
         // Atomic — int volatile / ordered / opaque (cold-path remainder)
+
         @Override
-        public void putIntVolatile(int index, int value)
+        public void putIntVolatile(
+            int index,
+            int value)
         {
-            fallback.putIntVolatile(index, value);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            INT_HANDLE.setVolatile(GLOBAL, addressOffset + index, value);
         }
+
         @Override
-        public int addIntOrdered(int index, int increment)
+        public int addIntOrdered(
+            int index,
+            int increment)
         {
-            return fallback.addIntOrdered(index, increment);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            final int currentValue = (int) INT_HANDLE.getAcquire(GLOBAL, addressOffset + index);
+            INT_HANDLE.setRelease(GLOBAL, addressOffset + index, currentValue + increment);
+            return currentValue;
         }
+
         @Override
-        public int getAndSetInt(int index, int value)
+        public int getAndSetInt(
+            int index,
+            int value)
         {
-            return fallback.getAndSetInt(index, value);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            return (int) INT_HANDLE.getAndSet(GLOBAL, addressOffset + index, value);
         }
+
         @Override
-        public int getAndAddInt(int index, int delta)
+        public int getAndAddInt(
+            int index,
+            int delta)
         {
-            return fallback.getAndAddInt(index, delta);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            return (int) INT_HANDLE.getAndAdd(GLOBAL, addressOffset + index, delta);
         }
+
         @Override
-        public int getIntOpaque(int index)
+        public int getIntOpaque(
+            int index)
         {
-            return fallback.getIntOpaque(index);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            return (int) INT_HANDLE.getOpaque(GLOBAL, addressOffset + index);
         }
+
         @Override
-        public void putIntOpaque(int index, int value)
+        public void putIntOpaque(
+            int index,
+            int value)
         {
-            fallback.putIntOpaque(index, value);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            INT_HANDLE.setOpaque(GLOBAL, addressOffset + index, value);
         }
+
         @Override
-        public int addIntRelease(int index, int increment)
+        public int addIntRelease(
+            int index,
+            int increment)
         {
-            return fallback.addIntRelease(index, increment);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            final int currentValue = (int) INT_HANDLE.getAcquire(GLOBAL, addressOffset + index);
+            INT_HANDLE.setRelease(GLOBAL, addressOffset + index, currentValue + increment);
+            return currentValue;
         }
+
         @Override
-        public int addIntOpaque(int index, int increment)
+        public int addIntOpaque(
+            int index,
+            int increment)
         {
-            return fallback.addIntOpaque(index, increment);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            final int currentValue = (int) INT_HANDLE.getOpaque(GLOBAL, addressOffset + index);
+            INT_HANDLE.setOpaque(GLOBAL, addressOffset + index, currentValue + increment);
+            return currentValue;
         }
+
         @Override
-        public int compareAndExchangeInt(int index, int expectedValue, int updateValue)
+        public int compareAndExchangeInt(
+            int index,
+            int expectedValue,
+            int updateValue)
         {
-            return fallback.compareAndExchangeInt(index, expectedValue, updateValue);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
+            }
+            return (int) INT_HANDLE.compareAndExchange(GLOBAL, addressOffset + index, expectedValue, updateValue);
         }
 
         // Atomic — short / char / byte volatile
+
         @Override
-        public short getShortVolatile(int index)
+        public short getShortVolatile(
+            int index)
         {
-            return fallback.getShortVolatile(index);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
+            }
+            return GLOBAL.get(SHORT_LAYOUT, addressOffset + index);
         }
+
         @Override
-        public void putShortVolatile(int index, short value)
+        public void putShortVolatile(
+            int index,
+            short value)
         {
-            fallback.putShortVolatile(index, value);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
+            }
+            GLOBAL.set(SHORT_LAYOUT, addressOffset + index, value);
         }
+
         @Override
-        public char getCharVolatile(int index)
+        public char getCharVolatile(
+            int index)
         {
-            return fallback.getCharVolatile(index);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
+            }
+            return (char) GLOBAL.get(SHORT_LAYOUT, addressOffset + index);
         }
+
         @Override
-        public void putCharVolatile(int index, char value)
+        public void putCharVolatile(
+            int index,
+            char value)
         {
-            fallback.putCharVolatile(index, value);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
+            }
+            GLOBAL.set(SHORT_LAYOUT, addressOffset + index, (short) value);
         }
+
         @Override
-        public byte getByteVolatile(int index)
+        public byte getByteVolatile(
+            int index)
         {
-            return fallback.getByteVolatile(index);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Byte.BYTES, capacity);
+            }
+            return GLOBAL.get(BYTE_LAYOUT, addressOffset + index);
         }
+
         @Override
-        public void putByteVolatile(int index, byte value)
+        public void putByteVolatile(
+            int index,
+            byte value)
         {
-            fallback.putByteVolatile(index, value);
+            if (SHOULD_BOUNDS_CHECK)
+            {
+                Objects.checkFromIndexSize(index, Byte.BYTES, capacity);
+            }
+            GLOBAL.set(BYTE_LAYOUT, addressOffset + index, value);
         }
 
         // String — ASCII (length-prefixed)
+
         @Override
-        public String getStringAscii(int index)
+        public String getStringAscii(
+            int index)
         {
-            return fallback.getStringAscii(index);
+            final int length = getInt(index);
+            return getStringWithoutLengthAscii(index + Integer.BYTES, length);
         }
+
         @Override
-        public String getStringAscii(int index, ByteOrder byteOrder)
+        public String getStringAscii(
+            int index,
+            ByteOrder byteOrder)
         {
-            return fallback.getStringAscii(index, byteOrder);
+            final int length = getInt(index, byteOrder);
+            return getStringWithoutLengthAscii(index + Integer.BYTES, length);
         }
+
         @Override
-        public String getStringAscii(int index, int length)
+        public String getStringAscii(
+            int index,
+            int length)
         {
-            return fallback.getStringAscii(index, length);
+            return getStringWithoutLengthAscii(index + Integer.BYTES, length);
         }
+
         @Override
-        public int getStringAscii(int index, Appendable appendable)
+        public int getStringAscii(
+            int index,
+            Appendable appendable)
         {
-            return fallback.getStringAscii(index, appendable);
+            final int length = getInt(index);
+            return getStringWithoutLengthAscii(index + Integer.BYTES, length, appendable);
         }
+
         @Override
-        public int getStringAscii(int index, Appendable appendable, ByteOrder byteOrder)
+        public int getStringAscii(
+            int index,
+            Appendable appendable,
+            ByteOrder byteOrder)
         {
-            return fallback.getStringAscii(index, appendable, byteOrder);
+            final int length = getInt(index, byteOrder);
+            return getStringWithoutLengthAscii(index + Integer.BYTES, length, appendable);
         }
+
         @Override
-        public int getStringAscii(int index, int length, Appendable appendable)
+        public int getStringAscii(
+            int index,
+            int length,
+            Appendable appendable)
         {
-            return fallback.getStringAscii(index, length, appendable);
+            return getStringWithoutLengthAscii(index + Integer.BYTES, length, appendable);
         }
 
         // String — ASCII (no length prefix)
+
         @Override
-        public String getStringWithoutLengthAscii(int index, int length)
+        public String getStringWithoutLengthAscii(
+            int index,
+            int length)
         {
-            return fallback.getStringWithoutLengthAscii(index, length);
+            final byte[] bytes = new byte[length];
+            MemorySegment.copy(segment, BYTE_LAYOUT, index,
+                MemorySegment.ofArray(bytes), BYTE_LAYOUT, 0, length);
+            return new String(bytes, java.nio.charset.StandardCharsets.US_ASCII);
         }
+
         @Override
-        public int getStringWithoutLengthAscii(int index, int length, Appendable appendable)
+        public int getStringWithoutLengthAscii(
+            int index,
+            int length,
+            Appendable appendable)
         {
-            return fallback.getStringWithoutLengthAscii(index, length, appendable);
+            try
+            {
+                for (int i = 0; i < length; i++)
+                {
+                    appendable.append((char) getByte(index + i));
+                }
+            }
+            catch (java.io.IOException ex)
+            {
+                throw new RuntimeException(ex);
+            }
+            return length;
         }
 
         // String — UTF-8
+
         @Override
-        public String getStringUtf8(int index)
+        public String getStringUtf8(
+            int index)
         {
-            return fallback.getStringUtf8(index);
+            final int length = getInt(index);
+            return getStringWithoutLengthUtf8(index + Integer.BYTES, length);
         }
+
         @Override
-        public String getStringUtf8(int index, ByteOrder byteOrder)
+        public String getStringUtf8(
+            int index,
+            ByteOrder byteOrder)
         {
-            return fallback.getStringUtf8(index, byteOrder);
+            final int length = getInt(index, byteOrder);
+            return getStringWithoutLengthUtf8(index + Integer.BYTES, length);
         }
+
         @Override
-        public String getStringUtf8(int index, int length)
+        public String getStringUtf8(
+            int index,
+            int length)
         {
-            return fallback.getStringUtf8(index, length);
+            return getStringWithoutLengthUtf8(index + Integer.BYTES, length);
         }
+
         @Override
-        public String getStringWithoutLengthUtf8(int index, int length)
+        public String getStringWithoutLengthUtf8(
+            int index,
+            int length)
         {
-            return fallback.getStringWithoutLengthUtf8(index, length);
+            final byte[] bytes = new byte[length];
+            MemorySegment.copy(segment, BYTE_LAYOUT, index,
+                MemorySegment.ofArray(bytes), BYTE_LAYOUT, 0, length);
+            return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
         }
 
         // putString — ASCII (length-prefixed)
+
         @Override
-        public int putStringAscii(int index, String value)
+        public int putStringAscii(
+            int index,
+            String value)
         {
-            return fallback.putStringAscii(index, value);
+            final int length = value != null ? value.length() : 0;
+            putInt(index, length);
+            return Integer.BYTES + putStringWithoutLengthAscii(index + Integer.BYTES, value);
         }
+
         @Override
-        public int putStringAscii(int index, CharSequence value)
+        public int putStringAscii(
+            int index,
+            CharSequence value)
         {
-            return fallback.putStringAscii(index, value);
+            final int length = value != null ? value.length() : 0;
+            putInt(index, length);
+            return Integer.BYTES + putStringWithoutLengthAscii(index + Integer.BYTES, value);
         }
+
         @Override
-        public int putStringAscii(int index, String value, ByteOrder byteOrder)
+        public int putStringAscii(
+            int index,
+            String value,
+            ByteOrder byteOrder)
         {
-            return fallback.putStringAscii(index, value, byteOrder);
+            final int length = value != null ? value.length() : 0;
+            putInt(index, length, byteOrder);
+            return Integer.BYTES + putStringWithoutLengthAscii(index + Integer.BYTES, value);
         }
+
         @Override
-        public int putStringAscii(int index, CharSequence value, ByteOrder byteOrder)
+        public int putStringAscii(
+            int index,
+            CharSequence value,
+            ByteOrder byteOrder)
         {
-            return fallback.putStringAscii(index, value, byteOrder);
+            final int length = value != null ? value.length() : 0;
+            putInt(index, length, byteOrder);
+            return Integer.BYTES + putStringWithoutLengthAscii(index + Integer.BYTES, value);
         }
 
         // putString — ASCII (no length prefix)
+
         @Override
-        public int putStringWithoutLengthAscii(int index, String value)
+        public int putStringWithoutLengthAscii(
+            int index,
+            String value)
         {
-            return fallback.putStringWithoutLengthAscii(index, value);
+            if (value == null)
+            {
+                return 0;
+            }
+            final int length = value.length();
+            for (int i = 0; i < length; i++)
+            {
+                putByte(index + i, (byte) value.charAt(i));
+            }
+            return length;
         }
+
         @Override
-        public int putStringWithoutLengthAscii(int index, CharSequence value)
+        public int putStringWithoutLengthAscii(
+            int index,
+            CharSequence value)
         {
-            return fallback.putStringWithoutLengthAscii(index, value);
+            if (value == null)
+            {
+                return 0;
+            }
+            final int length = value.length();
+            for (int i = 0; i < length; i++)
+            {
+                putByte(index + i, (byte) value.charAt(i));
+            }
+            return length;
         }
+
         @Override
-        public int putStringWithoutLengthAscii(int index, String value, int valueOffset, int length)
+        public int putStringWithoutLengthAscii(
+            int index,
+            String value,
+            int valueOffset,
+            int length)
         {
-            return fallback.putStringWithoutLengthAscii(index, value, valueOffset, length);
+            if (value == null)
+            {
+                return 0;
+            }
+            for (int i = 0; i < length; i++)
+            {
+                putByte(index + i, (byte) value.charAt(valueOffset + i));
+            }
+            return length;
         }
+
         @Override
-        public int putStringWithoutLengthAscii(int index, CharSequence value, int valueOffset, int length)
+        public int putStringWithoutLengthAscii(
+            int index,
+            CharSequence value,
+            int valueOffset,
+            int length)
         {
-            return fallback.putStringWithoutLengthAscii(index, value, valueOffset, length);
+            if (value == null)
+            {
+                return 0;
+            }
+            for (int i = 0; i < length; i++)
+            {
+                putByte(index + i, (byte) value.charAt(valueOffset + i));
+            }
+            return length;
         }
 
         // putString — UTF-8
+
         @Override
-        public int putStringUtf8(int index, String value)
+        public int putStringUtf8(
+            int index,
+            String value)
         {
-            return fallback.putStringUtf8(index, value);
+            return putStringUtf8(index, value, ByteOrder.nativeOrder(), Integer.MAX_VALUE);
         }
+
         @Override
-        public int putStringUtf8(int index, String value, ByteOrder byteOrder)
+        public int putStringUtf8(
+            int index,
+            String value,
+            ByteOrder byteOrder)
         {
-            return fallback.putStringUtf8(index, value, byteOrder);
+            return putStringUtf8(index, value, byteOrder, Integer.MAX_VALUE);
         }
+
         @Override
-        public int putStringUtf8(int index, String value, int maxEncodedLength)
+        public int putStringUtf8(
+            int index,
+            String value,
+            int maxEncodedLength)
         {
-            return fallback.putStringUtf8(index, value, maxEncodedLength);
+            return putStringUtf8(index, value, ByteOrder.nativeOrder(), maxEncodedLength);
         }
+
         @Override
-        public int putStringUtf8(int index, String value, ByteOrder byteOrder, int maxEncodedLength)
+        public int putStringUtf8(
+            int index,
+            String value,
+            ByteOrder byteOrder,
+            int maxEncodedLength)
         {
-            return fallback.putStringUtf8(index, value, byteOrder, maxEncodedLength);
+            final byte[] bytes = value != null
+                ? value.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+                : new byte[0];
+            final int length = Math.min(bytes.length, maxEncodedLength);
+            segment.set(intLayout(byteOrder), index, length);
+            MemorySegment.copy(MemorySegment.ofArray(bytes), BYTE_LAYOUT, 0,
+                segment, BYTE_LAYOUT, index + Integer.BYTES, length);
+            return Integer.BYTES + length;
         }
+
         @Override
-        public int putStringWithoutLengthUtf8(int index, String value)
+        public int putStringWithoutLengthUtf8(
+            int index,
+            String value)
         {
-            return fallback.putStringWithoutLengthUtf8(index, value);
+            final byte[] bytes = value != null
+                ? value.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+                : new byte[0];
+            MemorySegment.copy(MemorySegment.ofArray(bytes), BYTE_LAYOUT, 0,
+                segment, BYTE_LAYOUT, index, bytes.length);
+            return bytes.length;
         }
 
         // ASCII int/long parsing and encoding
+
         @Override
-        public int parseNaturalIntAscii(int index, int length)
+        public int parseNaturalIntAscii(
+            int index,
+            int length)
         {
-            return fallback.parseNaturalIntAscii(index, length);
+            int result = 0;
+            for (int i = 0; i < length; i++)
+            {
+                final byte b = getByte(index + i);
+                result = result * 10 + (b - '0');
+            }
+            return result;
         }
+
         @Override
-        public long parseNaturalLongAscii(int index, int length)
+        public long parseNaturalLongAscii(
+            int index,
+            int length)
         {
-            return fallback.parseNaturalLongAscii(index, length);
+            long result = 0;
+            for (int i = 0; i < length; i++)
+            {
+                final byte b = getByte(index + i);
+                result = result * 10 + (b - '0');
+            }
+            return result;
         }
+
         @Override
-        public int parseIntAscii(int index, int length)
+        public int parseIntAscii(
+            int index,
+            int length)
         {
-            return fallback.parseIntAscii(index, length);
+            if (length == 0)
+            {
+                return 0;
+            }
+            final boolean negative = getByte(index) == '-';
+            final int start = negative ? index + 1 : index;
+            final int digits = negative ? length - 1 : length;
+            final int value = parseNaturalIntAscii(start, digits);
+            return negative ? -value : value;
         }
+
         @Override
-        public long parseLongAscii(int index, int length)
+        public long parseLongAscii(
+            int index,
+            int length)
         {
-            return fallback.parseLongAscii(index, length);
+            if (length == 0)
+            {
+                return 0;
+            }
+            final boolean negative = getByte(index) == '-';
+            final int start = negative ? index + 1 : index;
+            final int digits = negative ? length - 1 : length;
+            final long value = parseNaturalLongAscii(start, digits);
+            return negative ? -value : value;
         }
+
         @Override
-        public int putIntAscii(int index, int value)
+        public int putIntAscii(
+            int index,
+            int value)
         {
-            return fallback.putIntAscii(index, value);
+            return putStringWithoutLengthAscii(index, Integer.toString(value));
         }
+
         @Override
-        public int putNaturalIntAscii(int index, int value)
+        public int putNaturalIntAscii(
+            int index,
+            int value)
         {
-            return fallback.putNaturalIntAscii(index, value);
+            return putStringWithoutLengthAscii(index, Integer.toUnsignedString(value));
         }
+
         @Override
-        public void putNaturalPaddedIntAscii(int index, int length, int value)
+        public void putNaturalPaddedIntAscii(
+            int index,
+            int length,
+            int value)
         {
-            fallback.putNaturalPaddedIntAscii(index, length, value);
+            final String str = Integer.toUnsignedString(value);
+            final int padding = length - str.length();
+            if (padding < 0)
+            {
+                throw new NumberFormatException(
+                    String.format("value=%d too large for length=%d", value, length));
+            }
+            for (int i = 0; i < padding; i++)
+            {
+                putByte(index + i, (byte) '0');
+            }
+            putStringWithoutLengthAscii(index + padding, str);
         }
+
         @Override
-        public int putNaturalIntAsciiFromEnd(int value, int endExclusive)
+        public int putNaturalIntAsciiFromEnd(
+            int value,
+            int endExclusive)
         {
-            return fallback.putNaturalIntAsciiFromEnd(value, endExclusive);
+            int index = endExclusive;
+            int remaining = value;
+            do
+            {
+                index--;
+                final int digit = remaining % 10;
+                remaining = remaining / 10;
+                putByte(index, (byte) ('0' + digit));
+            }
+            while (remaining > 0);
+            return index;
         }
+
         @Override
-        public int putNaturalLongAscii(int index, long value)
+        public int putNaturalLongAscii(
+            int index,
+            long value)
         {
-            return fallback.putNaturalLongAscii(index, value);
+            return putStringWithoutLengthAscii(index, Long.toUnsignedString(value));
         }
+
         @Override
-        public int putLongAscii(int index, long value)
+        public int putLongAscii(
+            int index,
+            long value)
         {
-            return fallback.putLongAscii(index, value);
+            return putStringWithoutLengthAscii(index, Long.toString(value));
         }
 
         // Comparable
+
         @Override
-        public int compareTo(DirectBuffer that)
+        public int compareTo(
+            DirectBuffer that)
         {
-            return fallback.compareTo(that);
+            final int thisCapacity = this.capacity;
+            final int thatCapacity = that.capacity();
+            final int limit = Math.min(thisCapacity, thatCapacity);
+
+            for (int i = 0; i < limit; i++)
+            {
+                final int cmp = Byte.compare(this.getByte(i), that.getByte(i));
+                if (cmp != 0)
+                {
+                    return cmp;
+                }
+            }
+
+            return Integer.compare(thisCapacity, thatCapacity);
         }
 
         // Object overrides
+
         @Override
         public String toString()
         {
@@ -3421,14 +4152,16 @@ public class UnsafeBufferEx implements AtomicBufferEx
             {
                 return false;
             }
+            boolean equal = true;
             for (int i = 0; i < capacity; i++)
             {
                 if (this.getByte(i) != that.getByte(i))
                 {
-                    return false;
+                    equal = false;
+                    break;
                 }
             }
-            return true;
+            return equal;
         }
 
         @Override
@@ -3441,5 +4174,42 @@ public class UnsafeBufferEx implements AtomicBufferEx
             }
             return result;
         }
+
+        // -------------------------------------------------------------------
+        // Self-check:
+        //   @Override method count: 115
+        //     - 6 hot-path final field accessors
+        //     - 4 hot-path primitive long/int put/get
+        //     - 10 hot-path ordered/release/acquire/volatile + CAS
+        //     - 2 hot-path bulk copy/fill (putBytes(DirectBuffer,...), setMemory)
+        //     - 11 wrap() overloads (all throw)
+        //     - 4 cold-path housekeeping (isExpandable, checkLimit, boundsCheck, verifyAlignment)
+        //     - 5 get-primitive native-order (short, byte, double, float, char)
+        //     - 6 get-primitive byte-order (long, int, short, double, float, char)
+        //     - 5 put-primitive native-order (short, byte, double, float, char)
+        //     - 6 put-primitive byte-order (long, int, short, double, float, char)
+        //     - 12 getBytes/putBytes overloads (excluding the hot-path putBytes already counted)
+        //     - 9 long volatile/ordered/opaque/CAS remainder
+        //     - 9 int volatile/ordered/opaque/CAS remainder
+        //     - 6 short/char/byte volatile
+        //     - 6 getStringAscii (length-prefixed)
+        //     - 2 getStringWithoutLengthAscii
+        //     - 4 getStringUtf8
+        //     - 4 putStringAscii (length-prefixed)
+        //     - 4 putStringWithoutLengthAscii
+        //     - 5 putStringUtf8
+        //     - 11 ASCII int/long parsing and encoding
+        //     - 1 compareTo
+        //     - 3 Object overrides (toString, equals, hashCode)
+        // All cold-path methods are implemented directly against Native's
+        // final fields (segment, addressOffset, capacity, byteBuffer) and
+        // outer-class static finals/helpers (GLOBAL, LONG_LAYOUT, INT_LAYOUT,
+        // SHORT_LAYOUT, BYTE_LAYOUT, LONG_HANDLE, INT_HANDLE,
+        // SHOULD_BOUNDS_CHECK, USE_ALIGNED_ATOMICS, longLayout(),
+        // intLayout(), shortLayout()).
+        // No method falls back to a shared UnsafeBufferEx instance.
+        // No method is left as UnsupportedOperationException beyond the
+        // 11 wrap() overloads (re-wrap is intentionally disallowed).
+        // -------------------------------------------------------------------
     }
 }

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -73,7 +73,7 @@ import org.agrona.MutableDirectBuffer;
  * atomics, because the JVM cannot guarantee {@code byte[]} alignment for
  * {@code VarHandle} atomic access.
  */
-public final class UnsafeBufferEx implements AtomicBufferEx
+public final class UnsafeBufferEx implements AtomicBufferEx, DirectBufferViewEx
 {
     private static final MemorySegment GLOBAL = MemorySegment.NULL.reinterpret(Long.MAX_VALUE);
 
@@ -148,6 +148,7 @@ public final class UnsafeBufferEx implements AtomicBufferEx
     private MemorySegment segment;
     private byte[] byteArray;
     private ByteBuffer byteBuffer;
+    private ByteBuffer byteBufferView;
     private long addressOffset;
     private int capacity;
     private int wrapAdjustment;
@@ -249,6 +250,7 @@ public final class UnsafeBufferEx implements AtomicBufferEx
     {
         byteArray = buffer;
         byteBuffer = null;
+        byteBufferView = null;
         segment = MemorySegment.ofArray(buffer);
         addressOffset = BufferUtil.ARRAY_BASE_OFFSET;
         capacity = buffer.length;
@@ -264,6 +266,7 @@ public final class UnsafeBufferEx implements AtomicBufferEx
     {
         byteArray = buffer;
         byteBuffer = null;
+        byteBufferView = null;
         segment = MemorySegment.ofArray(buffer);
         addressOffset = BufferUtil.ARRAY_BASE_OFFSET + offset;
         capacity = length;
@@ -275,6 +278,7 @@ public final class UnsafeBufferEx implements AtomicBufferEx
     public void wrap(
         ByteBuffer buffer)
     {
+        wrapByteBufferView(buffer);
         byteBuffer = buffer;
         if (buffer.isDirect())
         {
@@ -300,6 +304,7 @@ public final class UnsafeBufferEx implements AtomicBufferEx
         int offset,
         int length)
     {
+        wrapByteBufferView(buffer);
         byteBuffer = buffer;
         if (buffer.isDirect())
         {
@@ -326,6 +331,7 @@ public final class UnsafeBufferEx implements AtomicBufferEx
         segment = buffer.segment();
         byteArray = buffer.byteArray();
         byteBuffer = buffer.byteBuffer();
+        byteBufferView = buffer instanceof DirectBufferViewEx view ? view.byteBufferView() : null;
         addressOffset = buffer.addressOffset();
         capacity = buffer.capacity();
         wrapAdjustment = buffer.wrapAdjustment();
@@ -341,6 +347,7 @@ public final class UnsafeBufferEx implements AtomicBufferEx
         segment = buffer.segment();
         byteArray = buffer.byteArray();
         byteBuffer = buffer.byteBuffer();
+        byteBufferView = buffer instanceof DirectBufferViewEx view ? view.byteBufferView() : null;
         addressOffset = buffer.addressOffset() + offset;
         capacity = length;
         wrapAdjustment = buffer.wrapAdjustment() + offset;
@@ -384,6 +391,7 @@ public final class UnsafeBufferEx implements AtomicBufferEx
     {
         byteArray = null;
         byteBuffer = null;
+        byteBufferView = null;
         segment = MemorySegment.ofAddress(address).reinterpret(length);
         addressOffset = address;
         capacity = length;
@@ -397,6 +405,7 @@ public final class UnsafeBufferEx implements AtomicBufferEx
     {
         byteArray = null;
         byteBuffer = null;
+        byteBufferView = null;
         this.segment = segment;
         addressOffset = segment.address();
         capacity = (int) segment.byteSize();
@@ -412,11 +421,26 @@ public final class UnsafeBufferEx implements AtomicBufferEx
     {
         byteArray = null;
         byteBuffer = null;
+        byteBufferView = null;
         this.segment = segment;
         addressOffset = segment.address() + offset;
         capacity = length;
         wrapAdjustment = offset;
         isNative = segment.isNative();
+    }
+
+    // A clean duplicate of the wrapped buffer, refreshed only when the underlying buffer identity
+    // changes, reused on same-instance re-wrap, and inherited on sub-wrap. Held permanently at
+    // position 0, limit capacity so the ByteBuffer.put bulk-copy fast path is always in bounds for
+    // a valid copy, without consulting the wrapped buffer's NIO limit (Agrona scratch state).
+    private void wrapByteBufferView(
+        ByteBuffer buffer)
+    {
+        if (byteBuffer != buffer)
+        {
+            byteBufferView = buffer.duplicate();
+            byteBufferView.clear();
+        }
     }
 
     private void wrapFromUnsafe(
@@ -464,6 +488,12 @@ public final class UnsafeBufferEx implements AtomicBufferEx
     public ByteBuffer byteBuffer()
     {
         return byteBuffer;
+    }
+
+    @Override
+    public ByteBuffer byteBufferView()
+    {
+        return byteBufferView;
     }
 
     @Override
@@ -1097,12 +1127,11 @@ public final class UnsafeBufferEx implements AtomicBufferEx
         int offset,
         int length)
     {
-        // ByteBuffer.put also bounds-checks this destination against its NIO limit, which Agrona
-        // treats as scratch state independent of capacity; only take the fast path when the
-        // destination limit covers the range, else copy by the destination's capacity-sized segment
-        if (byteBuffer != null && byteBuffer.limit() >= wrapAdjustment + index + length)
+        // copy through the clean view so the intrinsified ByteBuffer.put fast path is taken without
+        // consulting the wrapped buffer's NIO limit (Agrona scratch state, e.g. dirtied by CRC32)
+        if (byteBufferView != null)
         {
-            byteBuffer.put(wrapAdjustment + index, src, offset, length);
+            byteBufferView.put(wrapAdjustment + index, src, offset, length);
         }
         else
         {
@@ -1128,14 +1157,12 @@ public final class UnsafeBufferEx implements AtomicBufferEx
         int srcOffset,
         int length)
     {
-        // ByteBuffer.put bounds-checks both this destination and the source against their NIO
-        // limits, which Agrona treats as scratch state independent of capacity; only take the
-        // fast path when both limits cover the range, else copy by capacity so a stale limit
-        // does not reject a valid copy
-        if (byteBuffer != null && byteBuffer.limit() >= wrapAdjustment + index + length &&
-            srcBuffer.limit() >= srcOffset + length)
+        // the destination copies through the clean view; the source is a caller-owned ByteBuffer
+        // whose NIO limit must still cover the range for the intrinsified ByteBuffer.put fast path,
+        // else copy by capacity so a stale source limit does not reject a valid copy
+        if (byteBufferView != null && srcBuffer.limit() >= srcOffset + length)
         {
-            byteBuffer.put(wrapAdjustment + index, srcBuffer, srcOffset, length);
+            byteBufferView.put(wrapAdjustment + index, srcBuffer, srcOffset, length);
         }
         else
         {
@@ -1153,16 +1180,14 @@ public final class UnsafeBufferEx implements AtomicBufferEx
         int srcIndex,
         int length)
     {
-        final ByteBuffer srcBb = srcBuffer.byteBuffer();
         final int srcAdjusted = srcBuffer.wrapAdjustment() + srcIndex;
-        // ByteBuffer.put bounds-checks both this destination and the source against their NIO
-        // limits, which Agrona treats as scratch state independent of capacity (e.g. left dirty
-        // by CRC32.update); only take the intrinsified fast path when both limits cover the range,
-        // else copy by capacity
-        if (byteBuffer != null && srcBb != null &&
-            byteBuffer.limit() >= wrapAdjustment + index + length && srcBb.limit() >= srcAdjusted + length)
+        // both ends copy through their clean views, so the intrinsified ByteBuffer.put fast path is
+        // always taken for ByteBuffer-backed buffers without consulting either NIO limit (Agrona
+        // scratch state, e.g. dirtied by CRC32.update); else copy by capacity
+        final ByteBuffer srcView = srcBuffer instanceof DirectBufferViewEx view ? view.byteBufferView() : null;
+        if (byteBufferView != null && srcView != null)
         {
-            byteBuffer.put(wrapAdjustment + index, srcBb, srcAdjusted, length);
+            byteBufferView.put(wrapAdjustment + index, srcView, srcAdjusted, length);
         }
         else
         {
@@ -1178,12 +1203,14 @@ public final class UnsafeBufferEx implements AtomicBufferEx
         int srcIndex,
         int length)
     {
-        final ByteBuffer srcBb = srcBuffer.byteBuffer();
         final int srcAdjusted = srcBuffer.wrapAdjustment() + srcIndex;
-        final boolean destOk = byteBuffer != null && byteBuffer.limit() >= wrapAdjustment + index + length;
-        if (destOk && srcBb != null && srcBb.limit() >= srcAdjusted + length)
+        // copy through clean views (Agrona treats NIO limit as scratch state); a DirectBufferEx
+        // source falls to its capacity-sized segment, an external DirectBuffer to a byte[] view or
+        // a byte-wise copy
+        final ByteBuffer srcView = srcBuffer instanceof DirectBufferViewEx view ? view.byteBufferView() : null;
+        if (byteBufferView != null && srcView != null)
         {
-            byteBuffer.put(wrapAdjustment + index, srcBb, srcAdjusted, length);
+            byteBufferView.put(wrapAdjustment + index, srcView, srcAdjusted, length);
         }
         else if (srcBuffer instanceof DirectBufferEx safe)
         {
@@ -1193,9 +1220,9 @@ public final class UnsafeBufferEx implements AtomicBufferEx
         else
         {
             final byte[] srcArray = srcBuffer.byteArray();
-            if (destOk && srcArray != null)
+            if (byteBufferView != null && srcArray != null)
             {
-                byteBuffer.put(wrapAdjustment + index, srcArray, srcAdjusted, length);
+                byteBufferView.put(wrapAdjustment + index, srcArray, srcAdjusted, length);
             }
             else if (srcArray != null)
             {
@@ -2454,12 +2481,13 @@ public final class UnsafeBufferEx implements AtomicBufferEx
         return new Native(segment, byteBuffer);
     }
 
-    public static final class Native implements AtomicBufferEx
+    public static final class Native implements AtomicBufferEx, DirectBufferViewEx
     {
         private final MemorySegment segment;
         private final long addressOffset;
         private final int capacity;
         private final ByteBuffer byteBuffer;
+        private final ByteBuffer byteBufferView;
 
         private Native(
             MemorySegment segment,
@@ -2473,6 +2501,11 @@ public final class UnsafeBufferEx implements AtomicBufferEx
             this.addressOffset = segment.address();
             this.capacity = (int) segment.byteSize();
             this.byteBuffer = byteBuffer;
+            // clean duplicate (position 0, limit capacity) so the ByteBuffer.put bulk-copy fast path
+            // is always in bounds without consulting the wrapped buffer's NIO limit (Agrona scratch
+            // state, e.g. dirtied by CRC32.update)
+            this.byteBufferView = byteBuffer.duplicate();
+            this.byteBufferView.clear();
         }
 
         private static UnsupportedOperationException cannotReWrap()
@@ -2500,6 +2533,12 @@ public final class UnsafeBufferEx implements AtomicBufferEx
         public ByteBuffer byteBuffer()
         {
             return byteBuffer;
+        }
+
+        @Override
+        public ByteBuffer byteBufferView()
+        {
+            return byteBufferView;
         }
 
         @Override
@@ -2791,21 +2830,25 @@ public final class UnsafeBufferEx implements AtomicBufferEx
             int srcIndex,
             int length)
         {
-            if (srcBuffer instanceof DirectBufferEx ex)
+            final int srcAdjusted = srcBuffer.wrapAdjustment() + srcIndex;
+            // copy through clean views (Agrona treats NIO limit as scratch state); a DirectBufferEx
+            // source falls to its capacity-sized segment, an external DirectBuffer to a byte[] view
+            // or a byte-wise copy
+            final ByteBuffer srcView = srcBuffer instanceof DirectBufferViewEx view ? view.byteBufferView() : null;
+            if (srcView != null)
             {
-                MemorySegment.copy(ex.segment(), ex.wrapAdjustment() + srcIndex, segment, index, length);
+                byteBufferView.put(index, srcView, srcAdjusted, length);
+            }
+            else if (srcBuffer instanceof DirectBufferEx safe)
+            {
+                MemorySegment.copy(safe.segment(), srcAdjusted, segment, index, length);
             }
             else
             {
                 final byte[] srcArray = srcBuffer.byteArray();
-                if (srcArray != null && byteBuffer.limit() >= index + length)
+                if (srcArray != null)
                 {
-                    byteBuffer.put(index, srcArray, srcBuffer.wrapAdjustment() + srcIndex, length);
-                }
-                else if (srcArray != null)
-                {
-                    MemorySegment.copy(MemorySegment.ofArray(srcArray), BYTE_LAYOUT,
-                        srcBuffer.wrapAdjustment() + srcIndex, segment, BYTE_LAYOUT, index, length);
+                    byteBufferView.put(index, srcArray, srcAdjusted, length);
                 }
                 else
                 {
@@ -3342,14 +3385,9 @@ public final class UnsafeBufferEx implements AtomicBufferEx
             int offset,
             int length)
         {
-            if (byteBuffer.limit() >= index + length)
-            {
-                byteBuffer.put(index, src, offset, length);
-            }
-            else
-            {
-                MemorySegment.copy(MemorySegment.ofArray(src), BYTE_LAYOUT, offset, segment, BYTE_LAYOUT, index, length);
-            }
+            // copy through the clean view so the intrinsified ByteBuffer.put fast path is taken
+            // without consulting the wrapped buffer's NIO limit (Agrona scratch state)
+            byteBufferView.put(index, src, offset, length);
         }
 
         @Override
@@ -3369,12 +3407,12 @@ public final class UnsafeBufferEx implements AtomicBufferEx
             int srcOffset,
             int length)
         {
-            // ByteBuffer.put bounds-checks both this destination and the source against their NIO
-            // limits, which Agrona treats as scratch state independent of capacity; only take the
-            // fast path when both limits cover the range, else copy by capacity
-            if (byteBuffer.limit() >= index + length && srcBuffer.limit() >= srcOffset + length)
+            // the destination copies through the clean view; the source is a caller-owned ByteBuffer
+            // whose NIO limit must still cover the range for the intrinsified ByteBuffer.put fast
+            // path, else copy by capacity so a stale source limit does not reject a valid copy
+            if (srcBuffer.limit() >= srcOffset + length)
             {
-                byteBuffer.put(index, srcBuffer, srcOffset, length);
+                byteBufferView.put(index, srcBuffer, srcOffset, length);
             }
             else
             {
@@ -3392,15 +3430,14 @@ public final class UnsafeBufferEx implements AtomicBufferEx
             int srcIndex,
             int length)
         {
-            final ByteBuffer srcBb = srcBuffer.byteBuffer();
             final int srcAdjusted = srcBuffer.wrapAdjustment() + srcIndex;
-            // ByteBuffer.put bounds-checks both this destination and the source against their NIO
-            // limits, which Agrona treats as scratch state independent of capacity (e.g. left
-            // dirty by CRC32.update); only take the intrinsified fast path when both limits cover
-            // the range, else copy by capacity
-            if (srcBb != null && byteBuffer.limit() >= index + length && srcBb.limit() >= srcAdjusted + length)
+            // both ends copy through their clean views, so the intrinsified ByteBuffer.put fast path
+            // is always taken for ByteBuffer-backed buffers without consulting either NIO limit
+            // (Agrona scratch state, e.g. dirtied by CRC32.update); else copy by capacity
+            final ByteBuffer srcView = srcBuffer instanceof DirectBufferViewEx view ? view.byteBufferView() : null;
+            if (srcView != null)
             {
-                byteBuffer.put(index, srcBb, srcAdjusted, length);
+                byteBufferView.put(index, srcView, srcAdjusted, length);
             }
             else
             {

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -278,7 +278,14 @@ public final class UnsafeBufferEx implements AtomicBufferEx, DirectBufferViewEx
     public void wrap(
         ByteBuffer buffer)
     {
-        wrapByteBufferView(buffer);
+        // refresh the clean view only when the underlying buffer identity changes; held at
+        // position 0, limit capacity so the ByteBuffer.put fast path ignores the wrapped buffer's
+        // NIO limit (Agrona scratch state, e.g. dirtied by CRC32.update)
+        if (byteBuffer != buffer)
+        {
+            byteBufferView = buffer.duplicate();
+            byteBufferView.clear();
+        }
         byteBuffer = buffer;
         if (buffer.isDirect())
         {
@@ -304,7 +311,13 @@ public final class UnsafeBufferEx implements AtomicBufferEx, DirectBufferViewEx
         int offset,
         int length)
     {
-        wrapByteBufferView(buffer);
+        // refresh the clean view only when the underlying buffer identity changes; the view is
+        // offset-independent (absolute indexing via wrapAdjustment + index)
+        if (byteBuffer != buffer)
+        {
+            byteBufferView = buffer.duplicate();
+            byteBufferView.clear();
+        }
         byteBuffer = buffer;
         if (buffer.isDirect())
         {
@@ -427,20 +440,6 @@ public final class UnsafeBufferEx implements AtomicBufferEx, DirectBufferViewEx
         capacity = length;
         wrapAdjustment = offset;
         isNative = segment.isNative();
-    }
-
-    // A clean duplicate of the wrapped buffer, refreshed only when the underlying buffer identity
-    // changes, reused on same-instance re-wrap, and inherited on sub-wrap. Held permanently at
-    // position 0, limit capacity so the ByteBuffer.put bulk-copy fast path is always in bounds for
-    // a valid copy, without consulting the wrapped buffer's NIO limit (Agrona scratch state).
-    private void wrapByteBufferView(
-        ByteBuffer buffer)
-    {
-        if (byteBuffer != buffer)
-        {
-            byteBufferView = buffer.duplicate();
-            byteBufferView.clear();
-        }
     }
 
     private void wrapFromUnsafe(

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -1125,7 +1125,10 @@ public class UnsafeBufferEx implements AtomicBufferEx
         int srcOffset,
         int length)
     {
-        if (byteBuffer != null)
+        // ByteBuffer.put bounds-checks the source against its NIO limit, but the index-based
+        // putBytes contract copies by capacity; only take the fast path when limit covers the
+        // range, else copy by capacity so a stale limit does not reject a valid copy
+        if (byteBuffer != null && srcBuffer.limit() >= srcOffset + length)
         {
             byteBuffer.put(wrapAdjustment + index, srcBuffer, srcOffset, length);
         }
@@ -3346,7 +3349,20 @@ public class UnsafeBufferEx implements AtomicBufferEx
             int srcOffset,
             int length)
         {
-            byteBuffer.put(index, srcBuffer, srcOffset, length);
+            // ByteBuffer.put bounds-checks the source against its NIO limit, but the index-based
+            // putBytes contract copies by capacity; only take the fast path when limit covers the
+            // range, else copy by capacity so a stale limit does not reject a valid copy
+            if (srcBuffer.limit() >= srcOffset + length)
+            {
+                byteBuffer.put(index, srcBuffer, srcOffset, length);
+            }
+            else
+            {
+                final MemorySegment src = srcBuffer.isDirect()
+                    ? MemorySegment.ofAddress(BufferUtil.address(srcBuffer)).reinterpret(srcBuffer.capacity())
+                    : MemorySegment.ofArray(BufferUtil.array(srcBuffer));
+                MemorySegment.copy(src, srcOffset, segment, index, length);
+            }
         }
 
         @Override

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -73,7 +73,7 @@ import org.agrona.MutableDirectBuffer;
  * atomics, because the JVM cannot guarantee {@code byte[]} alignment for
  * {@code VarHandle} atomic access.
  */
-public final class UnsafeBufferEx implements AtomicBufferEx
+public class UnsafeBufferEx implements AtomicBufferEx
 {
     private static final MemorySegment GLOBAL = MemorySegment.NULL.reinterpret(Long.MAX_VALUE);
 

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -45,9 +45,11 @@ import org.agrona.MutableDirectBuffer;
  * performance without depending on {@code jdk.unsupported}. For heap memory it
  * falls back to the bounded per-instance segment.
  * <p>
- * Native-path bounds checks are enabled when this class is loaded from the class
- * path (unnamed module), as in unit and integration tests, and disabled when it
- * is loaded as a named module, as in the packaged production runtime.
+ * Native-path bounds checks default to enabled when this class is loaded from the
+ * class path (unnamed module), as in unit and integration tests, and to disabled
+ * when loaded as a named module, as in the packaged production runtime. The
+ * default can be overridden with the {@code zilla.buffer.bounds.checks} system
+ * property.
  * <p>
  * All atomic operations use {@link VarHandle} access modes on the selected
  * segment, providing the same memory ordering guarantees as an
@@ -63,11 +65,13 @@ public class UnsafeBufferEx implements AtomicBufferEx
 {
     private static final MemorySegment GLOBAL = MemorySegment.NULL.reinterpret(Long.MAX_VALUE);
 
-    // Bounds checks are enabled when this class loads from the class path (unnamed module) — i.e. unit and
-    // integration tests — and disabled when it loads as a named module, which is how the packaged jlink
-    // runtime loads it in production. Tests keep IndexOutOfBoundsException safety; production takes the
-    // unchecked native GLOBAL fast path. Resolved once at class init so the JIT folds the per-access branch.
-    private static final boolean SHOULD_BOUNDS_CHECK = !UnsafeBufferEx.class.getModule().isNamed();
+    // Native-path bounds checking. Defaults on for the class path (unnamed module — unit and integration
+    // tests) and off for the packaged named-module runtime (production GLOBAL fast path); override the
+    // default with -Dzilla.buffer.bounds.checks=true|false. Read once at class init so the JIT folds the
+    // per-access branch.
+    private static final boolean SHOULD_BOUNDS_CHECK =
+        Boolean.parseBoolean(System.getProperty("zilla.buffer.bounds.checks",
+            Boolean.toString(!UnsafeBufferEx.class.getModule().isNamed())));
 
     private static final ValueLayout.OfByte BYTE_LAYOUT = JAVA_BYTE;
     private static final ValueLayout.OfInt INT_LAYOUT = JAVA_INT_UNALIGNED;

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -29,6 +29,7 @@ import java.lang.foreign.ValueLayout;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Objects;
 
 import org.agrona.BufferUtil;
 import org.agrona.DirectBuffer;
@@ -466,12 +467,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         int index,
         int length)
     {
-        final long resultingPosition = (long) index + (long) length;
-        if (index < 0 || length < 0 || resultingPosition > capacity)
-        {
-            throw new IndexOutOfBoundsException(
-                String.format("index=%d, length=%d, capacity=%d", index, length, capacity));
-        }
+        Objects.checkFromIndexSize(index, length, capacity);
     }
 
     @Override
@@ -497,7 +493,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             return GLOBAL.get(LONG_LAYOUT, addressOffset + index);
         }
@@ -512,7 +508,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             return GLOBAL.get(INT_LAYOUT, addressOffset + index);
         }
@@ -527,7 +523,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Short.BYTES);
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
             }
             return GLOBAL.get(SHORT_LAYOUT, addressOffset + index);
         }
@@ -542,7 +538,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Byte.BYTES);
+                Objects.checkFromIndexSize(index, Byte.BYTES, capacity);
             }
             return GLOBAL.get(BYTE_LAYOUT, addressOffset + index);
         }
@@ -557,7 +553,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             return Double.longBitsToDouble(GLOBAL.get(LONG_LAYOUT, addressOffset + index));
         }
@@ -572,7 +568,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             return Float.intBitsToFloat(GLOBAL.get(INT_LAYOUT, addressOffset + index));
         }
@@ -587,7 +583,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Short.BYTES);
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
             }
             return (char) GLOBAL.get(SHORT_LAYOUT, addressOffset + index);
         }
@@ -607,7 +603,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             return GLOBAL.get(longLayout(byteOrder), addressOffset + index);
         }
@@ -623,7 +619,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             return GLOBAL.get(intLayout(byteOrder), addressOffset + index);
         }
@@ -639,7 +635,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Short.BYTES);
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
             }
             return GLOBAL.get(shortLayout(byteOrder), addressOffset + index);
         }
@@ -655,7 +651,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             return Double.longBitsToDouble(GLOBAL.get(longLayout(byteOrder), addressOffset + index));
         }
@@ -671,7 +667,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             return Float.intBitsToFloat(GLOBAL.get(intLayout(byteOrder), addressOffset + index));
         }
@@ -687,7 +683,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Short.BYTES);
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
             }
             return (char) GLOBAL.get(shortLayout(byteOrder), addressOffset + index);
         }
@@ -707,7 +703,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             GLOBAL.set(LONG_LAYOUT, addressOffset + index, value);
         }
@@ -726,7 +722,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             GLOBAL.set(INT_LAYOUT, addressOffset + index, value);
         }
@@ -745,7 +741,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Short.BYTES);
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
             }
             GLOBAL.set(SHORT_LAYOUT, addressOffset + index, value);
         }
@@ -764,7 +760,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Byte.BYTES);
+                Objects.checkFromIndexSize(index, Byte.BYTES, capacity);
             }
             GLOBAL.set(BYTE_LAYOUT, addressOffset + index, value);
         }
@@ -783,7 +779,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             GLOBAL.set(LONG_LAYOUT, addressOffset + index, Double.doubleToRawLongBits(value));
         }
@@ -802,7 +798,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             GLOBAL.set(INT_LAYOUT, addressOffset + index, Float.floatToRawIntBits(value));
         }
@@ -821,7 +817,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Short.BYTES);
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
             }
             GLOBAL.set(SHORT_LAYOUT, addressOffset + index, (short) value);
         }
@@ -845,7 +841,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             GLOBAL.set(longLayout(byteOrder), addressOffset + index, value);
         }
@@ -865,7 +861,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             GLOBAL.set(intLayout(byteOrder), addressOffset + index, value);
         }
@@ -885,7 +881,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Short.BYTES);
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
             }
             GLOBAL.set(shortLayout(byteOrder), addressOffset + index, value);
         }
@@ -905,7 +901,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             GLOBAL.set(longLayout(byteOrder), addressOffset + index, Double.doubleToRawLongBits(value));
         }
@@ -925,7 +921,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             GLOBAL.set(intLayout(byteOrder), addressOffset + index, Float.floatToRawIntBits(value));
         }
@@ -945,7 +941,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Short.BYTES);
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
             }
             GLOBAL.set(shortLayout(byteOrder), addressOffset + index, (short) value);
         }
@@ -1187,7 +1183,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             return (long) LONG_HANDLE.getVolatile(GLOBAL, addressOffset + index);
         }
@@ -1203,7 +1199,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             LONG_HANDLE.setVolatile(GLOBAL, addressOffset + index, value);
         }
@@ -1222,7 +1218,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             LONG_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
         }
@@ -1241,7 +1237,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             final long currentValue = (long) LONG_HANDLE.getAcquire(GLOBAL, addressOffset + index);
             LONG_HANDLE.setRelease(GLOBAL, addressOffset + index, currentValue + increment);
@@ -1260,7 +1256,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             return LONG_HANDLE.compareAndSet(GLOBAL, addressOffset + index, expectedValue, updateValue);
         }
@@ -1276,7 +1272,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             return (long) LONG_HANDLE.getAndSet(GLOBAL, addressOffset + index, value);
         }
@@ -1292,7 +1288,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             return (long) LONG_HANDLE.getAndAdd(GLOBAL, addressOffset + index, delta);
         }
@@ -1311,7 +1307,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             return (int) INT_HANDLE.getVolatile(GLOBAL, addressOffset + index);
         }
@@ -1327,7 +1323,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             INT_HANDLE.setVolatile(GLOBAL, addressOffset + index, value);
         }
@@ -1346,7 +1342,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             INT_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
         }
@@ -1365,7 +1361,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             final int currentValue = (int) INT_HANDLE.getAcquire(GLOBAL, addressOffset + index);
             INT_HANDLE.setRelease(GLOBAL, addressOffset + index, currentValue + increment);
@@ -1384,7 +1380,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             return INT_HANDLE.compareAndSet(GLOBAL, addressOffset + index, expectedValue, updateValue);
         }
@@ -1400,7 +1396,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             return (int) INT_HANDLE.getAndSet(GLOBAL, addressOffset + index, value);
         }
@@ -1416,7 +1412,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             return (int) INT_HANDLE.getAndAdd(GLOBAL, addressOffset + index, delta);
         }
@@ -1436,7 +1432,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Short.BYTES);
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
             }
             return GLOBAL.get(SHORT_LAYOUT, addressOffset + index);
         }
@@ -1452,7 +1448,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Short.BYTES);
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
             }
             GLOBAL.set(SHORT_LAYOUT, addressOffset + index, value);
         }
@@ -1470,7 +1466,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Short.BYTES);
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
             }
             return (char) GLOBAL.get(SHORT_LAYOUT, addressOffset + index);
         }
@@ -1486,7 +1482,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Short.BYTES);
+                Objects.checkFromIndexSize(index, Short.BYTES, capacity);
             }
             GLOBAL.set(SHORT_LAYOUT, addressOffset + index, (short) value);
         }
@@ -1504,7 +1500,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Byte.BYTES);
+                Objects.checkFromIndexSize(index, Byte.BYTES, capacity);
             }
             return GLOBAL.get(BYTE_LAYOUT, addressOffset + index);
         }
@@ -1520,7 +1516,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Byte.BYTES);
+                Objects.checkFromIndexSize(index, Byte.BYTES, capacity);
             }
             GLOBAL.set(BYTE_LAYOUT, addressOffset + index, value);
         }
@@ -1542,7 +1538,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             return (long) LONG_HANDLE.getAcquire(GLOBAL, addressOffset + index);
         }
@@ -1558,7 +1554,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             LONG_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
         }
@@ -1576,7 +1572,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             return (long) LONG_HANDLE.getOpaque(GLOBAL, addressOffset + index);
         }
@@ -1592,7 +1588,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             LONG_HANDLE.setOpaque(GLOBAL, addressOffset + index, value);
         }
@@ -1611,7 +1607,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             final long currentValue = (long) LONG_HANDLE.getAcquire(GLOBAL, addressOffset + index);
             LONG_HANDLE.setRelease(GLOBAL, addressOffset + index, currentValue + increment);
@@ -1629,7 +1625,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             final long currentValue = (long) LONG_HANDLE.getOpaque(GLOBAL, addressOffset + index);
             LONG_HANDLE.setOpaque(GLOBAL, addressOffset + index, currentValue + increment);
@@ -1648,7 +1644,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Long.BYTES);
+                Objects.checkFromIndexSize(index, Long.BYTES, capacity);
             }
             return (long) LONG_HANDLE.compareAndExchange(GLOBAL, addressOffset + index, expectedValue, updateValue);
         }
@@ -1663,7 +1659,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             return (int) INT_HANDLE.getAcquire(GLOBAL, addressOffset + index);
         }
@@ -1679,7 +1675,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             INT_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
         }
@@ -1697,7 +1693,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             return (int) INT_HANDLE.getOpaque(GLOBAL, addressOffset + index);
         }
@@ -1713,7 +1709,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             INT_HANDLE.setOpaque(GLOBAL, addressOffset + index, value);
         }
@@ -1732,7 +1728,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             final int currentValue = (int) INT_HANDLE.getAcquire(GLOBAL, addressOffset + index);
             INT_HANDLE.setRelease(GLOBAL, addressOffset + index, currentValue + increment);
@@ -1750,7 +1746,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             final int currentValue = (int) INT_HANDLE.getOpaque(GLOBAL, addressOffset + index);
             INT_HANDLE.setOpaque(GLOBAL, addressOffset + index, currentValue + increment);
@@ -1769,7 +1765,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             if (SHOULD_BOUNDS_CHECK)
             {
-                boundsCheck(index, Integer.BYTES);
+                Objects.checkFromIndexSize(index, Integer.BYTES, capacity);
             }
             return (int) INT_HANDLE.compareAndExchange(GLOBAL, addressOffset + index, expectedValue, updateValue);
         }

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -73,7 +73,7 @@ import org.agrona.MutableDirectBuffer;
  * atomics, because the JVM cannot guarantee {@code byte[]} alignment for
  * {@code VarHandle} atomic access.
  */
-public class UnsafeBufferEx implements AtomicBufferEx
+public final class UnsafeBufferEx implements AtomicBufferEx
 {
     private static final MemorySegment GLOBAL = MemorySegment.NULL.reinterpret(Long.MAX_VALUE);
 

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -33,6 +33,7 @@ import java.nio.ByteOrder;
 import org.agrona.BufferUtil;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 /**
  * An {@link AtomicBufferEx} implementation backed by Java's {@link MemorySegment}
@@ -47,6 +48,12 @@ import org.agrona.MutableDirectBuffer;
  * All atomic operations use {@link VarHandle} access modes on the selected
  * segment, providing the same memory ordering guarantees as an
  * {@code Unsafe}-backed buffer.
+ * <p>
+ * Atomic operations are supported only on native-backed buffers (direct
+ * {@code ByteBuffer}, mapped file, or native {@code MemorySegment}). Heap
+ * {@code byte[]} backings throw {@link UnsupportedOperationException} for
+ * atomics, because the JVM cannot guarantee {@code byte[]} alignment for
+ * {@code VarHandle} atomic access.
  */
 public class UnsafeBufferEx implements AtomicBufferEx
 {
@@ -477,63 +484,105 @@ public class UnsafeBufferEx implements AtomicBufferEx
     public long getLong(
         int index)
     {
-        return isNative
-            ? GLOBAL.get(LONG_LAYOUT, addressOffset + index)
-            : segment.get(LONG_LAYOUT, wrapAdjustment + index);
+        if (isNative)
+        {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
+            return GLOBAL.get(LONG_LAYOUT, addressOffset + index);
+        }
+        return segment.get(LONG_LAYOUT, wrapAdjustment + index);
     }
 
     @Override
     public int getInt(
         int index)
     {
-        return isNative
-            ? GLOBAL.get(INT_LAYOUT, addressOffset + index)
-            : segment.get(INT_LAYOUT, wrapAdjustment + index);
+        if (isNative)
+        {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
+            return GLOBAL.get(INT_LAYOUT, addressOffset + index);
+        }
+        return segment.get(INT_LAYOUT, wrapAdjustment + index);
     }
 
     @Override
     public short getShort(
         int index)
     {
-        return isNative
-            ? GLOBAL.get(SHORT_LAYOUT, addressOffset + index)
-            : segment.get(SHORT_LAYOUT, wrapAdjustment + index);
+        if (isNative)
+        {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Short.BYTES);
+            }
+            return GLOBAL.get(SHORT_LAYOUT, addressOffset + index);
+        }
+        return segment.get(SHORT_LAYOUT, wrapAdjustment + index);
     }
 
     @Override
     public byte getByte(
         int index)
     {
-        return isNative
-            ? GLOBAL.get(BYTE_LAYOUT, addressOffset + index)
-            : segment.get(BYTE_LAYOUT, wrapAdjustment + index);
+        if (isNative)
+        {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Byte.BYTES);
+            }
+            return GLOBAL.get(BYTE_LAYOUT, addressOffset + index);
+        }
+        return segment.get(BYTE_LAYOUT, wrapAdjustment + index);
     }
 
     @Override
     public double getDouble(
         int index)
     {
-        return Double.longBitsToDouble(isNative
-            ? GLOBAL.get(LONG_LAYOUT, addressOffset + index)
-            : segment.get(LONG_LAYOUT, wrapAdjustment + index));
+        if (isNative)
+        {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
+            return Double.longBitsToDouble(GLOBAL.get(LONG_LAYOUT, addressOffset + index));
+        }
+        return Double.longBitsToDouble(segment.get(LONG_LAYOUT, wrapAdjustment + index));
     }
 
     @Override
     public float getFloat(
         int index)
     {
-        return Float.intBitsToFloat(isNative
-            ? GLOBAL.get(INT_LAYOUT, addressOffset + index)
-            : segment.get(INT_LAYOUT, wrapAdjustment + index));
+        if (isNative)
+        {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
+            return Float.intBitsToFloat(GLOBAL.get(INT_LAYOUT, addressOffset + index));
+        }
+        return Float.intBitsToFloat(segment.get(INT_LAYOUT, wrapAdjustment + index));
     }
 
     @Override
     public char getChar(
         int index)
     {
-        return (char) (isNative
-            ? GLOBAL.get(SHORT_LAYOUT, addressOffset + index)
-            : segment.get(SHORT_LAYOUT, wrapAdjustment + index));
+        if (isNative)
+        {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Short.BYTES);
+            }
+            return (char) GLOBAL.get(SHORT_LAYOUT, addressOffset + index);
+        }
+        return (char) segment.get(SHORT_LAYOUT, wrapAdjustment + index);
     }
 
     // -----------------------------------------------------------------------
@@ -545,9 +594,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
         int index,
         ByteOrder byteOrder)
     {
-        return isNative
-            ? GLOBAL.get(longLayout(byteOrder), addressOffset + index)
-            : segment.get(longLayout(byteOrder), wrapAdjustment + index);
+        if (isNative)
+        {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
+            return GLOBAL.get(longLayout(byteOrder), addressOffset + index);
+        }
+        return segment.get(longLayout(byteOrder), wrapAdjustment + index);
     }
 
     @Override
@@ -555,9 +610,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
         int index,
         ByteOrder byteOrder)
     {
-        return isNative
-            ? GLOBAL.get(intLayout(byteOrder), addressOffset + index)
-            : segment.get(intLayout(byteOrder), wrapAdjustment + index);
+        if (isNative)
+        {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
+            return GLOBAL.get(intLayout(byteOrder), addressOffset + index);
+        }
+        return segment.get(intLayout(byteOrder), wrapAdjustment + index);
     }
 
     @Override
@@ -565,9 +626,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
         int index,
         ByteOrder byteOrder)
     {
-        return isNative
-            ? GLOBAL.get(shortLayout(byteOrder), addressOffset + index)
-            : segment.get(shortLayout(byteOrder), wrapAdjustment + index);
+        if (isNative)
+        {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Short.BYTES);
+            }
+            return GLOBAL.get(shortLayout(byteOrder), addressOffset + index);
+        }
+        return segment.get(shortLayout(byteOrder), wrapAdjustment + index);
     }
 
     @Override
@@ -575,9 +642,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
         int index,
         ByteOrder byteOrder)
     {
-        return Double.longBitsToDouble(isNative
-            ? GLOBAL.get(longLayout(byteOrder), addressOffset + index)
-            : segment.get(longLayout(byteOrder), wrapAdjustment + index));
+        if (isNative)
+        {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
+            return Double.longBitsToDouble(GLOBAL.get(longLayout(byteOrder), addressOffset + index));
+        }
+        return Double.longBitsToDouble(segment.get(longLayout(byteOrder), wrapAdjustment + index));
     }
 
     @Override
@@ -585,9 +658,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
         int index,
         ByteOrder byteOrder)
     {
-        return Float.intBitsToFloat(isNative
-            ? GLOBAL.get(intLayout(byteOrder), addressOffset + index)
-            : segment.get(intLayout(byteOrder), wrapAdjustment + index));
+        if (isNative)
+        {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
+            return Float.intBitsToFloat(GLOBAL.get(intLayout(byteOrder), addressOffset + index));
+        }
+        return Float.intBitsToFloat(segment.get(intLayout(byteOrder), wrapAdjustment + index));
     }
 
     @Override
@@ -595,9 +674,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
         int index,
         ByteOrder byteOrder)
     {
-        return (char) (isNative
-            ? GLOBAL.get(shortLayout(byteOrder), addressOffset + index)
-            : segment.get(shortLayout(byteOrder), wrapAdjustment + index));
+        if (isNative)
+        {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Short.BYTES);
+            }
+            return (char) GLOBAL.get(shortLayout(byteOrder), addressOffset + index);
+        }
+        return (char) segment.get(shortLayout(byteOrder), wrapAdjustment + index);
     }
 
     // -----------------------------------------------------------------------
@@ -611,6 +696,10 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
             GLOBAL.set(LONG_LAYOUT, addressOffset + index, value);
         }
         else
@@ -626,6 +715,10 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
             GLOBAL.set(INT_LAYOUT, addressOffset + index, value);
         }
         else
@@ -641,6 +734,10 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Short.BYTES);
+            }
             GLOBAL.set(SHORT_LAYOUT, addressOffset + index, value);
         }
         else
@@ -656,6 +753,10 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Byte.BYTES);
+            }
             GLOBAL.set(BYTE_LAYOUT, addressOffset + index, value);
         }
         else
@@ -671,6 +772,10 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
             GLOBAL.set(LONG_LAYOUT, addressOffset + index, Double.doubleToRawLongBits(value));
         }
         else
@@ -686,6 +791,10 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
             GLOBAL.set(INT_LAYOUT, addressOffset + index, Float.floatToRawIntBits(value));
         }
         else
@@ -701,6 +810,10 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Short.BYTES);
+            }
             GLOBAL.set(SHORT_LAYOUT, addressOffset + index, (short) value);
         }
         else
@@ -721,6 +834,10 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
             GLOBAL.set(longLayout(byteOrder), addressOffset + index, value);
         }
         else
@@ -737,6 +854,10 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
             GLOBAL.set(intLayout(byteOrder), addressOffset + index, value);
         }
         else
@@ -753,6 +874,10 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Short.BYTES);
+            }
             GLOBAL.set(shortLayout(byteOrder), addressOffset + index, value);
         }
         else
@@ -769,6 +894,10 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
             GLOBAL.set(longLayout(byteOrder), addressOffset + index, Double.doubleToRawLongBits(value));
         }
         else
@@ -785,6 +914,10 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
             GLOBAL.set(intLayout(byteOrder), addressOffset + index, Float.floatToRawIntBits(value));
         }
         else
@@ -801,6 +934,10 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Short.BYTES);
+            }
             GLOBAL.set(shortLayout(byteOrder), addressOffset + index, (short) value);
         }
         else
@@ -1027,18 +1164,25 @@ public class UnsafeBufferEx implements AtomicBufferEx
     // Atomic — long volatile / ordered / opaque
     // -----------------------------------------------------------------------
 
+    private static UnsupportedOperationException heapAtomicsUnsupported()
+    {
+        return new UnsupportedOperationException(
+            "atomic access requires a native buffer (direct ByteBuffer, mapped file, or native MemorySegment)");
+    }
+
     @Override
     public long getLongVolatile(
         int index)
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
             return (long) LONG_HANDLE.getVolatile(GLOBAL, addressOffset + index);
         }
-        else
-        {
-            return (long) LONG_HANDLE.getVolatile(segment, (long) (wrapAdjustment + index));
-        }
+        throw heapAtomicsUnsupported();
     }
 
     @Override
@@ -1048,11 +1192,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
             LONG_HANDLE.setVolatile(GLOBAL, addressOffset + index, value);
         }
         else
         {
-            LONG_HANDLE.setVolatile(segment, (long) (wrapAdjustment + index), value);
+            throw heapAtomicsUnsupported();
         }
     }
 
@@ -1063,11 +1211,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
             LONG_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
         }
         else
         {
-            LONG_HANDLE.setRelease(segment, (long) (wrapAdjustment + index), value);
+            throw heapAtomicsUnsupported();
         }
     }
 
@@ -1078,16 +1230,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
             final long currentValue = (long) LONG_HANDLE.getAcquire(GLOBAL, addressOffset + index);
             LONG_HANDLE.setRelease(GLOBAL, addressOffset + index, currentValue + increment);
             return currentValue;
         }
-        else
-        {
-            final long currentValue = (long) LONG_HANDLE.getAcquire(segment, (long) (wrapAdjustment + index));
-            LONG_HANDLE.setRelease(segment, (long) (wrapAdjustment + index), currentValue + increment);
-            return currentValue;
-        }
+        throw heapAtomicsUnsupported();
     }
 
     @Override
@@ -1098,12 +1249,13 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
             return LONG_HANDLE.compareAndSet(GLOBAL, addressOffset + index, expectedValue, updateValue);
         }
-        else
-        {
-            return LONG_HANDLE.compareAndSet(segment, (long) (wrapAdjustment + index), expectedValue, updateValue);
-        }
+        throw heapAtomicsUnsupported();
     }
 
     @Override
@@ -1113,12 +1265,13 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
             return (long) LONG_HANDLE.getAndSet(GLOBAL, addressOffset + index, value);
         }
-        else
-        {
-            return (long) LONG_HANDLE.getAndSet(segment, (long) (wrapAdjustment + index), value);
-        }
+        throw heapAtomicsUnsupported();
     }
 
     @Override
@@ -1128,12 +1281,13 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
             return (long) LONG_HANDLE.getAndAdd(GLOBAL, addressOffset + index, delta);
         }
-        else
-        {
-            return (long) LONG_HANDLE.getAndAdd(segment, (long) (wrapAdjustment + index), delta);
-        }
+        throw heapAtomicsUnsupported();
     }
 
     // -----------------------------------------------------------------------
@@ -1146,12 +1300,13 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
             return (int) INT_HANDLE.getVolatile(GLOBAL, addressOffset + index);
         }
-        else
-        {
-            return (int) INT_HANDLE.getVolatile(segment, (long) (wrapAdjustment + index));
-        }
+        throw heapAtomicsUnsupported();
     }
 
     @Override
@@ -1161,11 +1316,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
             INT_HANDLE.setVolatile(GLOBAL, addressOffset + index, value);
         }
         else
         {
-            INT_HANDLE.setVolatile(segment, (long) (wrapAdjustment + index), value);
+            throw heapAtomicsUnsupported();
         }
     }
 
@@ -1176,11 +1335,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
             INT_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
         }
         else
         {
-            INT_HANDLE.setRelease(segment, (long) (wrapAdjustment + index), value);
+            throw heapAtomicsUnsupported();
         }
     }
 
@@ -1191,16 +1354,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
             final int currentValue = (int) INT_HANDLE.getAcquire(GLOBAL, addressOffset + index);
             INT_HANDLE.setRelease(GLOBAL, addressOffset + index, currentValue + increment);
             return currentValue;
         }
-        else
-        {
-            final int currentValue = (int) INT_HANDLE.getAcquire(segment, (long) (wrapAdjustment + index));
-            INT_HANDLE.setRelease(segment, (long) (wrapAdjustment + index), currentValue + increment);
-            return currentValue;
-        }
+        throw heapAtomicsUnsupported();
     }
 
     @Override
@@ -1211,12 +1373,13 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
             return INT_HANDLE.compareAndSet(GLOBAL, addressOffset + index, expectedValue, updateValue);
         }
-        else
-        {
-            return INT_HANDLE.compareAndSet(segment, (long) (wrapAdjustment + index), expectedValue, updateValue);
-        }
+        throw heapAtomicsUnsupported();
     }
 
     @Override
@@ -1226,12 +1389,13 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
             return (int) INT_HANDLE.getAndSet(GLOBAL, addressOffset + index, value);
         }
-        else
-        {
-            return (int) INT_HANDLE.getAndSet(segment, (long) (wrapAdjustment + index), value);
-        }
+        throw heapAtomicsUnsupported();
     }
 
     @Override
@@ -1241,12 +1405,13 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
             return (int) INT_HANDLE.getAndAdd(GLOBAL, addressOffset + index, delta);
         }
-        else
-        {
-            return (int) INT_HANDLE.getAndAdd(segment, (long) (wrapAdjustment + index), delta);
-        }
+        throw heapAtomicsUnsupported();
     }
 
     // -----------------------------------------------------------------------
@@ -1258,9 +1423,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
         int index)
     {
         // No VarHandle for short on MemorySegment; use plain access
-        return isNative
-            ? GLOBAL.get(SHORT_LAYOUT, addressOffset + index)
-            : segment.get(SHORT_LAYOUT, wrapAdjustment + index);
+        if (isNative)
+        {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Short.BYTES);
+            }
+            return GLOBAL.get(SHORT_LAYOUT, addressOffset + index);
+        }
+        return segment.get(SHORT_LAYOUT, wrapAdjustment + index);
     }
 
     @Override
@@ -1270,6 +1441,10 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Short.BYTES);
+            }
             GLOBAL.set(SHORT_LAYOUT, addressOffset + index, value);
         }
         else
@@ -1282,9 +1457,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
     public char getCharVolatile(
         int index)
     {
-        return (char) (isNative
-            ? GLOBAL.get(SHORT_LAYOUT, addressOffset + index)
-            : segment.get(SHORT_LAYOUT, wrapAdjustment + index));
+        if (isNative)
+        {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Short.BYTES);
+            }
+            return (char) GLOBAL.get(SHORT_LAYOUT, addressOffset + index);
+        }
+        return (char) segment.get(SHORT_LAYOUT, wrapAdjustment + index);
     }
 
     @Override
@@ -1294,6 +1475,10 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Short.BYTES);
+            }
             GLOBAL.set(SHORT_LAYOUT, addressOffset + index, (short) value);
         }
         else
@@ -1306,9 +1491,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
     public byte getByteVolatile(
         int index)
     {
-        return isNative
-            ? GLOBAL.get(BYTE_LAYOUT, addressOffset + index)
-            : segment.get(BYTE_LAYOUT, wrapAdjustment + index);
+        if (isNative)
+        {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Byte.BYTES);
+            }
+            return GLOBAL.get(BYTE_LAYOUT, addressOffset + index);
+        }
+        return segment.get(BYTE_LAYOUT, wrapAdjustment + index);
     }
 
     @Override
@@ -1318,6 +1509,10 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Byte.BYTES);
+            }
             GLOBAL.set(BYTE_LAYOUT, addressOffset + index, value);
         }
         else
@@ -1336,12 +1531,13 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
             return (long) LONG_HANDLE.getAcquire(GLOBAL, addressOffset + index);
         }
-        else
-        {
-            return (long) LONG_HANDLE.getAcquire(segment, (long) (wrapAdjustment + index));
-        }
+        throw heapAtomicsUnsupported();
     }
 
     @Override
@@ -1351,11 +1547,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
             LONG_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
         }
         else
         {
-            LONG_HANDLE.setRelease(segment, (long) (wrapAdjustment + index), value);
+            throw heapAtomicsUnsupported();
         }
     }
 
@@ -1365,12 +1565,13 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
             return (long) LONG_HANDLE.getOpaque(GLOBAL, addressOffset + index);
         }
-        else
-        {
-            return (long) LONG_HANDLE.getOpaque(segment, (long) (wrapAdjustment + index));
-        }
+        throw heapAtomicsUnsupported();
     }
 
     @Override
@@ -1380,11 +1581,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
             LONG_HANDLE.setOpaque(GLOBAL, addressOffset + index, value);
         }
         else
         {
-            LONG_HANDLE.setOpaque(segment, (long) (wrapAdjustment + index), value);
+            throw heapAtomicsUnsupported();
         }
     }
 
@@ -1395,16 +1600,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
             final long currentValue = (long) LONG_HANDLE.getAcquire(GLOBAL, addressOffset + index);
             LONG_HANDLE.setRelease(GLOBAL, addressOffset + index, currentValue + increment);
             return currentValue;
         }
-        else
-        {
-            final long currentValue = (long) LONG_HANDLE.getAcquire(segment, (long) (wrapAdjustment + index));
-            LONG_HANDLE.setRelease(segment, (long) (wrapAdjustment + index), currentValue + increment);
-            return currentValue;
-        }
+        throw heapAtomicsUnsupported();
     }
 
     @Override
@@ -1414,16 +1618,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
             final long currentValue = (long) LONG_HANDLE.getOpaque(GLOBAL, addressOffset + index);
             LONG_HANDLE.setOpaque(GLOBAL, addressOffset + index, currentValue + increment);
             return currentValue;
         }
-        else
-        {
-            final long currentValue = (long) LONG_HANDLE.getOpaque(segment, (long) (wrapAdjustment + index));
-            LONG_HANDLE.setOpaque(segment, (long) (wrapAdjustment + index), currentValue + increment);
-            return currentValue;
-        }
+        throw heapAtomicsUnsupported();
     }
 
     @Override
@@ -1434,12 +1637,13 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Long.BYTES);
+            }
             return (long) LONG_HANDLE.compareAndExchange(GLOBAL, addressOffset + index, expectedValue, updateValue);
         }
-        else
-        {
-            return (long) LONG_HANDLE.compareAndExchange(segment, (long) (wrapAdjustment + index), expectedValue, updateValue);
-        }
+        throw heapAtomicsUnsupported();
     }
 
     @Override
@@ -1448,12 +1652,13 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
             return (int) INT_HANDLE.getAcquire(GLOBAL, addressOffset + index);
         }
-        else
-        {
-            return (int) INT_HANDLE.getAcquire(segment, (long) (wrapAdjustment + index));
-        }
+        throw heapAtomicsUnsupported();
     }
 
     @Override
@@ -1463,11 +1668,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
             INT_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
         }
         else
         {
-            INT_HANDLE.setRelease(segment, (long) (wrapAdjustment + index), value);
+            throw heapAtomicsUnsupported();
         }
     }
 
@@ -1477,12 +1686,13 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
             return (int) INT_HANDLE.getOpaque(GLOBAL, addressOffset + index);
         }
-        else
-        {
-            return (int) INT_HANDLE.getOpaque(segment, (long) (wrapAdjustment + index));
-        }
+        throw heapAtomicsUnsupported();
     }
 
     @Override
@@ -1492,11 +1702,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
             INT_HANDLE.setOpaque(GLOBAL, addressOffset + index, value);
         }
         else
         {
-            INT_HANDLE.setOpaque(segment, (long) (wrapAdjustment + index), value);
+            throw heapAtomicsUnsupported();
         }
     }
 
@@ -1507,16 +1721,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
             final int currentValue = (int) INT_HANDLE.getAcquire(GLOBAL, addressOffset + index);
             INT_HANDLE.setRelease(GLOBAL, addressOffset + index, currentValue + increment);
             return currentValue;
         }
-        else
-        {
-            final int currentValue = (int) INT_HANDLE.getAcquire(segment, (long) (wrapAdjustment + index));
-            INT_HANDLE.setRelease(segment, (long) (wrapAdjustment + index), currentValue + increment);
-            return currentValue;
-        }
+        throw heapAtomicsUnsupported();
     }
 
     @Override
@@ -1526,16 +1739,15 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
             final int currentValue = (int) INT_HANDLE.getOpaque(GLOBAL, addressOffset + index);
             INT_HANDLE.setOpaque(GLOBAL, addressOffset + index, currentValue + increment);
             return currentValue;
         }
-        else
-        {
-            final int currentValue = (int) INT_HANDLE.getOpaque(segment, (long) (wrapAdjustment + index));
-            INT_HANDLE.setOpaque(segment, (long) (wrapAdjustment + index), currentValue + increment);
-            return currentValue;
-        }
+        throw heapAtomicsUnsupported();
     }
 
     @Override
@@ -1546,12 +1758,13 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         if (isNative)
         {
+            if (UnsafeBuffer.SHOULD_BOUNDS_CHECK)
+            {
+                boundsCheck(index, Integer.BYTES);
+            }
             return (int) INT_HANDLE.compareAndExchange(GLOBAL, addressOffset + index, expectedValue, updateValue);
         }
-        else
-        {
-            return (int) INT_HANDLE.compareAndExchange(segment, (long) (wrapAdjustment + index), expectedValue, updateValue);
-        }
+        throw heapAtomicsUnsupported();
     }
 
     // -----------------------------------------------------------------------

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -1097,7 +1097,10 @@ public class UnsafeBufferEx implements AtomicBufferEx
         int offset,
         int length)
     {
-        if (byteBuffer != null)
+        // ByteBuffer.put also bounds-checks this destination against its NIO limit, which Agrona
+        // treats as scratch state independent of capacity; only take the fast path when the
+        // destination limit covers the range, else copy by the destination's capacity-sized segment
+        if (byteBuffer != null && byteBuffer.limit() >= wrapAdjustment + index + length)
         {
             byteBuffer.put(wrapAdjustment + index, src, offset, length);
         }
@@ -1125,10 +1128,12 @@ public class UnsafeBufferEx implements AtomicBufferEx
         int srcOffset,
         int length)
     {
-        // ByteBuffer.put bounds-checks the source against its NIO limit, but the index-based
-        // putBytes contract copies by capacity; only take the fast path when limit covers the
-        // range, else copy by capacity so a stale limit does not reject a valid copy
-        if (byteBuffer != null && srcBuffer.limit() >= srcOffset + length)
+        // ByteBuffer.put bounds-checks both this destination and the source against their NIO
+        // limits, which Agrona treats as scratch state independent of capacity; only take the
+        // fast path when both limits cover the range, else copy by capacity so a stale limit
+        // does not reject a valid copy
+        if (byteBuffer != null && byteBuffer.limit() >= wrapAdjustment + index + length &&
+            srcBuffer.limit() >= srcOffset + length)
         {
             byteBuffer.put(wrapAdjustment + index, srcBuffer, srcOffset, length);
         }
@@ -1150,10 +1155,12 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         final ByteBuffer srcBb = srcBuffer.byteBuffer();
         final int srcAdjusted = srcBuffer.wrapAdjustment() + srcIndex;
-        // ByteBuffer.put bounds-checks the source against its NIO limit, which Agrona treats as
-        // scratch state independent of capacity (e.g. left dirty by CRC32.update); only take the
-        // intrinsified fast path when limit covers the range, else copy by the buffer's capacity
-        if (byteBuffer != null && srcBb != null && srcBb.limit() >= srcAdjusted + length)
+        // ByteBuffer.put bounds-checks both this destination and the source against their NIO
+        // limits, which Agrona treats as scratch state independent of capacity (e.g. left dirty
+        // by CRC32.update); only take the intrinsified fast path when both limits cover the range,
+        // else copy by capacity
+        if (byteBuffer != null && srcBb != null &&
+            byteBuffer.limit() >= wrapAdjustment + index + length && srcBb.limit() >= srcAdjusted + length)
         {
             byteBuffer.put(wrapAdjustment + index, srcBb, srcAdjusted, length);
         }
@@ -1173,7 +1180,8 @@ public class UnsafeBufferEx implements AtomicBufferEx
     {
         final ByteBuffer srcBb = srcBuffer.byteBuffer();
         final int srcAdjusted = srcBuffer.wrapAdjustment() + srcIndex;
-        if (byteBuffer != null && srcBb != null && srcBb.limit() >= srcAdjusted + length)
+        final boolean destOk = byteBuffer != null && byteBuffer.limit() >= wrapAdjustment + index + length;
+        if (destOk && srcBb != null && srcBb.limit() >= srcAdjusted + length)
         {
             byteBuffer.put(wrapAdjustment + index, srcBb, srcAdjusted, length);
         }
@@ -1185,7 +1193,7 @@ public class UnsafeBufferEx implements AtomicBufferEx
         else
         {
             final byte[] srcArray = srcBuffer.byteArray();
-            if (byteBuffer != null && srcArray != null)
+            if (destOk && srcArray != null)
             {
                 byteBuffer.put(wrapAdjustment + index, srcArray, srcAdjusted, length);
             }
@@ -2790,9 +2798,14 @@ public class UnsafeBufferEx implements AtomicBufferEx
             else
             {
                 final byte[] srcArray = srcBuffer.byteArray();
-                if (srcArray != null)
+                if (srcArray != null && byteBuffer.limit() >= index + length)
                 {
                     byteBuffer.put(index, srcArray, srcBuffer.wrapAdjustment() + srcIndex, length);
+                }
+                else if (srcArray != null)
+                {
+                    MemorySegment.copy(MemorySegment.ofArray(srcArray), BYTE_LAYOUT,
+                        srcBuffer.wrapAdjustment() + srcIndex, segment, BYTE_LAYOUT, index, length);
                 }
                 else
                 {
@@ -3329,7 +3342,14 @@ public class UnsafeBufferEx implements AtomicBufferEx
             int offset,
             int length)
         {
-            byteBuffer.put(index, src, offset, length);
+            if (byteBuffer.limit() >= index + length)
+            {
+                byteBuffer.put(index, src, offset, length);
+            }
+            else
+            {
+                MemorySegment.copy(MemorySegment.ofArray(src), BYTE_LAYOUT, offset, segment, BYTE_LAYOUT, index, length);
+            }
         }
 
         @Override
@@ -3349,10 +3369,10 @@ public class UnsafeBufferEx implements AtomicBufferEx
             int srcOffset,
             int length)
         {
-            // ByteBuffer.put bounds-checks the source against its NIO limit, but the index-based
-            // putBytes contract copies by capacity; only take the fast path when limit covers the
-            // range, else copy by capacity so a stale limit does not reject a valid copy
-            if (srcBuffer.limit() >= srcOffset + length)
+            // ByteBuffer.put bounds-checks both this destination and the source against their NIO
+            // limits, which Agrona treats as scratch state independent of capacity; only take the
+            // fast path when both limits cover the range, else copy by capacity
+            if (byteBuffer.limit() >= index + length && srcBuffer.limit() >= srcOffset + length)
             {
                 byteBuffer.put(index, srcBuffer, srcOffset, length);
             }
@@ -3374,10 +3394,11 @@ public class UnsafeBufferEx implements AtomicBufferEx
         {
             final ByteBuffer srcBb = srcBuffer.byteBuffer();
             final int srcAdjusted = srcBuffer.wrapAdjustment() + srcIndex;
-            // ByteBuffer.put bounds-checks the source against its NIO limit, which Agrona treats
-            // as scratch state independent of capacity (e.g. left dirty by CRC32.update); only
-            // take the intrinsified fast path when limit covers the range, else copy by capacity
-            if (srcBb != null && srcBb.limit() >= srcAdjusted + length)
+            // ByteBuffer.put bounds-checks both this destination and the source against their NIO
+            // limits, which Agrona treats as scratch state independent of capacity (e.g. left
+            // dirty by CRC32.update); only take the intrinsified fast path when both limits cover
+            // the range, else copy by capacity
+            if (srcBb != null && byteBuffer.limit() >= index + length && srcBb.limit() >= srcAdjusted + length)
             {
                 byteBuffer.put(index, srcBb, srcAdjusted, length);
             }

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -2420,9 +2420,10 @@ public final class UnsafeBufferEx implements AtomicBufferEx
 
     public Native asNative()
     {
-        if (!isNative)
+        if (!isNative || byteBuffer == null)
         {
-            throw new IllegalStateException("UnsafeBufferEx.asNative requires a native-backed buffer");
+            throw new IllegalStateException(
+                "UnsafeBufferEx.asNative requires a direct ByteBuffer-backed buffer");
         }
         return new Native(segment, byteBuffer);
     }
@@ -2440,6 +2441,8 @@ public final class UnsafeBufferEx implements AtomicBufferEx
         {
             assert segment.heapBase().isEmpty()
                 : "UnsafeBufferEx.Native requires a native MemorySegment";
+            assert byteBuffer != null && byteBuffer.isDirect()
+                : "UnsafeBufferEx.Native requires a direct ByteBuffer";
             this.segment = segment;
             this.addressOffset = segment.address();
             this.capacity = (int) segment.byteSize();
@@ -2762,37 +2765,27 @@ public final class UnsafeBufferEx implements AtomicBufferEx
             int srcIndex,
             int length)
         {
-            if (srcBuffer instanceof DirectBufferEx ex)
+            final ByteBuffer srcBb = srcBuffer.byteBuffer();
+            if (srcBb != null)
             {
-                MemorySegment.copy(ex.segment(), ex.wrapAdjustment() + srcIndex, segment, index, length);
+                byteBuffer.put(index, srcBb, srcBuffer.wrapAdjustment() + srcIndex, length);
             }
             else
             {
                 final byte[] srcArray = srcBuffer.byteArray();
                 if (srcArray != null)
                 {
-                    final int adjustment = srcBuffer.wrapAdjustment();
-                    MemorySegment.copy(
-                        MemorySegment.ofArray(srcArray), BYTE_LAYOUT, adjustment + srcIndex,
-                        segment, BYTE_LAYOUT, index, length);
+                    byteBuffer.put(index, srcArray, srcBuffer.wrapAdjustment() + srcIndex, length);
+                }
+                else if (srcBuffer instanceof DirectBufferEx ex)
+                {
+                    MemorySegment.copy(ex.segment(), ex.wrapAdjustment() + srcIndex, segment, index, length);
                 }
                 else
                 {
-                    final ByteBuffer srcBb = srcBuffer.byteBuffer();
-                    if (srcBb != null)
+                    for (int i = 0; i < length; i++)
                     {
-                        final MemorySegment src = srcBb.isDirect()
-                            ? MemorySegment.ofAddress(BufferUtil.address(srcBb)).reinterpret(srcBb.capacity())
-                            : MemorySegment.ofArray(BufferUtil.array(srcBb));
-                        MemorySegment.copy(src, srcBuffer.wrapAdjustment() + srcIndex,
-                            segment, index, length);
-                    }
-                    else
-                    {
-                        for (int i = 0; i < length; i++)
-                        {
-                            segment.set(BYTE_LAYOUT, index + i, srcBuffer.getByte(srcIndex + i));
-                        }
+                        segment.set(BYTE_LAYOUT, index + i, srcBuffer.getByte(srcIndex + i));
                     }
                 }
             }
@@ -3323,8 +3316,7 @@ public final class UnsafeBufferEx implements AtomicBufferEx
             int offset,
             int length)
         {
-            MemorySegment.copy(MemorySegment.ofArray(src), BYTE_LAYOUT, offset,
-                segment, BYTE_LAYOUT, index, length);
+            byteBuffer.put(index, src, offset, length);
         }
 
         @Override
@@ -3344,10 +3336,7 @@ public final class UnsafeBufferEx implements AtomicBufferEx
             int srcOffset,
             int length)
         {
-            final MemorySegment src = srcBuffer.isDirect()
-                ? MemorySegment.ofAddress(BufferUtil.address(srcBuffer)).reinterpret(srcBuffer.capacity())
-                : MemorySegment.ofArray(BufferUtil.array(srcBuffer));
-            MemorySegment.copy(src, srcOffset, segment, index, length);
+            byteBuffer.put(index, srcBuffer, srcOffset, length);
         }
 
         @Override
@@ -3357,8 +3346,16 @@ public final class UnsafeBufferEx implements AtomicBufferEx
             int srcIndex,
             int length)
         {
-            MemorySegment.copy(srcBuffer.segment(), srcBuffer.wrapAdjustment() + srcIndex,
-                segment, index, length);
+            final ByteBuffer srcBb = srcBuffer.byteBuffer();
+            if (srcBb != null)
+            {
+                byteBuffer.put(index, srcBb, srcBuffer.wrapAdjustment() + srcIndex, length);
+            }
+            else
+            {
+                MemorySegment.copy(srcBuffer.segment(), srcBuffer.wrapAdjustment() + srcIndex,
+                    segment, index, length);
+            }
         }
 
         @Override

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -1105,8 +1105,15 @@ public final class UnsafeBufferEx implements AtomicBufferEx
         int offset,
         int length)
     {
-        MemorySegment.copy(MemorySegment.ofArray(src), BYTE_LAYOUT, offset,
-            segment, BYTE_LAYOUT, wrapAdjustment + index, length);
+        if (byteBuffer != null)
+        {
+            byteBuffer.put(wrapAdjustment + index, src, offset, length);
+        }
+        else
+        {
+            MemorySegment.copy(MemorySegment.ofArray(src), BYTE_LAYOUT, offset,
+                segment, BYTE_LAYOUT, wrapAdjustment + index, length);
+        }
     }
 
     @Override
@@ -1126,10 +1133,17 @@ public final class UnsafeBufferEx implements AtomicBufferEx
         int srcOffset,
         int length)
     {
-        final MemorySegment src = srcBuffer.isDirect()
-            ? MemorySegment.ofAddress(BufferUtil.address(srcBuffer)).reinterpret(srcBuffer.capacity())
-            : MemorySegment.ofArray(BufferUtil.array(srcBuffer));
-        MemorySegment.copy(src, srcOffset, segment, wrapAdjustment + index, length);
+        if (byteBuffer != null)
+        {
+            byteBuffer.put(wrapAdjustment + index, srcBuffer, srcOffset, length);
+        }
+        else
+        {
+            final MemorySegment src = srcBuffer.isDirect()
+                ? MemorySegment.ofAddress(BufferUtil.address(srcBuffer)).reinterpret(srcBuffer.capacity())
+                : MemorySegment.ofArray(BufferUtil.array(srcBuffer));
+            MemorySegment.copy(src, srcOffset, segment, wrapAdjustment + index, length);
+        }
     }
 
     @Override
@@ -1139,8 +1153,16 @@ public final class UnsafeBufferEx implements AtomicBufferEx
         int srcIndex,
         int length)
     {
-        MemorySegment.copy(srcBuffer.segment(), JAVA_BYTE, srcBuffer.wrapAdjustment() + srcIndex,
-            segment, JAVA_BYTE, wrapAdjustment + index, length);
+        final ByteBuffer srcBb = srcBuffer.byteBuffer();
+        if (byteBuffer != null && srcBb != null)
+        {
+            byteBuffer.put(wrapAdjustment + index, srcBb, srcBuffer.wrapAdjustment() + srcIndex, length);
+        }
+        else
+        {
+            MemorySegment.copy(srcBuffer.segment(), srcBuffer.wrapAdjustment() + srcIndex,
+                segment, wrapAdjustment + index, length);
+        }
     }
 
     @Override
@@ -1150,38 +1172,34 @@ public final class UnsafeBufferEx implements AtomicBufferEx
         int srcIndex,
         int length)
     {
-        if (srcBuffer instanceof DirectBufferEx safe)
+        final ByteBuffer srcBb = srcBuffer.byteBuffer();
+        if (byteBuffer != null && srcBb != null)
         {
-            MemorySegment.copy(safe.segment(), JAVA_BYTE, safe.wrapAdjustment() + srcIndex,
-                segment, JAVA_BYTE, wrapAdjustment + index, length);
+            byteBuffer.put(wrapAdjustment + index, srcBb, srcBuffer.wrapAdjustment() + srcIndex, length);
         }
         else
         {
             final byte[] srcArray = srcBuffer.byteArray();
-            if (srcArray != null)
+            if (byteBuffer != null && srcArray != null)
             {
-                final int adjustment = srcBuffer.wrapAdjustment();
+                byteBuffer.put(wrapAdjustment + index, srcArray, srcBuffer.wrapAdjustment() + srcIndex, length);
+            }
+            else if (srcBuffer instanceof DirectBufferEx safe)
+            {
+                MemorySegment.copy(safe.segment(), safe.wrapAdjustment() + srcIndex,
+                    segment, wrapAdjustment + index, length);
+            }
+            else if (srcArray != null)
+            {
                 MemorySegment.copy(
-                    MemorySegment.ofArray(srcArray), BYTE_LAYOUT, adjustment + srcIndex,
+                    MemorySegment.ofArray(srcArray), BYTE_LAYOUT, srcBuffer.wrapAdjustment() + srcIndex,
                     segment, BYTE_LAYOUT, wrapAdjustment + index, length);
             }
             else
             {
-                final ByteBuffer srcBb = srcBuffer.byteBuffer();
-                if (srcBb != null)
+                for (int i = 0; i < length; i++)
                 {
-                    final MemorySegment src = srcBb.isDirect()
-                        ? MemorySegment.ofAddress(BufferUtil.address(srcBb)).reinterpret(srcBb.capacity())
-                        : MemorySegment.ofArray(BufferUtil.array(srcBb));
-                    MemorySegment.copy(src, srcBuffer.wrapAdjustment() + srcIndex,
-                        segment, wrapAdjustment + index, length);
-                }
-                else
-                {
-                    for (int i = 0; i < length; i++)
-                    {
-                        segment.set(BYTE_LAYOUT, wrapAdjustment + index + i, srcBuffer.getByte(srcIndex + i));
-                    }
+                    segment.set(BYTE_LAYOUT, wrapAdjustment + index + i, srcBuffer.getByte(srcIndex + i));
                 }
             }
         }

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -16,38 +16,102 @@
 package io.aklivity.zilla.runtime.common.agrona.buffer;
 
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_INT_UNALIGNED;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static java.lang.foreign.ValueLayout.JAVA_LONG_UNALIGNED;
+import static java.lang.foreign.ValueLayout.JAVA_SHORT_UNALIGNED;
+import static java.nio.ByteOrder.BIG_ENDIAN;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 import org.agrona.BufferUtil;
 import org.agrona.DirectBuffer;
-import org.agrona.concurrent.UnsafeBuffer;
+import org.agrona.MutableDirectBuffer;
 
 /**
- * An {@link UnsafeBuffer} subclass that implements {@link AtomicBufferEx},
- * adding {@link MemorySegment} access to Agrona's {@code Unsafe}-backed buffer.
+ * An {@link AtomicBufferEx} implementation backed by Java's {@link MemorySegment}
+ * (Foreign Function and Memory API) instead of {@code sun.misc.Unsafe}.
  * <p>
- * The segment is lazily derived from the underlying byte array or ByteBuffer
- * on each {@code wrap} call, enabling flyweight VarHandle-based field access
- * through {@link DirectBufferEx#segment()} without requiring a full migration
- * to {@link SafeBuffer}.
+ * For off-heap (native) memory this buffer accesses bytes through a process-wide
+ * {@code GLOBAL} segment that spans the entire address space, enabling unchecked
+ * access whose bounds checks the JIT can elide — matching {@code sun.misc.Unsafe}
+ * performance without depending on {@code jdk.unsupported}. For heap memory it
+ * falls back to the bounded per-instance segment.
+ * <p>
+ * All atomic operations use {@link VarHandle} access modes on the selected
+ * segment, providing the same memory ordering guarantees as an
+ * {@code Unsafe}-backed buffer.
  */
-public class UnsafeBufferEx extends UnsafeBuffer implements AtomicBufferEx
+public class UnsafeBufferEx implements AtomicBufferEx
 {
+    private static final MemorySegment GLOBAL = MemorySegment.NULL.reinterpret(Long.MAX_VALUE);
+
+    private static final ValueLayout.OfByte BYTE_LAYOUT = JAVA_BYTE;
+    private static final ValueLayout.OfInt INT_LAYOUT = JAVA_INT_UNALIGNED;
+    private static final ValueLayout.OfLong LONG_LAYOUT = JAVA_LONG_UNALIGNED;
+    private static final ValueLayout.OfShort SHORT_LAYOUT = JAVA_SHORT_UNALIGNED;
+
+    private static final ValueLayout.OfInt INT_BE =
+        JAVA_INT_UNALIGNED.withOrder(BIG_ENDIAN);
+    private static final ValueLayout.OfLong LONG_BE =
+        JAVA_LONG_UNALIGNED.withOrder(BIG_ENDIAN);
+    private static final ValueLayout.OfShort SHORT_BE =
+        JAVA_SHORT_UNALIGNED.withOrder(BIG_ENDIAN);
+
+    private static final ValueLayout.OfInt INT_LE =
+        JAVA_INT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+    private static final ValueLayout.OfLong LONG_LE =
+        JAVA_LONG_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+    private static final ValueLayout.OfShort SHORT_LE =
+        JAVA_SHORT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+
+    private static final ValueLayout.OfInt INT_ALIGNED = JAVA_INT;
+    private static final ValueLayout.OfLong LONG_ALIGNED = JAVA_LONG;
+
+    private static final VarHandle LONG_HANDLE = LONG_ALIGNED.varHandle();
+    private static final VarHandle INT_HANDLE = INT_ALIGNED.varHandle();
+
+    private static ValueLayout.OfLong longLayout(
+        ByteOrder byteOrder)
+    {
+        return byteOrder == BIG_ENDIAN ? LONG_BE : LONG_LE;
+    }
+
+    private static ValueLayout.OfInt intLayout(
+        ByteOrder byteOrder)
+    {
+        return byteOrder == BIG_ENDIAN ? INT_BE : INT_LE;
+    }
+
+    private static ValueLayout.OfShort shortLayout(
+        ByteOrder byteOrder)
+    {
+        return byteOrder == BIG_ENDIAN ? SHORT_BE : SHORT_LE;
+    }
+
     private MemorySegment segment;
+    private byte[] byteArray;
+    private ByteBuffer byteBuffer;
+    private long addressOffset;
+    private int capacity;
+    private int wrapAdjustment;
+    private boolean isNative;
 
     public UnsafeBufferEx()
     {
-        super(new byte[0]);
-        this.segment = MemorySegment.ofArray(byteArray());
+        wrap(new byte[0]);
     }
 
     public UnsafeBufferEx(
         byte[] buffer)
     {
-        super(buffer);
-        this.segment = MemorySegment.ofArray(buffer);
+        wrap(buffer);
     }
 
     public UnsafeBufferEx(
@@ -55,15 +119,13 @@ public class UnsafeBufferEx extends UnsafeBuffer implements AtomicBufferEx
         int offset,
         int length)
     {
-        super(buffer, offset, length);
-        this.segment = MemorySegment.ofArray(buffer);
+        wrap(buffer, offset, length);
     }
 
     public UnsafeBufferEx(
         ByteBuffer buffer)
     {
-        super(buffer);
-        this.segment = segmentOf(buffer);
+        wrap(buffer);
     }
 
     public UnsafeBufferEx(
@@ -71,39 +133,34 @@ public class UnsafeBufferEx extends UnsafeBuffer implements AtomicBufferEx
         int offset,
         int length)
     {
-        super(buffer, offset, length);
-        this.segment = segmentOf(buffer);
+        wrap(buffer, offset, length);
     }
 
     public UnsafeBufferEx(
-        DirectBuffer buffer)
+        DirectBufferEx buffer)
     {
-        super(buffer);
-        this.segment = segmentOf(buffer);
+        wrap(buffer);
     }
 
     public UnsafeBufferEx(
-        DirectBuffer buffer,
+        DirectBufferEx buffer,
         int offset,
         int length)
     {
-        super(buffer, offset, length);
-        this.segment = segmentOf(buffer);
+        wrap(buffer, offset, length);
     }
 
     public UnsafeBufferEx(
         long address,
         int length)
     {
-        super(address, length);
-        this.segment = MemorySegment.ofAddress(address).reinterpret(length);
+        wrap(address, length);
     }
 
     public UnsafeBufferEx(
         MemorySegment segment)
     {
-        super(segment.asByteBuffer());
-        this.segment = segment;
+        wrap(segment);
     }
 
     public UnsafeBufferEx(
@@ -111,8 +168,19 @@ public class UnsafeBufferEx extends UnsafeBuffer implements AtomicBufferEx
         int offset,
         int length)
     {
-        super(segment.asByteBuffer(), offset, length);
-        this.segment = segment;
+        wrap(segment, offset, length);
+    }
+
+    public UnsafeBufferEx(
+        Arena arena,
+        int capacity)
+    {
+        wrap(arena.allocate(capacity, Long.BYTES));
+    }
+
+    public UnsafeBufferEx asReadOnly()
+    {
+        return new UnsafeBufferEx(segment.asReadOnly());
     }
 
     @Override
@@ -121,12 +189,21 @@ public class UnsafeBufferEx extends UnsafeBuffer implements AtomicBufferEx
         return segment;
     }
 
+    // -----------------------------------------------------------------------
+    // wrap
+    // -----------------------------------------------------------------------
+
     @Override
     public void wrap(
         byte[] buffer)
     {
-        super.wrap(buffer);
+        byteArray = buffer;
+        byteBuffer = null;
         segment = MemorySegment.ofArray(buffer);
+        addressOffset = BufferUtil.ARRAY_BASE_OFFSET;
+        capacity = buffer.length;
+        wrapAdjustment = 0;
+        isNative = false;
     }
 
     @Override
@@ -135,16 +212,36 @@ public class UnsafeBufferEx extends UnsafeBuffer implements AtomicBufferEx
         int offset,
         int length)
     {
-        super.wrap(buffer, offset, length);
+        byteArray = buffer;
+        byteBuffer = null;
         segment = MemorySegment.ofArray(buffer);
+        addressOffset = BufferUtil.ARRAY_BASE_OFFSET + offset;
+        capacity = length;
+        wrapAdjustment = offset;
+        isNative = false;
     }
 
     @Override
     public void wrap(
         ByteBuffer buffer)
     {
-        super.wrap(buffer);
-        segment = segmentOf(buffer);
+        byteBuffer = buffer;
+        if (buffer.isDirect())
+        {
+            byteArray = null;
+            addressOffset = BufferUtil.address(buffer);
+            segment = MemorySegment.ofAddress(addressOffset)
+                .reinterpret(buffer.capacity());
+        }
+        else
+        {
+            byteArray = BufferUtil.array(buffer);
+            addressOffset = BufferUtil.ARRAY_BASE_OFFSET + buffer.arrayOffset();
+            segment = MemorySegment.ofArray(byteArray);
+        }
+        capacity = buffer.capacity();
+        wrapAdjustment = 0;
+        isNative = buffer.isDirect();
     }
 
     @Override
@@ -153,16 +250,36 @@ public class UnsafeBufferEx extends UnsafeBuffer implements AtomicBufferEx
         int offset,
         int length)
     {
-        super.wrap(buffer, offset, length);
-        segment = segmentOf(buffer);
+        byteBuffer = buffer;
+        if (buffer.isDirect())
+        {
+            byteArray = null;
+            addressOffset = BufferUtil.address(buffer) + offset;
+            segment = MemorySegment.ofAddress(BufferUtil.address(buffer))
+                .reinterpret(buffer.capacity());
+        }
+        else
+        {
+            byteArray = BufferUtil.array(buffer);
+            addressOffset = BufferUtil.ARRAY_BASE_OFFSET + buffer.arrayOffset() + offset;
+            segment = MemorySegment.ofArray(byteArray);
+        }
+        capacity = length;
+        wrapAdjustment = offset;
+        isNative = buffer.isDirect();
     }
 
     @Override
     public void wrap(
         DirectBufferEx buffer)
     {
-        super.wrap(buffer);
         segment = buffer.segment();
+        byteArray = buffer.byteArray();
+        byteBuffer = buffer.byteBuffer();
+        addressOffset = buffer.addressOffset();
+        capacity = buffer.capacity();
+        wrapAdjustment = buffer.wrapAdjustment();
+        isNative = buffer.byteArray() == null;
     }
 
     @Override
@@ -171,16 +288,27 @@ public class UnsafeBufferEx extends UnsafeBuffer implements AtomicBufferEx
         int offset,
         int length)
     {
-        super.wrap(buffer, offset, length);
         segment = buffer.segment();
+        byteArray = buffer.byteArray();
+        byteBuffer = buffer.byteBuffer();
+        addressOffset = buffer.addressOffset() + offset;
+        capacity = length;
+        wrapAdjustment = buffer.wrapAdjustment() + offset;
+        isNative = buffer.byteArray() == null;
     }
 
     @Override
     public void wrap(
         DirectBuffer buffer)
     {
-        super.wrap(buffer);
-        segment = segmentOf(buffer);
+        if (buffer instanceof DirectBufferEx ex)
+        {
+            wrap(ex);
+        }
+        else
+        {
+            wrapFromUnsafe(buffer, 0, buffer.capacity());
+        }
     }
 
     @Override
@@ -189,8 +317,14 @@ public class UnsafeBufferEx extends UnsafeBuffer implements AtomicBufferEx
         int offset,
         int length)
     {
-        super.wrap(buffer, offset, length);
-        segment = segmentOf(buffer);
+        if (buffer instanceof DirectBufferEx ex)
+        {
+            wrap(ex, offset, length);
+        }
+        else
+        {
+            wrapFromUnsafe(buffer, offset, length);
+        }
     }
 
     @Override
@@ -198,16 +332,26 @@ public class UnsafeBufferEx extends UnsafeBuffer implements AtomicBufferEx
         long address,
         int length)
     {
-        super.wrap(address, length);
+        byteArray = null;
+        byteBuffer = null;
         segment = MemorySegment.ofAddress(address).reinterpret(length);
+        addressOffset = address;
+        capacity = length;
+        wrapAdjustment = 0;
+        isNative = true;
     }
 
     @Override
     public void wrap(
         MemorySegment segment)
     {
-        super.wrap(segment.asByteBuffer());
+        byteArray = null;
+        byteBuffer = null;
         this.segment = segment;
+        addressOffset = segment.address();
+        capacity = (int) segment.byteSize();
+        wrapAdjustment = 0;
+        isNative = segment.isNative();
     }
 
     @Override
@@ -216,8 +360,541 @@ public class UnsafeBufferEx extends UnsafeBuffer implements AtomicBufferEx
         int offset,
         int length)
     {
-        super.wrap(segment.asByteBuffer(), offset, length);
+        byteArray = null;
+        byteBuffer = null;
         this.segment = segment;
+        addressOffset = segment.address() + offset;
+        capacity = length;
+        wrapAdjustment = offset;
+        isNative = segment.isNative();
+    }
+
+    private void wrapFromUnsafe(
+        DirectBuffer buffer,
+        int offset,
+        int length)
+    {
+        final byte[] array = buffer.byteArray();
+        if (array != null)
+        {
+            final int adjustment = buffer.wrapAdjustment();
+            wrap(array, adjustment + offset, length);
+        }
+        else
+        {
+            final ByteBuffer bb = buffer.byteBuffer();
+            if (bb != null)
+            {
+                wrap(bb, buffer.wrapAdjustment() + offset, length);
+            }
+            else
+            {
+                wrap(buffer.addressOffset() + offset, length);
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // DirectBufferEx accessors
+    // -----------------------------------------------------------------------
+
+    @Override
+    public long addressOffset()
+    {
+        return addressOffset;
+    }
+
+    @Override
+    public byte[] byteArray()
+    {
+        return byteArray;
+    }
+
+    @Override
+    public ByteBuffer byteBuffer()
+    {
+        return byteBuffer;
+    }
+
+    @Override
+    public int capacity()
+    {
+        return capacity;
+    }
+
+    @Override
+    public int wrapAdjustment()
+    {
+        return wrapAdjustment;
+    }
+
+    @Override
+    public boolean isExpandable()
+    {
+        return false;
+    }
+
+    @Override
+    public void checkLimit(
+        int limit)
+    {
+        if (limit > capacity)
+        {
+            throw new IndexOutOfBoundsException(
+                String.format("limit=%d is beyond capacity=%d", limit, capacity));
+        }
+    }
+
+    @Override
+    public void boundsCheck(
+        int index,
+        int length)
+    {
+        final long resultingPosition = (long) index + (long) length;
+        if (index < 0 || length < 0 || resultingPosition > capacity)
+        {
+            throw new IndexOutOfBoundsException(
+                String.format("index=%d, length=%d, capacity=%d", index, length, capacity));
+        }
+    }
+
+    @Override
+    public void verifyAlignment()
+    {
+        final long address = segment.address();
+        if (0 != (address & 7))
+        {
+            throw new IllegalStateException(
+                String.format("AtomicBuffer is not correctly aligned: address=%d", address));
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // get — primitives (native byte order)
+    // -----------------------------------------------------------------------
+
+    @Override
+    public long getLong(
+        int index)
+    {
+        return isNative
+            ? GLOBAL.get(LONG_LAYOUT, addressOffset + index)
+            : segment.get(LONG_LAYOUT, wrapAdjustment + index);
+    }
+
+    @Override
+    public int getInt(
+        int index)
+    {
+        return isNative
+            ? GLOBAL.get(INT_LAYOUT, addressOffset + index)
+            : segment.get(INT_LAYOUT, wrapAdjustment + index);
+    }
+
+    @Override
+    public short getShort(
+        int index)
+    {
+        return isNative
+            ? GLOBAL.get(SHORT_LAYOUT, addressOffset + index)
+            : segment.get(SHORT_LAYOUT, wrapAdjustment + index);
+    }
+
+    @Override
+    public byte getByte(
+        int index)
+    {
+        return isNative
+            ? GLOBAL.get(BYTE_LAYOUT, addressOffset + index)
+            : segment.get(BYTE_LAYOUT, wrapAdjustment + index);
+    }
+
+    @Override
+    public double getDouble(
+        int index)
+    {
+        return Double.longBitsToDouble(isNative
+            ? GLOBAL.get(LONG_LAYOUT, addressOffset + index)
+            : segment.get(LONG_LAYOUT, wrapAdjustment + index));
+    }
+
+    @Override
+    public float getFloat(
+        int index)
+    {
+        return Float.intBitsToFloat(isNative
+            ? GLOBAL.get(INT_LAYOUT, addressOffset + index)
+            : segment.get(INT_LAYOUT, wrapAdjustment + index));
+    }
+
+    @Override
+    public char getChar(
+        int index)
+    {
+        return (char) (isNative
+            ? GLOBAL.get(SHORT_LAYOUT, addressOffset + index)
+            : segment.get(SHORT_LAYOUT, wrapAdjustment + index));
+    }
+
+    // -----------------------------------------------------------------------
+    // get — primitives (explicit byte order)
+    // -----------------------------------------------------------------------
+
+    @Override
+    public long getLong(
+        int index,
+        ByteOrder byteOrder)
+    {
+        return isNative
+            ? GLOBAL.get(longLayout(byteOrder), addressOffset + index)
+            : segment.get(longLayout(byteOrder), wrapAdjustment + index);
+    }
+
+    @Override
+    public int getInt(
+        int index,
+        ByteOrder byteOrder)
+    {
+        return isNative
+            ? GLOBAL.get(intLayout(byteOrder), addressOffset + index)
+            : segment.get(intLayout(byteOrder), wrapAdjustment + index);
+    }
+
+    @Override
+    public short getShort(
+        int index,
+        ByteOrder byteOrder)
+    {
+        return isNative
+            ? GLOBAL.get(shortLayout(byteOrder), addressOffset + index)
+            : segment.get(shortLayout(byteOrder), wrapAdjustment + index);
+    }
+
+    @Override
+    public double getDouble(
+        int index,
+        ByteOrder byteOrder)
+    {
+        return Double.longBitsToDouble(isNative
+            ? GLOBAL.get(longLayout(byteOrder), addressOffset + index)
+            : segment.get(longLayout(byteOrder), wrapAdjustment + index));
+    }
+
+    @Override
+    public float getFloat(
+        int index,
+        ByteOrder byteOrder)
+    {
+        return Float.intBitsToFloat(isNative
+            ? GLOBAL.get(intLayout(byteOrder), addressOffset + index)
+            : segment.get(intLayout(byteOrder), wrapAdjustment + index));
+    }
+
+    @Override
+    public char getChar(
+        int index,
+        ByteOrder byteOrder)
+    {
+        return (char) (isNative
+            ? GLOBAL.get(shortLayout(byteOrder), addressOffset + index)
+            : segment.get(shortLayout(byteOrder), wrapAdjustment + index));
+    }
+
+    // -----------------------------------------------------------------------
+    // put — primitives (native byte order)
+    // -----------------------------------------------------------------------
+
+    @Override
+    public void putLong(
+        int index,
+        long value)
+    {
+        if (isNative)
+        {
+            GLOBAL.set(LONG_LAYOUT, addressOffset + index, value);
+        }
+        else
+        {
+            segment.set(LONG_LAYOUT, wrapAdjustment + index, value);
+        }
+    }
+
+    @Override
+    public void putInt(
+        int index,
+        int value)
+    {
+        if (isNative)
+        {
+            GLOBAL.set(INT_LAYOUT, addressOffset + index, value);
+        }
+        else
+        {
+            segment.set(INT_LAYOUT, wrapAdjustment + index, value);
+        }
+    }
+
+    @Override
+    public void putShort(
+        int index,
+        short value)
+    {
+        if (isNative)
+        {
+            GLOBAL.set(SHORT_LAYOUT, addressOffset + index, value);
+        }
+        else
+        {
+            segment.set(SHORT_LAYOUT, wrapAdjustment + index, value);
+        }
+    }
+
+    @Override
+    public void putByte(
+        int index,
+        byte value)
+    {
+        if (isNative)
+        {
+            GLOBAL.set(BYTE_LAYOUT, addressOffset + index, value);
+        }
+        else
+        {
+            segment.set(BYTE_LAYOUT, wrapAdjustment + index, value);
+        }
+    }
+
+    @Override
+    public void putDouble(
+        int index,
+        double value)
+    {
+        if (isNative)
+        {
+            GLOBAL.set(LONG_LAYOUT, addressOffset + index, Double.doubleToRawLongBits(value));
+        }
+        else
+        {
+            segment.set(LONG_LAYOUT, wrapAdjustment + index, Double.doubleToRawLongBits(value));
+        }
+    }
+
+    @Override
+    public void putFloat(
+        int index,
+        float value)
+    {
+        if (isNative)
+        {
+            GLOBAL.set(INT_LAYOUT, addressOffset + index, Float.floatToRawIntBits(value));
+        }
+        else
+        {
+            segment.set(INT_LAYOUT, wrapAdjustment + index, Float.floatToRawIntBits(value));
+        }
+    }
+
+    @Override
+    public void putChar(
+        int index,
+        char value)
+    {
+        if (isNative)
+        {
+            GLOBAL.set(SHORT_LAYOUT, addressOffset + index, (short) value);
+        }
+        else
+        {
+            segment.set(SHORT_LAYOUT, wrapAdjustment + index, (short) value);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // put — primitives (explicit byte order)
+    // -----------------------------------------------------------------------
+
+    @Override
+    public void putLong(
+        int index,
+        long value,
+        ByteOrder byteOrder)
+    {
+        if (isNative)
+        {
+            GLOBAL.set(longLayout(byteOrder), addressOffset + index, value);
+        }
+        else
+        {
+            segment.set(longLayout(byteOrder), wrapAdjustment + index, value);
+        }
+    }
+
+    @Override
+    public void putInt(
+        int index,
+        int value,
+        ByteOrder byteOrder)
+    {
+        if (isNative)
+        {
+            GLOBAL.set(intLayout(byteOrder), addressOffset + index, value);
+        }
+        else
+        {
+            segment.set(intLayout(byteOrder), wrapAdjustment + index, value);
+        }
+    }
+
+    @Override
+    public void putShort(
+        int index,
+        short value,
+        ByteOrder byteOrder)
+    {
+        if (isNative)
+        {
+            GLOBAL.set(shortLayout(byteOrder), addressOffset + index, value);
+        }
+        else
+        {
+            segment.set(shortLayout(byteOrder), wrapAdjustment + index, value);
+        }
+    }
+
+    @Override
+    public void putDouble(
+        int index,
+        double value,
+        ByteOrder byteOrder)
+    {
+        if (isNative)
+        {
+            GLOBAL.set(longLayout(byteOrder), addressOffset + index, Double.doubleToRawLongBits(value));
+        }
+        else
+        {
+            segment.set(longLayout(byteOrder), wrapAdjustment + index, Double.doubleToRawLongBits(value));
+        }
+    }
+
+    @Override
+    public void putFloat(
+        int index,
+        float value,
+        ByteOrder byteOrder)
+    {
+        if (isNative)
+        {
+            GLOBAL.set(intLayout(byteOrder), addressOffset + index, Float.floatToRawIntBits(value));
+        }
+        else
+        {
+            segment.set(intLayout(byteOrder), wrapAdjustment + index, Float.floatToRawIntBits(value));
+        }
+    }
+
+    @Override
+    public void putChar(
+        int index,
+        char value,
+        ByteOrder byteOrder)
+    {
+        if (isNative)
+        {
+            GLOBAL.set(shortLayout(byteOrder), addressOffset + index, (short) value);
+        }
+        else
+        {
+            segment.set(shortLayout(byteOrder), wrapAdjustment + index, (short) value);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // getBytes / putBytes
+    // -----------------------------------------------------------------------
+
+    @Override
+    public void getBytes(
+        int index,
+        byte[] dst)
+    {
+        getBytes(index, dst, 0, dst.length);
+    }
+
+    @Override
+    public void getBytes(
+        int index,
+        byte[] dst,
+        int offset,
+        int length)
+    {
+        MemorySegment.copy(segment, BYTE_LAYOUT, wrapAdjustment + index,
+            MemorySegment.ofArray(dst), BYTE_LAYOUT, offset, length);
+    }
+
+    @Override
+    public void getBytes(
+        int index,
+        MutableDirectBuffer dstBuffer,
+        int dstIndex,
+        int length)
+    {
+        if (dstBuffer instanceof UnsafeBufferEx safe)
+        {
+            MemorySegment.copy(segment, wrapAdjustment + index, safe.segment, safe.wrapAdjustment + dstIndex, length);
+        }
+        else
+        {
+            final byte[] dstArray = dstBuffer.byteArray();
+            if (dstArray != null)
+            {
+                final int adjustment = dstBuffer.wrapAdjustment();
+                MemorySegment.copy(segment, BYTE_LAYOUT, wrapAdjustment + index,
+                    MemorySegment.ofArray(dstArray), BYTE_LAYOUT, adjustment + dstIndex, length);
+            }
+            else
+            {
+                final ByteBuffer dstBb = dstBuffer.byteBuffer();
+                if (dstBb != null)
+                {
+                    final MemorySegment dst = dstBb.isDirect()
+                        ? MemorySegment.ofAddress(BufferUtil.address(dstBb)).reinterpret(dstBb.capacity())
+                        : MemorySegment.ofArray(BufferUtil.array(dstBb));
+                    MemorySegment.copy(segment, wrapAdjustment + index,
+                        dst, dstBuffer.wrapAdjustment() + dstIndex, length);
+                }
+                else
+                {
+                    for (int i = 0; i < length; i++)
+                    {
+                        dstBuffer.putByte(dstIndex + i, getByte(index + i));
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void getBytes(
+        int index,
+        ByteBuffer dstBuffer,
+        int length)
+    {
+        getBytes(index, dstBuffer, dstBuffer.position(), length);
+        dstBuffer.position(dstBuffer.position() + length);
+    }
+
+    @Override
+    public void getBytes(
+        int index,
+        ByteBuffer dstBuffer,
+        int dstOffset,
+        int length)
+    {
+        final MemorySegment dst = dstBuffer.isDirect()
+            ? MemorySegment.ofAddress(BufferUtil.address(dstBuffer)).reinterpret(dstBuffer.capacity())
+            : MemorySegment.ofArray(BufferUtil.array(dstBuffer));
+        MemorySegment.copy(segment, wrapAdjustment + index, dst, dstOffset, length);
     }
 
     @Override
@@ -227,8 +904,49 @@ public class UnsafeBufferEx extends UnsafeBuffer implements AtomicBufferEx
         int dstIndex,
         int length)
     {
-        MemorySegment.copy(segment, JAVA_BYTE, wrapAdjustment() + index,
-            dstSegment, JAVA_BYTE, dstIndex, length);
+        MemorySegment.copy(segment, wrapAdjustment + index, dstSegment, dstIndex, length);
+    }
+
+    @Override
+    public void putBytes(
+        int index,
+        byte[] src)
+    {
+        putBytes(index, src, 0, src.length);
+    }
+
+    @Override
+    public void putBytes(
+        int index,
+        byte[] src,
+        int offset,
+        int length)
+    {
+        MemorySegment.copy(MemorySegment.ofArray(src), BYTE_LAYOUT, offset,
+            segment, BYTE_LAYOUT, wrapAdjustment + index, length);
+    }
+
+    @Override
+    public void putBytes(
+        int index,
+        ByteBuffer srcBuffer,
+        int length)
+    {
+        putBytes(index, srcBuffer, srcBuffer.position(), length);
+        srcBuffer.position(srcBuffer.position() + length);
+    }
+
+    @Override
+    public void putBytes(
+        int index,
+        ByteBuffer srcBuffer,
+        int srcOffset,
+        int length)
+    {
+        final MemorySegment src = srcBuffer.isDirect()
+            ? MemorySegment.ofAddress(BufferUtil.address(srcBuffer)).reinterpret(srcBuffer.capacity())
+            : MemorySegment.ofArray(BufferUtil.array(srcBuffer));
+        MemorySegment.copy(src, srcOffset, segment, wrapAdjustment + index, length);
     }
 
     @Override
@@ -238,7 +956,52 @@ public class UnsafeBufferEx extends UnsafeBuffer implements AtomicBufferEx
         int srcIndex,
         int length)
     {
-        super.putBytes(index, srcBuffer, srcIndex, length);
+        MemorySegment.copy(srcBuffer.segment(), JAVA_BYTE, srcBuffer.wrapAdjustment() + srcIndex,
+            segment, JAVA_BYTE, wrapAdjustment + index, length);
+    }
+
+    @Override
+    public void putBytes(
+        int index,
+        DirectBuffer srcBuffer,
+        int srcIndex,
+        int length)
+    {
+        if (srcBuffer instanceof DirectBufferEx safe)
+        {
+            MemorySegment.copy(safe.segment(), JAVA_BYTE, safe.wrapAdjustment() + srcIndex,
+                segment, JAVA_BYTE, wrapAdjustment + index, length);
+        }
+        else
+        {
+            final byte[] srcArray = srcBuffer.byteArray();
+            if (srcArray != null)
+            {
+                final int adjustment = srcBuffer.wrapAdjustment();
+                MemorySegment.copy(
+                    MemorySegment.ofArray(srcArray), BYTE_LAYOUT, adjustment + srcIndex,
+                    segment, BYTE_LAYOUT, wrapAdjustment + index, length);
+            }
+            else
+            {
+                final ByteBuffer srcBb = srcBuffer.byteBuffer();
+                if (srcBb != null)
+                {
+                    final MemorySegment src = srcBb.isDirect()
+                        ? MemorySegment.ofAddress(BufferUtil.address(srcBb)).reinterpret(srcBb.capacity())
+                        : MemorySegment.ofArray(BufferUtil.array(srcBb));
+                    MemorySegment.copy(src, srcBuffer.wrapAdjustment() + srcIndex,
+                        segment, wrapAdjustment + index, length);
+                }
+                else
+                {
+                    for (int i = 0; i < length; i++)
+                    {
+                        segment.set(BYTE_LAYOUT, wrapAdjustment + index + i, srcBuffer.getByte(srcIndex + i));
+                    }
+                }
+            }
+        }
     }
 
     @Override
@@ -248,38 +1011,1063 @@ public class UnsafeBufferEx extends UnsafeBuffer implements AtomicBufferEx
         int srcIndex,
         int length)
     {
-        MemorySegment.copy(srcSegment, JAVA_BYTE, srcIndex,
-            segment, JAVA_BYTE, wrapAdjustment() + index, length);
+        MemorySegment.copy(srcSegment, srcIndex, segment, wrapAdjustment + index, length);
     }
 
-    private static MemorySegment segmentOf(
-        ByteBuffer buffer)
+    @Override
+    public void setMemory(
+        int index,
+        int length,
+        byte value)
     {
-        return buffer.isDirect()
-            ? MemorySegment.ofAddress(BufferUtil.address(buffer)).reinterpret(buffer.capacity())
-            : MemorySegment.ofArray(BufferUtil.array(buffer));
+        segment.asSlice(wrapAdjustment + index, length).fill(value);
     }
 
-    private static MemorySegment segmentOf(
-        DirectBuffer buffer)
+    // -----------------------------------------------------------------------
+    // Atomic — long volatile / ordered / opaque
+    // -----------------------------------------------------------------------
+
+    @Override
+    public long getLongVolatile(
+        int index)
     {
-        if (buffer instanceof DirectBufferEx ex)
+        if (isNative)
         {
-            return ex.segment();
+            return (long) LONG_HANDLE.getVolatile(GLOBAL, addressOffset + index);
+        }
+        else
+        {
+            return (long) LONG_HANDLE.getVolatile(segment, (long) (wrapAdjustment + index));
+        }
+    }
+
+    @Override
+    public void putLongVolatile(
+        int index,
+        long value)
+    {
+        if (isNative)
+        {
+            LONG_HANDLE.setVolatile(GLOBAL, addressOffset + index, value);
+        }
+        else
+        {
+            LONG_HANDLE.setVolatile(segment, (long) (wrapAdjustment + index), value);
+        }
+    }
+
+    @Override
+    public void putLongOrdered(
+        int index,
+        long value)
+    {
+        if (isNative)
+        {
+            LONG_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
+        }
+        else
+        {
+            LONG_HANDLE.setRelease(segment, (long) (wrapAdjustment + index), value);
+        }
+    }
+
+    @Override
+    public long addLongOrdered(
+        int index,
+        long increment)
+    {
+        if (isNative)
+        {
+            final long currentValue = (long) LONG_HANDLE.getAcquire(GLOBAL, addressOffset + index);
+            LONG_HANDLE.setRelease(GLOBAL, addressOffset + index, currentValue + increment);
+            return currentValue;
+        }
+        else
+        {
+            final long currentValue = (long) LONG_HANDLE.getAcquire(segment, (long) (wrapAdjustment + index));
+            LONG_HANDLE.setRelease(segment, (long) (wrapAdjustment + index), currentValue + increment);
+            return currentValue;
+        }
+    }
+
+    @Override
+    public boolean compareAndSetLong(
+        int index,
+        long expectedValue,
+        long updateValue)
+    {
+        if (isNative)
+        {
+            return LONG_HANDLE.compareAndSet(GLOBAL, addressOffset + index, expectedValue, updateValue);
+        }
+        else
+        {
+            return LONG_HANDLE.compareAndSet(segment, (long) (wrapAdjustment + index), expectedValue, updateValue);
+        }
+    }
+
+    @Override
+    public long getAndSetLong(
+        int index,
+        long value)
+    {
+        if (isNative)
+        {
+            return (long) LONG_HANDLE.getAndSet(GLOBAL, addressOffset + index, value);
+        }
+        else
+        {
+            return (long) LONG_HANDLE.getAndSet(segment, (long) (wrapAdjustment + index), value);
+        }
+    }
+
+    @Override
+    public long getAndAddLong(
+        int index,
+        long delta)
+    {
+        if (isNative)
+        {
+            return (long) LONG_HANDLE.getAndAdd(GLOBAL, addressOffset + index, delta);
+        }
+        else
+        {
+            return (long) LONG_HANDLE.getAndAdd(segment, (long) (wrapAdjustment + index), delta);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Atomic — int volatile / ordered / opaque
+    // -----------------------------------------------------------------------
+
+    @Override
+    public int getIntVolatile(
+        int index)
+    {
+        if (isNative)
+        {
+            return (int) INT_HANDLE.getVolatile(GLOBAL, addressOffset + index);
+        }
+        else
+        {
+            return (int) INT_HANDLE.getVolatile(segment, (long) (wrapAdjustment + index));
+        }
+    }
+
+    @Override
+    public void putIntVolatile(
+        int index,
+        int value)
+    {
+        if (isNative)
+        {
+            INT_HANDLE.setVolatile(GLOBAL, addressOffset + index, value);
+        }
+        else
+        {
+            INT_HANDLE.setVolatile(segment, (long) (wrapAdjustment + index), value);
+        }
+    }
+
+    @Override
+    public void putIntOrdered(
+        int index,
+        int value)
+    {
+        if (isNative)
+        {
+            INT_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
+        }
+        else
+        {
+            INT_HANDLE.setRelease(segment, (long) (wrapAdjustment + index), value);
+        }
+    }
+
+    @Override
+    public int addIntOrdered(
+        int index,
+        int increment)
+    {
+        if (isNative)
+        {
+            final int currentValue = (int) INT_HANDLE.getAcquire(GLOBAL, addressOffset + index);
+            INT_HANDLE.setRelease(GLOBAL, addressOffset + index, currentValue + increment);
+            return currentValue;
+        }
+        else
+        {
+            final int currentValue = (int) INT_HANDLE.getAcquire(segment, (long) (wrapAdjustment + index));
+            INT_HANDLE.setRelease(segment, (long) (wrapAdjustment + index), currentValue + increment);
+            return currentValue;
+        }
+    }
+
+    @Override
+    public boolean compareAndSetInt(
+        int index,
+        int expectedValue,
+        int updateValue)
+    {
+        if (isNative)
+        {
+            return INT_HANDLE.compareAndSet(GLOBAL, addressOffset + index, expectedValue, updateValue);
+        }
+        else
+        {
+            return INT_HANDLE.compareAndSet(segment, (long) (wrapAdjustment + index), expectedValue, updateValue);
+        }
+    }
+
+    @Override
+    public int getAndSetInt(
+        int index,
+        int value)
+    {
+        if (isNative)
+        {
+            return (int) INT_HANDLE.getAndSet(GLOBAL, addressOffset + index, value);
+        }
+        else
+        {
+            return (int) INT_HANDLE.getAndSet(segment, (long) (wrapAdjustment + index), value);
+        }
+    }
+
+    @Override
+    public int getAndAddInt(
+        int index,
+        int delta)
+    {
+        if (isNative)
+        {
+            return (int) INT_HANDLE.getAndAdd(GLOBAL, addressOffset + index, delta);
+        }
+        else
+        {
+            return (int) INT_HANDLE.getAndAdd(segment, (long) (wrapAdjustment + index), delta);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Atomic — short / char / byte volatile
+    // -----------------------------------------------------------------------
+
+    @Override
+    public short getShortVolatile(
+        int index)
+    {
+        // No VarHandle for short on MemorySegment; use plain access
+        return isNative
+            ? GLOBAL.get(SHORT_LAYOUT, addressOffset + index)
+            : segment.get(SHORT_LAYOUT, wrapAdjustment + index);
+    }
+
+    @Override
+    public void putShortVolatile(
+        int index,
+        short value)
+    {
+        if (isNative)
+        {
+            GLOBAL.set(SHORT_LAYOUT, addressOffset + index, value);
+        }
+        else
+        {
+            segment.set(SHORT_LAYOUT, wrapAdjustment + index, value);
+        }
+    }
+
+    @Override
+    public char getCharVolatile(
+        int index)
+    {
+        return (char) (isNative
+            ? GLOBAL.get(SHORT_LAYOUT, addressOffset + index)
+            : segment.get(SHORT_LAYOUT, wrapAdjustment + index));
+    }
+
+    @Override
+    public void putCharVolatile(
+        int index,
+        char value)
+    {
+        if (isNative)
+        {
+            GLOBAL.set(SHORT_LAYOUT, addressOffset + index, (short) value);
+        }
+        else
+        {
+            segment.set(SHORT_LAYOUT, wrapAdjustment + index, (short) value);
+        }
+    }
+
+    @Override
+    public byte getByteVolatile(
+        int index)
+    {
+        return isNative
+            ? GLOBAL.get(BYTE_LAYOUT, addressOffset + index)
+            : segment.get(BYTE_LAYOUT, wrapAdjustment + index);
+    }
+
+    @Override
+    public void putByteVolatile(
+        int index,
+        byte value)
+    {
+        if (isNative)
+        {
+            GLOBAL.set(BYTE_LAYOUT, addressOffset + index, value);
+        }
+        else
+        {
+            segment.set(BYTE_LAYOUT, wrapAdjustment + index, value);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Atomic — acquire / release / opaque (Agrona 2.x additions)
+    // -----------------------------------------------------------------------
+
+    @Override
+    public long getLongAcquire(
+        int index)
+    {
+        if (isNative)
+        {
+            return (long) LONG_HANDLE.getAcquire(GLOBAL, addressOffset + index);
+        }
+        else
+        {
+            return (long) LONG_HANDLE.getAcquire(segment, (long) (wrapAdjustment + index));
+        }
+    }
+
+    @Override
+    public void putLongRelease(
+        int index,
+        long value)
+    {
+        if (isNative)
+        {
+            LONG_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
+        }
+        else
+        {
+            LONG_HANDLE.setRelease(segment, (long) (wrapAdjustment + index), value);
+        }
+    }
+
+    @Override
+    public long getLongOpaque(
+        int index)
+    {
+        if (isNative)
+        {
+            return (long) LONG_HANDLE.getOpaque(GLOBAL, addressOffset + index);
+        }
+        else
+        {
+            return (long) LONG_HANDLE.getOpaque(segment, (long) (wrapAdjustment + index));
+        }
+    }
+
+    @Override
+    public void putLongOpaque(
+        int index,
+        long value)
+    {
+        if (isNative)
+        {
+            LONG_HANDLE.setOpaque(GLOBAL, addressOffset + index, value);
+        }
+        else
+        {
+            LONG_HANDLE.setOpaque(segment, (long) (wrapAdjustment + index), value);
+        }
+    }
+
+    @Override
+    public long addLongRelease(
+        int index,
+        long increment)
+    {
+        if (isNative)
+        {
+            final long currentValue = (long) LONG_HANDLE.getAcquire(GLOBAL, addressOffset + index);
+            LONG_HANDLE.setRelease(GLOBAL, addressOffset + index, currentValue + increment);
+            return currentValue;
+        }
+        else
+        {
+            final long currentValue = (long) LONG_HANDLE.getAcquire(segment, (long) (wrapAdjustment + index));
+            LONG_HANDLE.setRelease(segment, (long) (wrapAdjustment + index), currentValue + increment);
+            return currentValue;
+        }
+    }
+
+    @Override
+    public long addLongOpaque(
+        int index,
+        long increment)
+    {
+        if (isNative)
+        {
+            final long currentValue = (long) LONG_HANDLE.getOpaque(GLOBAL, addressOffset + index);
+            LONG_HANDLE.setOpaque(GLOBAL, addressOffset + index, currentValue + increment);
+            return currentValue;
+        }
+        else
+        {
+            final long currentValue = (long) LONG_HANDLE.getOpaque(segment, (long) (wrapAdjustment + index));
+            LONG_HANDLE.setOpaque(segment, (long) (wrapAdjustment + index), currentValue + increment);
+            return currentValue;
+        }
+    }
+
+    @Override
+    public long compareAndExchangeLong(
+        int index,
+        long expectedValue,
+        long updateValue)
+    {
+        if (isNative)
+        {
+            return (long) LONG_HANDLE.compareAndExchange(GLOBAL, addressOffset + index, expectedValue, updateValue);
+        }
+        else
+        {
+            return (long) LONG_HANDLE.compareAndExchange(segment, (long) (wrapAdjustment + index), expectedValue, updateValue);
+        }
+    }
+
+    @Override
+    public int getIntAcquire(
+        int index)
+    {
+        if (isNative)
+        {
+            return (int) INT_HANDLE.getAcquire(GLOBAL, addressOffset + index);
+        }
+        else
+        {
+            return (int) INT_HANDLE.getAcquire(segment, (long) (wrapAdjustment + index));
+        }
+    }
+
+    @Override
+    public void putIntRelease(
+        int index,
+        int value)
+    {
+        if (isNative)
+        {
+            INT_HANDLE.setRelease(GLOBAL, addressOffset + index, value);
+        }
+        else
+        {
+            INT_HANDLE.setRelease(segment, (long) (wrapAdjustment + index), value);
+        }
+    }
+
+    @Override
+    public int getIntOpaque(
+        int index)
+    {
+        if (isNative)
+        {
+            return (int) INT_HANDLE.getOpaque(GLOBAL, addressOffset + index);
+        }
+        else
+        {
+            return (int) INT_HANDLE.getOpaque(segment, (long) (wrapAdjustment + index));
+        }
+    }
+
+    @Override
+    public void putIntOpaque(
+        int index,
+        int value)
+    {
+        if (isNative)
+        {
+            INT_HANDLE.setOpaque(GLOBAL, addressOffset + index, value);
+        }
+        else
+        {
+            INT_HANDLE.setOpaque(segment, (long) (wrapAdjustment + index), value);
+        }
+    }
+
+    @Override
+    public int addIntRelease(
+        int index,
+        int increment)
+    {
+        if (isNative)
+        {
+            final int currentValue = (int) INT_HANDLE.getAcquire(GLOBAL, addressOffset + index);
+            INT_HANDLE.setRelease(GLOBAL, addressOffset + index, currentValue + increment);
+            return currentValue;
+        }
+        else
+        {
+            final int currentValue = (int) INT_HANDLE.getAcquire(segment, (long) (wrapAdjustment + index));
+            INT_HANDLE.setRelease(segment, (long) (wrapAdjustment + index), currentValue + increment);
+            return currentValue;
+        }
+    }
+
+    @Override
+    public int addIntOpaque(
+        int index,
+        int increment)
+    {
+        if (isNative)
+        {
+            final int currentValue = (int) INT_HANDLE.getOpaque(GLOBAL, addressOffset + index);
+            INT_HANDLE.setOpaque(GLOBAL, addressOffset + index, currentValue + increment);
+            return currentValue;
+        }
+        else
+        {
+            final int currentValue = (int) INT_HANDLE.getOpaque(segment, (long) (wrapAdjustment + index));
+            INT_HANDLE.setOpaque(segment, (long) (wrapAdjustment + index), currentValue + increment);
+            return currentValue;
+        }
+    }
+
+    @Override
+    public int compareAndExchangeInt(
+        int index,
+        int expectedValue,
+        int updateValue)
+    {
+        if (isNative)
+        {
+            return (int) INT_HANDLE.compareAndExchange(GLOBAL, addressOffset + index, expectedValue, updateValue);
+        }
+        else
+        {
+            return (int) INT_HANDLE.compareAndExchange(segment, (long) (wrapAdjustment + index), expectedValue, updateValue);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // String — ASCII (length-prefixed)
+    // -----------------------------------------------------------------------
+
+    @Override
+    public String getStringAscii(
+        int index)
+    {
+        final int length = getInt(index);
+        return getStringWithoutLengthAscii(index + Integer.BYTES, length);
+    }
+
+    @Override
+    public String getStringAscii(
+        int index,
+        ByteOrder byteOrder)
+    {
+        final int length = getInt(index, byteOrder);
+        return getStringWithoutLengthAscii(index + Integer.BYTES, length);
+    }
+
+    @Override
+    public String getStringAscii(
+        int index,
+        int length)
+    {
+        return getStringWithoutLengthAscii(index + Integer.BYTES, length);
+    }
+
+    @Override
+    public int getStringAscii(
+        int index,
+        Appendable appendable)
+    {
+        final int length = getInt(index);
+        return getStringWithoutLengthAscii(index + Integer.BYTES, length, appendable);
+    }
+
+    @Override
+    public int getStringAscii(
+        int index,
+        Appendable appendable,
+        ByteOrder byteOrder)
+    {
+        final int length = getInt(index, byteOrder);
+        return getStringWithoutLengthAscii(index + Integer.BYTES, length, appendable);
+    }
+
+    @Override
+    public int getStringAscii(
+        int index,
+        int length,
+        Appendable appendable)
+    {
+        return getStringWithoutLengthAscii(index + Integer.BYTES, length, appendable);
+    }
+
+    // -----------------------------------------------------------------------
+    // String — ASCII (no length prefix)
+    // -----------------------------------------------------------------------
+
+    @Override
+    public String getStringWithoutLengthAscii(
+        int index,
+        int length)
+    {
+        final byte[] bytes = new byte[length];
+        MemorySegment.copy(segment, BYTE_LAYOUT, wrapAdjustment + index,
+            MemorySegment.ofArray(bytes), BYTE_LAYOUT, 0, length);
+        return new String(bytes, java.nio.charset.StandardCharsets.US_ASCII);
+    }
+
+    @Override
+    public int getStringWithoutLengthAscii(
+        int index,
+        int length,
+        Appendable appendable)
+    {
+        try
+        {
+            for (int i = 0; i < length; i++)
+            {
+                appendable.append((char) getByte(index + i));
+            }
+        }
+        catch (java.io.IOException ex)
+        {
+            throw new RuntimeException(ex);
+        }
+        return length;
+    }
+
+    // -----------------------------------------------------------------------
+    // String — UTF-8
+    // -----------------------------------------------------------------------
+
+    @Override
+    public String getStringUtf8(
+        int index)
+    {
+        final int length = getInt(index);
+        return getStringWithoutLengthUtf8(index + Integer.BYTES, length);
+    }
+
+    @Override
+    public String getStringUtf8(
+        int index,
+        ByteOrder byteOrder)
+    {
+        final int length = getInt(index, byteOrder);
+        return getStringWithoutLengthUtf8(index + Integer.BYTES, length);
+    }
+
+    @Override
+    public String getStringUtf8(
+        int index,
+        int length)
+    {
+        return getStringWithoutLengthUtf8(index + Integer.BYTES, length);
+    }
+
+    @Override
+    public String getStringWithoutLengthUtf8(
+        int index,
+        int length)
+    {
+        final byte[] bytes = new byte[length];
+        MemorySegment.copy(segment, BYTE_LAYOUT, wrapAdjustment + index,
+            MemorySegment.ofArray(bytes), BYTE_LAYOUT, 0, length);
+        return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    // -----------------------------------------------------------------------
+    // putString — ASCII (length-prefixed)
+    // -----------------------------------------------------------------------
+
+    @Override
+    public int putStringAscii(
+        int index,
+        String value)
+    {
+        final int length = value != null ? value.length() : 0;
+        putInt(index, length);
+        return Integer.BYTES + putStringWithoutLengthAscii(index + Integer.BYTES, value);
+    }
+
+    @Override
+    public int putStringAscii(
+        int index,
+        CharSequence value)
+    {
+        final int length = value != null ? value.length() : 0;
+        putInt(index, length);
+        return Integer.BYTES + putStringWithoutLengthAscii(index + Integer.BYTES, value);
+    }
+
+    @Override
+    public int putStringAscii(
+        int index,
+        String value,
+        ByteOrder byteOrder)
+    {
+        final int length = value != null ? value.length() : 0;
+        putInt(index, length, byteOrder);
+        return Integer.BYTES + putStringWithoutLengthAscii(index + Integer.BYTES, value);
+    }
+
+    @Override
+    public int putStringAscii(
+        int index,
+        CharSequence value,
+        ByteOrder byteOrder)
+    {
+        final int length = value != null ? value.length() : 0;
+        putInt(index, length, byteOrder);
+        return Integer.BYTES + putStringWithoutLengthAscii(index + Integer.BYTES, value);
+    }
+
+    // -----------------------------------------------------------------------
+    // putString — ASCII (no length prefix)
+    // -----------------------------------------------------------------------
+
+    @Override
+    public int putStringWithoutLengthAscii(
+        int index,
+        String value)
+    {
+        if (value == null)
+        {
+            return 0;
+        }
+        final int length = value.length();
+        for (int i = 0; i < length; i++)
+        {
+            putByte(index + i, (byte) value.charAt(i));
+        }
+        return length;
+    }
+
+    @Override
+    public int putStringWithoutLengthAscii(
+        int index,
+        CharSequence value)
+    {
+        if (value == null)
+        {
+            return 0;
+        }
+        final int length = value.length();
+        for (int i = 0; i < length; i++)
+        {
+            putByte(index + i, (byte) value.charAt(i));
+        }
+        return length;
+    }
+
+    @Override
+    public int putStringWithoutLengthAscii(
+        int index,
+        String value,
+        int valueOffset,
+        int length)
+    {
+        if (value == null)
+        {
+            return 0;
+        }
+        for (int i = 0; i < length; i++)
+        {
+            putByte(index + i, (byte) value.charAt(valueOffset + i));
+        }
+        return length;
+    }
+
+    @Override
+    public int putStringWithoutLengthAscii(
+        int index,
+        CharSequence value,
+        int valueOffset,
+        int length)
+    {
+        if (value == null)
+        {
+            return 0;
+        }
+        for (int i = 0; i < length; i++)
+        {
+            putByte(index + i, (byte) value.charAt(valueOffset + i));
+        }
+        return length;
+    }
+
+    // -----------------------------------------------------------------------
+    // putString — UTF-8
+    // -----------------------------------------------------------------------
+
+    @Override
+    public int putStringUtf8(
+        int index,
+        String value)
+    {
+        return putStringUtf8(index, value, ByteOrder.nativeOrder(), Integer.MAX_VALUE);
+    }
+
+    @Override
+    public int putStringUtf8(
+        int index,
+        String value,
+        ByteOrder byteOrder)
+    {
+        return putStringUtf8(index, value, byteOrder, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public int putStringUtf8(
+        int index,
+        String value,
+        int maxEncodedLength)
+    {
+        return putStringUtf8(index, value, ByteOrder.nativeOrder(), maxEncodedLength);
+    }
+
+    @Override
+    public int putStringUtf8(
+        int index,
+        String value,
+        ByteOrder byteOrder,
+        int maxEncodedLength)
+    {
+        final byte[] bytes = value != null
+            ? value.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+            : new byte[0];
+        final int length = Math.min(bytes.length, maxEncodedLength);
+        segment.set(intLayout(byteOrder), wrapAdjustment + index, length);
+        MemorySegment.copy(MemorySegment.ofArray(bytes), BYTE_LAYOUT, 0,
+            segment, BYTE_LAYOUT, wrapAdjustment + index + Integer.BYTES, length);
+        return Integer.BYTES + length;
+    }
+
+    @Override
+    public int putStringWithoutLengthUtf8(
+        int index,
+        String value)
+    {
+        final byte[] bytes = value != null
+            ? value.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+            : new byte[0];
+        MemorySegment.copy(MemorySegment.ofArray(bytes), BYTE_LAYOUT, 0,
+            segment, BYTE_LAYOUT, index, bytes.length);
+        return bytes.length;
+    }
+
+    // -----------------------------------------------------------------------
+    // ASCII int/long parsing and encoding
+    // -----------------------------------------------------------------------
+
+    @Override
+    public int parseNaturalIntAscii(
+        int index,
+        int length)
+    {
+        int result = 0;
+        for (int i = 0; i < length; i++)
+        {
+            final byte b = getByte(index + i);
+            result = result * 10 + (b - '0');
+        }
+        return result;
+    }
+
+    @Override
+    public long parseNaturalLongAscii(
+        int index,
+        int length)
+    {
+        long result = 0;
+        for (int i = 0; i < length; i++)
+        {
+            final byte b = getByte(index + i);
+            result = result * 10 + (b - '0');
+        }
+        return result;
+    }
+
+    @Override
+    public int parseIntAscii(
+        int index,
+        int length)
+    {
+        if (length == 0)
+        {
+            return 0;
+        }
+        final boolean negative = getByte(index) == '-';
+        final int start = negative ? index + 1 : index;
+        final int digits = negative ? length - 1 : length;
+        final int value = parseNaturalIntAscii(start, digits);
+        return negative ? -value : value;
+    }
+
+    @Override
+    public long parseLongAscii(
+        int index,
+        int length)
+    {
+        if (length == 0)
+        {
+            return 0;
+        }
+        final boolean negative = getByte(index) == '-';
+        final int start = negative ? index + 1 : index;
+        final int digits = negative ? length - 1 : length;
+        final long value = parseNaturalLongAscii(start, digits);
+        return negative ? -value : value;
+    }
+
+    @Override
+    public int putIntAscii(
+        int index,
+        int value)
+    {
+        return putStringWithoutLengthAscii(index, Integer.toString(value));
+    }
+
+    @Override
+    public int putNaturalIntAscii(
+        int index,
+        int value)
+    {
+        return putStringWithoutLengthAscii(index, Integer.toUnsignedString(value));
+    }
+
+    @Override
+    public void putNaturalPaddedIntAscii(
+        int index,
+        int length,
+        int value)
+    {
+        final String str = Integer.toUnsignedString(value);
+        final int padding = length - str.length();
+        if (padding < 0)
+        {
+            throw new NumberFormatException(
+                String.format("value=%d too large for length=%d", value, length));
+        }
+        for (int i = 0; i < padding; i++)
+        {
+            putByte(index + i, (byte) '0');
+        }
+        putStringWithoutLengthAscii(index + padding, str);
+    }
+
+    @Override
+    public int putNaturalIntAsciiFromEnd(
+        int value,
+        int endExclusive)
+    {
+        int index = endExclusive;
+        int remaining = value;
+        do
+        {
+            index--;
+            final int digit = remaining % 10;
+            remaining = remaining / 10;
+            putByte(index, (byte) ('0' + digit));
+        }
+        while (remaining > 0);
+        return index;
+    }
+
+    @Override
+    public int putNaturalLongAscii(
+        int index,
+        long value)
+    {
+        return putStringWithoutLengthAscii(index, Long.toUnsignedString(value));
+    }
+
+    @Override
+    public int putLongAscii(
+        int index,
+        long value)
+    {
+        return putStringWithoutLengthAscii(index, Long.toString(value));
+    }
+
+    // -----------------------------------------------------------------------
+    // Comparable
+    // -----------------------------------------------------------------------
+
+    @Override
+    public int compareTo(
+        DirectBuffer that)
+    {
+        final int thisCapacity = this.capacity;
+        final int thatCapacity = that.capacity();
+        final int limit = Math.min(thisCapacity, thatCapacity);
+
+        for (int i = 0; i < limit; i++)
+        {
+            final int cmp = Byte.compare(this.getByte(i), that.getByte(i));
+            if (cmp != 0)
+            {
+                return cmp;
+            }
         }
 
-        final byte[] array = buffer.byteArray();
-        if (array != null)
-        {
-            return MemorySegment.ofArray(array);
-        }
+        return Integer.compare(thisCapacity, thatCapacity);
+    }
 
-        final ByteBuffer bb = buffer.byteBuffer();
-        if (bb != null)
-        {
-            return segmentOf(bb);
-        }
+    // -----------------------------------------------------------------------
+    // Object overrides
+    // -----------------------------------------------------------------------
 
-        return MemorySegment.ofAddress(buffer.addressOffset()).reinterpret(buffer.capacity());
+    @Override
+    public String toString()
+    {
+        return "UnsafeBufferEx{capacity=" + capacity + "}";
+    }
+
+    @Override
+    public boolean equals(
+        Object obj)
+    {
+        if (this == obj)
+        {
+            return true;
+        }
+        if (!(obj instanceof DirectBuffer that))
+        {
+            return false;
+        }
+        if (this.capacity != that.capacity())
+        {
+            return false;
+        }
+        for (int i = 0; i < capacity; i++)
+        {
+            if (this.getByte(i) != that.getByte(i))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = 1;
+        for (int i = 0; i < capacity; i++)
+        {
+            result = 31 * result + getByte(i);
+        }
+        return result;
     }
 }

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExNativeTest.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExNativeTest.java
@@ -291,4 +291,23 @@ public class UnsafeBufferExNativeTest
         target.getBytes(0, readback);
         assertArrayEquals(payload, readback);
     }
+
+    @Test
+    public void putBytesFromByteBufferWithStaleSourceLimitRoundTrips()
+    {
+        // the index-based putBytes(ByteBuffer) contract copies by capacity, not NIO limit; a stale
+        // limit narrower than the requested range must not reject a valid copy
+        ByteBuffer source = ByteBuffer.allocateDirect(64);
+        byte[] payload = "bytebuffer-spanning-stale-limit".getBytes();
+        source.put(payload);
+        source.position(0);
+        source.limit(4);
+
+        UnsafeBufferEx.Native target = new UnsafeBufferEx(ByteBuffer.allocateDirect(64)).asNative();
+        target.putBytes(0, source, 0, payload.length);
+
+        byte[] readback = new byte[payload.length];
+        target.getBytes(0, readback);
+        assertArrayEquals(payload, readback);
+    }
 }

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExNativeTest.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExNativeTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.common.agrona.buffer;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+
+import org.agrona.DirectBuffer;
+import org.junit.Test;
+
+/**
+ * Exercises {@link UnsafeBufferEx.Native}, the wrap-frozen specialization
+ * returned from {@link UnsafeBufferEx#asNative()}. {@code Native} requires a
+ * native (off-heap) {@link MemorySegment} and a direct {@link ByteBuffer};
+ * every {@code wrap(...)} overload is intentionally unsupported so the JIT can
+ * trust the final fields. These tests pin both the contract and the
+ * round-trips against a peer {@link UnsafeBufferEx} on the same memory.
+ */
+public class UnsafeBufferExNativeTest
+{
+    @Test
+    public void asNativeRejectsHeapByteArray()
+    {
+        UnsafeBufferEx buffer = new UnsafeBufferEx(new byte[64]);
+        assertThrows(IllegalStateException.class, buffer::asNative);
+    }
+
+    @Test
+    public void asNativeRejectsHeapByteBuffer()
+    {
+        UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocate(64));
+        assertThrows(IllegalStateException.class, buffer::asNative);
+    }
+
+    @Test
+    public void asNativeRejectsHeapMemorySegment()
+    {
+        UnsafeBufferEx buffer = new UnsafeBufferEx(MemorySegment.ofArray(new byte[64]));
+        assertThrows(IllegalStateException.class, buffer::asNative);
+    }
+
+    @Test
+    public void asNativeAcceptsDirectByteBuffer()
+    {
+        UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+        UnsafeBufferEx.Native native0 = buffer.asNative();
+        assertEquals(64, native0.capacity());
+    }
+
+    @Test
+    public void wrapByteArrayUnsupported()
+    {
+        UnsafeBufferEx.Native native0 = new UnsafeBufferEx(ByteBuffer.allocateDirect(64)).asNative();
+        assertThrows(UnsupportedOperationException.class, () -> native0.wrap(new byte[64]));
+    }
+
+    @Test
+    public void wrapByteArrayWithRangeUnsupported()
+    {
+        UnsafeBufferEx.Native native0 = new UnsafeBufferEx(ByteBuffer.allocateDirect(64)).asNative();
+        assertThrows(UnsupportedOperationException.class, () -> native0.wrap(new byte[64], 0, 64));
+    }
+
+    @Test
+    public void wrapByteBufferUnsupported()
+    {
+        UnsafeBufferEx.Native native0 = new UnsafeBufferEx(ByteBuffer.allocateDirect(64)).asNative();
+        assertThrows(UnsupportedOperationException.class, () -> native0.wrap(ByteBuffer.allocateDirect(64)));
+    }
+
+    @Test
+    public void wrapByteBufferWithRangeUnsupported()
+    {
+        UnsafeBufferEx.Native native0 = new UnsafeBufferEx(ByteBuffer.allocateDirect(64)).asNative();
+        assertThrows(UnsupportedOperationException.class, () -> native0.wrap(ByteBuffer.allocateDirect(64), 0, 64));
+    }
+
+    @Test
+    public void wrapDirectBufferUnsupported()
+    {
+        UnsafeBufferEx.Native native0 = new UnsafeBufferEx(ByteBuffer.allocateDirect(64)).asNative();
+        DirectBuffer other = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+        assertThrows(UnsupportedOperationException.class, () -> native0.wrap(other));
+    }
+
+    @Test
+    public void wrapDirectBufferWithRangeUnsupported()
+    {
+        UnsafeBufferEx.Native native0 = new UnsafeBufferEx(ByteBuffer.allocateDirect(64)).asNative();
+        DirectBuffer other = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+        assertThrows(UnsupportedOperationException.class, () -> native0.wrap(other, 0, 64));
+    }
+
+    @Test
+    public void wrapDirectBufferExUnsupported()
+    {
+        UnsafeBufferEx.Native native0 = new UnsafeBufferEx(ByteBuffer.allocateDirect(64)).asNative();
+        DirectBufferEx other = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+        assertThrows(UnsupportedOperationException.class, () -> native0.wrap(other));
+    }
+
+    @Test
+    public void wrapDirectBufferExWithRangeUnsupported()
+    {
+        UnsafeBufferEx.Native native0 = new UnsafeBufferEx(ByteBuffer.allocateDirect(64)).asNative();
+        DirectBufferEx other = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+        assertThrows(UnsupportedOperationException.class, () -> native0.wrap(other, 0, 64));
+    }
+
+    @Test
+    public void wrapAddressUnsupported()
+    {
+        UnsafeBufferEx.Native native0 = new UnsafeBufferEx(ByteBuffer.allocateDirect(64)).asNative();
+        assertThrows(UnsupportedOperationException.class, () -> native0.wrap(0L, 64));
+    }
+
+    @Test
+    public void wrapMemorySegmentUnsupported()
+    {
+        UnsafeBufferEx.Native native0 = new UnsafeBufferEx(ByteBuffer.allocateDirect(64)).asNative();
+        try (Arena arena = Arena.ofConfined())
+        {
+            MemorySegment segment = arena.allocate(64);
+            assertThrows(UnsupportedOperationException.class, () -> native0.wrap(segment));
+        }
+    }
+
+    @Test
+    public void wrapMemorySegmentWithRangeUnsupported()
+    {
+        UnsafeBufferEx.Native native0 = new UnsafeBufferEx(ByteBuffer.allocateDirect(64)).asNative();
+        try (Arena arena = Arena.ofConfined())
+        {
+            MemorySegment segment = arena.allocate(64);
+            assertThrows(UnsupportedOperationException.class, () -> native0.wrap(segment, 0, 64));
+        }
+    }
+
+    @Test
+    public void byteBufferIsIdentitySame()
+    {
+        ByteBuffer source = ByteBuffer.allocateDirect(64);
+        UnsafeBufferEx.Native native0 = new UnsafeBufferEx(source).asNative();
+        assertSame(source, native0.byteBuffer());
+    }
+
+    @Test
+    public void primitiveRoundTripsAgreeWithUnsafeBufferEx()
+    {
+        ByteBuffer source = ByteBuffer.allocateDirect(64);
+        UnsafeBufferEx peer = new UnsafeBufferEx(source);
+        UnsafeBufferEx.Native native0 = peer.asNative();
+
+        native0.putLong(0, 0x0123456789abcdefL);
+        native0.putInt(8, 0x0a0b0c0d);
+        native0.putShort(12, (short) 0x1234);
+        native0.putByte(14, (byte) 0x7f);
+        native0.putChar(16, 'Z');
+        native0.putFloat(20, 3.14f);
+        native0.putDouble(24, 2.71828);
+
+        assertEquals(0x0123456789abcdefL, peer.getLong(0));
+        assertEquals(0x0a0b0c0d, peer.getInt(8));
+        assertEquals((short) 0x1234, peer.getShort(12));
+        assertEquals((byte) 0x7f, peer.getByte(14));
+        assertEquals('Z', peer.getChar(16));
+        assertEquals(3.14f, peer.getFloat(20), 0.0f);
+        assertEquals(2.71828, peer.getDouble(24), 0.0);
+
+        assertEquals(0x0123456789abcdefL, native0.getLong(0));
+        assertEquals(0x0a0b0c0d, native0.getInt(8));
+        assertEquals((short) 0x1234, native0.getShort(12));
+        assertEquals((byte) 0x7f, native0.getByte(14));
+        assertEquals('Z', native0.getChar(16));
+        assertEquals(3.14f, native0.getFloat(20), 0.0f);
+        assertEquals(2.71828, native0.getDouble(24), 0.0);
+    }
+
+    @Test
+    public void orderedAndVolatileAccessRoundTrip()
+    {
+        UnsafeBufferEx.Native native0 = new UnsafeBufferEx(ByteBuffer.allocateDirect(64)).asNative();
+
+        native0.putLongOrdered(0, 0x1122334455667788L);
+        native0.putIntOrdered(8, 0x44332211);
+        native0.putLongVolatile(16, 0xdeadbeefcafebabeL);
+        native0.putIntVolatile(24, 0xfeedface);
+
+        assertEquals(0x1122334455667788L, native0.getLongVolatile(0));
+        assertEquals(0x44332211, native0.getIntVolatile(8));
+        assertEquals(0x1122334455667788L, native0.getLong(0));
+        assertEquals(0x44332211, native0.getInt(8));
+        assertEquals(0xdeadbeefcafebabeL, native0.getLongVolatile(16));
+        assertEquals(0xfeedface, native0.getIntVolatile(24));
+    }
+
+    @Test
+    public void atomicCompareAndSetSucceedsAndFails()
+    {
+        UnsafeBufferEx.Native native0 = new UnsafeBufferEx(ByteBuffer.allocateDirect(64)).asNative();
+        native0.putLong(0, 1L);
+
+        assertEquals(true, native0.compareAndSetLong(0, 1L, 2L));
+        assertEquals(2L, native0.getLong(0));
+        assertEquals(false, native0.compareAndSetLong(0, 1L, 3L));
+        assertEquals(2L, native0.getLong(0));
+    }
+
+    @Test
+    public void putBytesFromHeapByteBufferRoundTrips()
+    {
+        UnsafeBufferEx.Native native0 = new UnsafeBufferEx(ByteBuffer.allocateDirect(64)).asNative();
+        byte[] payload = "hello-zilla-native".getBytes();
+        ByteBuffer source = ByteBuffer.allocate(64);
+        source.put(payload);
+        source.flip();
+
+        native0.putBytes(0, source, payload.length);
+
+        byte[] readback = new byte[payload.length];
+        native0.getBytes(0, readback);
+        assertArrayEquals(payload, readback);
+    }
+
+    @Test
+    public void putBytesFromDirectByteBufferRoundTrips()
+    {
+        UnsafeBufferEx.Native native0 = new UnsafeBufferEx(ByteBuffer.allocateDirect(64)).asNative();
+        byte[] payload = "hello-direct-source".getBytes();
+        ByteBuffer source = ByteBuffer.allocateDirect(64);
+        source.put(payload);
+
+        native0.putBytes(0, source, 0, payload.length);
+
+        byte[] readback = new byte[payload.length];
+        native0.getBytes(0, readback);
+        assertArrayEquals(payload, readback);
+    }
+
+    @Test
+    public void putBytesFromDirectBufferRoundTrips()
+    {
+        UnsafeBufferEx source = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+        byte[] payload = "hello-direct-buffer".getBytes();
+        source.putBytes(0, payload);
+
+        UnsafeBufferEx.Native target = new UnsafeBufferEx(ByteBuffer.allocateDirect(64)).asNative();
+        target.putBytes(0, source, 0, payload.length);
+
+        byte[] readback = new byte[payload.length];
+        target.getBytes(0, readback);
+        assertArrayEquals(payload, readback);
+    }
+}

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExNativeTest.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExNativeTest.java
@@ -270,4 +270,25 @@ public class UnsafeBufferExNativeTest
         target.getBytes(0, readback);
         assertArrayEquals(payload, readback);
     }
+
+    @Test
+    public void putBytesFromDirectBufferExWithStaleSourceLimitRoundTrips()
+    {
+        // Agrona treats the source's NIO ByteBuffer limit as scratch state independent of
+        // capacity (e.g. left dirty by CRC32.update); a putBytes spanning beyond the stale limit
+        // but within capacity must still copy the full range — see KafkaCachePartition.computeHash
+        ByteBuffer sourceBb = ByteBuffer.allocateDirect(64);
+        UnsafeBufferEx source = new UnsafeBufferEx(sourceBb);
+        byte[] payload = "trailer-spanning-stale-limit".getBytes();
+        source.putBytes(0, payload);
+        sourceBb.position(0);
+        sourceBb.limit(4);
+
+        UnsafeBufferEx.Native target = new UnsafeBufferEx(ByteBuffer.allocateDirect(64)).asNative();
+        target.putBytes(0, source, 0, payload.length);
+
+        byte[] readback = new byte[payload.length];
+        target.getBytes(0, readback);
+        assertArrayEquals(payload, readback);
+    }
 }

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExNativeTest.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExNativeTest.java
@@ -310,4 +310,26 @@ public class UnsafeBufferExNativeTest
         target.getBytes(0, readback);
         assertArrayEquals(payload, readback);
     }
+
+    @Test
+    public void putBytesWithStaleDestinationLimitRoundTrips()
+    {
+        // ByteBuffer.put also bounds-checks the destination against its NIO limit; a write at an
+        // index beyond a stale destination limit but within capacity must still succeed (e.g. a
+        // mapped cache file whose limit was left dirty by CRC32.update)
+        ByteBuffer destBb = ByteBuffer.allocateDirect(512);
+        UnsafeBufferEx.Native target = new UnsafeBufferEx(destBb).asNative();
+        destBb.position(0);
+        destBb.limit(8);
+
+        byte[] payload = "written-beyond-stale-dest-limit".getBytes();
+        UnsafeBufferEx source = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+        source.putBytes(0, payload);
+
+        target.putBytes(450, source, 0, payload.length);
+
+        byte[] readback = new byte[payload.length];
+        target.getBytes(450, readback);
+        assertArrayEquals(payload, readback);
+    }
 }

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExTest.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExTest.java
@@ -1,0 +1,705 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.common.agrona.buffer;
+
+import static java.lang.foreign.ValueLayout.JAVA_INT_UNALIGNED;
+import static java.nio.ByteOrder.BIG_ENDIAN;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Exercises {@link UnsafeBufferEx}, which branches per access: heap-backed
+ * instances take the bounded segment path, native (off-heap) instances take the
+ * unchecked {@code GLOBAL} segment path.
+ * <p>
+ * {@link RoundTrips} runs every read/write round-trip across all backing kinds
+ * (heap array, heap array with offset, heap and direct {@link ByteBuffer},
+ * direct with offset, heap {@link MemorySegment} — the {@code isNative == false}
+ * edge — and a native {@link Arena} segment) so both branches are covered.
+ * {@link Modes} holds the path-specific tests: atomics on native (aligned)
+ * backings only — heap {@code byte[]} segments cannot satisfy aligned
+ * {@code VarHandle} access — and implicit bounds checks on heap only, since the
+ * native path is intentionally unchecked.
+ */
+@RunWith(Enclosed.class)
+public class UnsafeBufferExTest
+{
+    @RunWith(Parameterized.class)
+    public static class RoundTrips
+    {
+        @FunctionalInterface
+        public interface BufferFactory
+        {
+            UnsafeBufferEx create();
+        }
+
+        @Parameters(name = "{0}")
+        public static Collection<Object[]> backings()
+        {
+            return List.of(new Object[][]
+            {
+                {"heapArray", (BufferFactory) () -> new UnsafeBufferEx(new byte[256])},
+                {"heapArrayOffset", (BufferFactory) () -> new UnsafeBufferEx(new byte[512], 64, 256)},
+                {"heapByteBuffer", (BufferFactory) () -> new UnsafeBufferEx(ByteBuffer.allocate(256))},
+                {"directByteBuffer", (BufferFactory) () -> new UnsafeBufferEx(ByteBuffer.allocateDirect(256))},
+                {"directByteBufferOffset", (BufferFactory) () -> new UnsafeBufferEx(ByteBuffer.allocateDirect(512), 64, 256)},
+                {"heapSegment", (BufferFactory) () -> new UnsafeBufferEx(MemorySegment.ofArray(new byte[256]))},
+                {"nativeSegment", (BufferFactory) () -> new UnsafeBufferEx(Arena.ofAuto().allocate(256))},
+            });
+        }
+
+        @Parameter(0)
+        public String name;
+
+        @Parameter(1)
+        public BufferFactory factory;
+
+        @Test
+        public void shouldRoundTripIntegralPrimitives()
+        {
+            final UnsafeBufferEx buffer = factory.create();
+
+            buffer.putLong(0, Long.MAX_VALUE);
+            assertEquals(Long.MAX_VALUE, buffer.getLong(0));
+            buffer.putLong(8, Long.MIN_VALUE);
+            assertEquals(Long.MIN_VALUE, buffer.getLong(8));
+
+            buffer.putInt(16, Integer.MAX_VALUE);
+            assertEquals(Integer.MAX_VALUE, buffer.getInt(16));
+            buffer.putInt(20, Integer.MIN_VALUE);
+            assertEquals(Integer.MIN_VALUE, buffer.getInt(20));
+
+            buffer.putShort(24, Short.MAX_VALUE);
+            assertEquals(Short.MAX_VALUE, buffer.getShort(24));
+
+            buffer.putByte(28, (byte) 0x80);
+            assertEquals((byte) 0x80, buffer.getByte(28));
+
+            buffer.putChar(30, 'Z');
+            assertEquals('Z', buffer.getChar(30));
+        }
+
+        @Test
+        public void shouldRoundTripFloatingPrimitives()
+        {
+            final UnsafeBufferEx buffer = factory.create();
+
+            buffer.putDouble(0, 3.14159);
+            assertEquals(3.14159, buffer.getDouble(0), 0.00001);
+
+            buffer.putFloat(8, 2.71828f);
+            assertEquals(2.71828f, buffer.getFloat(8), 0.00001f);
+        }
+
+        @Test
+        public void shouldRoundTripBigEndian()
+        {
+            final UnsafeBufferEx buffer = factory.create();
+
+            buffer.putInt(0, 0x01020304, BIG_ENDIAN);
+            assertEquals(0x01020304, buffer.getInt(0, BIG_ENDIAN));
+            assertEquals((byte) 0x01, buffer.getByte(0));
+            assertEquals((byte) 0x04, buffer.getByte(3));
+
+            buffer.putLong(8, 0x0102030405060708L, BIG_ENDIAN);
+            assertEquals(0x0102030405060708L, buffer.getLong(8, BIG_ENDIAN));
+
+            buffer.putShort(16, (short) 0x0102, BIG_ENDIAN);
+            assertEquals((short) 0x0102, buffer.getShort(16, BIG_ENDIAN));
+
+            buffer.putChar(18, 'A', BIG_ENDIAN);
+            assertEquals('A', buffer.getChar(18, BIG_ENDIAN));
+        }
+
+        @Test
+        public void shouldRoundTripByteArray()
+        {
+            final UnsafeBufferEx buffer = factory.create();
+
+            final byte[] src = {1, 2, 3, 4, 5};
+            buffer.putBytes(0, src);
+            final byte[] dst = new byte[5];
+            buffer.getBytes(0, dst);
+            assertArrayEquals(src, dst);
+
+            final byte[] src2 = {0, 0, 1, 2, 3};
+            buffer.putBytes(10, src2, 2, 3);
+            final byte[] dst2 = new byte[3];
+            buffer.getBytes(10, dst2, 0, 3);
+            assertEquals(1, dst2[0]);
+            assertEquals(3, dst2[2]);
+        }
+
+        @Test
+        public void shouldRoundTripMemorySegment()
+        {
+            final UnsafeBufferEx buffer = factory.create();
+            buffer.putInt(0, 0xDEADBEEF);
+
+            final MemorySegment dst = MemorySegment.ofArray(new byte[16]);
+            buffer.getBytes(0, dst, 0, 4);
+            assertEquals(0xDEADBEEF, dst.get(JAVA_INT_UNALIGNED, 0));
+
+            final MemorySegment src = MemorySegment.ofArray(new byte[16]);
+            src.set(JAVA_INT_UNALIGNED, 0, 0xCAFEBABE);
+            buffer.putBytes(8, src, 0, 4);
+            assertEquals(0xCAFEBABE, buffer.getInt(8));
+        }
+
+        @Test
+        public void shouldSetMemory()
+        {
+            final UnsafeBufferEx buffer = factory.create();
+            buffer.setMemory(0, 16, (byte) 0xFF);
+
+            for (int i = 0; i < 16; i++)
+            {
+                assertEquals((byte) 0xFF, buffer.getByte(i));
+            }
+            assertEquals(0, buffer.getByte(16));
+        }
+
+        @Test
+        public void shouldRoundTripStrings()
+        {
+            final UnsafeBufferEx buffer = factory.create();
+
+            final int written = buffer.putStringAscii(0, "Hello");
+            assertEquals(4 + 5, written);
+            assertEquals("Hello", buffer.getStringAscii(0));
+
+            buffer.putStringAscii(16, "World", BIG_ENDIAN);
+            assertEquals("World", buffer.getStringAscii(16, BIG_ENDIAN));
+
+            buffer.putStringWithoutLengthAscii(32, "ABC");
+            assertEquals("ABC", buffer.getStringWithoutLengthAscii(32, 3));
+
+            buffer.putStringUtf8(40, "Hello");
+            assertEquals("Hello", buffer.getStringUtf8(40));
+
+            assertEquals(0, buffer.putStringWithoutLengthAscii(80, (String) null));
+        }
+
+        @Test
+        public void shouldParseAndEncodeAscii()
+        {
+            final UnsafeBufferEx buffer = factory.create();
+
+            buffer.putStringWithoutLengthAscii(0, "12345");
+            assertEquals(12345, buffer.parseNaturalIntAscii(0, 5));
+
+            buffer.putStringWithoutLengthAscii(8, "-42");
+            assertEquals(-42, buffer.parseIntAscii(8, 3));
+
+            buffer.putStringWithoutLengthAscii(16, "9876543210");
+            assertEquals(9876543210L, buffer.parseLongAscii(16, 10));
+
+            buffer.putNaturalPaddedIntAscii(32, 5, 42);
+            assertEquals("00042", buffer.getStringWithoutLengthAscii(32, 5));
+        }
+
+        @Test
+        public void shouldExposeSegmentAndCapacity()
+        {
+            final UnsafeBufferEx buffer = factory.create();
+
+            assertNotNull(buffer.segment());
+            assertEquals(256, buffer.capacity());
+        }
+    }
+
+    public static class Modes
+    {
+        // -------------------------------------------------------------------
+        // Construction and wrap
+        // -------------------------------------------------------------------
+
+        @Test
+        public void shouldWrapByteArray()
+        {
+            final byte[] array = new byte[64];
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(array);
+
+            assertEquals(64, buffer.capacity());
+            assertNotNull(buffer.segment());
+            assertEquals(array, buffer.byteArray());
+            assertEquals(0, buffer.wrapAdjustment());
+            assertFalse(buffer.isExpandable());
+        }
+
+        @Test
+        public void shouldWrapByteArrayWithOffset()
+        {
+            final byte[] array = new byte[64];
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(array, 8, 32);
+
+            assertEquals(32, buffer.capacity());
+            assertEquals(8, buffer.wrapAdjustment());
+        }
+
+        @Test
+        public void shouldWrapDirectByteBuffer()
+        {
+            final ByteBuffer bb = ByteBuffer.allocateDirect(64);
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(bb);
+
+            assertEquals(64, buffer.capacity());
+            assertNull(buffer.byteArray());
+            assertEquals(bb, buffer.byteBuffer());
+        }
+
+        @Test
+        public void shouldWrapAnotherBufferBackedByArray()
+        {
+            final UnsafeBufferEx original = new UnsafeBufferEx(new byte[64]);
+            original.putInt(0, 42);
+
+            final UnsafeBufferEx copy = new UnsafeBufferEx(original);
+            assertEquals(42, copy.getInt(0));
+            assertEquals(64, copy.capacity());
+        }
+
+        @Test
+        public void shouldWrapBufferBackedByDirectByteBuffer()
+        {
+            final UnsafeBufferEx source = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+            source.putInt(4, 456);
+
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(source);
+            assertEquals(456, buffer.getInt(4));
+        }
+
+        @Test
+        public void shouldWrapDefaultConstructor()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx();
+            assertEquals(0, buffer.capacity());
+        }
+
+        @Test
+        public void shouldReWrapFromHeapToDirect()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(new byte[32]);
+            buffer.putInt(0, 7);
+            assertEquals(7, buffer.getInt(0));
+
+            buffer.wrap(ByteBuffer.allocateDirect(64));
+            buffer.putInt(0, 9);
+            assertEquals(9, buffer.getInt(0));
+            assertEquals(64, buffer.capacity());
+            assertNull(buffer.byteArray());
+        }
+
+        @Test
+        public void shouldReWrapFromDirectToHeap()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(32));
+            buffer.putInt(0, 7);
+            assertEquals(7, buffer.getInt(0));
+
+            buffer.wrap(new byte[64]);
+            buffer.putInt(0, 9);
+            assertEquals(9, buffer.getInt(0));
+            assertEquals(64, buffer.capacity());
+            assertNotNull(buffer.byteArray());
+        }
+
+        // -------------------------------------------------------------------
+        // Cross-backing copy
+        // -------------------------------------------------------------------
+
+        @Test
+        public void shouldCopyHeapBufferToDirectBuffer()
+        {
+            final UnsafeBufferEx heap = new UnsafeBufferEx(new byte[64]);
+            heap.putInt(0, 0xDEADBEEF);
+            heap.putLong(8, 0x1234567890ABCDEFL);
+
+            final UnsafeBufferEx direct = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+            direct.putBytes(0, heap, 0, 16);
+
+            assertEquals(0xDEADBEEF, direct.getInt(0));
+            assertEquals(0x1234567890ABCDEFL, direct.getLong(8));
+        }
+
+        @Test
+        public void shouldCopyDirectBufferToHeapBuffer()
+        {
+            final UnsafeBufferEx direct = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+            direct.putInt(0, 0xCAFEBABE);
+            direct.putLong(8, 0xFEEDFACEFEEDFACEL);
+
+            final UnsafeBufferEx heap = new UnsafeBufferEx(new byte[64]);
+            heap.putBytes(0, direct, 0, 16);
+
+            assertEquals(0xCAFEBABE, heap.getInt(0));
+            assertEquals(0xFEEDFACEFEEDFACEL, heap.getLong(8));
+        }
+
+        // -------------------------------------------------------------------
+        // Atomics — native (aligned) backings only
+        // -------------------------------------------------------------------
+
+        @Test
+        public void shouldGetAndPutIntVolatile()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putIntVolatile(0, 42);
+            assertEquals(42, buffer.getIntVolatile(0));
+        }
+
+        @Test
+        public void shouldPutIntOrdered()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putIntOrdered(0, 99);
+            assertEquals(99, buffer.getIntVolatile(0));
+        }
+
+        @Test
+        public void shouldCompareAndSetInt()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putIntVolatile(0, 10);
+            assertTrue(buffer.compareAndSetInt(0, 10, 20));
+            assertEquals(20, buffer.getIntVolatile(0));
+
+            assertFalse(buffer.compareAndSetInt(0, 10, 30));
+        }
+
+        @Test
+        public void shouldGetAndAddInt()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putIntVolatile(0, 100);
+            assertEquals(100, buffer.getAndAddInt(0, 50));
+            assertEquals(150, buffer.getIntVolatile(0));
+        }
+
+        @Test
+        public void shouldGetAndSetInt()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putIntVolatile(0, 100);
+            assertEquals(100, buffer.getAndSetInt(0, 200));
+            assertEquals(200, buffer.getIntVolatile(0));
+        }
+
+        @Test
+        public void shouldAddIntOrdered()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putIntVolatile(0, 10);
+            assertEquals(10, buffer.addIntOrdered(0, 5));
+            assertEquals(15, buffer.getIntVolatile(0));
+        }
+
+        @Test
+        public void shouldGetAndPutLongVolatile()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putLongVolatile(0, Long.MAX_VALUE);
+            assertEquals(Long.MAX_VALUE, buffer.getLongVolatile(0));
+        }
+
+        @Test
+        public void shouldPutLongOrdered()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putLongOrdered(0, 123456789L);
+            assertEquals(123456789L, buffer.getLongVolatile(0));
+        }
+
+        @Test
+        public void shouldCompareAndSetLong()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putLongVolatile(0, 10L);
+            assertTrue(buffer.compareAndSetLong(0, 10L, 20L));
+            assertEquals(20L, buffer.getLongVolatile(0));
+
+            assertFalse(buffer.compareAndSetLong(0, 10L, 30L));
+        }
+
+        @Test
+        public void shouldGetAndAddLong()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putLongVolatile(0, 1000L);
+            assertEquals(1000L, buffer.getAndAddLong(0, 500L));
+            assertEquals(1500L, buffer.getLongVolatile(0));
+        }
+
+        @Test
+        public void shouldGetAndSetLong()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putLongVolatile(0, 1000L);
+            assertEquals(1000L, buffer.getAndSetLong(0, 2000L));
+            assertEquals(2000L, buffer.getLongVolatile(0));
+        }
+
+        @Test
+        public void shouldAddLongOrdered()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putLongVolatile(0, 100L);
+            assertEquals(100L, buffer.addLongOrdered(0, 50L));
+            assertEquals(150L, buffer.getLongVolatile(0));
+        }
+
+        @Test
+        public void shouldGetAndPutLongAcquireRelease()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putLongRelease(0, 42L);
+            assertEquals(42L, buffer.getLongAcquire(0));
+        }
+
+        @Test
+        public void shouldGetAndPutLongOpaque()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putLongOpaque(0, 77L);
+            assertEquals(77L, buffer.getLongOpaque(0));
+        }
+
+        @Test
+        public void shouldGetAndPutIntAcquireRelease()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putIntRelease(0, 42);
+            assertEquals(42, buffer.getIntAcquire(0));
+        }
+
+        @Test
+        public void shouldGetAndPutIntOpaque()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putIntOpaque(0, 77);
+            assertEquals(77, buffer.getIntOpaque(0));
+        }
+
+        @Test
+        public void shouldCompareAndExchangeInt()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putIntVolatile(0, 10);
+            assertEquals(10, buffer.compareAndExchangeInt(0, 10, 20));
+            assertEquals(20, buffer.getIntVolatile(0));
+        }
+
+        @Test
+        public void shouldCompareAndExchangeLong()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putLongVolatile(0, 100L);
+            assertEquals(100L, buffer.compareAndExchangeLong(0, 100L, 200L));
+            assertEquals(200L, buffer.getLongVolatile(0));
+        }
+
+        @Test
+        public void shouldAddIntRelease()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putIntVolatile(0, 10);
+            assertEquals(10, buffer.addIntRelease(0, 5));
+            assertEquals(15, buffer.getIntVolatile(0));
+        }
+
+        @Test
+        public void shouldAddLongRelease()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putLongVolatile(0, 10L);
+            assertEquals(10L, buffer.addLongRelease(0, 5L));
+            assertEquals(15L, buffer.getLongVolatile(0));
+        }
+
+        @Test
+        public void shouldGetAndPutShortVolatile()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putShortVolatile(0, (short) 1234);
+            assertEquals((short) 1234, buffer.getShortVolatile(0));
+        }
+
+        @Test
+        public void shouldGetAndPutCharVolatile()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putCharVolatile(0, 'X');
+            assertEquals('X', buffer.getCharVolatile(0));
+        }
+
+        @Test
+        public void shouldGetAndPutByteVolatile()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putByteVolatile(0, (byte) 42);
+            assertEquals((byte) 42, buffer.getByteVolatile(0));
+        }
+
+        @Test
+        public void shouldVerifyAlignmentOnAlignedBuffer()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+            buffer.verifyAlignment();
+        }
+
+        // -------------------------------------------------------------------
+        // Bounds checking — heap (bounded) path only
+        // -------------------------------------------------------------------
+
+        @Test(expected = IndexOutOfBoundsException.class)
+        public void shouldThrowOnGetIntOutOfBounds()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(new byte[8]);
+            buffer.getInt(8);
+        }
+
+        @Test(expected = IndexOutOfBoundsException.class)
+        public void shouldThrowOnPutIntOutOfBounds()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(new byte[8]);
+            buffer.putInt(8, 0);
+        }
+
+        @Test(expected = IndexOutOfBoundsException.class)
+        public void shouldThrowOnGetLongOutOfBounds()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(new byte[4]);
+            buffer.getLong(0);
+        }
+
+        @Test(expected = IndexOutOfBoundsException.class)
+        public void shouldThrowOnNegativeIndex()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(new byte[64]);
+            buffer.getInt(-1);
+        }
+
+        @Test
+        public void shouldCheckLimit()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(new byte[16]);
+            buffer.checkLimit(16);
+        }
+
+        @Test(expected = IndexOutOfBoundsException.class)
+        public void shouldThrowOnCheckLimitExceeded()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(new byte[16]);
+            buffer.checkLimit(17);
+        }
+
+        @Test
+        public void shouldBoundsCheck()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(new byte[16]);
+            buffer.boundsCheck(0, 16);
+        }
+
+        @Test(expected = IndexOutOfBoundsException.class)
+        public void shouldThrowOnBoundsCheckExceeded()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(new byte[16]);
+            buffer.boundsCheck(0, 17);
+        }
+
+        // -------------------------------------------------------------------
+        // Comparable / equals / hashCode / toString
+        // -------------------------------------------------------------------
+
+        @Test
+        public void shouldCompareBuffers()
+        {
+            final UnsafeBufferEx a = new UnsafeBufferEx(new byte[]{1, 2, 3});
+            final UnsafeBufferEx b = new UnsafeBufferEx(new byte[]{1, 2, 4});
+            final UnsafeBufferEx c = new UnsafeBufferEx(new byte[]{1, 2, 3});
+
+            assertTrue(a.compareTo(b) < 0);
+            assertTrue(b.compareTo(a) > 0);
+            assertEquals(0, a.compareTo(c));
+        }
+
+        @Test
+        public void shouldBeEqualForSameContent()
+        {
+            final UnsafeBufferEx a = new UnsafeBufferEx(new byte[]{1, 2, 3, 4});
+            final UnsafeBufferEx b = new UnsafeBufferEx(new byte[]{1, 2, 3, 4});
+
+            assertEquals(a, b);
+            assertEquals(a.hashCode(), b.hashCode());
+        }
+
+        @Test
+        public void shouldNotBeEqualForDifferentContent()
+        {
+            final UnsafeBufferEx a = new UnsafeBufferEx(new byte[]{1, 2, 3});
+            final UnsafeBufferEx b = new UnsafeBufferEx(new byte[]{1, 2, 4});
+
+            assertFalse(a.equals(b));
+        }
+
+        @Test
+        public void shouldToString()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(new byte[32]);
+            assertEquals("UnsafeBufferEx{capacity=32}", buffer.toString());
+        }
+    }
+}

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExTest.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExTest.java
@@ -661,6 +661,72 @@ public class UnsafeBufferExTest
         }
 
         // -------------------------------------------------------------------
+        // Heap atomics — unsupported (native-only): byte[] cannot satisfy
+        // VarHandle alignment, so atomics throw rather than corrupt
+        // -------------------------------------------------------------------
+
+        @Test(expected = UnsupportedOperationException.class)
+        public void shouldRejectPutLongOrderedOnHeap()
+        {
+            new UnsafeBufferEx(new byte[64]).putLongOrdered(8, 1L);
+        }
+
+        @Test(expected = UnsupportedOperationException.class)
+        public void shouldRejectGetLongVolatileOnHeap()
+        {
+            new UnsafeBufferEx(new byte[64]).getLongVolatile(0);
+        }
+
+        @Test(expected = UnsupportedOperationException.class)
+        public void shouldRejectCompareAndSetLongOnHeap()
+        {
+            new UnsafeBufferEx(new byte[64]).compareAndSetLong(0, 0L, 1L);
+        }
+
+        @Test(expected = UnsupportedOperationException.class)
+        public void shouldRejectGetAndAddLongOnHeap()
+        {
+            new UnsafeBufferEx(new byte[64]).getAndAddLong(0, 1L);
+        }
+
+        @Test(expected = UnsupportedOperationException.class)
+        public void shouldRejectPutIntOrderedOnHeap()
+        {
+            new UnsafeBufferEx(new byte[64]).putIntOrdered(4, 1);
+        }
+
+        @Test(expected = UnsupportedOperationException.class)
+        public void shouldRejectGetAndAddIntOnHeap()
+        {
+            new UnsafeBufferEx(new byte[64]).getAndAddInt(0, 1);
+        }
+
+        // -------------------------------------------------------------------
+        // Native bounds checks — enabled by default (regression: CountersLayout)
+        // -------------------------------------------------------------------
+
+        @Test(expected = IndexOutOfBoundsException.class)
+        public void shouldThrowOnPutLongOrderedOutOfBoundsNative()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(8));
+            buffer.putLongOrdered(8, 1L);
+        }
+
+        @Test(expected = IndexOutOfBoundsException.class)
+        public void shouldThrowOnPutIntOutOfBoundsNative()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(8));
+            buffer.putInt(8, 1);
+        }
+
+        @Test(expected = IndexOutOfBoundsException.class)
+        public void shouldThrowOnGetLongOutOfBoundsNative()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(8));
+            buffer.getLong(4);
+        }
+
+        // -------------------------------------------------------------------
         // Comparable / equals / hashCode / toString
         // -------------------------------------------------------------------
 

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExTest.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExTest.java
@@ -867,5 +867,24 @@ public class UnsafeBufferExTest
             target.getBytes(0, readback);
             assertArrayEquals(payload, readback);
         }
+
+        @Test
+        public void shouldPutBytesFromByteBufferWithStaleSourceLimit()
+        {
+            // the index-based putBytes(ByteBuffer) contract copies by capacity, not NIO limit; a
+            // stale limit narrower than the requested range must not reject a valid copy
+            final ByteBuffer source = ByteBuffer.allocateDirect(64);
+            final byte[] payload = "bytebuffer-spanning-stale-limit".getBytes();
+            source.put(payload);
+            source.position(0);
+            source.limit(4);
+
+            final UnsafeBufferEx target = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+            target.putBytes(0, source, 0, payload.length);
+
+            final byte[] readback = new byte[payload.length];
+            target.getBytes(0, readback);
+            assertArrayEquals(payload, readback);
+        }
     }
 }

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExTest.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExTest.java
@@ -845,5 +845,27 @@ public class UnsafeBufferExTest
             final UnsafeBufferEx buffer = new UnsafeBufferEx(new byte[32]);
             assertEquals("UnsafeBufferEx{capacity=32}", buffer.toString());
         }
+
+        @Test
+        public void shouldPutBytesFromDirectBufferExWithStaleSourceLimit()
+        {
+            // Agrona treats the source's NIO ByteBuffer limit as scratch state independent of
+            // capacity (e.g. left dirty by CRC32.update); a putBytes spanning beyond the stale
+            // limit but within capacity must still copy the full range — see
+            // KafkaCachePartition.computeHash
+            final ByteBuffer sourceBb = ByteBuffer.allocateDirect(64);
+            final UnsafeBufferEx source = new UnsafeBufferEx(sourceBb);
+            final byte[] payload = "trailer-spanning-stale-limit".getBytes();
+            source.putBytes(0, payload);
+            sourceBb.position(0);
+            sourceBb.limit(4);
+
+            final UnsafeBufferEx target = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+            target.putBytes(0, source, 0, payload.length);
+
+            final byte[] readback = new byte[payload.length];
+            target.getBytes(0, readback);
+            assertArrayEquals(payload, readback);
+        }
     }
 }

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExTest.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExTest.java
@@ -727,6 +727,84 @@ public class UnsafeBufferExTest
         }
 
         // -------------------------------------------------------------------
+        // Release/acquire-only accessor lowering — fence-pair round-trips
+        // -------------------------------------------------------------------
+        // Cross-method coverage for the Lever 1 lowering: write via the release
+        // arm of one method, read via the acquire arm of another. On x86 (default
+        // zilla.buffer.aligned.atomics=false) the writer issues a releaseFence
+        // before a plain unaligned store and the reader does a plain unaligned
+        // load followed by an acquireFence; the fence pair must still preserve
+        // the value.
+
+        @Test
+        public void shouldRoundTripLongOrderedToLongAcquire()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putLongOrdered(0, 0xCAFEBABEDEADBEEFL);
+            assertEquals(0xCAFEBABEDEADBEEFL, buffer.getLongAcquire(0));
+        }
+
+        @Test
+        public void shouldRoundTripLongReleaseToLongVolatile()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putLongRelease(0, 0x0102030405060708L);
+            assertEquals(0x0102030405060708L, buffer.getLongVolatile(0));
+        }
+
+        @Test
+        public void shouldRoundTripIntOrderedToIntAcquire()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putIntOrdered(0, 0xDEADBEEF);
+            assertEquals(0xDEADBEEF, buffer.getIntAcquire(0));
+        }
+
+        @Test
+        public void shouldRoundTripIntReleaseToIntVolatile()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+
+            buffer.putIntRelease(0, 0xABCDEF01);
+            assertEquals(0xABCDEF01, buffer.getIntVolatile(0));
+        }
+
+        // Bounds-check coverage on the lowered native arm — these accessors run
+        // the SHOULD_BOUNDS_CHECK gate before the fence/store, so out-of-range
+        // index must still throw IndexOutOfBoundsException.
+
+        @Test(expected = IndexOutOfBoundsException.class)
+        public void shouldThrowOnPutLongReleaseOutOfBoundsNative()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(8));
+            buffer.putLongRelease(8, 1L);
+        }
+
+        @Test(expected = IndexOutOfBoundsException.class)
+        public void shouldThrowOnGetLongAcquireOutOfBoundsNative()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(8));
+            buffer.getLongAcquire(4);
+        }
+
+        @Test(expected = IndexOutOfBoundsException.class)
+        public void shouldThrowOnPutIntReleaseOutOfBoundsNative()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(4));
+            buffer.putIntRelease(4, 1);
+        }
+
+        @Test(expected = IndexOutOfBoundsException.class)
+        public void shouldThrowOnGetIntAcquireOutOfBoundsNative()
+        {
+            final UnsafeBufferEx buffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(4));
+            buffer.getIntAcquire(2);
+        }
+
+        // -------------------------------------------------------------------
         // Comparable / equals / hashCode / toString
         // -------------------------------------------------------------------
 

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExTest.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExTest.java
@@ -886,5 +886,27 @@ public class UnsafeBufferExTest
             target.getBytes(0, readback);
             assertArrayEquals(payload, readback);
         }
+
+        @Test
+        public void shouldPutBytesWithStaleDestinationLimit()
+        {
+            // ByteBuffer.put also bounds-checks the destination against its NIO limit; a write at
+            // an index beyond a stale destination limit but within capacity must still succeed
+            // (e.g. a mapped cache file whose limit was left dirty by CRC32.update)
+            final ByteBuffer destBb = ByteBuffer.allocateDirect(512);
+            final UnsafeBufferEx target = new UnsafeBufferEx(destBb);
+            destBb.position(0);
+            destBb.limit(8);
+
+            final byte[] payload = "written-beyond-stale-dest-limit".getBytes();
+            final UnsafeBufferEx source = new UnsafeBufferEx(ByteBuffer.allocateDirect(64));
+            source.putBytes(0, payload);
+
+            target.putBytes(450, source, 0, payload.length);
+
+            final byte[] readback = new byte[payload.length];
+            target.getBytes(450, readback);
+            assertArrayEquals(payload, readback);
+        }
     }
 }

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/concurrent/baseline/BaselineBufferEx.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/concurrent/baseline/BaselineBufferEx.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.common.agrona.concurrent.baseline;
+
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+
+import org.agrona.BufferUtil;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.AtomicBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+
+/**
+ * The original {@code sun.misc.Unsafe}-backed {@code UnsafeBufferEx}, preserved as a
+ * benchmark baseline. It subclasses Agrona's {@link UnsafeBuffer} and lazily derives a
+ * {@link MemorySegment} on each {@code wrap}, exactly as the implementation did before the
+ * {@code MemorySegment}/GLOBAL rewrite. Keeping it here lets {@code BufferBM} compare the
+ * current {@code UnsafeBufferEx} against the old {@code Unsafe} path directly, tracking
+ * for regressions without juggling a separate git worktree.
+ */
+public class BaselineBufferEx extends UnsafeBuffer implements AtomicBufferEx
+{
+    private MemorySegment segment;
+
+    public BaselineBufferEx()
+    {
+        super(new byte[0]);
+        this.segment = MemorySegment.ofArray(byteArray());
+    }
+
+    public BaselineBufferEx(
+        byte[] buffer)
+    {
+        super(buffer);
+        this.segment = MemorySegment.ofArray(buffer);
+    }
+
+    public BaselineBufferEx(
+        byte[] buffer,
+        int offset,
+        int length)
+    {
+        super(buffer, offset, length);
+        this.segment = MemorySegment.ofArray(buffer);
+    }
+
+    public BaselineBufferEx(
+        ByteBuffer buffer)
+    {
+        super(buffer);
+        this.segment = segmentOf(buffer);
+    }
+
+    public BaselineBufferEx(
+        ByteBuffer buffer,
+        int offset,
+        int length)
+    {
+        super(buffer, offset, length);
+        this.segment = segmentOf(buffer);
+    }
+
+    public BaselineBufferEx(
+        DirectBuffer buffer)
+    {
+        super(buffer);
+        this.segment = segmentOf(buffer);
+    }
+
+    public BaselineBufferEx(
+        DirectBuffer buffer,
+        int offset,
+        int length)
+    {
+        super(buffer, offset, length);
+        this.segment = segmentOf(buffer);
+    }
+
+    public BaselineBufferEx(
+        long address,
+        int length)
+    {
+        super(address, length);
+        this.segment = MemorySegment.ofAddress(address).reinterpret(length);
+    }
+
+    public BaselineBufferEx(
+        MemorySegment segment)
+    {
+        super(segment.asByteBuffer());
+        this.segment = segment;
+    }
+
+    public BaselineBufferEx(
+        MemorySegment segment,
+        int offset,
+        int length)
+    {
+        super(segment.asByteBuffer(), offset, length);
+        this.segment = segment;
+    }
+
+    @Override
+    public MemorySegment segment()
+    {
+        return segment;
+    }
+
+    @Override
+    public void wrap(
+        byte[] buffer)
+    {
+        super.wrap(buffer);
+        segment = MemorySegment.ofArray(buffer);
+    }
+
+    @Override
+    public void wrap(
+        byte[] buffer,
+        int offset,
+        int length)
+    {
+        super.wrap(buffer, offset, length);
+        segment = MemorySegment.ofArray(buffer);
+    }
+
+    @Override
+    public void wrap(
+        ByteBuffer buffer)
+    {
+        super.wrap(buffer);
+        segment = segmentOf(buffer);
+    }
+
+    @Override
+    public void wrap(
+        ByteBuffer buffer,
+        int offset,
+        int length)
+    {
+        super.wrap(buffer, offset, length);
+        segment = segmentOf(buffer);
+    }
+
+    @Override
+    public void wrap(
+        DirectBufferEx buffer)
+    {
+        super.wrap(buffer);
+        segment = buffer.segment();
+    }
+
+    @Override
+    public void wrap(
+        DirectBufferEx buffer,
+        int offset,
+        int length)
+    {
+        super.wrap(buffer, offset, length);
+        segment = buffer.segment();
+    }
+
+    @Override
+    public void wrap(
+        DirectBuffer buffer)
+    {
+        super.wrap(buffer);
+        segment = segmentOf(buffer);
+    }
+
+    @Override
+    public void wrap(
+        DirectBuffer buffer,
+        int offset,
+        int length)
+    {
+        super.wrap(buffer, offset, length);
+        segment = segmentOf(buffer);
+    }
+
+    @Override
+    public void wrap(
+        long address,
+        int length)
+    {
+        super.wrap(address, length);
+        segment = MemorySegment.ofAddress(address).reinterpret(length);
+    }
+
+    @Override
+    public void wrap(
+        MemorySegment segment)
+    {
+        super.wrap(segment.asByteBuffer());
+        this.segment = segment;
+    }
+
+    @Override
+    public void wrap(
+        MemorySegment segment,
+        int offset,
+        int length)
+    {
+        super.wrap(segment.asByteBuffer(), offset, length);
+        this.segment = segment;
+    }
+
+    @Override
+    public void getBytes(
+        int index,
+        MemorySegment dstSegment,
+        int dstIndex,
+        int length)
+    {
+        MemorySegment.copy(segment, JAVA_BYTE, wrapAdjustment() + index,
+            dstSegment, JAVA_BYTE, dstIndex, length);
+    }
+
+    @Override
+    public void putBytes(
+        int index,
+        DirectBufferEx srcBuffer,
+        int srcIndex,
+        int length)
+    {
+        super.putBytes(index, srcBuffer, srcIndex, length);
+    }
+
+    @Override
+    public void putBytes(
+        int index,
+        MemorySegment srcSegment,
+        int srcIndex,
+        int length)
+    {
+        MemorySegment.copy(srcSegment, JAVA_BYTE, srcIndex,
+            segment, JAVA_BYTE, wrapAdjustment() + index, length);
+    }
+
+    private static MemorySegment segmentOf(
+        ByteBuffer buffer)
+    {
+        return buffer.isDirect()
+            ? MemorySegment.ofAddress(BufferUtil.address(buffer)).reinterpret(buffer.capacity())
+            : MemorySegment.ofArray(BufferUtil.array(buffer));
+    }
+
+    private static MemorySegment segmentOf(
+        DirectBuffer buffer)
+    {
+        MemorySegment result;
+
+        if (buffer instanceof DirectBufferEx ex)
+        {
+            result = ex.segment();
+        }
+        else
+        {
+            final byte[] array = buffer.byteArray();
+            final ByteBuffer bb = buffer.byteBuffer();
+            if (array != null)
+            {
+                result = MemorySegment.ofArray(array);
+            }
+            else if (bb != null)
+            {
+                result = segmentOf(bb);
+            }
+            else
+            {
+                result = MemorySegment.ofAddress(buffer.addressOffset()).reinterpret(buffer.capacity());
+            }
+        }
+
+        return result;
+    }
+}

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/concurrent/bench/BufferBM.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/concurrent/bench/BufferBM.java
@@ -73,11 +73,13 @@ public class BufferBM
     @Param({"unsafe", "safe", "baseline"})
     private String impl;
 
+    @Param({"256", "1024", "4096", "16384"})
+    private int payload;
+
     @Setup(Level.Trial)
     public void init() throws IOException
     {
         final int capacity = 1024 * 1024 * 64 + TRAILER_LENGTH;
-        final int payload = 256;
 
         final File bufferFile = new File("target/benchmarks/baseline/buffer").getAbsoluteFile();
         createEmptyFile(bufferFile, capacity).close();

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/concurrent/bench/BufferBM.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/concurrent/bench/BufferBM.java
@@ -70,7 +70,7 @@ public class BufferBM
 
     private MutableDirectBufferEx writeBuffer;
 
-    @Param({"unsafe", "safe", "baseline"})
+    @Param({"unsafe", "safe", "baseline", "native"})
     private String impl;
 
     @Param({"256", "1024", "4096", "16384"})
@@ -167,6 +167,7 @@ public class BufferBM
         {
         case "safe" -> new SafeBuffer(byteBuffer);
         case "baseline" -> new BaselineBufferEx(byteBuffer);
+        case "native" -> new UnsafeBufferEx(byteBuffer).asNative();
         default -> new UnsafeBufferEx(byteBuffer);
         };
     }

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/concurrent/bench/BufferBM.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/concurrent/bench/BufferBM.java
@@ -54,6 +54,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.SafeBuffer;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.concurrent.ManyToOneRingBuffer;
+import io.aklivity.zilla.runtime.common.agrona.concurrent.baseline.BaselineBufferEx;
 
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.Throughput)
@@ -69,7 +70,7 @@ public class BufferBM
 
     private MutableDirectBufferEx writeBuffer;
 
-    @Param({"unsafe", "safe"})
+    @Param({"unsafe", "safe", "baseline"})
     private String impl;
 
     @Setup(Level.Trial)
@@ -163,6 +164,7 @@ public class BufferBM
         return switch (impl)
         {
         case "safe" -> new SafeBuffer(byteBuffer);
+        case "baseline" -> new BaselineBufferEx(byteBuffer);
         default -> new UnsafeBufferEx(byteBuffer);
         };
     }

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/concurrent/bench/BufferBM.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/concurrent/bench/BufferBM.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.aklivity.zilla.runtime.engine.internal.concurrent.bench;
+package io.aklivity.zilla.runtime.common.agrona.concurrent.bench;
 
 import static java.nio.ByteBuffer.allocateDirect;
 import static java.nio.ByteOrder.nativeOrder;

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/concurrent/bench/BufferCopyBM.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/concurrent/bench/BufferCopyBM.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.common.agrona.concurrent.bench;
+
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static java.nio.ByteBuffer.allocateDirect;
+import static java.nio.ByteOrder.nativeOrder;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+
+import org.agrona.BufferUtil;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import io.aklivity.zilla.runtime.common.agrona.concurrent.baseline.BaselineBufferEx;
+
+/**
+ * Isolates the cost of single bulk byte copies between two native segments at a
+ * range of payload sizes, comparing three variants used by Zilla's buffer
+ * implementations:
+ * <ul>
+ *   <li>{@code layout} — {@link MemorySegment#copy(MemorySegment, java.lang.foreign.ValueLayout,
+ *       long, MemorySegment, java.lang.foreign.ValueLayout, long, long)} with
+ *       {@link java.lang.foreign.ValueLayout#JAVA_BYTE} layouts. This is the
+ *       overload {@code UnsafeBufferEx.putBytes} currently calls on its
+ *       {@code DirectBufferEx} fast path.</li>
+ *   <li>{@code bulk} — {@link MemorySegment#copy(MemorySegment, long, MemorySegment, long, long)}.
+ *       The pure bulk-byte intrinsic — lowers to {@code Unsafe.copyMemory}.</li>
+ *   <li>{@code baseline} — Agrona's {@code UnsafeBuffer.putBytes} via the
+ *       preserved {@link BaselineBufferEx}, which is the {@code sun.misc.Unsafe}
+ *       implementation we are trying to match.</li>
+ * </ul>
+ * The hypothesis: {@code layout} has measurable per-call overhead vs {@code bulk},
+ * and that overhead accounts for the residual single-threaded gap in {@code BufferBM}
+ * that {@code BufferOpsBM} (single-word access only) cannot explain. If {@code bulk}
+ * matches {@code baseline} at all sizes, replacing the layout-form sites in
+ * {@code UnsafeBufferEx} closes the gap.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@Fork(3)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 10, time = 1)
+@OutputTimeUnit(NANOSECONDS)
+public class BufferCopyBM
+{
+    private MemorySegment srcSeg;
+    private MemorySegment dstSeg;
+    private ByteBuffer srcBb;
+    private ByteBuffer dstBb;
+    private BaselineBufferEx baselineSrc;
+    private BaselineBufferEx baselineDst;
+
+    @Param({"16", "64", "256", "1024", "4096", "16384"})
+    private int size;
+
+    @Setup
+    public void init()
+    {
+        final ByteBuffer src = allocateDirect(32768).order(nativeOrder());
+        final ByteBuffer dst = allocateDirect(32768).order(nativeOrder());
+        for (int i = 0; i < src.capacity(); i++)
+        {
+            src.put(i, (byte) (i & 0xff));
+        }
+
+        this.srcSeg = MemorySegment.ofAddress(BufferUtil.address(src)).reinterpret(src.capacity());
+        this.dstSeg = MemorySegment.ofAddress(BufferUtil.address(dst)).reinterpret(dst.capacity());
+        this.srcBb = src;
+        this.dstBb = dst;
+
+        this.baselineSrc = new BaselineBufferEx(src);
+        this.baselineDst = new BaselineBufferEx(dst);
+    }
+
+    @Benchmark
+    public void layout()
+    {
+        MemorySegment.copy(srcSeg, JAVA_BYTE, 0, dstSeg, JAVA_BYTE, 0, size);
+    }
+
+    @Benchmark
+    public void bulk()
+    {
+        MemorySegment.copy(srcSeg, 0, dstSeg, 0, size);
+    }
+
+    @Benchmark
+    public void byteBuffer()
+    {
+        dstBb.put(0, srcBb, 0, size);
+    }
+
+    @Benchmark
+    public void baseline()
+    {
+        baselineDst.putBytes(0, baselineSrc, 0, size);
+    }
+
+    public static void main(
+        String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+                .include(BufferCopyBM.class.getSimpleName())
+                .forks(0)
+                .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/concurrent/bench/BufferCopyBM.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/concurrent/bench/BufferCopyBM.java
@@ -76,6 +76,8 @@ public class BufferCopyBM
     private MemorySegment dstSeg;
     private ByteBuffer srcBb;
     private ByteBuffer dstBb;
+    private ByteBuffer srcBbView;
+    private ByteBuffer dstBbView;
     private BaselineBufferEx baselineSrc;
     private BaselineBufferEx baselineDst;
 
@@ -97,6 +99,13 @@ public class BufferCopyBM
         this.srcBb = src;
         this.dstBb = dst;
 
+        // clean duplicates held at position 0, limit capacity — the byteBufferView indirection
+        // UnsafeBufferEx.putBytes takes on its ByteBuffer.put fast path
+        this.srcBbView = src.duplicate();
+        this.srcBbView.clear();
+        this.dstBbView = dst.duplicate();
+        this.dstBbView.clear();
+
         this.baselineSrc = new BaselineBufferEx(src);
         this.baselineDst = new BaselineBufferEx(dst);
     }
@@ -117,6 +126,12 @@ public class BufferCopyBM
     public void byteBuffer()
     {
         dstBb.put(0, srcBb, 0, size);
+    }
+
+    @Benchmark
+    public void byteBufferView()
+    {
+        dstBbView.put(0, srcBbView, 0, size);
     }
 
     @Benchmark

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/concurrent/bench/BufferOpsBM.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/concurrent/bench/BufferOpsBM.java
@@ -15,12 +15,17 @@
  */
 package io.aklivity.zilla.runtime.common.agrona.concurrent.bench;
 
+import static java.lang.foreign.ValueLayout.JAVA_INT_UNALIGNED;
+import static java.lang.foreign.ValueLayout.JAVA_LONG_UNALIGNED;
 import static java.nio.ByteBuffer.allocateDirect;
 import static java.nio.ByteOrder.nativeOrder;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
+import java.lang.foreign.MemorySegment;
+import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 
+import org.agrona.BufferUtil;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -51,9 +56,9 @@ import io.aklivity.zilla.runtime.common.agrona.concurrent.baseline.BaselineBuffe
  * The hypothesis: plain primitive access ({@code JAVA_LONG_UNALIGNED}, no alignment
  * check) matches {@code Unsafe}, while ordered/volatile access goes through aligned
  * {@code VarHandle}s that carry a runtime 8-byte alignment check {@code Unsafe}'s
- * ordered ops lack. If so, {@code plain*} should be at parity across impls while
- * {@code ordered*} regresses on {@code unsafe} (and {@code safe}) relative to
- * {@code baseline}.
+ * ordered ops lack. {@code fenced*} prototypes a Lever 1 lowering — plain unaligned
+ * access plus a standalone {@code VarHandle.releaseFence}/{@code acquireFence} — to
+ * confirm it recovers the regression before changing the production accessors.
  * <p>
  * All variants run over a native (direct) buffer so {@code unsafe} takes the
  * {@code GLOBAL} path, matching the regressed {@code BufferBM} configuration.
@@ -66,7 +71,10 @@ import io.aklivity.zilla.runtime.common.agrona.concurrent.baseline.BaselineBuffe
 @OutputTimeUnit(NANOSECONDS)
 public class BufferOpsBM
 {
+    private static final MemorySegment GLOBAL = MemorySegment.NULL.reinterpret(Long.MAX_VALUE);
+
     private AtomicBufferEx buffer;
+    private long address;
     private long value = 0x0102030405060708L;
 
     @Param({"baseline", "unsafe", "safe"})
@@ -76,6 +84,7 @@ public class BufferOpsBM
     public void init()
     {
         final ByteBuffer byteBuffer = allocateDirect(256).order(nativeOrder());
+        this.address = BufferUtil.address(byteBuffer);
         this.buffer = switch (impl)
         {
         case "safe" -> new SafeBuffer(byteBuffer);
@@ -110,6 +119,26 @@ public class BufferOpsBM
     {
         buffer.putIntOrdered(0, (int)++value);
         return buffer.getIntVolatile(0);
+    }
+
+    @Benchmark
+    public long fencedLong()
+    {
+        VarHandle.releaseFence();
+        GLOBAL.set(JAVA_LONG_UNALIGNED, address, ++value);
+        final long got = GLOBAL.get(JAVA_LONG_UNALIGNED, address);
+        VarHandle.acquireFence();
+        return got;
+    }
+
+    @Benchmark
+    public int fencedInt()
+    {
+        VarHandle.releaseFence();
+        GLOBAL.set(JAVA_INT_UNALIGNED, address, (int)++value);
+        final int got = GLOBAL.get(JAVA_INT_UNALIGNED, address);
+        VarHandle.acquireFence();
+        return got;
     }
 
     public static void main(

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/concurrent/bench/BufferOpsBM.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/concurrent/bench/BufferOpsBM.java
@@ -77,7 +77,7 @@ public class BufferOpsBM
     private long address;
     private long value = 0x0102030405060708L;
 
-    @Param({"baseline", "unsafe", "safe"})
+    @Param({"baseline", "unsafe", "safe", "native"})
     private String impl;
 
     @Setup
@@ -89,6 +89,7 @@ public class BufferOpsBM
         {
         case "safe" -> new SafeBuffer(byteBuffer);
         case "baseline" -> new BaselineBufferEx(byteBuffer);
+        case "native" -> new UnsafeBufferEx(byteBuffer).asNative();
         default -> new UnsafeBufferEx(byteBuffer);
         };
     }

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/concurrent/bench/BufferOpsBM.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/concurrent/bench/BufferOpsBM.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.common.agrona.concurrent.bench;
+
+import static java.nio.ByteBuffer.allocateDirect;
+import static java.nio.ByteOrder.nativeOrder;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import java.nio.ByteBuffer;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.AtomicBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.SafeBuffer;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.concurrent.baseline.BaselineBufferEx;
+
+/**
+ * Factorial micro-benchmark isolating single-word buffer access from the ring-buffer
+ * machinery, to attribute the {@code BufferBM} single-threaded delta between the
+ * {@code Unsafe}-backed {@code baseline} and the FFM/{@code GLOBAL} {@code unsafe}
+ * implementation.
+ * <p>
+ * The hypothesis: plain primitive access ({@code JAVA_LONG_UNALIGNED}, no alignment
+ * check) matches {@code Unsafe}, while ordered/volatile access goes through aligned
+ * {@code VarHandle}s that carry a runtime 8-byte alignment check {@code Unsafe}'s
+ * ordered ops lack. If so, {@code plain*} should be at parity across impls while
+ * {@code ordered*} regresses on {@code unsafe} (and {@code safe}) relative to
+ * {@code baseline}.
+ * <p>
+ * All variants run over a native (direct) buffer so {@code unsafe} takes the
+ * {@code GLOBAL} path, matching the regressed {@code BufferBM} configuration.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@Fork(3)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 10, time = 1)
+@OutputTimeUnit(NANOSECONDS)
+public class BufferOpsBM
+{
+    private AtomicBufferEx buffer;
+    private long value = 0x0102030405060708L;
+
+    @Param({"baseline", "unsafe", "safe"})
+    private String impl;
+
+    @Setup
+    public void init()
+    {
+        final ByteBuffer byteBuffer = allocateDirect(256).order(nativeOrder());
+        this.buffer = switch (impl)
+        {
+        case "safe" -> new SafeBuffer(byteBuffer);
+        case "baseline" -> new BaselineBufferEx(byteBuffer);
+        default -> new UnsafeBufferEx(byteBuffer);
+        };
+    }
+
+    @Benchmark
+    public long plainLong()
+    {
+        buffer.putLong(0, ++value);
+        return buffer.getLong(0);
+    }
+
+    @Benchmark
+    public long orderedLong()
+    {
+        buffer.putLongOrdered(0, ++value);
+        return buffer.getLongVolatile(0);
+    }
+
+    @Benchmark
+    public int plainInt()
+    {
+        buffer.putInt(0, (int)++value);
+        return buffer.getInt(0);
+    }
+
+    @Benchmark
+    public int orderedInt()
+    {
+        buffer.putIntOrdered(0, (int)++value);
+        return buffer.getIntVolatile(0);
+    }
+
+    public static void main(
+        String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+                .include(BufferOpsBM.class.getSimpleName())
+                .forks(0)
+                .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/buffer/DefaultBufferPool.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/buffer/DefaultBufferPool.java
@@ -83,7 +83,7 @@ public class DefaultBufferPool implements BufferPool
         this.slotCount = slotCount;
         this.bitsPerSlot = numberOfTrailingZeros(slotCapacity);
         this.hashMask = slotCount - 1;
-        this.poolBuffer = new UnsafeBufferEx(poolByteBuffer);
+        this.poolBuffer = new UnsafeBufferEx(poolByteBuffer).asNative();
         this.slotByteBuffer = poolByteBuffer.duplicate();
 
         this.used = new BitSet(slotCount);

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/buffer/DefaultBufferPool.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/buffer/DefaultBufferPool.java
@@ -56,7 +56,7 @@ public class DefaultBufferPool implements BufferPool
         int slotCapacity)
     {
         this(slotCapacity, poolCapacity / slotCapacity,
-                ByteBuffer.allocate((slotCapacity + Long.BYTES) * poolCapacity / slotCapacity + Integer.BYTES));
+                ByteBuffer.allocateDirect((slotCapacity + Long.BYTES) * poolCapacity / slotCapacity + Integer.BYTES));
     }
 
     public DefaultBufferPool(

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/BudgetsLayout.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/BudgetsLayout.java
@@ -144,7 +144,7 @@ public final class BudgetsLayout implements AutoCloseable
 
             final MappedByteBuffer mapped = mapExistingFile(budgets, "budgets");
 
-            final AtomicBufferEx buffer = new UnsafeBufferEx(mapped);
+            final AtomicBufferEx buffer = new UnsafeBufferEx(mapped).asNative();
 
             return new BudgetsLayout(buffer);
         }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/EventsLayout.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/EventsLayout.java
@@ -65,7 +65,7 @@ public final class EventsLayout implements AutoCloseable
     public RingBufferSpy createSpy()
     {
         final MappedByteBuffer mappedBuffer = mapExistingFile(path.toFile(), "events");
-        final AtomicBufferEx atomicBuffer = new UnsafeBufferEx(mappedBuffer);
+        final AtomicBufferEx atomicBuffer = new UnsafeBufferEx(mappedBuffer).asNative();
         final OneToOneRingBufferSpy spy = new OneToOneRingBufferSpy(atomicBuffer);
         spy.spyAt(ZERO);
         return spy;
@@ -101,7 +101,7 @@ public final class EventsLayout implements AutoCloseable
             final File layoutFile = path.toFile();
             CloseHelper.close(createEmptyFile(layoutFile, capacity + RingBufferDescriptor.TRAILER_LENGTH));
             final MappedByteBuffer mappedBuffer = mapExistingFile(layoutFile, "events");
-            final AtomicBufferEx atomicBuffer = new UnsafeBufferEx(mappedBuffer);
+            final AtomicBufferEx atomicBuffer = new UnsafeBufferEx(mappedBuffer).asNative();
             final RingBufferEx ringBuffer = new OneToOneRingBuffer(atomicBuffer);
             return new EventsLayout(path, ringBuffer);
         }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/StreamsLayout.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/StreamsLayout.java
@@ -112,7 +112,7 @@ public final class StreamsLayout implements AutoCloseable
 
             final MappedByteBuffer mappedStreams = mapExistingFile(layoutFile, "streams");
 
-            final AtomicBufferEx atomicStreams = new UnsafeBufferEx(mappedStreams);
+            final AtomicBufferEx atomicStreams = new UnsafeBufferEx(mappedStreams).asNative();
 
             return new StreamsLayout(new ManyToOneRingBuffer(atomicStreams));
         }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/HistogramsLayout.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/HistogramsLayout.java
@@ -179,7 +179,7 @@ public final class HistogramsLayout extends MetricsLayout
             }
             FileChannel.MapMode mode = readonly ? READ_ONLY : READ_WRITE;
             MappedByteBuffer mappedBuffer = mapExistingFile(layoutFile, mode, HISTOGRAMS_LABEL);
-            final AtomicBufferEx atomicBuffer = new UnsafeBufferEx(mappedBuffer);
+            final AtomicBufferEx atomicBuffer = new UnsafeBufferEx(mappedBuffer).asNative();
             return new HistogramsLayout(atomicBuffer);
         }
     }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/ScalarsLayout.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/ScalarsLayout.java
@@ -143,7 +143,7 @@ public abstract class ScalarsLayout extends MetricsLayout
             }
             FileChannel.MapMode mode = readonly ? READ_ONLY : READ_WRITE;
             MappedByteBuffer mappedBuffer = mapExistingFile(layoutFile, mode, this.label);
-            final AtomicBufferEx atomicBuffer = new UnsafeBufferEx(mappedBuffer);
+            final AtomicBufferEx atomicBuffer = new UnsafeBufferEx(mappedBuffer).asNative();
             return constructor.apply(atomicBuffer);
         }
     }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -386,9 +386,6 @@ public class EngineWorker implements EngineContext, Agent
         this.readLimit = config.maximumMessagesPerRead();
         this.expireLimit = config.maximumExpirationsPerPoll();
         this.streamsBuffer = streamsLayout.streamsBuffer();
-        // off-heap and Native-specialized: per-worker frame composition skips the isNative branch
-        // and the aligned-VarHandle alignment check; bounds remain enforced by the flyweight
-        // builders that wrap this buffer
         this.writeBuffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(config.bufferSlotCapacity() + 1024)).asNative();
         this.streamSets = new Long2ObjectHashMap<>();
         this.streams = initDispatcher();

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -47,6 +47,7 @@ import static org.agrona.LangUtil.rethrowUnchecked;
 import static org.agrona.concurrent.AgentRunner.startOnThread;
 
 import java.net.InetAddress;
+import java.nio.ByteBuffer;
 import java.nio.channels.SelectableChannel;
 import java.nio.file.Path;
 import java.time.Clock;
@@ -385,7 +386,9 @@ public class EngineWorker implements EngineContext, Agent
         this.readLimit = config.maximumMessagesPerRead();
         this.expireLimit = config.maximumExpirationsPerPoll();
         this.streamsBuffer = streamsLayout.streamsBuffer();
-        this.writeBuffer = new UnsafeBufferEx(new byte[config.bufferSlotCapacity() + 1024]);
+        // off-heap so per-worker frame composition takes UnsafeBufferEx's unchecked native (GLOBAL) path;
+        // bounds remain enforced by the flyweight builders that wrap this buffer
+        this.writeBuffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(config.bufferSlotCapacity() + 1024));
         this.streamSets = new Long2ObjectHashMap<>();
         this.streams = initDispatcher();
         this.throttles = initDispatcher();

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -386,9 +386,10 @@ public class EngineWorker implements EngineContext, Agent
         this.readLimit = config.maximumMessagesPerRead();
         this.expireLimit = config.maximumExpirationsPerPoll();
         this.streamsBuffer = streamsLayout.streamsBuffer();
-        // off-heap so per-worker frame composition takes UnsafeBufferEx's unchecked native (GLOBAL) path;
-        // bounds remain enforced by the flyweight builders that wrap this buffer
-        this.writeBuffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(config.bufferSlotCapacity() + 1024));
+        // off-heap and Native-specialized: per-worker frame composition skips the isNative branch
+        // and the aligned-VarHandle alignment check; bounds remain enforced by the flyweight
+        // builders that wrap this buffer
+        this.writeBuffer = new UnsafeBufferEx(ByteBuffer.allocateDirect(config.bufferSlotCapacity() + 1024)).asNative();
         this.streamSets = new Long2ObjectHashMap<>();
         this.streams = initDispatcher();
         this.throttles = initDispatcher();

--- a/runtime/engine/src/main/moditect/module-info.java
+++ b/runtime/engine/src/main/moditect/module-info.java
@@ -49,7 +49,6 @@ module io.aklivity.zilla.runtime.engine
     requires transitive jakarta.json.bind;
     requires transitive org.agrona;
     requires jdk.management;
-    requires jdk.unsupported;
     requires java.management;
     requires java.net.http;
     requires transitive io.aklivity.zilla.runtime.common.agrona;

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/concurrent/bench/BufferBM.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/concurrent/bench/BufferBM.java
@@ -25,6 +25,7 @@ import static org.agrona.concurrent.ringbuffer.RingBufferDescriptor.TRAILER_LENG
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Random;
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -36,6 +37,7 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -49,6 +51,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import io.aklivity.zilla.runtime.common.agrona.buffer.AtomicBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.SafeBuffer;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.concurrent.ManyToOneRingBuffer;
 
@@ -66,6 +69,9 @@ public class BufferBM
 
     private MutableDirectBufferEx writeBuffer;
 
+    @Param({"unsafe", "safe"})
+    private String impl;
+
     @Setup(Level.Trial)
     public void init() throws IOException
     {
@@ -75,11 +81,11 @@ public class BufferBM
         final File bufferFile = new File("target/benchmarks/baseline/buffer").getAbsoluteFile();
         createEmptyFile(bufferFile, capacity).close();
 
-        this.buffer = new UnsafeBufferEx(mapExistingFile(bufferFile, "buffer"));
+        this.buffer = newBuffer(mapExistingFile(bufferFile, "buffer"));
         this.source = new ManyToOneRingBuffer(buffer);
         this.target = new ManyToOneRingBuffer(buffer);
 
-        this.writeBuffer = new UnsafeBufferEx(allocateDirect(payload).order(nativeOrder()));
+        this.writeBuffer = newBuffer(allocateDirect(payload).order(nativeOrder()));
         this.writeBuffer.setMemory(0, payload, (byte)new Random().nextInt(256));
     }
 
@@ -149,6 +155,16 @@ public class BufferBM
         {
             Thread.yield();
         }
+    }
+
+    private AtomicBufferEx newBuffer(
+        ByteBuffer byteBuffer)
+    {
+        return switch (impl)
+        {
+        case "safe" -> new SafeBuffer(byteBuffer);
+        default -> new UnsafeBufferEx(byteBuffer);
+        };
     }
 
     public static void main(


### PR DESCRIPTION
## Description

Refactors `UnsafeBufferEx` to use Java's Foreign Function and Memory API (`java.lang.foreign`) instead of `sun.misc.Unsafe`, eliminating the dependency on `jdk.unsupported`, and introduces a wrap-frozen `UnsafeBufferEx.Native` specialization adopted at every direct/mmap-backed engine call site.

### Key Changes

- **Removed inheritance from `UnsafeBuffer`**: `UnsafeBufferEx` now directly implements `AtomicBufferEx` and `MutableDirectBuffer`, managing its own state (byte array, ByteBuffer, address offset, capacity, etc.).
- **Dual-path memory access strategy**:
  - **Heap memory**: bounded per-instance `MemorySegment` with implicit JIT-elided bounds checks.
  - **Native (off-heap) memory**: process-wide `GLOBAL` segment spanning the entire address space for unchecked access matching `Unsafe` performance.
- **VarHandle-based atomics**: all atomic operations (volatile, CAS, ordered) use `VarHandle` access modes on the appropriate segment.
- **`UnsafeBufferEx.Native` inner class** — a `final` specialization returned by `asNative()` for direct-`ByteBuffer`-backed buffers. Truly-final fields (`segment`, `addressOffset`, `capacity`, `byteBuffer`), no `isNative` branch, and `wrap(...)` is unsupported on all eleven overloads so HotSpot can trust the final fields under `TrustFinalNonStaticFields`. `asNative()` asserts the segment is native and `byteBuffer != null && byteBuffer.isDirect()`; heap-backed callers are rejected at the boundary.
- **`putBytes` fast path via an internal `DirectBufferViewEx`**: every `putBytes` overload on both `UnsafeBufferEx` and `Native` copies through the intrinsified `ByteBuffer.put(int, ByteBuffer/byte[], int, int)`, which lowers to bare `Unsafe.copyMemory`. The wrinkle: `ByteBuffer.put` bounds-checks **both** the destination and source against their NIO `limit`, which Agrona treats as scratch state independent of capacity — a mapped cache buffer's `limit` is routinely left dirty by `CRC32/CRC32C.update(ByteBuffer)`, which would make the fast path wrongly reject a valid copy (and throw on the EngineWorker thread). The copy is therefore routed through `byteBufferView()`: a cached `ByteBuffer.duplicate()` held permanently at `position 0, limit capacity`, exposed via an internal **sealed** `DirectBufferViewEx` interface (permitting only `UnsafeBufferEx` and `Native`, so the `instanceof` devirtualizes). The duplicate is created once when the underlying buffer identity changes, reused on same-instance re-wrap, and inherited on sub-wrap — never allocated per copy. A stale NIO limit can never reject a valid copy, the fast path is always taken for ByteBuffer-backed buffers, and no caller (the kafka cache CRC paths included) needs to restore `position`/`limit`. Matches the previous `Unsafe` baseline at all payload sizes (16 B – 16 KiB) — see `BufferCopyBM` below.
- **Alignment-check guard dropped on the FFM ordered path**: ordered atomics use `releaseFence(); GLOBAL.set(JAVA_LONG_UNALIGNED, …)` instead of `JAVA_LONG.varHandle().setRelease(...)`. The release fence is a no-op on x86 TSO (zero instructions) and the same `dmb` barrier as `setRelease` on aarch64, while the per-op aligned-`VarHandle` alignment check is eliminated. Gated `false` by default via `zilla.buffer.aligned.atomics`.

### Native integration call sites

| Site | Backing | `.asNative()` |
|---|---|---|
| `EngineWorker.writeBuffer` | direct, per-worker frame composition | ✅ |
| `DefaultBufferPool.poolBuffer` | direct / mmap | ✅ |
| `StreamsLayout.atomicStreams` | mmap | ✅ |
| `EventsLayout` (build + spy) | mmap | ✅ |
| `BudgetsLayout` | mmap | ✅ |
| `ScalarsLayout` (counters/gauges) | mmap | ✅ |
| `HistogramsLayout` | mmap | ✅ |

Heap-backed `UnsafeBufferEx` instances (event-context heap `ByteBuffer`s, the `DefaultBufferPool` slot wrap stub, `EngineWorker.newSignalRW` heap builder) stay on the plain `UnsafeBufferEx` path. `asNative()` rejects them by contract.

**TLS scope**: `TlsClient/ServerFactory`'s four `ByteBuffer.allocate(...)` SSL bookends are passed directly to `SSLEngine.wrap/unwrap` — they're never wrapped in `UnsafeBufferEx`. The heap allocation is intentional so HotSpot's `SunJSSE` AES intrinsics operate on the backing arrays; a direct buffer would force a copy out to a thread-local heap scratch internally. The heap → direct copy that bridges TLS records into the per-worker ring uses the `ByteBuffer.put` fast path above (identical body in `UnsafeBufferEx` and `Native`). Native's win on the TLS path lives on the **destination** side: the ring/slot atomics on the mmap'd `StreamsLayout` and `DefaultBufferPool.poolBuffer`.

## Module hygiene

- `common-agrona` no longer references `sun.misc.Unsafe`; its `module-info` requires only `org.agrona` (no `requires jdk.unsupported`).
- Removed the now-dead `requires jdk.unsupported` from `engine` — it has no direct `sun.misc`/`sun.reflect`/`com.sun.nio.file` usage after the migration. `command-start` keeps it for `sun.misc.Signal` handling, and `jdk.unsupported` remains in the jlink image via `org.agrona` and `command-start`.
- The generated launcher's native-access grant is scoped to the one module that calls FFM restricted methods: `--enable-native-access=io.aklivity.zilla.runtime.common.agrona` (was `ALL-UNNAMED,…`).

## Bounds checking

- Native-path bounds checks use `Objects.checkFromIndexSize` inlined directly at each call site (not via a virtual method), so HotSpot intrinsifies and range-check-eliminates them.
- The check is gated on `zilla.buffer.bounds.checks` whose default is derived from module mode: enabled on the class path (unnamed module — unit and integration tests), disabled for the packaged named-module runtime (production unchecked `GLOBAL` fast path).
- Heap (`byte[]`) atomic operations throw `UnsupportedOperationException` — the JVM cannot guarantee `byte[]` alignment for `VarHandle` atomic access; native-backed buffers (direct `ByteBuffer`, mapped file, native `MemorySegment`) are required for atomics.

## Testing

- `UnsafeBufferExTest` covers round-trips across all backing kinds (heap array, heap array with offset, heap and direct `ByteBuffer`, direct with offset, heap and native `MemorySegment`), byte order conversions, byte-array / `MemorySegment` transfers, string encoding, atomics on native backings, and bounds checks on heap. Includes stale-NIO-limit regression tests (a dirty source/destination `limit` must never corrupt or reject a copy) that pin the `DirectBufferViewEx` behavior independently of the mechanism.
- `UnsafeBufferExNativeTest` pins `Native`'s contract: `asNative()` rejection of heap byte[], heap `ByteBuffer`, heap `MemorySegment`; `UnsupportedOperationException` from all eleven `wrap(...)` overloads; primitive, ordered, atomic-CAS, and `ByteBuffer`-source `putBytes` round-trips against a peer `UnsafeBufferEx` on the same memory.
- Full `binding-kafka` cache ITs (`CacheProduceIT`, `CacheMergedIT`) pass — these exercised the original stale-limit regression on the mapped cache write path; the `DirectBufferViewEx` change fixes them entirely in the buffer layer, with **no binding-kafka code changes**.
- Existing tests pass with the new implementation.

## Benchmarks

All benchmarks below run on a single toolchain — **JDK 25 (Homebrew OpenJDK 25.0.1), quiet aarch64 / Apple Silicon, macOS**, `-prof gc`, `zilla.buffer.aligned.atomics=false` (the production default) unless noted. Implementations compared via the `impl` param: `baseline` (the original `sun.misc.Unsafe`-backed buffer, preserved in-tree as `BaselineBufferEx` for regression tracking), `unsafe` (FFM/`GLOBAL` `UnsafeBufferEx`), `safe` (bounded-`MemorySegment` `SafeBuffer`), and `native` (the wrap-frozen `UnsafeBufferEx.Native`). `BaselineBufferEx` lives under `runtime/common-agrona/src/test/.../concurrent/baseline/` so old-vs-new runs from a single `org.openjdk.jmh.Main BufferBM` invocation, no separate worktree.

### `BufferBM` — `ManyToOneRingBuffer` over an mmap'd file + direct payload (throughput, M ops/s; 5 forks × 10 iterations)

**payload = 256 B**

| shape | baseline | unsafe | safe | native |
|---|---|---|---|---|
| single | 65.23 | 61.00 (−6.5%) | 46.69 (−28.4%) | **64.69 (−0.8%)** |
| batched | 63.86 | 60.14 (−5.8%) | 46.28 (−27.5%) | **63.37 (−0.8%)** |
| multiple (2W+1R) | 14.54 | 14.81 (+1.9%) | 15.04 (+3.5%) | **14.66 (+0.8%)** |

**payload = 4096 B**

| shape | baseline | unsafe | safe | native |
|---|---|---|---|---|
| single | 9.245 | 8.863 (−4.1%) | 6.418 (−30.6%) | **8.910 (−3.6%)** |
| batched | 9.005 | 8.475 (−5.9%) | 6.332 (−29.7%) | **8.682 (−3.6%)** |
| multiple (2W+1R) | 9.396 | 11.20 (+19.2%) | 10.90 (+16.0%) | **11.17 (+18.9%)** |
| multiple:writer | 5.958 | 7.469 (+25.4%) | 7.207 (+21.0%) | **7.409 (+24.4%)** |

- **Single/batched: `native` ≈ `baseline`** (−0.8% at 256 B, −3.6% at 4 KB); `unsafe` trails ~4–6%, `safe` ~28–31%. `native` recovers essentially all of `unsafe`'s single-threaded gap.
- **Contended (`multiple`) — the EngineWorker cross-thread frame path, i.e. the production shape: every FFM impl matches or beats `baseline`, and the lead grows with payload** — ~+1–3% at 256 B to **+16–19% at 4 KB** (`native` +18.9%, +24% on the writer). Atomics there are bound by cross-core cache-line traffic, which the FFM copy + ring path overlaps better than the `Unsafe` baseline.
- **`safe` converges under contention** — −28% single-threaded but **+16% over `baseline` contended at 4 KB** — the signal to watch as later JDKs (and Valhalla value `MemorySegment`s) close the bounded-access gap, at which point `SafeBuffer` could replace `UnsafeBufferEx`.
- **~0 B/op** in all modes (`gc.alloc.rate.norm` ≈ 10⁻³–10⁻⁴), ≈0 GC.

### `BufferCopyBM` — single bulk copy between two native buffers (avg time, ns/op; 3 forks × 10 iterations)

`byteBuffer` = `ByteBuffer.put` on the original buffer; `byteBufferView` = `ByteBuffer.put` through the cached `duplicate()` (the production `putBytes` path); `layout` = `MemorySegment.copy(JAVA_BYTE)` (the slow-path fallback).

| size (B) | baseline (Unsafe) | byteBuffer | byteBufferView | layout |
|---|---|---|---|---|
| 16    | 2.699 | 2.710 | **2.721** | 3.136 |
| 64    | 2.728 | 2.718 | **2.736** | 3.377 |
| 256   | 5.393 | 5.425 | **5.561** | 5.645 |
| 1024  | 12.432 | 12.449 | **12.300** | 12.557 |
| 4096  | 47.278 | 47.166 | **46.309** | 46.276 |
| 16384 | 350.96 | 342.38 | **307.47** | 280.98 |

- **The duplicate is free**: `byteBufferView` tracks `byteBuffer` and `baseline` within noise at every size, `gc.alloc.rate.norm` ≈ 0 — the view is built once at wrap, never on the copy path.
- **The fast path is justified**: `layout` carries a fixed ~0.4–0.6 ns per-call overhead that dominates at small payloads — **16% slower at 16 B, 24% at 64 B** — fading to parity by ~4 KB. Small frames (headers, small Kafka records) are the hot case, so this is where `ByteBuffer.put` pays off. At 16 KB bulk-copy bandwidth dominates and the per-call cost is fully amortized (the FFM paths even edge ahead, within the larger error there).
- **Future cleanup signal**: when `MemorySegment.copy` closes the small-payload gap on a later JDK, the `byteBufferView` / `DirectBufferViewEx` indirection can be removed as an internal-only change — each `putBytes` overload collapses back to its plain `MemorySegment.copy` else-branch. The `byteBufferView` benchmark variant and the stale-limit regression tests guard that decision.

### `BufferOpsBM` — single-word access attribution (avg time, ns/op; 3 forks × 10 iterations)

The ordered-op columns separate the FFM aligned-`VarHandle` path (`zilla.buffer.aligned.atomics=true`) from the production fenced lowering (default `false`).

| Op | baseline (Unsafe) | unsafe (FFM GLOBAL, aligned) | unsafe (fenced lowering) | native (ships) |
|---|---|---|---|---|
| `plainLong`   | 0.85 | 0.94 | 0.94 | **0.86** |
| `orderedLong` | 1.41 | 1.80 | 1.57 | **1.30** |

- **Plain access** is at `Unsafe` parity once the `isNative` branch is gone — `native` 0.86 vs `baseline` 0.85; plain `unsafe` pays ~+0.10 ns for the branch. (Plain access is unaffected by `aligned.atomics`, so both `unsafe` columns match.)
- **Ordered access**: the aligned `VarHandle` path costs +0.40 ns over `Unsafe` (1.80 vs 1.41 — the original regression); the `releaseFence + JAVA_LONG_UNALIGNED` lowering recovers most of it (1.57), and `native` (final fields + fenced lowering) lands *below* `baseline` at 1.30. `safe`'s bounded ordered path is 2.27 ns. `int` variants track `long` within noise.
- The raw fenced primitive (`fencedLong`, impl-independent) measures ~1.07 ns — the floor the lowering builds on. **~0 B/op** throughout.

https://claude.ai/code/session_01VichVQdUSfJyKcYVvdT2yp