### PR TITLE
ci(release): generalize no-merge/tag-first protection on develop's own release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,24 +143,17 @@ jobs:
     - name: Commit POM versions and CHANGELOG on release branch
       run: git commit -a -m "Prepare release ${{ inputs.version }}"
 
-    - name: No-merge release branch into develop branch
-      if: github.ref_name == 'develop'
+    - name: No-merge release branch into base branch
       run: |
         git config merge.ours.driver true
-        git fetch origin develop
-        git checkout develop
+        git fetch origin ${{ github.ref_name }}
+        git checkout ${{ github.ref_name }}
         git merge -s ours release/${{ inputs.version }} \
-            -m "No-merge release ${{ inputs.version }} into develop"
+            -m "No-merge release ${{ inputs.version }} into ${{ github.ref_name }}"
 
-    - name: Push changes to develop and release branch
-      if: github.ref_name == 'develop'
+    - name: Push changes to base branch and release branch
       run: |
-        git push origin develop release/${{ inputs.version }}
-
-    - name: Push release branch
-      if: startsWith(github.ref_name, 'support/')
-      run: |
-        git push origin release/${{ inputs.version }}
+        git push origin ${{ github.ref_name }} release/${{ inputs.version }}
 
   deploy:
     name: Deploy ${{ inputs.version }}
@@ -369,11 +362,21 @@ jobs:
         git branch ${{ github.ref_name }} origin/${{ github.ref_name }} || true
         git flow init -df
 
+    - name: Tag the release
+      if: startsWith(github.ref_name, 'support/')
+      run: |
+        git tag -a ${{ inputs.version }} -m "${{ inputs.version }}" release/${{ inputs.version }}
+        git push origin refs/tags/${{ inputs.version }}
+
     - name: Finish release
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         git config --local "gitflow.branch.release/${{ inputs.version }}.base" ${{ github.ref_name }}
-        git flow release finish -p ${{ inputs.version }} -m "${{ inputs.version }}"
+        if [[ "${{ github.ref_name }}" == support/* ]]; then
+          git flow release finish -p -n ${{ inputs.version }}
+        else
+          git flow release finish -p ${{ inputs.version }} -m "${{ inputs.version }}"
+        fi
 
     - name: Checkout base branch for CHANGELOG
       run: |


### PR DESCRIPTION
## Description

`develop`'s own copy of `release.yml` still had the original develop-only no-merge protection and git-flow's default (non-tag-first) finish. That's exactly the shape that produced the "support branch stuck at exact release version" bug fixed in #1988 — it works fine for `develop` today, but a *new* support branch forked from `develop` tomorrow would inherit the same unprotected file and need this same retrofit all over again.

### Changes

- Generalize "No-merge release branch into develop branch" → "No-merge release branch into base branch" (unconditional, uses `${{ github.ref_name }}`). **Zero behavior change for `develop`** — `github.ref_name` is literally `develop` there, so this produces the identical merge it always did.
- Gate the tag-first + `-n`/`--notag` finish path on a `support/*` ref pattern rather than making it unconditional. `develop`'s tag placement stays exactly as today — git-flow's own tag, correctly anchored to the real `main`-merge commit, since only `develop`'s own merge is protected (`main`'s merge is real and unaffected by that protection, unlike a support branch which has no separate `main` merge to anchor a tag to). A future support branch's inherited copy of this file evaluates the same pattern against its own `ref_name` and gets the correct support-branch behavior from day one.

No behavior change for real `develop`-based releases; this only changes what a newly-cut support branch inherits.

No associated issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5bGVS9PYHAbXzqiHZDXie)_