### PR TITLE
feat(manager): support enabling incubator modules via --incubator

### DIFF
--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
@@ -123,6 +123,11 @@ public final class ZpmInstall extends ZpmCommand
         hidden = true)
     public Boolean instrument = false;
 
+    @Option(name = {"--incubator"},
+        description = "Enable an incubator module (repeatable), e.g. --incubator vector",
+        hidden = true)
+    public List<String> incubator = new ArrayList<>();
+
     @Option(name = {"--exclude-local-repository"},
         description = "Exclude the local Maven repository")
     public boolean excludeLocalRepo;
@@ -732,6 +737,13 @@ public final class ZpmInstall extends ZpmCommand
         }
     }
 
+    private List<String> incubatorModuleNames()
+    {
+        return incubator.stream()
+            .map(name -> String.format("jdk.incubator.%s", name))
+            .collect(toList());
+    }
+
     private void linkModules(
         Collection<ZpmModule> modules) throws IOException
     {
@@ -748,6 +760,7 @@ public final class ZpmInstall extends ZpmCommand
         {
             extraModuleNames.add("java.instrument");
         }
+        extraModuleNames.addAll(incubatorModuleNames());
 
         extraModuleNames.add("java.management");
         extraModuleNames.add("jdk.management");
@@ -782,8 +795,7 @@ public final class ZpmInstall extends ZpmCommand
 
     private void generateLauncher() throws IOException
     {
-        Path zillaPath = launcherDir.resolve("zilla");
-        Files.write(zillaPath, Arrays.asList(
+        List<String> lines = new ArrayList<>(Arrays.asList(
             "#!/bin/sh",
             "if [ -n \"$ZILLA_INCUBATOR_ENABLED\" ]; then",
             "JAVA_OPTIONS=\"$JAVA_OPTIONS -Dzilla.incubator.enabled=$ZILLA_INCUBATOR_ENABLED\"",
@@ -793,12 +805,23 @@ public final class ZpmInstall extends ZpmCommand
             "JAVA_OPTIONS=\"$JAVA_OPTIONS --add-opens java.base/jdk.internal.misc=ALL-UNNAMED " +
                 "--add-opens java.base/jdk.internal.misc=org.agrona " +
                 "--enable-native-access=io.aklivity.zilla.runtime.common.agrona " +
-                "--sun-misc-unsafe-memory-access=%s\"".formatted(unsafeMemoryAccess),
-            String.format(String.join(" ", Arrays.asList(
-                    "exec $ZILLA_DIRECTORY/%s/bin/java",
-                    "$JAVA_OPTIONS",
-                    "-m io.aklivity.zilla.runtime.command/io.aklivity.zilla.runtime.command.internal.ZillaMain \"$@\"")),
-                imageDir)));
+                "--sun-misc-unsafe-memory-access=%s\"".formatted(unsafeMemoryAccess)));
+
+        List<String> incubatorModuleNames = incubatorModuleNames();
+        if (!incubatorModuleNames.isEmpty())
+        {
+            lines.add(String.format("JAVA_OPTIONS=\"$JAVA_OPTIONS --add-modules %s\"",
+                String.join(",", incubatorModuleNames)));
+        }
+
+        lines.add(String.format(String.join(" ", Arrays.asList(
+                "exec $ZILLA_DIRECTORY/%s/bin/java",
+                "$JAVA_OPTIONS",
+                "-m io.aklivity.zilla.runtime.command/io.aklivity.zilla.runtime.command.internal.ZillaMain \"$@\"")),
+            imageDir));
+
+        Path zillaPath = launcherDir.resolve("zilla");
+        Files.write(zillaPath, lines);
         zillaPath.toFile().setExecutable(true);
     }
 

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
@@ -737,7 +737,7 @@ public final class ZpmInstall extends ZpmCommand
         }
     }
 
