### PR TITLE
ci(release): make CHANGELOG generation resilient to transient failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,10 +113,32 @@ jobs:
       run: |
         ./mvnw versions:set -DgenerateBackupPoms=false -DnewVersion=${{ inputs.version }}
 
-    - name: Generate CHANGELOG on release branch
+    - name: Generate CHANGELOG on release branch (attempt 1)
+      id: changelog-1
+      continue-on-error: true
       uses: janheinrichmerker/action-github-changelog-generator@v2.4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Generate CHANGELOG on release branch (attempt 2)
+      id: changelog-2
+      if: steps.changelog-1.outcome == 'failure'
+      continue-on-error: true
+      uses: janheinrichmerker/action-github-changelog-generator@v2.4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Generate CHANGELOG on release branch (attempt 3)
+      id: changelog-3
+      if: steps.changelog-1.outcome == 'failure' && steps.changelog-2.outcome == 'failure'
+      continue-on-error: true
+      uses: janheinrichmerker/action-github-changelog-generator@v2.4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Warn if CHANGELOG generation failed on release branch
+      if: steps.changelog-1.outcome == 'failure' && steps.changelog-2.outcome == 'failure' && steps.changelog-3.outcome == 'failure'
+      run: echo "::warning::CHANGELOG generation failed after 3 attempts; release/${{ inputs.version }} will carry the previous CHANGELOG.md unchanged."
 
     - name: Commit POM versions and CHANGELOG on release branch
       run: git commit -a -m "Prepare release ${{ inputs.version }}"
@@ -332,10 +354,32 @@ jobs:
         git fetch origin ${{ github.ref_name }}
         git checkout ${{ github.ref_name }}
 
-    - name: Generate CHANGELOG on base branch
+    - name: Generate CHANGELOG on base branch (attempt 1)
+      id: changelog-1
+      continue-on-error: true
       uses: janheinrichmerker/action-github-changelog-generator@v2.4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Generate CHANGELOG on base branch (attempt 2)
+      id: changelog-2
+      if: steps.changelog-1.outcome == 'failure'
+      continue-on-error: true
+      uses: janheinrichmerker/action-github-changelog-generator@v2.4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Generate CHANGELOG on base branch (attempt 3)
+      id: changelog-3
+      if: steps.changelog-1.outcome == 'failure' && steps.changelog-2.outcome == 'failure'
+      continue-on-error: true
+      uses: janheinrichmerker/action-github-changelog-generator@v2.4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Warn if CHANGELOG generation failed on base branch
+      if: steps.changelog-1.outcome == 'failure' && steps.changelog-2.outcome == 'failure' && steps.changelog-3.outcome == 'failure'
+      run: echo "::warning::CHANGELOG generation failed after 3 attempts; ${{ github.ref_name }} was not updated. The release itself (tag, merge) already completed successfully — rerun CHANGELOG generation manually or it will catch up next release."
 
     - name: Commit and push CHANGELOG on base branch (if needed)
       run: |


### PR DESCRIPTION
## Description

Mirrors #1990 (same fix on `develop`'s copy of `release.yml`) onto `support/1.x`'s copy.

`janheinrichmerker/action-github-changelog-generator` paginates through every issue/PR event via GitHub's REST API and can drop the connection mid-fetch on a large repo (seen on `develop`'s `2.0.0-alpha-17` Finalize run: `Protocol::HTTP2::StreamError` after 1578/1581 events). A single transient failure there fails the whole job even though the release itself already completed successfully.

### Fix

In both `Prepare` and `Finalize`:
- Retry CHANGELOG generation up to 3 times.
- If all 3 attempts fail, emit a `::warning::` instead of failing the job — `CHANGELOG.md` is documentation, not release-critical.

No change to the release-critical path (version bump, no-merge protection, tag-first/`-n` finish, deploy).

## Test plan

- [ ] YAML validated (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`)
- [ ] Next `support/1.x` release run exercises the retry path (or confirms no regression on the happy path)

No associated issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5bGVS9PYHAbXzqiHZDXie)_