### PR TITLE
fix(manager): generate delegate module-info with strict jdeps validation

### DIFF
--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
@@ -30,6 +30,7 @@ import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -56,7 +57,6 @@ import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -226,7 +226,8 @@ public final class ZpmInstall extends ZpmCommand
 
             if (!delegate.paths.isEmpty())
             {
-                generateDelegate(logger, delegate);
+                Collection<ZpmArtifact> optional = cache.resolveOptional(config.imports, config.dependencies);
+                generateDelegate(logger, delegate, optional);
                 generateDelegating(modules);
             }
 
@@ -511,13 +512,155 @@ public final class ZpmInstall extends ZpmCommand
 
     private void generateDelegate(
         ConsoleLogger logger,
-        ZpmModule delegate) throws IOException
+        ZpmModule delegate,
+        Collection<ZpmArtifact> optional) throws IOException
     {
         Path generatedModulesDir = generatedDir.resolve("modules");
         Path generatedDelegateDir = generatedModulesDir.resolve(delegate.name);
         Files.createDirectories(generatedModulesDir);
 
         Path generatedDelegatePath = generatedModulesDir.resolve(String.format("%s.jar", delegate.name));
+        generateDelegateJar(delegate, generatedDelegatePath);
+
+        // Merge the optional dependency tree resolved via Aether into a single validation-only module so
+        // jdeps can resolve the delegate's static references to optional third-party libraries (for
+        // example Netty's Brotli/LZ4/Zstd/Protobuf codecs). As one flat automatic module it avoids the
+        // split-package and inter-module resolution failures of supplying the optional jars separately,
+        // and lets jdeps run strictly: any reference not satisfied by the delegate or this module is a
+        // genuinely missing dependency rather than one silently ignored.
+        Path optionalModulesDir = generatedDir.resolve("optional-modules");
+        deleteDirectories(optionalModulesDir);
+        Files.createDirectories(optionalModulesDir);
+        String optionalName = String.format("%s.optional", delegate.name);
+        Path optionalPath = optionalModulesDir.resolve(String.format("%s.jar", optionalName));
+        generateDelegateOptional(optionalPath, optional, jarPackages(generatedDelegatePath));
+
+        deleteDirectories(generatedDelegateDir);
+
+        Path generatedModuleInfo = generatedDelegateDir.resolve(MODULE_INFO_JAVA_FILENAME);
+        ToolProvider jdeps = ToolProvider.findFirst("jdeps").get();
+
+        boolean strict = !ignoreMissingDependencies;
+        if (strict)
+        {
+            int result = jdeps.run(
+                System.out,
+                System.err,
+                "--generate-module-info", generatedModulesDir.toString(),
+                "--module-path", optionalModulesDir.toString(),
+                generatedDelegatePath.toString());
+            strict = result == 0 && Files.exists(generatedModuleInfo);
+        }
+
+        if (!strict)
+        {
+            // jdeps could not resolve every reference against the optional dependency tree (for example
+            // offline with an incomplete tree); fall back to generating while ignoring missing
+            // dependencies and report what forced the fallback so accidental prunes remain visible
+            Set<String> missing = missingDependencies(generatedDelegatePath, optionalModulesDir);
+            if (!missing.isEmpty())
+            {
+                String details = missing.stream()
+                    .sorted()
+                    .map(c -> String.format("    %s", c))
+                    .collect(Collectors.joining("\n"));
+                logger.warn(String.format(
+                    "delegate module references %d dependencies not resolved by the optional dependency tree;" +
+                    " generating module info while ignoring them:%n%s", missing.size(), details));
+            }
+            deleteDirectories(generatedDelegateDir);
+            jdeps.run(
+                System.out,
+                System.err,
+                "--generate-module-info", generatedModulesDir.toString(),
+                "--ignore-missing-deps",
+                generatedDelegatePath.toString());
+        }
+
+        if (!Files.exists(generatedModuleInfo))
+        {
+            throw new IOException("Failed to generate module info for delegate module");
+        }
+
+        logger.info(String.format("Generated module info for delegate module\n"));
+
+        String moduleInfoContents = Files.readString(generatedModuleInfo);
+
+        // drop the requires on the validation-only optional module; it is never linked into the image
+        moduleInfoContents = moduleInfoContents.replaceAll(
+            String.format("(?m)^\\s*requires\\s+(transitive\\s+)?%s\\s*;\\R?", Pattern.quote(optionalName)), "");
+
+        // keep only service providers whose service interface is present in the delegate module, pruning
+        // phantom provides declarations whose interface lives solely in the optional dependency tree
+        Set<String> delegateClasses = jarClasses(generatedDelegatePath);
+        Pattern providesPattern = Pattern.compile("(?m)^\\s*provides\\s+([^\\s;]+)\\s+with\\s+[^;]+;\\R?");
+        Matcher providesMatcher = providesPattern.matcher(moduleInfoContents);
+        StringBuilder cleanedModuleInfo = new StringBuilder();
+
+        List<String> uses = new ArrayList<>();
+
+        while (providesMatcher.find())
+        {
+            String serviceInterface = providesMatcher.group(1);
+            if (delegateClasses.contains(serviceInterface))
+            {
+                providesMatcher.appendReplacement(cleanedModuleInfo, Matcher.quoteReplacement(providesMatcher.group(0)));
+                uses.add(String.format("    uses %s;", serviceInterface));
+            }
+            else
+            {
+                providesMatcher.appendReplacement(cleanedModuleInfo, "");
+            }
+        }
+        providesMatcher.appendTail(cleanedModuleInfo);
+        moduleInfoContents = cleanedModuleInfo.toString();
+
+        if (!uses.isEmpty())
+        {
+            int lastBraceIndex = moduleInfoContents.lastIndexOf('}');
+            if (lastBraceIndex != -1)
+            {
+                moduleInfoContents = moduleInfoContents.substring(0, lastBraceIndex) +
+                    String.join("\n", uses) +
+                    "\n}";
+            }
+        }
+
+        Files.writeString(generatedModuleInfo, moduleInfoContents);
+
+        expandJar(generatedDelegateDir, generatedDelegatePath);
+
+        ToolProvider javac = ToolProvider.findFirst("javac").get();
+
+        List<String> args = new ArrayList<>();
+        if (atLeastVersion(javac, 21))
+        {
+            args.add("-proc:none");
+        }
+
+        args.add("-d");
+        args.add(generatedDelegateDir.toString());
+
+        args.add(generatedModuleInfo.toString());
+
+        javac.run(
+            System.out,
+            System.err,
+            args.toArray(String[]::new));
+
+        Path compiledModuleInfo = generatedDelegateDir.resolve(MODULE_INFO_CLASS_FILENAME);
+        assert Files.exists(compiledModuleInfo);
+
+        Path delegatePath = modulePath(delegate);
+        JarEntry moduleInfoEntry = new JarEntry(MODULE_INFO_CLASS_FILENAME);
+        moduleInfoEntry.setTime(318240000000L);
+        extendJar(generatedDelegatePath, delegatePath, moduleInfoEntry, compiledModuleInfo);
+    }
+
+    private void generateDelegateJar(
+        ZpmModule delegate,
+        Path generatedDelegatePath) throws IOException
+    {
         try (JarOutputStream moduleJar = new JarOutputStream(Files.newOutputStream(generatedDelegatePath)))
         {
             Path moduleInfoPath = Paths.get(MODULE_INFO_CLASS_FILENAME);
@@ -581,104 +724,134 @@ public final class ZpmInstall extends ZpmCommand
                 moduleJar.closeEntry();
             }
         }
