### PR TITLE
build: route io.aklivity.* to github via resolver groupId filter on support/1.x

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Daether.remoteRepositoryFilter.groupId=true
+-Daether.remoteRepositoryFilter.filterBasedir=${session.rootDirectory}/.mvn/rrf

--- a/.mvn/rrf/groupId-github.txt
+++ b/.mvn/rrf/groupId-github.txt
@@ -1,0 +1,1 @@
+io.aklivity


### PR DESCRIPTION
## Description

Backports #1947 ("route io.aklivity.\* to github via resolver groupId filter") from `develop` onto `support/1.x`, which never received it since it's a separate git-flow line — confirmed via `git merge-base --is-ancestor`.

Enables Maven Resolver's [Remote Repository Filtering](https://maven.apache.org/resolver/remote-repository-filtering.html) `groupId` filter so the `github` repository (`maven.packages.aklivity.io`) is only ever queried for `io.aklivity.*` artifacts:

- `.mvn/maven.config`: `-Daether.remoteRepositoryFilter.groupId=true` + `-Daether.remoteRepositoryFilter.filterBasedir=${session.rootDirectory}/.mvn/rrf` (keeps filter data checked into the repo, so it's present on every fresh CI checkout rather than relying on a warm local `~/.m2`).
- `.mvn/rrf/groupId-github.txt`: `io.aklivity` — the only groupId prefix allowed from that repository.

Central already self-filters via its own published `prefixes.txt` (discovered automatically), so the practical effect is: every third-party dependency (Jackson, Mockito, plugin deps, etc.) resolves from Central only and never touches `maven.packages.aklivity.io`; only genuine `io.aklivity.*` artifacts do. This should meaningfully help `support/1.x`'s `prepare` job, which runs with a cold `~/.m2` (no cache-restore step) and has been hit repeatedly by that host's connect-timeout flakiness — every dependency was previously paying that tax before falling back to Central, not just the `io.aklivity.*` ones that actually need it.

No pom.xml changes needed — `support/1.x`'s `<repositories>` block already only declares `github`, without the redundant `central` entry #1947 also cleaned up on `develop`.

No associated issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5bGVS9PYHAbXzqiHZDXie)_