### PR TITLE
fix(common-yaml): advance parser cursor when materializing getObject()/getValue()/getArray()

### DIFF
--- a/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/json/YamlJsonParser.java
+++ b/runtime/common-yaml/src/main/java/io/aklivity/zilla/runtime/common/yaml/internal/json/YamlJsonParser.java
@@ -225,7 +225,15 @@ public final class YamlJsonParser implements JsonParser
         {
             throw new IllegalStateException("No value is available for current event");
         }
-        return value(new int[] {current});
+        int[] at = new int[] {current};
+        JsonValue value = value(at);
+        // per the JsonParser contract, materializing a structured value advances the parser to the
+        // matching END_OBJECT/END_ARRAY event; a scalar value is already positioned there, so this is a
+        // no-op for scalars. Skipping this step leaves cursor/current stale, so a subsequent next() replays
+        // the just-materialized value's events instead of continuing after it.
+        current = at[0] - 1;
+        cursor = at[0];
+        return value;
     }
 
     @Override

--- a/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/YamlJsonParserTest.java
+++ b/runtime/common-yaml/src/test/java/io/aklivity/zilla/runtime/common/yaml/YamlJsonParserTest.java
@@ -804,18 +804,108 @@ class YamlJsonParserTest
         assertThrows(IllegalStateException.class, parser::getValue);
         assertEquals(START_OBJECT, parser.next());
         assertEquals(START_OBJECT, parser.currentEvent());
+        assertThrows(IllegalStateException.class, parser::skipArray);
         JsonObject object = parser.getObject();
         assertEquals("test", object.getString("name"));
         assertEquals(1, object.getJsonArray("values").getInt(0));
-        assertEquals(2, parser.getObjectStream().count());
-        assertEquals(1, parser.getValueStream().count());
-        assertThrows(IllegalStateException.class, parser::skipArray);
-
-        while (parser.hasNext())
-        {
-            parser.next();
-        }
+        // getObject() must advance the parser to the matching END_OBJECT, consuming the whole document
+        assertEquals(END_OBJECT, parser.currentEvent());
+        assertFalse(parser.hasNext());
         assertThrows(JsonParsingException.class, parser::next);
+    }
+
+    @Test
+    void shouldExposeObjectAndValueStreams()
+    {
+        JsonParser parser = parserFor("""
+            name: test
+            values: [1]
+            """);
+        assertEquals(START_OBJECT, parser.next());
+        assertEquals(2, parser.getObjectStream().count());
+        assertFalse(parser.hasNext());
+
+        parser = parserFor("""
+            name: test
+            """);
+        assertEquals(START_OBJECT, parser.next());
+        assertEquals(1, parser.getValueStream().count());
+        assertFalse(parser.hasNext());
+    }
+
+    @Test
+    void shouldAdvancePastMaterializedObjectSoSiblingPropertiesRemainReadable()
+    {
+        // reproduces the corruption from GH-1997: getObject()/getValue() must not leave the parser
+        // positioned back at the start of the value it just materialized, or the sibling properties that
+        // follow it in the document are misread or skipped entirely
+        JsonParser parser = parserFor("""
+            first:
+              nested: value
+            second: after
+            """);
+
+        assertEquals(START_OBJECT, parser.next());
+        assertEquals(KEY_NAME, parser.next());
+        assertEquals("first", parser.getString());
+        assertEquals(START_OBJECT, parser.next());
+
+        JsonObject nested = parser.getObject();
+        assertEquals("value", nested.getString("nested"));
+        assertEquals(END_OBJECT, parser.currentEvent());
+
+        assertEquals(KEY_NAME, parser.next());
+        assertEquals("second", parser.getString());
+        assertEquals(VALUE_STRING, parser.next());
+        assertEquals("after", parser.getString());
+        assertEquals(END_OBJECT, parser.next());
+        assertFalse(parser.hasNext());
+    }
+
+    @Test
+    void shouldAdvancePastMaterializedArraySoSiblingPropertiesRemainReadable()
+    {
+        JsonParser parser = parserFor("""
+            first: [1, 2]
+            second: after
+            """);
+
+        assertEquals(START_OBJECT, parser.next());
+        assertEquals(KEY_NAME, parser.next());
+        assertEquals("first", parser.getString());
+        assertEquals(START_ARRAY, parser.next());
+
+        assertEquals(2, parser.getArray().size());
+        assertEquals(END_ARRAY, parser.currentEvent());
+
+        assertEquals(KEY_NAME, parser.next());
+        assertEquals("second", parser.getString());
+        assertEquals(VALUE_STRING, parser.next());
+        assertEquals("after", parser.getString());
+        assertEquals(END_OBJECT, parser.next());
+        assertFalse(parser.hasNext());
+    }
+
+    @Test
+    void shouldLeaveScalarValuePositionUnchangedAfterGetValue()
+    {
+        JsonParser parser = parserFor("""
+            first: alpha
+            second: beta
+            """);
+
+        assertEquals(START_OBJECT, parser.next());
+        assertEquals(KEY_NAME, parser.next());
+        assertEquals(VALUE_STRING, parser.next());
+        assertEquals("alpha", ((jakarta.json.JsonString) parser.getValue()).getString());
+        assertEquals(VALUE_STRING, parser.currentEvent());
+
+        assertEquals(KEY_NAME, parser.next());
+        assertEquals("second", parser.getString());
+        assertEquals(VALUE_STRING, parser.next());
+        assertEquals("beta", parser.getString());
+        assertEquals(END_OBJECT, parser.next());
+        assertFalse(parser.hasNext());
     }
 
     @Test