+    }
 
-        List<String> jdepsArgs = Arrays.asList(
-            "--generate-module-info", generatedModulesDir.toString(),
-            generatedDelegatePath.toString());
-        if (ignoreMissingDependencies)
+    private void generateDelegateOptional(
+        Path optionalPath,
+        Collection<ZpmArtifact> optional,
+        Set<String> delegatePackages) throws IOException
+    {
+        // packages owned by JDK system modules must be excluded, otherwise the merged automatic module
+        // would split a package the boot layer already exports (for example javax.xml)
+        Set<String> systemPackages = ModuleFinder.ofSystem().findAll().stream()
+            .flatMap(reference -> reference.descriptor().packages().stream())
+            .collect(Collectors.toSet());
+
+        Set<String> entryNames = new HashSet<>();
+        try (JarOutputStream optionalJar = new JarOutputStream(Files.newOutputStream(optionalPath)))
         {
-            jdepsArgs = new LinkedList<>(jdepsArgs);
-            jdepsArgs.add(0, "--ignore-missing-deps");
+            for (ZpmArtifact artifact : optional)
+            {
+                Path path = artifact.path;
+                if (path == null || !Files.exists(path))
+                {
+                    continue;
+                }
+
+                try (JarFile artifactJar = new JarFile(path.toFile()))
+                {
+                    for (JarEntry entry : list(artifactJar.entries()))
+                    {
+                        String entryName = entry.getName();
+                        if (entry.isDirectory() ||
+                            !entryName.endsWith(".class") ||
+                            entryName.endsWith(MODULE_INFO_CLASS_FILENAME) ||
+                            entryName.startsWith("META-INF/"))
+                        {
+                            continue;
+                        }
+
+                        int lastSlash = entryName.lastIndexOf('/');
+                        String packageName = lastSlash < 0 ? "" : entryName.substring(0, lastSlash).replace('/', '.');
+                        if (delegatePackages.contains(packageName) ||
+                            systemPackages.contains(packageName) ||
+                            !entryNames.add(entryName))
+                        {
+                            continue;
+                        }
+
+                        try (InputStream input = artifactJar.getInputStream(entry))
+                        {
+                            JarEntry newEntry = new JarEntry(entryName);
+                            newEntry.setTime(318240000000L);
+                            optionalJar.putNextEntry(newEntry);
+                            optionalJar.write(input.readAllBytes());
+                            optionalJar.closeEntry();
+                        }
+                    }
+                }
+                catch (IOException ex)
+                {
+                    // ignore artifacts that are not readable jars (for example sources or native
+                    // classifier archives); they cannot contribute classes to the validation module
+                }
+            }
         }
+    }
+
+    private Set<String> missingDependencies(
+        Path delegatePath,
+        Path optionalModulesDir)
+    {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        PrintStream capture = new PrintStream(buffer);
+        PrintStream nullOutput = new PrintStream(nullOutputStream());
         ToolProvider jdeps = ToolProvider.findFirst("jdeps").get();
         jdeps.run(
-            System.out,
-            System.err,
-            jdepsArgs.toArray(String[]::new));
+            capture,
+            nullOutput,
+            "--missing-deps",
+            "--module-path", optionalModulesDir.toString(),
+            delegatePath.toString());
 