-    private List<String> incubatorModuleNames()
+    private List<String> incubatorModules()
     {
         return incubator.stream()
             .map(name -> String.format("jdk.incubator.%s", name))
@@ -760,7 +760,7 @@ public final class ZpmInstall extends ZpmCommand
         {
             extraModuleNames.add("java.instrument");
         }
-        extraModuleNames.addAll(incubatorModuleNames());
+        extraModuleNames.addAll(incubatorModules());
 
         extraModuleNames.add("java.management");
         extraModuleNames.add("jdk.management");
@@ -795,7 +795,8 @@ public final class ZpmInstall extends ZpmCommand
 
     private void generateLauncher() throws IOException
     {
-        List<String> lines = new ArrayList<>(Arrays.asList(
+        Path zillaPath = launcherDir.resolve("zilla");
+        Files.write(zillaPath, Arrays.asList(
             "#!/bin/sh",
             "if [ -n \"$ZILLA_INCUBATOR_ENABLED\" ]; then",
             "JAVA_OPTIONS=\"$JAVA_OPTIONS -Dzilla.incubator.enabled=$ZILLA_INCUBATOR_ENABLED\"",
@@ -805,23 +806,12 @@ public final class ZpmInstall extends ZpmCommand
             "JAVA_OPTIONS=\"$JAVA_OPTIONS --add-opens java.base/jdk.internal.misc=ALL-UNNAMED " +
                 "--add-opens java.base/jdk.internal.misc=org.agrona " +
                 "--enable-native-access=io.aklivity.zilla.runtime.common.agrona " +
-                "--sun-misc-unsafe-memory-access=%s\"".formatted(unsafeMemoryAccess)));
-
-        List<String> incubatorModuleNames = incubatorModuleNames();
-        if (!incubatorModuleNames.isEmpty())
-        {
-            lines.add(String.format("JAVA_OPTIONS=\"$JAVA_OPTIONS --add-modules %s\"",
-                String.join(",", incubatorModuleNames)));
-        }
-
-        lines.add(String.format(String.join(" ", Arrays.asList(
-                "exec $ZILLA_DIRECTORY/%s/bin/java",
-                "$JAVA_OPTIONS",
-                "-m io.aklivity.zilla.runtime.command/io.aklivity.zilla.runtime.command.internal.ZillaMain \"$@\"")),
-            imageDir));
-
-        Path zillaPath = launcherDir.resolve("zilla");
-        Files.write(zillaPath, lines);
+                "--sun-misc-unsafe-memory-access=%s\"".formatted(unsafeMemoryAccess),
+            String.format(String.join(" ", Arrays.asList(
+                    "exec $ZILLA_DIRECTORY/%s/bin/java",
+                    "$JAVA_OPTIONS",
+                    "-m io.aklivity.zilla.runtime.command/io.aklivity.zilla.runtime.command.internal.ZillaMain \"$@\"")),
+                imageDir)));
         zillaPath.toFile().setExecutable(true);
     }
 

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
@@ -124,7 +124,7 @@ public final class ZpmInstall extends ZpmCommand
     public Boolean instrument = false;
 
     @Option(name = {"--incubator"},
-        description = "Enable an incubator module (repeatable), e.g. --incubator vector",
+        description = "Link an incubator module",
         hidden = true)
     public List<String> incubator = new ArrayList<>();
 

--- a/manager/src/test/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstallTest.java
+++ b/manager/src/test/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstallTest.java
@@ -15,6 +15,8 @@
  */
 package io.aklivity.zilla.manager.internal.commands.install;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -114,7 +116,7 @@ public class ZpmInstallTest
     }
 
     @Test
-    public void shouldGenerateLauncherWithIncubatorModule() throws Exception
+    public void shouldLinkIncubatorModuleIntoImage() throws Exception
     {
         Path configDir = Paths.get(getClass().getResource("/conf/install/zpm.json").toURI()).getParent();
         Path launcherDir = Paths.get("target/launcher-incubator");
@@ -139,10 +141,15 @@ public class ZpmInstallTest
 
         assertThat(install, instanceOf(ZpmInstall.class));
 
-        Path launcherPath = launcherDir.resolve("zilla");
-        assertThat(launcherPath.toFile(), anExistingFile());
+        Path imageJava = Paths.get("target/zpm-incubator/image/bin/java");
+        assertThat(imageJava.toFile(), anExistingFile());
 
-        String launcher = Files.readString(launcherPath);
-        assertThat(launcher, containsString("--add-modules jdk.incubator.vector"));
+        Process listModules = new ProcessBuilder(imageJava.toString(), "--list-modules")
+            .redirectErrorStream(true)
+            .start();
+        String modules = new String(listModules.getInputStream().readAllBytes(), UTF_8);
+        listModules.waitFor();
+
+        assertThat(modules, containsString("jdk.incubator.vector"));
     }
 }

--- a/manager/src/test/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstallTest.java
+++ b/manager/src/test/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstallTest.java
@@ -15,12 +15,14 @@
  */
 package io.aklivity.zilla.manager.internal.commands.install;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.io.FileMatchers.anExistingFile;
 
 import java.io.File;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
@@ -109,5 +111,36 @@ public class ZpmInstallTest
             anExistingFile());
         assertThat(new File(String.format("target/zpm-offline/cache/org/agrona/agrona/%1$s/agrona-%1$s.jar", agronaVersion)),
             anExistingFile());
