### PR TITLE
chore(binding-asyncapi): remove unused Jackson dependency

### DIFF
--- a/runtime/binding-asyncapi/NOTICE
+++ b/runtime/binding-asyncapi/NOTICE
@@ -11,12 +11,7 @@ specific language governing permissions and limitations under the License.
 
 This project includes:
   agrona under The Apache License, Version 2.0
-  Jackson-annotations under The Apache Software License, Version 2.0
-  Jackson-core under The Apache Software License, Version 2.0
-  jackson-databind under The Apache Software License, Version 2.0
-  Jackson-dataformat-YAML under The Apache Software License, Version 2.0
   Jakarta JSON Processing API under Eclipse Public License 2.0 or GNU General Public License, version 2 with the GNU Classpath Exception
-  SnakeYAML under Apache License, Version 2.0
   zilla::runtime::common-agrona under The Apache Software License, Version 2.0
   zilla::runtime::common-json under Aklivity Community License Agreement
   zilla::runtime::common-yaml under Aklivity Community License Agreement

--- a/runtime/binding-asyncapi/pom.xml
+++ b/runtime/binding-asyncapi/pom.xml
@@ -148,11 +148,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.16.1</version>
-    </dependency>
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>engine</artifactId>
       <type>test-jar</type>

--- a/runtime/binding-openapi-asyncapi/NOTICE
+++ b/runtime/binding-openapi-asyncapi/NOTICE
@@ -11,12 +11,7 @@ specific language governing permissions and limitations under the License.
 
 This project includes:
   agrona under The Apache License, Version 2.0
-  Jackson-annotations under The Apache Software License, Version 2.0
-  Jackson-core under The Apache Software License, Version 2.0
-  jackson-databind under The Apache Software License, Version 2.0
-  Jackson-dataformat-YAML under The Apache Software License, Version 2.0
   Jakarta JSON Processing API under Eclipse Public License 2.0 or GNU General Public License, version 2 with the GNU Classpath Exception
-  SnakeYAML under Apache License, Version 2.0
   zilla::runtime::binding-asyncapi under Aklivity Community License Agreement
   zilla::runtime::binding-http under The Apache Software License, Version 2.0
   zilla::runtime::binding-http-kafka under Aklivity Community License Agreement


### PR DESCRIPTION
The asyncapi parser uses common-yaml (YamlJson), a pure jakarta.json
YAML provider, so the jackson-dataformat-yaml dependency was dead and
pulled Jackson plus SnakeYAML transitively. Removing it also clears
Jackson from binding-openapi-asyncapi, which inherited it via
binding-asyncapi. binding-openapi never declared Jackson.

Regenerated the NOTICE files for both affected modules via
notice:generate.

Fixes #1967 

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S13xvNhf2ptUDFro8RpCoB