-        Path generatedModuleInfo = generatedDelegateDir.resolve(MODULE_INFO_JAVA_FILENAME);
-
-        if (!Files.exists(generatedModuleInfo))
+        Pattern missingPattern = Pattern.compile("->\\s+(\\S+)\\s+not found");
+        Matcher missingMatcher = missingPattern.matcher(buffer.toString(UTF_8));
+        Set<String> missing = new HashSet<>();
+        while (missingMatcher.find())
         {
-            throw new IOException("Failed to generate module info for delegate module");
+            missing.add(missingMatcher.group(1));
         }
+        return missing;
+    }
 
-        logger.info(String.format("Generated module info for delegate module\n"));
-
-        String moduleInfoContents = Files.readString(generatedModuleInfo);
-
-        Pattern providesPattern = Pattern.compile("(?m)^\\s*provides\\s+([^\\s;]+)\\s+with\\s+[^;]+;\\R?");
-        Matcher providesMatcher = providesPattern.matcher(moduleInfoContents);
-        StringBuilder cleanedModuleInfo = new StringBuilder();
-
-        List<String> uses = new ArrayList<>();
-
-        while (providesMatcher.find())
+    private Set<String> jarPackages(
+        Path path) throws IOException
+    {
+        Set<String> packages = new HashSet<>();
+        try (JarFile jar = new JarFile(path.toFile()))
         {
-            String serviceInterface = providesMatcher.group(1);
-            boolean serviceClassPresent = false;
-            try
+            for (JarEntry entry : list(jar.entries()))
             {
-                Class.forName(serviceInterface, false, this.getClass().getClassLoader());
-                serviceClassPresent = true;
-            }
-            catch (ClassNotFoundException e)
-            {
-                serviceClassPresent = false;
-            }
-            if (serviceClassPresent)
-            {
-                providesMatcher.appendReplacement(cleanedModuleInfo, providesMatcher.group(0));
-                uses.add(String.format("    uses %s;", serviceInterface));
-            }
-            else
-            {
-                providesMatcher.appendReplacement(cleanedModuleInfo, "");
+                String name = entry.getName();
+                if (!entry.isDirectory() && name.endsWith(".class"))
+                {
+                    int lastSlash = name.lastIndexOf('/');
+                    if (lastSlash > 0)
+                    {
+                        packages.add(name.substring(0, lastSlash).replace('/', '.'));
+                    }
+                }
             }
         }
-        providesMatcher.appendTail(cleanedModuleInfo);
-        moduleInfoContents = cleanedModuleInfo.toString();
+        return packages;
+    }
 