+    }
+
+    @Test
+    public void shouldGenerateLauncherWithIncubatorModule() throws Exception
+    {
+        Path configDir = Paths.get(getClass().getResource("/conf/install/zpm.json").toURI()).getParent();
+
+        String[] args =
+        {
+            "install",
+            "--config-directory", configDir.toString(),
+            "--lock-directory", "target/test-locks/install-incubator",
+            "--output-directory", "target/zpm-incubator",
+            "--launcher-directory", "target/launcher-incubator",
+            "--exclude-remote-repositories",
+            "--incubator", "vector",
+            "--silent"
+        };
+
+        Cli<Runnable> parser = new Cli<>(ZpmCli.class);
+        Runnable install = parser.parse(args);
+
+        install.run();
+
+        assertThat(install, instanceOf(ZpmInstall.class));
+
+        File launcherFile = new File("target/launcher-incubator/zilla");
+        assertThat(launcherFile, anExistingFile());
+
+        String launcher = Files.readString(launcherFile.toPath());
+        assertThat(launcher, containsString("--add-modules jdk.incubator.vector"));
     }
 }

--- a/manager/src/test/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstallTest.java
+++ b/manager/src/test/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstallTest.java
@@ -117,6 +117,8 @@ public class ZpmInstallTest
     public void shouldGenerateLauncherWithIncubatorModule() throws Exception
     {
         Path configDir = Paths.get(getClass().getResource("/conf/install/zpm.json").toURI()).getParent();
+        Path launcherDir = Paths.get("target/launcher-incubator");
+        Files.createDirectories(launcherDir);
 
         String[] args =
         {
@@ -124,7 +126,7 @@ public class ZpmInstallTest
             "--config-directory", configDir.toString(),
             "--lock-directory", "target/test-locks/install-incubator",
             "--output-directory", "target/zpm-incubator",
-            "--launcher-directory", "target/launcher-incubator",
+            "--launcher-directory", launcherDir.toString(),
             "--exclude-remote-repositories",
             "--incubator", "vector",
             "--silent"
@@ -137,10 +139,10 @@ public class ZpmInstallTest
 
         assertThat(install, instanceOf(ZpmInstall.class));
 
-        File launcherFile = new File("target/launcher-incubator/zilla");
-        assertThat(launcherFile, anExistingFile());
+        Path launcherPath = launcherDir.resolve("zilla");
+        assertThat(launcherPath.toFile(), anExistingFile());
 
-        String launcher = Files.readString(launcherFile.toPath());
+        String launcher = Files.readString(launcherPath);
         assertThat(launcher, containsString("--add-modules jdk.incubator.vector"));
     }
 }

--- a/manager/src/test/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstallTest.java
+++ b/manager/src/test/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstallTest.java
@@ -16,7 +16,6 @@
 package io.aklivity.zilla.manager.internal.commands.install;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;


### PR DESCRIPTION
## Description

`zpm install` (`ZpmInstall`) already links a fixed extra set of modules into the generated runtime image via `--debug` (`jdk.jdwp.agent`) and `--instrument` (`java.instrument`).

Some plugins need to link an optional JDK incubator module into the generated runtime image. Rather than hardcoding specific incubator module names into the shared install code, this adds a repeatable `--incubator <name>` option, following the same pattern as `--debug`/`--instrument`:

- `--incubator <name>` is repeatable and maps each name to `jdk.incubator.<name>`.
- The resulting module names are added to `linkModules()`'s existing `extraModuleNames` list, so `jlink` includes them in the generated runtime image.
- The option defaults to an empty list, so when it isn't passed, the generated image and launcher are unchanged from today.
- `generateLauncher()` is untouched: a jlink'd image's own module resolution (`ServiceLoader` `uses`/`provides` binding, plus transitive `requires`) already picks up a linked incubator module automatically at launch, so no extra `--add-modules` needs to be baked into the launcher script.

A new test (`shouldLinkIncubatorModuleIntoImage`) exercises `--incubator vector` end-to-end through the real `zilla install` CLI (`jdk.incubator.vector` is currently the only incubator module shipped in the JDK, so it's used to validate the mechanism actually links) and asserts the linked image's `--list-modules` output contains `jdk.incubator.vector`.

## Test plan

- [x] New unit test added covering the CLI option and the linked image's module list, run locally end-to-end (confirmed `jlink` links `jdk.incubator.vector` into the image and the image resolves it at launch with no extra runtime flags)
- [x] Existing `ZpmInstallTest` tests unaffected (option defaults to empty, no behavior change when unset)
- [ ] Full CI build (`./mvnw install`)

Fixes # N/A — no linked issue.