### PR DESCRIPTION
## Description

`YamlJsonParser.getObject()`/`getValue()`/`getArray()` materialize a `JsonValue` by walking the parser's internal step list using a locally-scoped index (`int[] at`), but never write that index back to the parser's own `cursor`/`current` fields. The parser's actual position is therefore left unchanged after these calls — as if the value had never been consumed. When Yasson (JSON-B) calls `getObject()`/`getValue()` from inside a custom `JsonbDeserializer` or `JsonbAdapter` and then resumes driving the parser itself, it replays the just-materialized value's own events instead of continuing after it. This showed up as two symptoms:

1. A `JsonbDeserializer` bound to a `Map` value calling `parser.getObject()` throws `NoSuchElementException: There are no more elements available!`.
2. A `JsonbAdapter` bound to a plain field silently desyncs the cursor, causing sibling properties later in the document to come back `null` with no exception.

### Fix

`getValue()` now sets `cursor`/`current` to reflect the full range of steps consumed while building the value — advancing to the matching `END_OBJECT`/`END_ARRAY` event for structured values (a no-op for scalars, which were already correctly positioned). This matches the `JsonParser` contract, where `getObject()`/`getArray()`/`getValue()` must leave the parser positioned at the value's closing event so a subsequent `next()` continues from there.

Verified this doesn't affect `common-json`'s `JsonParserImpl`, which has its own `getObject()`/`getArray()` implementation that drives through real `next()` calls and was already correctly advancing the shared parser state.

### Testing

- Fixed `shouldExposeParserMethods`, which had encoded the buggy idempotent behavior (calling `getObjectStream()`/`getValueStream()` again immediately after `getObject()` had already consumed the whole document).
- Added `shouldAdvancePastMaterializedObjectSoSiblingPropertiesRemainReadable` and `shouldAdvancePastMaterializedArraySoSiblingPropertiesRemainReadable`, which directly reproduce the corruption described in the issue: materializing a nested value via `getObject()`/`getArray()` must not prevent correctly reading the sibling properties that follow it.
- Added `shouldLeaveScalarValuePositionUnchangedAfterGetValue()` to confirm `getValue()` on a scalar remains idempotent.
- Added `shouldExposeObjectAndValueStreams()` to preserve coverage of `getObjectStream()`/`getValueStream()` on fresh parsers.

All 38 tests in `YamlJsonParserTest` pass (`./mvnw test -pl runtime/common-yaml`).

Fixes #1997


---
_Generated by [Claude Code](https://claude.ai/code/session_01ERm47w1Joqma5VmrrUehdy)_