### PR TITLE
ci(release): force Maven to IPv4 to avoid unreachable IPv6 package repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ permissions:
   packages: write
   pull-requests: read
 
+env:
+  MAVEN_OPTS: -Djava.net.preferIPv4Stack=true
+
 jobs:
   prepare:
     name: Prepare ${{ inputs.version }}


### PR DESCRIPTION
## Description

Follow-up to the support/1.x release-workflow change (already merged). A `support/1.x` release of `1.2.5` failed in `Deploy via Maven` resolving `io.aklivity.k3po:*:3.4.0` from `https://maven.packages.aklivity.io/` with **"Network is unreachable"**.

Root cause: that host publishes an AAAA (IPv6) record (`2a12:5240::1`) alongside its IPv4 (`89.106.200.1`). GitHub-hosted runners have no IPv6 route, so the JVM's attempt on the IPv6 address fails with `ENETUNREACH` instead of falling back to IPv4. It is unrelated to the workflow structure and affects any release that must download from that repo.

Fix: set `MAVEN_OPTS: -Djava.net.preferIPv4Stack=true` at the workflow level so every `mvnw` invocation uses the reachable IPv4 address.

Note: the real fix is infra-side (drop/repair the AAAA record if the IPv6 endpoint isn't served); this is a reliable runner-side workaround in the meantime.

No associated issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5bGVS9PYHAbXzqiHZDXie)_