### PR TITLE
Enforce --sun-misc-unsafe-memory-access=deny

### DIFF
--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
@@ -759,7 +759,8 @@ public final class ZpmInstall extends ZpmCommand
             "JAVA_OPTIONS=\"$JAVA_OPTIONS -Dzilla.directory=$ZILLA_DIRECTORY\"",
             "JAVA_OPTIONS=\"$JAVA_OPTIONS --add-opens java.base/jdk.internal.misc=ALL-UNNAMED " +
                 "--add-opens java.base/jdk.internal.misc=org.agrona " +
-                "--enable-native-access=io.aklivity.zilla.runtime.common.agrona\"",
+                "--enable-native-access=io.aklivity.zilla.runtime.common.agrona " +
+                "--sun-misc-unsafe-memory-access=deny\"",
             String.format(String.join(" ", Arrays.asList(
                     "exec $ZILLA_DIRECTORY/%s/bin/java",
                     "$JAVA_OPTIONS",

--- a/pom.xml
+++ b/pom.xml
@@ -446,7 +446,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.0.0-M5</version>
           <configuration>
-            <argLine>@{jacoco.java.option} -Xshare:off -Djdk.attach.allowAttachSelf=true -XX:+StartAttachListener --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --enable-native-access=ALL-UNNAMED -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
+            <argLine>@{jacoco.java.option} -Xshare:off -Djdk.attach.allowAttachSelf=true -XX:+StartAttachListener --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=deny -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
           </configuration>
           <dependencies>
             <dependency>
@@ -466,7 +466,7 @@
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>3.0.0-M4</version>
           <configuration>
-            <argLine>@{jacoco.java.option} -Xshare:off -Djdk.attach.allowAttachSelf=true -XX:+StartAttachListener --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --enable-native-access=ALL-UNNAMED -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
+            <argLine>@{jacoco.java.option} -Xshare:off -Djdk.attach.allowAttachSelf=true -XX:+StartAttachListener --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=deny -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
           </configuration>
           <dependencies>
             <dependency>


### PR DESCRIPTION
## Description

Adds `--sun-misc-unsafe-memory-access=deny` to the generated `zilla` launcher (`ZpmInstall.generateLauncher`) and to the surefire/failsafe `argLine`s, so the runtime and the test suite refuse any `sun.misc.Unsafe` memory-access call (JEP 498) rather than silently warning.

### Motivation

After #1968 migrated `UnsafeBufferEx` to the Foreign Function & Memory API, Zilla's own code no longer uses `sun.misc.Unsafe`. The remaining `Unsafe` usage is in Agrona — and Agrona 2.4.0 uses **`jdk.internal.misc.Unsafe`** (gated by `--add-opens java.base/jdk.internal.misc`, already granted in the launcher), **not** `sun.misc.Unsafe` (gated by `--sun-misc-unsafe-memory-access`). They are different classes governed by different mechanisms.

So nothing in the runtime is expected to call a `sun.misc.Unsafe` memory-access method. This change makes that an **enforced invariant** instead of an assumption: any such call — now or introduced by a future change/dependency — fails fast (`UnsupportedOperationException`) instead of warning. This PR is primarily a **verification gate** — the value is the full CI matrix and the examples run (which exercise the assembled jlink image) confirming the runtime is clean under `deny`.

### Verification done locally

- Probed the mmap teardown path directly: `IoUtil.unmap()` (a `MappedByteBuffer`) **succeeds** under `--sun-misc-unsafe-memory-access=deny` with the launcher's `--add-opens`, because it routes through `jdk.internal.misc.Unsafe.invokeCleaner`, not `sun.misc.Unsafe`. A control calling `sun.misc.Unsafe.allocateMemory` under the same flag throws `UnsupportedOperationException`, confirming the flag is enforcing.
- `runtime/common-agrona` unit tests (273) pass under the new `deny` argLine — covers the FFM `UnsafeBufferEx`/`Native` paths and the Agrona-backed `BaselineBufferEx`.
- `manager` builds (launcher change compiles).

### Scope

- Deny-clean only. This does **not** remove `jdk.unsupported` from the image — that stays via `org.agrona` and `command-start`'s `sun.misc.Signal` — and does not change any buffer/mmap code.

### Changes

- `manager/.../install/ZpmInstall.java` — append `--sun-misc-unsafe-memory-access=deny` to the generated launcher's `JAVA_OPTIONS`.
- `pom.xml` — append the same flag to the surefire and failsafe `argLine`s.

Fixes # (issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VichVQdUSfJyKcYVvdT2yp)_