-        if (!uses.isEmpty())
+    private Set<String> jarClasses(
+        Path path) throws IOException
+    {
+        Set<String> classes = new HashSet<>();
+        try (JarFile jar = new JarFile(path.toFile()))
         {
-            int lastBraceIndex = moduleInfoContents.lastIndexOf('}');
-            if (lastBraceIndex != -1)
+            for (JarEntry entry : list(jar.entries()))
             {
-                moduleInfoContents = moduleInfoContents.substring(0, lastBraceIndex) +
-                    String.join("\n", uses) +
-                    "\n}";
+                String name = entry.getName();
+                if (!entry.isDirectory() && name.endsWith(".class") && !name.endsWith(MODULE_INFO_CLASS_FILENAME))
+                {
+                    classes.add(name.substring(0, name.length() - ".class".length()).replace('/', '.'));
+                }
             }
         }
-
-        Files.writeString(generatedModuleInfo, moduleInfoContents);
-
-        expandJar(generatedDelegateDir, generatedDelegatePath);
-
-        ToolProvider javac = ToolProvider.findFirst("javac").get();
-
-        List<String> args = new ArrayList<>();
-        if (atLeastVersion(javac, 21))
-        {
-            args.add("-proc:none");
-        }
-
-        args.add("-d");
-        args.add(generatedDelegateDir.toString());
-
-        args.add(generatedModuleInfo.toString());
-
-        javac.run(
-            System.out,
-            System.err,
-            args.toArray(String[]::new));
-
-        Path compiledModuleInfo = generatedDelegateDir.resolve(MODULE_INFO_CLASS_FILENAME);
-        assert Files.exists(compiledModuleInfo);
-
-        Path delegatePath = modulePath(delegate);
-        JarEntry moduleInfoEntry = new JarEntry(MODULE_INFO_CLASS_FILENAME);
-        moduleInfoEntry.setTime(318240000000L);
-        extendJar(generatedDelegatePath, delegatePath, moduleInfoEntry, compiledModuleInfo);
+        return classes;
     }
 
     private void generateDelegating(

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/cache/ZpmCache.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/cache/ZpmCache.java
@@ -49,6 +49,7 @@ import org.eclipse.aether.resolution.ArtifactDescriptorException;
 import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
 import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.eclipse.aether.resolution.DependencyResult;
 import org.eclipse.aether.spi.connector.transport.TransporterFactory;
 import org.eclipse.aether.supplier.RepositorySystemSupplier;
@@ -82,6 +83,7 @@ public final class ZpmCache
     private final RepositorySystem repositorySystem;
 
     private final RepositorySystemSession session;
+    private final RepositorySystemSession optionalSession;
 
     private final List<RemoteRepository> repositories;
     private final ConsoleLogger logger;
@@ -94,7 +96,8 @@ public final class ZpmCache
     {
         this.logger = logger;
         this.repositorySystem = ZpmSupplierRepositorySystemFactory.newRepositorySystem();
-        this.session = newRepositorySystemSession(repositorySystem, directory, excludeRemote);
+        this.session = newRepositorySystemSession(repositorySystem, directory, excludeRemote, false);
+        this.optionalSession = newRepositorySystemSession(repositorySystem, directory, excludeRemote, true);
 
         this.repositories = repositories;
     }
@@ -102,6 +105,22 @@ public final class ZpmCache
     public List<ZpmArtifact> resolve(
         List<ZpmDependency> imports,
         List<ZpmDependency> dependencies)
+    {
+        return resolve(imports, dependencies, session, false);
+    }
+
+    public List<ZpmArtifact> resolveOptional(
+        List<ZpmDependency> imports,
+        List<ZpmDependency> dependencies)
+    {
+        return resolve(imports, dependencies, optionalSession, true);
+    }
+
+    private List<ZpmArtifact> resolve(
+        List<ZpmDependency> imports,
+        List<ZpmDependency> dependencies,
+        RepositorySystemSession session,
+        boolean lenient)
     {
         final List<ZpmArtifact> artifacts = new ArrayList<>();
         Map<ZpmDependency, String> imported = new HashMap<>();
@@ -153,10 +172,33 @@ public final class ZpmCache
             DependencyRequest dependencyRequest = new DependencyRequest(collectResult.getRoot(), null);
             result = repositorySystem.resolveDependencies(session, dependencyRequest);
         }
+        catch (DependencyResolutionException e)
+        {
+            // when resolving the optional validation-only tree, tolerate artifacts that cannot be
+            // resolved (for example when remote repositories are excluded) and continue with whatever
+            // was resolved successfully
+            if (!lenient)
+            {
+                throw new RuntimeException("Failed to resolve dependencies", e);
+            }
+            result = e.getResult();
+        }
         catch (Exception e)
         {
-            throw new RuntimeException("Failed to resolve dependencies", e);
+            // the optional validation-only tree is best-effort; if it cannot be collected at all
+            // (for example offline with missing descriptors) skip validation rather than fail install
+            if (!lenient)
+            {
+                throw new RuntimeException("Failed to resolve dependencies", e);
+            }
+            result = null;
         }
+
+        if (result == null)
+        {
+            return artifacts;
+        }
+
         DependencyNode root = result.getRoot();
 
         NodeListGenerator nlg = new NodeListGenerator();
@@ -181,7 +223,10 @@ public final class ZpmCache
                         new ZpmArtifactId(cArtifact.getGroupId(), cArtifact.getArtifactId(), cArtifact.getVersion());
                     depends.add(cid);
                 });
