### PR TITLE
ci: pin maven.packages.aklivity.io to IPv4 instead of forcing the JVM stack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,12 @@ jobs:
     steps:
     - name: Checkout GitHub sources
       uses: actions/checkout@v6
+    - name: Pin maven.packages.aklivity.io to IPv4
+      run: |
+        ipv4=$(getent ahostsv4 maven.packages.aklivity.io | awk 'NR==1{print $1}')
+        if [ -n "$ipv4" ]; then
+          echo "$ipv4 maven.packages.aklivity.io" | sudo tee -a /etc/hosts
+        fi
     - name: Setup JDK ${{ matrix.java }}
       uses: actions/setup-java@v5
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -76,6 +76,13 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
 
+    - name: Pin maven.packages.aklivity.io to IPv4
+      run: |
+        ipv4=$(getent ahostsv4 maven.packages.aklivity.io | awk 'NR==1{print $1}')
+        if [ -n "$ipv4" ]; then
+          echo "$ipv4 maven.packages.aklivity.io" | sudo tee -a /etc/hosts
+        fi
+
     - name: Autobuild
       uses: github/codeql-action/autobuild@v4
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
 
     - name: Deploy via Maven
       run: |
-        ./mvnw -B -U -nsu -ntp clean deploy -Drelease -Ddocker.latest.tag=${{ steps.tag.outputs.latest }}
+        ./mvnw -B -U -nsu -ntp clean deploy -Drelease -Ddocker.latest.tag=${{ steps.tag.outputs.latest }} -DskipTests
       env:
         GITHUB_ACTOR: ${{ github.actor }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,6 @@ permissions:
   packages: write
   pull-requests: read
 
-env:
-  MAVEN_OPTS: -Djava.net.preferIPv4Stack=true
-
 jobs:
   prepare:
     name: Prepare ${{ inputs.version }}
@@ -85,6 +82,13 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
 
+    - name: Pin maven.packages.aklivity.io to IPv4
+      run: |
+        ipv4=$(getent ahostsv4 maven.packages.aklivity.io | awk 'NR==1{print $1}')
+        if [ -n "$ipv4" ]; then
+          echo "$ipv4 maven.packages.aklivity.io" | sudo tee -a /etc/hosts
+        fi
+
     - name: Initialize GitFlow
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
@@ -147,6 +151,13 @@ jobs:
       with:
         ref: release/${{ inputs.version }}
         fetch-depth: 0
+
+    - name: Pin maven.packages.aklivity.io to IPv4
+      run: |
+        ipv4=$(getent ahostsv4 maven.packages.aklivity.io | awk 'NR==1{print $1}')
+        if [ -n "$ipv4" ]; then
+          echo "$ipv4 maven.packages.aklivity.io" | sudo tee -a /etc/hosts
+        fi
 
     - name: Setup JDK
       uses: actions/setup-java@v5


### PR DESCRIPTION
## Description

Replaces the `-Djava.net.preferIPv4Stack=true` workaround (merged via #1982) with a transient `/etc/hosts` entry pinning only `maven.packages.aklivity.io` to its IPv4 address.

`preferIPv4Stack` fixed the release deploy's unreachable AAAA record, but it disables the JVM's IPv6 stack entirely — which `build.yml` cannot tolerate, since it runs the full k3po IT suite including tests that bind IPv6 loopback (`[::1]`). Pinning just that one hostname's DNS resolution to IPv4 fixes the actual problem (the host's unreachable IPv6 endpoint) without touching the JVM's networking stack at all, so it's safe to apply uniformly.

Applied to `release.yml` (`prepare` + `deploy`, replacing the removed `MAVEN_OPTS`), `build.yml`, and `codeql.yml` (the "scan" workflow for this repo) — everywhere `mvnw` resolves dependencies from that host.

Note: `-DskipTests` on the release deploy (#1984) is kept — it's independently faster and no longer strictly required to avoid the IPv6 conflict, but there's no reason to re-add tests to the release path.

No associated issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5bGVS9PYHAbXzqiHZDXie)_