### PR TITLE
docs(examples): default to the 1.x image tag on support/1.x

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -21,7 +21,7 @@ docker compose --project-directory <example.name> up -d
 ![demo](.assets/demo.gif)
 
 > [!NOTE]
-Make sure you have the `latest` version of Zilla by running the `docker pull ghcr.io/aklivity/zilla:latest` command. To specify a specific Zilla image version you can set the `ZILLA_VERSION` environment variable before running an example.
+Make sure you have the latest 1.x version of Zilla by running the `docker pull ghcr.io/aklivity/zilla:1` command. To specify a specific Zilla image version you can set the `ZILLA_VERSION` environment variable before running an example.
 
 ## Examples
 

--- a/examples/amqp.reflect/compose.yaml
+++ b/examples/amqp.reflect/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-amqp-reflect}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/asyncapi.http.kafka.proxy/compose.yaml
+++ b/examples/asyncapi.http.kafka.proxy/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-asyncapi-http-kafka-proxy}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/asyncapi.mqtt.kafka.proxy/compose.yaml
+++ b/examples/asyncapi.mqtt.kafka.proxy/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-asyncapi-mqtt-kafka-proxy}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/asyncapi.mqtt.proxy/compose.yaml
+++ b/examples/asyncapi.mqtt.proxy/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-asyncapi-mqtt-proxy}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/asyncapi.sse.kafka.proxy/compose.yaml
+++ b/examples/asyncapi.sse.kafka.proxy/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-asyncapi-sse-kafka-proxy}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/asyncapi.sse.proxy/compose.yaml
+++ b/examples/asyncapi.sse.proxy/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-asyncapi-sse-proxy}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/grpc.echo/compose.yaml
+++ b/examples/grpc.echo/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-grpc-echo}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/grpc.kafka.echo/compose.yaml
+++ b/examples/grpc.kafka.echo/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-grpc-kafka-echo}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/grpc.kafka.fanout/compose.yaml
+++ b/examples/grpc.kafka.fanout/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-grpc-kafka-fanout}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/grpc.kafka.proxy/compose.yaml
+++ b/examples/grpc.kafka.proxy/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-grpc-kafka-proxy}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/grpc.proxy/compose.yaml
+++ b/examples/grpc.proxy/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-grpc-proxy}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/http.echo/compose.yaml
+++ b/examples/http.echo/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-http-echo}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/http.filesystem/compose.yaml
+++ b/examples/http.filesystem/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-http-filesystem}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/http.json.schema/compose.yaml
+++ b/examples/http.json.schema/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-http-json-schema}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/http.kafka.async/compose.yaml
+++ b/examples/http.kafka.async/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-http-kafka-async}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/http.kafka.avro.json/compose.yaml
+++ b/examples/http.kafka.avro.json/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-http-kafka-schema-registry}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/http.kafka.cache/compose.yaml
+++ b/examples/http.kafka.cache/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-http-kafka-cache}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/http.kafka.crud/compose.yaml
+++ b/examples/http.kafka.crud/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-http-kafka-crud}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/http.kafka.oneway/compose.yaml
+++ b/examples/http.kafka.oneway/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-http-kafka-oneway}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     ports:
       - 7114:7114

--- a/examples/http.kafka.proto.json/compose.yaml
+++ b/examples/http.kafka.proto.json/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-http-kafka-proto-json}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/http.kafka.proto.oneway/compose.yaml
+++ b/examples/http.kafka.proto.oneway/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-http-kafka-proto-oneway}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/http.kafka.sync/compose.yaml
+++ b/examples/http.kafka.sync/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-http-kafka-sync}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/http.metrics/compose.yaml
+++ b/examples/http.metrics/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-http-metrics}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/http.proxy.jwt/compose.yaml
+++ b/examples/http.proxy.jwt/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-http-proxy-jwt}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/http.proxy/compose.yaml
+++ b/examples/http.proxy/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-http-proxy}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/mqtt.kafka.proxy/compose.yaml
+++ b/examples/mqtt.kafka.proxy/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-mqtt-kafka-proxy}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/mqtt.proxy.jwt/compose.yaml
+++ b/examples/mqtt.proxy.jwt/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-mqtt-proxy-jwt}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/openapi.asyncapi.kakfa.proxy/compose.yaml
+++ b/examples/openapi.asyncapi.kakfa.proxy/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-openapi-asyncapi-proxy}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/openapi.proxy/compose.yaml
+++ b/examples/openapi.proxy/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-openapi-proxy}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/sse.kafka.fanout.jwt/compose.yaml
+++ b/examples/sse.kafka.fanout.jwt/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-sse-kafka-fanout}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/sse.kafka.fanout/compose.yaml
+++ b/examples/sse.kafka.fanout/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-sse-kafka-fanout}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/sse.proxy.jwt/compose.yaml
+++ b/examples/sse.proxy.jwt/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-sse-proxy-jwt}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/tcp.echo/compose.yaml
+++ b/examples/tcp.echo/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-tcp-echo}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/tcp.reflect/compose.yaml
+++ b/examples/tcp.reflect/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-tcp-reflect}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/tls.echo/compose.yaml
+++ b/examples/tls.echo/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-tls-echo}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/tls.reflect/compose.yaml
+++ b/examples/tls.reflect/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-tls-reflect}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/ws.echo/compose.yaml
+++ b/examples/ws.echo/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-ws-echo}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/ws.proxy/compose.yaml
+++ b/examples/ws.proxy/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-ws-proxy}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:

--- a/examples/ws.reflect/compose.yaml
+++ b/examples/ws.reflect/compose.yaml
@@ -1,7 +1,7 @@
 name: ${NAMESPACE:-zilla-ws-reflect}
 services:
   zilla:
-    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-latest}
+    image: ghcr.io/aklivity/zilla:${ZILLA_VERSION:-1}
     restart: unless-stopped
     hostname: zilla.examples.dev
     ports:


### PR DESCRIPTION
## Description

`examples/*/compose.yaml` defaulted `ZILLA_VERSION` to `:latest`, which now moves to whichever line (1.x or, eventually, 2.x) is the highest overall stable release — per the release workflow's tag logic landed in #1980/#1982/#1985. Once a stable 2.x ships from `develop`, `:latest` on `support/1.x` would silently point examples at a v2 image, defeating the purpose of a dedicated 1.x maintenance branch.

Change the default on `support/1.x` to `:1` (the moving major-version tag for this line), which will always resolve to the newest 1.x release regardless of what ships on `develop`. `develop`'s examples are untouched and keep defaulting to `:latest`.

Updated:
- All 39 `examples/*/compose.yaml` — `${ZILLA_VERSION:-latest}` → `${ZILLA_VERSION:-1}`
- `examples/README.md` — the `docker pull` guidance now references `:1`

No associated issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5bGVS9PYHAbXzqiHZDXie)_