-                artifacts.add(new ZpmArtifact(id, artifact.getPath(), depends));
+                if (artifact.getPath() != null)
+                {
+                    artifacts.add(new ZpmArtifact(id, artifact.getPath(), depends));
+                }
             }
         });
 
@@ -191,7 +236,8 @@ public final class ZpmCache
     private RepositorySystemSession newRepositorySystemSession(
         RepositorySystem system,
         Path dir,
-        boolean excludeRemote)
+        boolean excludeRemote,
+        boolean includeOptional)
     {
         ConflictResolver conflictResolver = new ConflictResolver(
             new ConfigurableVersionSelector(new ConfigurableVersionSelector.Nearest()),
@@ -228,8 +274,14 @@ public final class ZpmCache
                         new ConflictMarker(),
                         new ConflictIdSorter(),
                         conflictResolver))
-                .setDependencySelector(
-                    new AndDependencySelector(
+                .setDependencySelector(includeOptional
+                    // the validation-only tree also pulls in provided-scope dependencies (for example
+                    // Netty's provided org.jetbrains:annotations-java5) so jdeps can resolve their
+                    // static bytecode references; these artifacts are never linked into the runtime image
+                    ? new AndDependencySelector(
+                        new ExclusionDependencySelector(),
+                        ScopeDependencySelector.fromRoot(null, List.of("test")))
+                    : new AndDependencySelector(
                         OptionalDependencySelector.fromRoot(),
                         new ExclusionDependencySelector(),
                         ScopeDependencySelector.fromRoot(null, List.of("test", "provided"))))


### PR DESCRIPTION
## Description

`zpm install` merges the automatic and unnamed modules into a single delegate module and runs `jdeps --generate-module-info` to synthesize its `module-info.java`. Because the merged bytecode statically references optional third-party libraries pruned from the runtime tree (for example Netty's Brotli/LZ4/Zstd/Protobuf codecs), `jdeps` aborted unless the caller passed `--ignore-missing-dependencies` to add `--ignore-missing-deps` — which then **silently ignored every unresolved reference**, so an accidentally pruned runtime dependency looked identical to an intentional optional.

This change makes generation strict and well-specified:

- Resolve the dependency tree a second time via Aether **including the optional and provided dependencies** pruned from the runtime tree (`ZpmCache.resolveOptional`, resolved leniently and never linked into the image).
- Merge that closure into a single validation-only **`….delegate.optional`** module and place it on the `jdeps` module path. As one flat automatic module it avoids the split-package and inter-module resolution failures of supplying the optional jars individually (e.g. `brotli4j → brotli4j.service`), and JDK-owned packages (e.g. `javax.xml`) and the delegate's own packages are excluded to avoid split packages.
- Run `jdeps --generate-module-info` **strictly — without `--ignore-missing-deps`**. Every reference now resolves against either the delegate or the optional module, so a genuinely missing dependency fails fast instead of being ignored.
- Prune the generated `module-info`: drop the `requires` on the validation-only optional module (never linked), and keep `provides` declarations only when their service interface is actually present in the delegate module.
- If the optional tree cannot resolve every reference (for example offline with an incomplete local repository), fall back to generating with `--ignore-missing-deps` and log exactly which references forced the fallback, so the install never fails and accidental prunes stay visible.

This removes the reliance on `--ignore-missing-deps` for the common case and removes the need for callers to pass `--ignore-missing-dependencies` (the companion zilla-plus PR drops it from the image builds).

### Verification

- `./mvnw clean install -DskipTests` — full reactor green (the only module failure is the unrelated `helm-chart`, which is blocked from reaching `charts.helm.sh` by the sandbox network policy).
- `zpm install` over a Netty/AWS-SDK dependency set with slf4j managed to 2.0.17 (real-build condition): `jdeps` runs strict, no `--ignore-missing-deps`, clean pruned `module-info` (`requires java.logging; requires transitive jdk.unsupported;`, real `provides`/`uses` kept, phantom providers dropped), links successfully.
- Faithful `eclipse-temurin:25-jdk` offline image build (`--exclude-remote-repositories`): builds green, image JVM runs.

Enables aklivity/zilla-plus#889.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DJmP1MKdwW7xgEY4ozisLf)_