### PR TITLE
ci(release): cut 1.x maintenance releases from support/1.x with major/minor docker tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [ develop, 'feature/**'  ]
+    branches: [ develop, 'support/**', 'feature/**'  ]
   pull_request:
-    branches: [ develop, 'feature/**' ]
+    branches: [ develop, 'support/**', 'feature/**' ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,6 @@ jobs:
       with:
         require: admin
 
-    # The release runs from the branch it is dispatched on (github.ref_name),
-    # which is also the base for the release. Guard against releasing a version
-    # from the wrong line.
     - name: Validate release version against branch
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -35,14 +32,12 @@ jobs:
         REF="${{ github.ref_name }}"
         REPO="${{ github.repository }}"
         if [[ "$REF" == support/* ]]; then
-          # support/N.x may only cut N.* releases
           MAJOR="${REF#support/}"; MAJOR="${MAJOR%%.*}"
           if [[ "$VERSION" != "$MAJOR".* ]]; then
             echo "::error::Release version '$VERSION' is not part of the '$REF' line (expected ${MAJOR}.x). Aborting."
             exit 1
           fi
         elif [[ "$REF" == "develop" ]]; then
-          # develop must not release a major that is maintained on its own support branch
           MAJOR="${VERSION%%.*}"
           if git ls-remote --exit-code --heads \
                "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" \
@@ -119,9 +114,6 @@ jobs:
     - name: Commit POM versions and CHANGELOG on release branch
       run: git commit -a -m "Prepare release ${{ inputs.version }}"
 
-    # Mainline only: record the release on develop without taking the version bump,
-    # so develop keeps its own (next) version. Support releases skip this and merge
-    # for real during finalize (see below).
     - name: No-merge release branch into develop branch
       if: github.ref_name == 'develop'
       run: |
@@ -190,13 +182,9 @@ jobs:
         MAJOR=""
         MINOR=""
         LATEST=""
-        # Only stable X.Y.Z releases get the moving major / major.minor / latest tags;
-        # pre-releases (alpha, beta, rc, ...) publish only the exact version tag.
         if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
           MAJOR="${BASH_REMATCH[1]}"
           MINOR="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
-          # `latest` moves only when this is the highest stable release across all tags,
-          # so a 1.x release cut after 2.x has shipped never reclaims `latest`.
           HIGHEST=$({ git tag --list | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$'; echo "$VERSION"; } | sort -V | tail -n1)
           if [[ "$HIGHEST" == "$VERSION" ]]; then
             LATEST="latest"
@@ -319,8 +307,6 @@ jobs:
         git branch develop origin/develop
         git flow init -df
 
-    # Mainline release (develop): finish through git-flow — merge into main, tag,
-    # and back-merge into develop.
     - name: Finish mainline release
       if: github.ref_name == 'develop'
       run: |
@@ -341,8 +327,6 @@ jobs:
       if: github.ref_name == 'develop'
       run: git push origin develop
 
-    # Support release (support/*): merge into the support branch and tag only.
-    # Never advance main and never back-merge into develop, which now holds the next major.
     - name: Finish support release
       if: startsWith(github.ref_name, 'support/')
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       version:
         description: "Version to release (e.g. 0.1.0)"
         required: true
+      base:
+        description: "Branch to release from (develop for mainline, support/1.x for 1.x maintenance)"
+        required: false
+        default: develop
 
 permissions:
   contents: write
@@ -52,10 +56,10 @@ jobs:
         git config --global credential.helper store
         echo "https://x-access-token:${{ secrets.GITFLOW_RELEASES_TOKEN }}@github.com" > ~/.git-credentials
 
-    - name: Checkout sources on develop
+    - name: Checkout sources on base branch
       uses: actions/checkout@v6
       with:
-        ref: develop
+        ref: ${{ inputs.base }}
         fetch-depth: 0
         persist-credentials: false
 
@@ -63,13 +67,15 @@ jobs:
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         git fetch origin main
-        git branch main origin/main
+        git branch main origin/main || true
+        git fetch origin develop
+        git branch develop origin/develop || true
         git flow init -df
 
     - name: Start GitFlow release
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        git flow release start ${{ inputs.version }}
+        git flow release start ${{ inputs.version }} ${{ inputs.base }}
 
     - name: Setup JDK
       uses: actions/setup-java@v5
@@ -89,7 +95,11 @@ jobs:
     - name: Commit POM versions and CHANGELOG on release branch
       run: git commit -a -m "Prepare release ${{ inputs.version }}"
 
+    # Mainline only: record the release on develop without taking the version bump,
+    # so develop keeps its own (next) version. Support releases skip this and merge
+    # for real during finalize (see below).
     - name: No-merge release branch into develop branch
+      if: inputs.base == 'develop'
       run: |
         git config merge.ours.driver true
         git fetch origin develop
@@ -98,8 +108,14 @@ jobs:
             -m "No-merge release ${{ inputs.version }} into develop"
 
     - name: Push changes to develop and release branch
+      if: inputs.base == 'develop'
       run: |
         git push origin develop release/${{ inputs.version }}
+
+    - name: Push release branch
+      if: startsWith(inputs.base, 'support/')
+      run: |
+        git push origin release/${{ inputs.version }}
 
   deploy:
     name: Deploy ${{ inputs.version }}
@@ -143,16 +159,30 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Determine docker tag
+    - name: Determine docker tags
       id: tag
       run: |
-        VERSION="${{ github.event.inputs.version }}"
-        if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          TAG="latest"
-        else
-          TAG=""
+        VERSION="${{ inputs.version }}"
+        MAJOR=""
+        MINOR=""
+        LATEST=""
+        # Only stable X.Y.Z releases get the moving major / major.minor / latest tags;
+        # pre-releases (alpha, beta, rc, ...) publish only the exact version tag.
+        if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
+          MAJOR="${BASH_REMATCH[1]}"
+          MINOR="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+          # `latest` moves only when this is the highest stable release across all tags,
+          # so a 1.x release cut after 2.x has shipped never reclaims `latest`.
+          HIGHEST=$({ git tag --list | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$'; echo "$VERSION"; } | sort -V | tail -n1)
+          if [[ "$HIGHEST" == "$VERSION" ]]; then
+            LATEST="latest"
+          fi
         fi
-        echo "latest=$TAG" >> $GITHUB_OUTPUT
+        {
+          echo "major=$MAJOR"
+          echo "minor=$MINOR"
+          echo "latest=$LATEST"
+        } >> "$GITHUB_OUTPUT"
 
     - name: Deploy via Maven
       run: |
@@ -190,7 +220,9 @@ jobs:
         provenance: false
         tags: |
           ghcr.io/aklivity/zilla:${{ inputs.version }}
-          ${{ steps.tag.outputs.latest && format('ghcr.io/aklivity/zilla:{0}', steps.tag.outputs.latest) || '' }}
+          ${{ steps.tag.outputs.minor && format('ghcr.io/aklivity/zilla:{0}', steps.tag.outputs.minor) || '' }}
+          ${{ steps.tag.outputs.major && format('ghcr.io/aklivity/zilla:{0}', steps.tag.outputs.major) || '' }}
+          ${{ steps.tag.outputs.latest && 'ghcr.io/aklivity/zilla:latest' || '' }}
 
     - name: Publish zilla-alpine image to GitHub Container Registry
       uses: docker/build-push-action@v6
@@ -202,6 +234,8 @@ jobs:
         provenance: false
         tags: |
           ghcr.io/aklivity/zilla:${{ inputs.version }}-alpine
+          ${{ steps.tag.outputs.minor && format('ghcr.io/aklivity/zilla:{0}-alpine', steps.tag.outputs.minor) || '' }}
+          ${{ steps.tag.outputs.major && format('ghcr.io/aklivity/zilla:{0}-alpine', steps.tag.outputs.major) || '' }}
           ${{ steps.tag.outputs.latest && 'ghcr.io/aklivity/zilla:alpine' || '' }}
 
     - name: Setup helm
@@ -261,18 +295,49 @@ jobs:
         git branch develop origin/develop
         git flow init -df
 
-    - name: Finish release
+    # Mainline release (develop): finish through git-flow — merge into main, tag,
+    # and back-merge into develop.
+    - name: Finish mainline release
+      if: inputs.base == 'develop'
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         git flow release finish -p ${{ inputs.version }} -m "${{ inputs.version }}"
 
     - name: Generate CHANGELOG on develop
+      if: inputs.base == 'develop'
       uses: janheinrichmerker/action-github-changelog-generator@v2.4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Commit CHANGELOG on develop branch (if needed)
+      if: inputs.base == 'develop'
       run: git diff --quiet && git diff --cached --quiet || git commit -a -m "Update CHANGELOG.md"
 
     - name: Push CHANGELOG commit to develop
+      if: inputs.base == 'develop'
       run: git push origin develop
+
+    # Support release (support/*): merge into the support branch and tag only.
+    # Never advance main and never back-merge into develop, which now holds the next major.
+    - name: Finish support release
+      if: startsWith(inputs.base, 'support/')
+      run: |
+        git fetch origin ${{ inputs.base }}
+        git checkout ${{ inputs.base }}
+        git merge --no-ff release/${{ inputs.version }} \
+            -m "Merge release ${{ inputs.version }} into ${{ inputs.base }}"
+        git tag -a ${{ inputs.version }} -m "${{ inputs.version }}"
+        git push origin ${{ inputs.base }} refs/tags/${{ inputs.version }}
+        git push origin --delete release/${{ inputs.version }} || true
+
+    - name: Generate CHANGELOG on support branch
+      if: startsWith(inputs.base, 'support/')
+      uses: janheinrichmerker/action-github-changelog-generator@v2.4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Commit and push CHANGELOG on support branch (if needed)
+      if: startsWith(inputs.base, 'support/')
+      run: |
+        git diff --quiet && git diff --cached --quiet || git commit -a -m "Update CHANGELOG.md"
+        git push origin ${{ inputs.base }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,20 +313,6 @@ jobs:
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         git flow release finish -p ${{ inputs.version }} -m "${{ inputs.version }}"
 
-    - name: Generate CHANGELOG on develop
-      if: github.ref_name == 'develop'
-      uses: janheinrichmerker/action-github-changelog-generator@v2.4
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Commit CHANGELOG on develop branch (if needed)
-      if: github.ref_name == 'develop'
-      run: git diff --quiet && git diff --cached --quiet || git commit -a -m "Update CHANGELOG.md"
-
-    - name: Push CHANGELOG commit to develop
-      if: github.ref_name == 'develop'
-      run: git push origin develop
-
     - name: Finish support release
       if: startsWith(github.ref_name, 'support/')
       run: |
@@ -338,14 +324,17 @@ jobs:
         git push origin ${{ github.ref_name }} refs/tags/${{ inputs.version }}
         git push origin --delete release/${{ inputs.version }} || true
 
-    - name: Generate CHANGELOG on support branch
-      if: startsWith(github.ref_name, 'support/')
+    - name: Checkout base branch for CHANGELOG
+      run: |
+        git fetch origin ${{ github.ref_name }}
+        git checkout ${{ github.ref_name }}
+
+    - name: Generate CHANGELOG on base branch
       uses: janheinrichmerker/action-github-changelog-generator@v2.4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Commit and push CHANGELOG on support branch (if needed)
-      if: startsWith(github.ref_name, 'support/')
+    - name: Commit and push CHANGELOG on base branch (if needed)
       run: |
         git diff --quiet && git diff --cached --quiet || git commit -a -m "Update CHANGELOG.md"
         git push origin ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,27 +302,18 @@ jobs:
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         git fetch origin main
-        git branch main origin/main
+        git branch main origin/main || true
         git fetch origin develop
-        git branch develop origin/develop
+        git branch develop origin/develop || true
+        git fetch origin ${{ github.ref_name }}
+        git branch ${{ github.ref_name }} origin/${{ github.ref_name }} || true
         git flow init -df
 
-    - name: Finish mainline release
-      if: github.ref_name == 'develop'
+    - name: Finish release
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        git config --local "gitflow.branch.release/${{ inputs.version }}.base" ${{ github.ref_name }}
         git flow release finish -p ${{ inputs.version }} -m "${{ inputs.version }}"
-
-    - name: Finish support release
-      if: startsWith(github.ref_name, 'support/')
-      run: |
-        git fetch origin ${{ github.ref_name }}
-        git checkout ${{ github.ref_name }}
-        git merge --no-ff release/${{ inputs.version }} \
-            -m "Merge release ${{ inputs.version }} into ${{ github.ref_name }}"
-        git tag -a ${{ inputs.version }} -m "${{ inputs.version }}"
-        git push origin ${{ github.ref_name }} refs/tags/${{ inputs.version }}
-        git push origin --delete release/${{ inputs.version }} || true
 
     - name: Checkout base branch for CHANGELOG
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,6 @@ on:
       version:
         description: "Version to release (e.g. 0.1.0)"
         required: true
-      base:
-        description: "Branch to release from (develop for mainline, support/1.x for 1.x maintenance)"
-        required: false
-        default: develop
 
 permissions:
   contents: write
@@ -27,6 +23,34 @@ jobs:
       uses: skjnldsv/check-actor-permission@v3.0
       with:
         require: admin
+
+    # The release runs from the branch it is dispatched on (github.ref_name),
+    # which is also the base for the release. Guard against releasing a version
+    # from the wrong line.
+    - name: Validate release version against branch
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        VERSION="${{ inputs.version }}"
+        REF="${{ github.ref_name }}"
+        REPO="${{ github.repository }}"
+        if [[ "$REF" == support/* ]]; then
+          # support/N.x may only cut N.* releases
+          MAJOR="${REF#support/}"; MAJOR="${MAJOR%%.*}"
+          if [[ "$VERSION" != "$MAJOR".* ]]; then
+            echo "::error::Release version '$VERSION' is not part of the '$REF' line (expected ${MAJOR}.x). Aborting."
+            exit 1
+          fi
+        elif [[ "$REF" == "develop" ]]; then
+          # develop must not release a major that is maintained on its own support branch
+          MAJOR="${VERSION%%.*}"
+          if git ls-remote --exit-code --heads \
+               "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" \
+               "support/${MAJOR}.x" >/dev/null 2>&1; then
+            echo "::error::A 'support/${MAJOR}.x' branch exists; release version '$VERSION' from that branch, not develop. Aborting."
+            exit 1
+          fi
+        fi
 
     - name: Cache Homebrew
       uses: actions/cache@v5
@@ -59,7 +83,7 @@ jobs:
     - name: Checkout sources on base branch
       uses: actions/checkout@v6
       with:
-        ref: ${{ inputs.base }}
+        ref: ${{ github.ref_name }}
         fetch-depth: 0
         persist-credentials: false
 
@@ -75,7 +99,7 @@ jobs:
     - name: Start GitFlow release
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        git flow release start ${{ inputs.version }} ${{ inputs.base }}
+        git flow release start ${{ inputs.version }} ${{ github.ref_name }}
 
     - name: Setup JDK
       uses: actions/setup-java@v5
@@ -99,7 +123,7 @@ jobs:
     # so develop keeps its own (next) version. Support releases skip this and merge
     # for real during finalize (see below).
     - name: No-merge release branch into develop branch
-      if: inputs.base == 'develop'
+      if: github.ref_name == 'develop'
       run: |
         git config merge.ours.driver true
         git fetch origin develop
@@ -108,12 +132,12 @@ jobs:
             -m "No-merge release ${{ inputs.version }} into develop"
 
     - name: Push changes to develop and release branch
-      if: inputs.base == 'develop'
+      if: github.ref_name == 'develop'
       run: |
         git push origin develop release/${{ inputs.version }}
 
     - name: Push release branch
-      if: startsWith(inputs.base, 'support/')
+      if: startsWith(github.ref_name, 'support/')
       run: |
         git push origin release/${{ inputs.version }}
 
@@ -298,46 +322,46 @@ jobs:
     # Mainline release (develop): finish through git-flow — merge into main, tag,
     # and back-merge into develop.
     - name: Finish mainline release
-      if: inputs.base == 'develop'
+      if: github.ref_name == 'develop'
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         git flow release finish -p ${{ inputs.version }} -m "${{ inputs.version }}"
 
     - name: Generate CHANGELOG on develop
-      if: inputs.base == 'develop'
+      if: github.ref_name == 'develop'
       uses: janheinrichmerker/action-github-changelog-generator@v2.4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Commit CHANGELOG on develop branch (if needed)
-      if: inputs.base == 'develop'
+      if: github.ref_name == 'develop'
       run: git diff --quiet && git diff --cached --quiet || git commit -a -m "Update CHANGELOG.md"
 
     - name: Push CHANGELOG commit to develop
-      if: inputs.base == 'develop'
+      if: github.ref_name == 'develop'
       run: git push origin develop
 
     # Support release (support/*): merge into the support branch and tag only.
     # Never advance main and never back-merge into develop, which now holds the next major.
     - name: Finish support release
-      if: startsWith(inputs.base, 'support/')
+      if: startsWith(github.ref_name, 'support/')
       run: |
-        git fetch origin ${{ inputs.base }}
-        git checkout ${{ inputs.base }}
+        git fetch origin ${{ github.ref_name }}
+        git checkout ${{ github.ref_name }}
         git merge --no-ff release/${{ inputs.version }} \
-            -m "Merge release ${{ inputs.version }} into ${{ inputs.base }}"
+            -m "Merge release ${{ inputs.version }} into ${{ github.ref_name }}"
         git tag -a ${{ inputs.version }} -m "${{ inputs.version }}"
-        git push origin ${{ inputs.base }} refs/tags/${{ inputs.version }}
+        git push origin ${{ github.ref_name }} refs/tags/${{ inputs.version }}
         git push origin --delete release/${{ inputs.version }} || true
 
     - name: Generate CHANGELOG on support branch
-      if: startsWith(inputs.base, 'support/')
+      if: startsWith(github.ref_name, 'support/')
       uses: janheinrichmerker/action-github-changelog-generator@v2.4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Commit and push CHANGELOG on support branch (if needed)
-      if: startsWith(inputs.base, 'support/')
+      if: startsWith(github.ref_name, 'support/')
       run: |
         git diff --quiet && git diff --cached --quiet || git commit -a -m "Update CHANGELOG.md"
-        git push origin ${{ inputs.base }}
+        git push origin ${{ github.ref_name }}


### PR DESCRIPTION
## Description

Enables git-flow `support/1.x` releases so 1.x minor/patch versions can be cut from `support/1.x` while `develop` moves on to v2.

- The release base is the branch the workflow is dispatched from (`github.ref_name`) — no manual `base` input, so the ref and base can't diverge.
- A fail-fast guard rejects a version that does not match the branch's line: `support/N.x` only accepts `N.*`, and a `develop` run is blocked when a `support/<major>.x` branch already exists (so a 1.x release can't be cut from develop by mistake).
- Docker images publish moving `major` (`1`) and `major.minor` (`1.5`) tags alongside the exact `major.minor.patch`. The floating `latest` / `alpine` pointers move only for the highest stable release across all tags, so `support/1.x` keeps `latest` until a stable 2.x ships from develop; pre-releases publish only their exact version tag.
- A `support/*` release merges into the support branch and tags only — it never advances `main` or back-merges into `develop`. Mainline (`develop`) releases keep the existing git-flow finish.

Targets `support/1.x`. Companion PR against `develop` (`claude/release-workflow-support-branches-ss82ns`) brings the same workflow to the mainline so v2 releases also emit the new `2` / `2.0` tags.

Follow-up (deferred): switch `examples/*/compose.yaml` defaults on `support/1.x` from `${ZILLA_VERSION:-latest}` to `${ZILLA_VERSION:-1}`.

No associated issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5bGVS9PYHAbXzqiHZDXie)_