### PR TITLE
feat(common-json): extract pluggable JsonTokenizer SPI

### DIFF
--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonStringView.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonStringView.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+
+/**
+ * The {@link CharSequence} returned by {@link JsonTokenizer#stringView()}, with an optional hint for a
+ * caller that can do better than character-by-character access.
+ * <p>
+ * {@link #getSegment()} is the contiguous run of original source bytes this view's characters were decoded
+ * from, when such a run exists and corresponds 1:1 to this view's content — {@code null} when the
+ * characters were produced by transforming the source bytes during decoding (an escape sequence, a
+ * multi-byte UTF-8 sequence folded into canonical form, etc.) and so have no single corresponding byte
+ * range in the source document. A caller able to exploit a direct source-byte range — a generator splicing
+ * an unmodified value straight through instead of re-encoding it — treats this as an opportunistic hint,
+ * not a requirement, and falls back to ordinary {@link CharSequence} access whenever it is {@code null}.
+ * <p>
+ * The instance is non-owning and reused across calls; a caller must not retain it, or any segment obtained
+ * from it, past the current call.
+ */
+public interface JsonStringView extends CharSequence
+{
+    DirectBufferEx getSegment();
+}

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonStringView.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonStringView.java
@@ -28,6 +28,16 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
  * an unmodified value straight through instead of re-encoding it — treats this as an opportunistic hint,
  * not a requirement, and falls back to ordinary {@link CharSequence} access whenever it is {@code null}.
  * <p>
+ * <strong>When non-{@code null}, every byte in the returned segment must be plain ASCII and must never
+ * require escaping to appear unmodified in a JSON string body</strong> (no quote, backslash, control
+ * character, or byte outside the 7-bit ASCII range) — exactly the same guarantee a decoded value would
+ * need to have required zero transformation from source to canonical form in the first place. This is
+ * what lets a caller such as a generator copy the segment's bytes directly into JSON string-body output
+ * with no re-encoding or re-escaping pass, and lets {@link #getSegment()}'s byte length be relied on as
+ * equal to this view's {@link #length()} (one byte, one char). An implementation must never return a
+ * non-{@code null} segment for content it has not itself verified satisfies this — returning {@code null}
+ * is always the safe, correct answer when in doubt.
+ * <p>
  * The instance is non-owning and reused across calls; a caller must not retain it, or any segment obtained
  * from it, past the current call.
  */

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonTokenizer.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+import java.lang.foreign.MemorySegment;
+
+import jakarta.json.stream.JsonParser;
+
+public interface JsonTokenizer
+{
+    void reset();
+
+    void wrap(
+        MemorySegment segment,
+        int offset,
+        int limit);
+
+    void terminal(
+        boolean terminalEof);
+
+    void window(
+        int length);
+
+    boolean advance();
+
+    JsonParser.Event event();
+
+    void clearEvent();
+
+    String stringValue();
+
+    CharSequence stringView();
+
+    void markScratchConsumed(
+        int consumed);
+
+    long streamOffset();
+
+    long line();
+
+    long column();
+
+    long valueStreamStart();
+
+    long valueStreamEnd();
+
+    boolean done();
+
+    long documentEndOffset();
+
+    boolean inObjectContext();
+
+    boolean inArrayContext();
+
+    boolean memberSeparated();
+
+    boolean separatorBefore();
+
+    boolean fragmenting();
+
+    boolean stringVerbatim();
+
+    String currentPath();
+
+    void segmenting(
+        boolean segmenting);
+
+    void scalarSegment(
+        boolean scalarSegment);
+}

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonTokenizer.java
@@ -14,21 +14,24 @@
  */
 package io.aklivity.zilla.runtime.common.json;
 
-import java.lang.foreign.MemorySegment;
-
 import jakarta.json.stream.JsonParser;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 
 public interface JsonTokenizer
 {
     void reset();
 
     void wrap(
-        MemorySegment segment,
+        DirectBufferEx buffer,
         int offset,
         int limit);
 
-    void terminal(
-        boolean terminalEof);
+    void wrap(
+        DirectBufferEx buffer,
+        int offset,
+        int limit,
+        boolean last);
 
     void window(
         int length);

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonTokenizer.java
@@ -41,7 +41,7 @@ public interface JsonTokenizer
 
     String stringValue();
 
-    CharSequence stringView();
+    JsonStringView stringView();
 
     void markScratchConsumed(
         int consumed);

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonTokenizer.java
@@ -46,6 +46,12 @@ public interface JsonTokenizer
 
     JsonStringView stringView();
 
+    boolean numberIntegral();
+
+    boolean numberInLongRange();
+
+    long numberLongValue();
+
     void markScratchConsumed(
         int consumed);
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonTokenizerFactory.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonTokenizerFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+import java.util.ServiceLoader;
+
+public interface JsonTokenizerFactory
+{
+    JsonTokenizer create(
+        boolean terminalEof,
+        int maxValueSize);
+
+    int priority();
+
+    boolean available();
+
+    static JsonTokenizerFactory instantiate()
+    {
+        return instantiate(ServiceLoader.load(JsonTokenizerFactory.class));
+    }
+
+    // Iterable (not ServiceLoader) so tests can pass a fixed list of hand-rolled candidates
+    // and exercise the selection logic without any META-INF/services wiring.
+    static JsonTokenizerFactory instantiate(
+        Iterable<JsonTokenizerFactory> candidates)
+    {
+        JsonTokenizerFactory selected = null;
+        for (JsonTokenizerFactory candidate : candidates)
+        {
+            if (candidate.available() && (selected == null || candidate.priority() > selected.priority()))
+            {
+                selected = candidate;
+            }
+        }
+        if (selected == null)
+        {
+            throw new IllegalStateException("No available JsonTokenizerFactory found");
+        }
+        return selected;
+    }
+}

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -31,6 +31,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx.Completion;
 import io.aklivity.zilla.runtime.common.json.JsonStep;
+import io.aklivity.zilla.runtime.common.json.JsonStringView;
 import io.aklivity.zilla.runtime.common.json.JsonVerbatim;
 
 /**
@@ -241,7 +242,25 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         // closing quote on the final fragment); report the source chars taken via consumed() so a chunking
         // driver advances its cursor and resumes from the remainder, the char-domain analog of writeSegment
         final int reserve = completion == Completion.COMPLETE ? 1 : 0;
-        final int written = writeStringBody(value, reserve);
+        final int written;
+        if (value instanceof JsonStringView view && view.getSegment() != null &&
+            view.getSegment().capacity() <= limit - progress - reserve)
+        {
+            // whole segment fits the current output window: splice its (guaranteed plain-ASCII, see
+            // JsonStringView's javadoc) bytes directly instead of the codepoint-by-codepoint path below.
+            // A segment too large for one call falls through unchanged -- that path already knows how
+            // to bound and correctly resume a partial write, which this fast path does not attempt to
+            // duplicate.
+            final DirectBufferEx segment = view.getSegment();
+            final int length = segment.capacity();
+            buffer.putBytes(progress, segment, 0, length);
+            progress += length;
+            written = value.length();
+        }
+        else
+        {
+            written = writeStringBody(value, reserve);
+        }
         consumed += written;
         if (written == value.length() && completion == Completion.COMPLETE)
         {

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -16,6 +16,7 @@ package io.aklivity.zilla.runtime.common.json.internal;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.foreign.MemorySegment;
 import java.math.BigDecimal;
 import java.util.AbstractMap;
 import java.util.Arrays;
@@ -42,6 +43,8 @@ import io.aklivity.zilla.runtime.common.json.JsonEvent;
 import io.aklivity.zilla.runtime.common.json.JsonParserEx;
 import io.aklivity.zilla.runtime.common.json.JsonParserEx.Mode;
 import io.aklivity.zilla.runtime.common.json.JsonStep;
+import io.aklivity.zilla.runtime.common.json.JsonTokenizer;
+import io.aklivity.zilla.runtime.common.json.JsonTokenizerFactory;
 import io.aklivity.zilla.runtime.common.json.JsonVerbatim;
 import io.aklivity.zilla.runtime.common.json.internal.json.JsonValues;
 
@@ -55,8 +58,18 @@ public final class JsonParserImpl implements JsonParserEx
     // generous enough for any reasonable value, bounding only adversarial accumulation
     private static final int DEFAULT_MAX_VALUE_SIZE = 1 << 24;
 
-    private final InputStream in;
+    // DirectBufferInputStreamEx here is only a convenient (buffer, offset, length) holder for segment/verbatim
+    // view construction (bufferOffset(), getSegment(), getVerbatim()) — it no longer feeds the tokenizer,
+    // which reads directly from a MemorySegment. See zilla#1999 for its other, unrelated call sites.
     private final DirectBufferInputStreamEx ownedInput;
+    // non-null only for the InputStream-constructor (compatibility) path; null when fed via wrap(DirectBufferEx).
+    // A DirectBufferInputStreamEx may be re-wrapped by the caller between hasNext() calls (see
+    // rewrapRawInputIfNeeded()); any other InputStream is read once, lazily, on first use.
+    private final InputStream rawInput;
+    private boolean rawInputWrapped;
+    private DirectBufferEx rawInputBuffer;
+    private int rawInputOffset;
+    private int rawInputLength;
     private final JsonTokenizer tokenizer;
     private final JsonLocationImpl location;
     private final UnsafeBufferEx segmentView = new UnsafeBufferEx(0, 0);
@@ -121,8 +134,8 @@ public final class JsonParserImpl implements JsonParserEx
         Map<String, ?> config)
     {
         this.ownedInput = new DirectBufferInputStreamEx();
-        this.in = ownedInput;
-        this.tokenizer = new JsonTokenizer(false, maxValueSize(config));
+        this.rawInput = null;
+        this.tokenizer = JsonTokenizerFactory.instantiate().create(false, maxValueSize(config));
         this.location = new JsonLocationImpl(tokenizer);
     }
 
@@ -132,6 +145,13 @@ public final class JsonParserImpl implements JsonParserEx
         this(in, Map.of());
     }
 
+    // Compatibility path for an arbitrary caller-supplied InputStream (e.g. JsonEx.createParser(InputStream)).
+    // A DirectBufferInputStreamEx is a resumable frame source the caller may re-wrap directly between hasNext()
+    // calls — each re-wrap is detected and re-bound to the tokenizer by rewrapRawInputIfNeeded() — so its EOF is
+    // a frame boundary, not the terminal delimiter. Any other stream cannot be re-wrapped like that, so it is
+    // one-shot: read lazily in full on first use (not here — mark/reset support is required so this is a
+    // faithful replay of the original stream either way) and its EOF is the terminal delimiter for a trailing
+    // number.
     public JsonParserImpl(
         InputStream in,
         Map<String, ?> config)
@@ -140,11 +160,9 @@ public final class JsonParserImpl implements JsonParserEx
         {
             throw new IllegalArgumentException("InputStream must support mark/reset");
         }
-        this.in = in;
         this.ownedInput = null;
-        // A DirectBufferInputStreamEx is a resumable frame source whose EOF is a frame boundary;
-        // any other stream is one-shot, so its EOF is the terminal delimiter for a trailing number.
-        this.tokenizer = new JsonTokenizer(
+        this.rawInput = in;
+        this.tokenizer = JsonTokenizerFactory.instantiate().create(
             !(in instanceof DirectBufferInputStreamEx), maxValueSize(config));
         this.location = new JsonLocationImpl(tokenizer);
     }
@@ -165,6 +183,11 @@ public final class JsonParserImpl implements JsonParserEx
         frameBaseStreamOffset = tokenizer.streamOffset();
         tokenizer.window(limit - offset);
         ownedInput.wrap(buffer, offset, limit - offset);
+        // segment() is the raw, unadjusted backing segment (agrona's own getByte()-family accessors all add
+        // wrapAdjustment() to the logical index) — add it here so the tokenizer reads the same bytes buffer's
+        // own [offset, limit) would.
+        final int adjustment = buffer.wrapAdjustment();
+        tokenizer.wrap(buffer.segment(), adjustment + offset, adjustment + limit);
         windowLast = true;
         return this;
     }
@@ -247,16 +270,46 @@ public final class JsonParserImpl implements JsonParserEx
             {
                 tokenizer.markScratchConsumed(stringViewOffset);
             }
+            rewrapRawInputIfNeeded();
+            result = tokenizer.advance();
+        }
+        return result;
+    }
+
+    // Only does anything on the InputStream-constructor path (rawInput != null). A DirectBufferInputStreamEx
+    // may have been re-wrapped by the caller directly (outside this class) since the last check — detected by
+    // its (buffer, offset, length) tuple changing — in which case the tokenizer is re-bound to the new window.
+    // Any other InputStream is read once, in full, on the first call, and never again.
+    private void rewrapRawInputIfNeeded()
+    {
+        if (rawInput instanceof DirectBufferInputStreamEx rewrappable)
+        {
+            final DirectBufferEx buffer = rewrappable.buffer();
+            final int offset = rewrappable.offset();
+            final int length = rewrappable.length();
+            if (buffer != rawInputBuffer || offset != rawInputOffset || length != rawInputLength)
+            {
+                final int adjustment = buffer.wrapAdjustment();
+                tokenizer.wrap(buffer.segment(), adjustment + offset, adjustment + offset + length);
+                rawInputBuffer = buffer;
+                rawInputOffset = offset;
+                rawInputLength = length;
+            }
+        }
+        else if (rawInput != null && !rawInputWrapped)
+        {
+            byte[] bytes;
             try
             {
-                result = tokenizer.advance(in);
+                bytes = rawInput.readAllBytes();
             }
             catch (IOException ex)
             {
                 throw new JsonParsingException(ex.getMessage(), ex, location);
             }
+            tokenizer.wrap(MemorySegment.ofArray(bytes), 0, bytes.length);
+            rawInputWrapped = true;
         }
-        return result;
     }
 
     private int bufferOffset(

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -621,20 +621,7 @@ public final class JsonParserImpl implements JsonParserEx
     public boolean isIntegralNumber()
     {
         assert currentEvent == Event.VALUE_NUMBER;
-        // the current number's char view (not stringValue()), so scanning it materializes no String; with
-        // consumed(0) accumulation a value the caller needs whole is fully present in scratch by this point
-        final CharSequence v = tokenizer.stringView();
-        if (v == null)
-        {
-            throw new IllegalStateException("Not a number");
-        }
-        boolean integral = true;
-        for (int i = 0; integral && i < v.length(); i++)
-        {
-            final char c = v.charAt(i);
-            integral = c != '.' && c != 'e' && c != 'E';
-        }
-        return integral;
+        return tokenizer.numberIntegral();
     }
 
     @Override
@@ -642,6 +629,32 @@ public final class JsonParserImpl implements JsonParserEx
     {
         assert currentEvent == Event.VALUE_NUMBER;
         assert !deferredBytes();
+        final int value;
+        if (tokenizer.numberIntegral() && tokenizer.numberInLongRange())
+        {
+            final long longValue = tokenizer.numberLongValue();
+            value = longValue >= Integer.MIN_VALUE && longValue <= Integer.MAX_VALUE ? (int) longValue : legacyGetInt();
+        }
+        else
+        {
+            value = legacyGetInt();
+        }
+        return value;
+    }
+
+    @Override
+    public long getLong()
+    {
+        assert currentEvent == Event.VALUE_NUMBER;
+        assert !deferredBytes();
+        return tokenizer.numberIntegral() && tokenizer.numberInLongRange() ? tokenizer.numberLongValue() : legacyGetLong();
+    }
+
+    // Fallback for a non-integral number, one whose leading-digit run exceeds the fused fast path's
+    // LONG_SAFE_DIGITS bound (see JsonTokenizerImpl), or whose fused value narrows out of int range --
+    // the same CharSequence-based parse getInt()/getLong() always used before the fused fast path existed.
+    private int legacyGetInt()
+    {
         final CharSequence lexeme = tokenizer.stringView();
         if (integerDigits(lexeme) > LONG_DIGITS)
         {
@@ -650,11 +663,8 @@ public final class JsonParserImpl implements JsonParserEx
         return Integer.parseInt(lexeme, 0, lexeme.length(), 10);
     }
 
-    @Override
-    public long getLong()
+    private long legacyGetLong()
     {
-        assert currentEvent == Event.VALUE_NUMBER;
-        assert !deferredBytes();
         final CharSequence lexeme = tokenizer.stringView();
         if (integerDigits(lexeme) > LONG_DIGITS)
         {

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -16,7 +16,6 @@ package io.aklivity.zilla.runtime.common.json.internal;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.foreign.MemorySegment;
 import java.math.BigDecimal;
 import java.util.AbstractMap;
 import java.util.Arrays;
@@ -60,7 +59,7 @@ public final class JsonParserImpl implements JsonParserEx
 
     // DirectBufferInputStreamEx here is only a convenient (buffer, offset, length) holder for segment/verbatim
     // view construction (bufferOffset(), getSegment(), getVerbatim()) — it no longer feeds the tokenizer,
-    // which reads directly from a MemorySegment. See zilla#1999 for its other, unrelated call sites.
+    // which reads directly from the DirectBufferEx. See zilla#1999 for its other, unrelated call sites.
     private final DirectBufferInputStreamEx ownedInput;
     // non-null only for the InputStream-constructor (compatibility) path; null when fed via wrap(DirectBufferEx).
     // A DirectBufferInputStreamEx may be re-wrapped by the caller between hasNext() calls (see
@@ -183,11 +182,7 @@ public final class JsonParserImpl implements JsonParserEx
         frameBaseStreamOffset = tokenizer.streamOffset();
         tokenizer.window(limit - offset);
         ownedInput.wrap(buffer, offset, limit - offset);
-        // segment() is the raw, unadjusted backing segment (agrona's own getByte()-family accessors all add
-        // wrapAdjustment() to the logical index) — add it here so the tokenizer reads the same bytes buffer's
-        // own [offset, limit) would.
-        final int adjustment = buffer.wrapAdjustment();
-        tokenizer.wrap(buffer.segment(), adjustment + offset, adjustment + limit);
+        tokenizer.wrap(buffer, offset, limit);
         windowLast = true;
         return this;
     }
@@ -202,8 +197,10 @@ public final class JsonParserImpl implements JsonParserEx
         int limit,
         boolean last)
     {
-        tokenizer.terminal(last);
-        wrap(buffer, offset, limit);
+        frameBaseStreamOffset = tokenizer.streamOffset();
+        tokenizer.window(limit - offset);
+        ownedInput.wrap(buffer, offset, limit - offset);
+        tokenizer.wrap(buffer, offset, limit, last);
         windowLast = last;
         return this;
     }
@@ -289,8 +286,7 @@ public final class JsonParserImpl implements JsonParserEx
             final int length = rewrappable.length();
             if (buffer != rawInputBuffer || offset != rawInputOffset || length != rawInputLength)
             {
-                final int adjustment = buffer.wrapAdjustment();
-                tokenizer.wrap(buffer.segment(), adjustment + offset, adjustment + offset + length);
+                tokenizer.wrap(buffer, offset, offset + length);
                 rawInputBuffer = buffer;
                 rawInputOffset = offset;
                 rawInputLength = length;
@@ -307,7 +303,7 @@ public final class JsonParserImpl implements JsonParserEx
             {
                 throw new JsonParsingException(ex.getMessage(), ex, location);
             }
-            tokenizer.wrap(MemorySegment.ofArray(bytes), 0, bytes.length);
+            tokenizer.wrap(new UnsafeBufferEx(bytes), 0, bytes.length);
             rawInputWrapped = true;
         }
     }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerImpl.java
@@ -22,6 +22,8 @@ import java.util.Deque;
 import jakarta.json.stream.JsonParser;
 import jakarta.json.stream.JsonParsingException;
 
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.common.json.JsonStringView;
 import io.aklivity.zilla.runtime.common.json.JsonTokenizer;
 
 public final class JsonTokenizerImpl implements JsonTokenizer
@@ -65,6 +67,54 @@ public final class JsonTokenizerImpl implements JsonTokenizer
         EXP_INT
     }
 
+    // Reused view over an already-decoded CharSequence (scratch mid-decode, or a materialized String once
+    // taken) -- getSegment() is always null since this tokenizer never retains a byte-backed alternative;
+    // see stringViewRO's field comment for why that is always the correct answer here.
+    private static final class DecodedStringView implements JsonStringView
+    {
+        private CharSequence base;
+
+        private DecodedStringView wrap(
+            CharSequence base)
+        {
+            this.base = base;
+            return this;
+        }
+
+        @Override
+        public int length()
+        {
+            return base.length();
+        }
+
+        @Override
+        public char charAt(
+            int index)
+        {
+            return base.charAt(index);
+        }
+
+        @Override
+        public CharSequence subSequence(
+            int start,
+            int end)
+        {
+            return base.subSequence(start, end);
+        }
+
+        @Override
+        public String toString()
+        {
+            return base.toString();
+        }
+
+        @Override
+        public DirectBufferEx getSegment()
+        {
+            return null;
+        }
+    }
+
     private static final int MAX_DEPTH = 64;
 
     private final Deque<ParseState> stack = new ArrayDeque<>();
@@ -73,6 +123,11 @@ public final class JsonTokenizerImpl implements JsonTokenizer
     // unconsumed remainder accumulates, letting a consumer that declines fragments (consumed(0)) receive
     // the value whole. Set by the parser from its consumed cursor before each resuming advance.
     private int scratchConsumed;
+    // reused view returned by stringView(): this tokenizer always decodes into scratch, so its chars
+    // never correspond to a single contiguous run of source bytes once escapes or multi-byte UTF-8 are
+    // involved -- getSegment() is unconditionally null here, correctly signaling to a caller that there
+    // is no direct-byte-splice shortcut available for a canonically-decoded value.
+    private final DecodedStringView stringViewRO = new DecodedStringView();
     // cap on the decoded chars retained for one value/key; appendScratch fails closed past it so a
     // consumer that declines fragments cannot grow scratch without bound
     private final int maxValueSize;
@@ -419,9 +474,9 @@ public final class JsonTokenizerImpl implements JsonTokenizer
     // a downstream stage copy or compare the chars without a String; returns the materialized value if it
     // was already taken.
     @Override
-    public CharSequence stringView()
+    public JsonStringView stringView()
     {
-        return valuePending ? scratch : pendingString;
+        return stringViewRO.wrap(valuePending ? scratch : pendingString);
     }
 
     // The parser reports, before a resuming advance, how many chars of the current fragment the consumer

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerImpl.java
@@ -189,6 +189,17 @@ public final class JsonTokenizerImpl implements JsonTokenizer
     // windows needs no retained whole lexeme to validate; the state persists across fragments.
     private NumberState numberState;
 
+    // Fused alongside numberState, one leading-integer-part digit at a time (see validateNumberChar):
+    // lets getInt()/getLong() skip a second CharSequence pass through Integer.parseInt/Long.parseLong
+    // for the common case of a plain integral value. numberMagnitude stops accumulating past
+    // LONG_SAFE_DIGITS -- at or under that many digits the running value cannot overflow a signed long
+    // regardless of sign, so no per-digit overflow check is needed; a longer integer (rare) reports
+    // numberInLongRange() false and the caller falls back to the CharSequence-based path unchanged.
+    private static final int LONG_SAFE_DIGITS = 18;
+    private boolean numberNegative;
+    private long numberMagnitude;
+    private int numberDigitCount;
+
     // set at each VALUE_STRING delivery: true when the value-string was streamed verbatim as raw bytes
     // (a segment scan or an armed scalar leaf), so the caller splices its raw token bytes; false when it
     // was decoded into scratch, so the caller renders it canonically from the decoded chars.
@@ -252,6 +263,9 @@ public final class JsonTokenizerImpl implements JsonTokenizer
         scratch.setLength(0);
         scratchConsumed = 0;
         numberState = NumberState.START;
+        numberNegative = false;
+        numberMagnitude = 0L;
+        numberDigitCount = 0;
         stringVerbatim = false;
         memberSeparated = false;
         separatorBefore = false;
@@ -480,6 +494,30 @@ public final class JsonTokenizerImpl implements JsonTokenizer
     public JsonStringView stringView()
     {
         return stringViewRO.wrap(valuePending ? scratch : pendingString);
+    }
+
+    // Whether the just-completed VALUE_NUMBER has no fractional part or exponent -- the only two
+    // accepting states validateNumberComplete() allows that were never reached via a DOT/EXP transition.
+    @Override
+    public boolean numberIntegral()
+    {
+        return numberState == NumberState.ZERO || numberState == NumberState.INT;
+    }
+
+    // Whether numberLongValue() is safe to read: numberMagnitude only accumulates up to LONG_SAFE_DIGITS
+    // leading digits (see validateNumberChar), past which it stops -- so a digit count beyond that bound
+    // correctly reports false here rather than returning a truncated value.
+    @Override
+    public boolean numberInLongRange()
+    {
+        return numberDigitCount <= LONG_SAFE_DIGITS;
+    }
+
+    // Valid only when numberIntegral() && numberInLongRange() both hold for the current VALUE_NUMBER.
+    @Override
+    public long numberLongValue()
+    {
+        return numberNegative ? -numberMagnitude : numberMagnitude;
     }
 
     // The parser reports, before a resuming advance, how many chars of the current fragment the consumer
@@ -956,6 +994,9 @@ public final class JsonTokenizerImpl implements JsonTokenizer
                 scratch.setLength(0);
                 scratchConsumed = 0;
                 numberState = NumberState.START;
+                numberNegative = false;
+                numberMagnitude = 0L;
+                numberDigitCount = 0;
                 appendScratch((char) c);
                 validateNumberChar(c);
                 resumeOp = ResumeOp.VALUE_NUMBER;
@@ -1337,6 +1378,24 @@ public final class JsonTokenizerImpl implements JsonTokenizer
     private void validateNumberChar(
         int c)
     {
+        // Fuses numberMagnitude/numberDigitCount accumulation into the same one-char-at-a-time scan:
+        // only the leading integer-part digits count (START/SIGN/INT, checked against the state before
+        // this char's own transition below), matching exactly the digits getLong()/getInt()'s fast path
+        // needs -- a fractional or exponent digit never reaches here since numberIntegral() (numberState
+        // == ZERO or INT once the number completes) is what gates whether that fast path is even tried.
+        if (c == '-' && numberState == NumberState.START)
+        {
+            numberNegative = true;
+        }
+        else if (isDigit((char) c) &&
+            (numberState == NumberState.START || numberState == NumberState.SIGN || numberState == NumberState.INT))
+        {
+            numberDigitCount++;
+            if (numberDigitCount <= LONG_SAFE_DIGITS)
+            {
+                numberMagnitude = numberMagnitude * 10 + (c - '0');
+            }
+        }
         switch (numberState)
         {
         case START:

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerImpl.java
@@ -14,15 +14,17 @@
  */
 package io.aklivity.zilla.runtime.common.json.internal;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
 import jakarta.json.stream.JsonParser;
 import jakarta.json.stream.JsonParsingException;
 
-public final class JsonTokenizer
+import io.aklivity.zilla.runtime.common.json.JsonTokenizer;
+
+public final class JsonTokenizerImpl implements JsonTokenizer
 {
     private enum ParseState
     {
@@ -77,7 +79,17 @@ public final class JsonTokenizer
     private boolean terminalEof;
     // byte length of the current input window; a value whose own bytes reach this length without
     // completing fills the window and is delivered as fragments rather than reassembled across windows.
+    // Set independently via window() — a caller that never calls it (e.g. one driving advance() by
+    // repeatedly re-wrapping small ranges without an explicit per-slot window size) keeps the default
+    // below, disabling the fragmentation threshold entirely.
     private int windowLength = Integer.MAX_VALUE;
+
+    // the currently wrapped input: advance() may be called many times against the same wrapped
+    // segment (once per token drained from it); cursor is the next unread position, persisting
+    // across those calls until the next wrap() rebinds it to a new window.
+    private MemorySegment segment;
+    private int cursor;
+    private int limit;
 
     // path tracking — pre-allocated, no per-event allocation
     private final boolean[] pathInArray = new boolean[MAX_DEPTH];
@@ -152,12 +164,12 @@ public final class JsonTokenizer
     private int resumeUnicodeValue;
     private int resumeLiteralIndex;     // chars matched so far for true/false/null
 
-    public JsonTokenizer()
+    public JsonTokenizerImpl()
     {
         this(false);
     }
 
-    public JsonTokenizer(
+    public JsonTokenizerImpl(
         boolean terminalEof)
     {
         this(terminalEof, Integer.MAX_VALUE);
@@ -168,7 +180,7 @@ public final class JsonTokenizer
     // only matters for numbers, which unlike strings and the true/false/null literals are not
     // self-terminating and need a following non-digit byte to know they have ended.
     // maxValueSize caps the decoded chars retained for one value/key; growth past it fails closed.
-    public JsonTokenizer(
+    public JsonTokenizerImpl(
         boolean terminalEof,
         int maxValueSize)
     {
@@ -180,6 +192,7 @@ public final class JsonTokenizer
         }
     }
 
+    @Override
     public void reset()
     {
         stack.clear();
@@ -214,16 +227,44 @@ public final class JsonTokenizer
         resumeLiteralIndex = 0;
     }
 
+    // Binds the next input window to scan: advance() may be called many times against this same
+    // window (once per token drained from it) before the caller wraps the next one. Independent of
+    // windowLength (set separately via window()) — a caller that never calls window() gets the
+    // Integer.MAX_VALUE default, i.e. no fragmentation threshold, regardless of how small this
+    // particular wrapped range is.
+    @Override
+    public void wrap(
+        MemorySegment segment,
+        int offset,
+        int limit)
+    {
+        this.segment = segment;
+        this.cursor = offset;
+        this.limit = limit;
+    }
+
+    // Set per input window: its byte length is the fragmentation bound — a value whose own bytes reach
+    // it without completing is delivered as fragments instead of reassembled across windows. Independent
+    // of wrap()'s (offset, limit) — a caller may wrap a small range without calling this at all.
+    @Override
+    public void window(
+        int length)
+    {
+        this.windowLength = length;
+    }
+
     // Tracks whether a segment scan is in progress so a value-string spanning frames is streamed as raw
     // bytes instead of rewound (which would require it whole in one frame) or retained whole in scratch.
-    void segmenting(
+    @Override
+    public void segmenting(
         boolean segmenting)
     {
         this.segmenting = segmenting;
     }
 
     // Arms the next value-string to stream verbatim as raw fragments (no decoded retention).
-    void scalarSegment(
+    @Override
+    public void scalarSegment(
         boolean scalarSegment)
     {
         this.scalarSegment = scalarSegment;
@@ -232,22 +273,15 @@ public final class JsonTokenizer
     // Set per input window: when true this window's EOF is the terminal delimiter (one-shot or final
     // window), so a trailing scalar completes at EOF and an incomplete value is rejected; when false EOF
     // is a frame boundary with more bytes still to come.
-    void terminal(
+    @Override
+    public void terminal(
         boolean terminalEof)
     {
         this.terminalEof = terminalEof;
     }
 
-    // Set per input window: its byte length is the fragmentation bound — a value whose own bytes reach
-    // it without completing is delivered as fragments instead of reassembled across windows.
-    void window(
-        int length)
-    {
-        this.windowLength = length;
-    }
-
-    public boolean advance(
-        InputStream in) throws IOException
+    @Override
+    public boolean advance()
     {
         starved = false;
 
@@ -255,7 +289,7 @@ public final class JsonTokenizer
         {
             if (terminalEof)
             {
-                enforceEndOfInput(in);
+                enforceEndOfInput();
             }
             return false;
         }
@@ -269,11 +303,11 @@ public final class JsonTokenizer
         {
             if (resumeOp != ResumeOp.NONE)
             {
-                resumeScan(in);
+                resumeScan();
             }
             else
             {
-                advanceOne(in);
+                advanceOne();
             }
         }
 
@@ -357,16 +391,19 @@ public final class JsonTokenizer
         return delivered;
     }
 
+    @Override
     public JsonParser.Event event()
     {
         return pendingEvent;
     }
 
+    @Override
     public void clearEvent()
     {
         pendingEvent = null;
     }
 
+    @Override
     public String stringValue()
     {
         if (valuePending)
@@ -381,6 +418,7 @@ public final class JsonTokenizer
     // valid while the unescaped chars are still in scratch because nobody has materialized them yet. Lets
     // a downstream stage copy or compare the chars without a String; returns the materialized value if it
     // was already taken.
+    @Override
     public CharSequence stringView()
     {
         return valuePending ? scratch : pendingString;
@@ -388,22 +426,26 @@ public final class JsonTokenizer
 
     // The parser reports, before a resuming advance, how many chars of the current fragment the consumer
     // took, so resume keeps the unconsumed remainder rather than discarding the whole fragment.
-    void markScratchConsumed(
+    @Override
+    public void markScratchConsumed(
         int consumed)
     {
         this.scratchConsumed = consumed;
     }
 
+    @Override
     public long streamOffset()
     {
         return streamOffset;
     }
 
+    @Override
     public long line()
     {
         return line;
     }
 
+    @Override
     public long column()
     {
         return column;
@@ -413,31 +455,37 @@ public final class JsonTokenizer
     // surrounding quotes, or a VALUE_NUMBER lexeme). The EOF rewind for a readable scalar guarantees the
     // whole token is contiguous in one frame, so this span maps to a single contiguous slice the sink can
     // splice or fragment.
+    @Override
     public long valueStreamStart()
     {
         return valueStreamStart;
     }
 
+    @Override
     public long valueStreamEnd()
     {
         return valueStreamEnd;
     }
 
+    @Override
     public boolean done()
     {
         return state == ParseState.DOC_DONE;
     }
 
+    @Override
     public long documentEndOffset()
     {
         return documentEndOffset;
     }
 
+    @Override
     public boolean inObjectContext()
     {
         return pathDepth > 0 && !pathInArray[pathDepth - 1];
     }
 
+    @Override
     public boolean inArrayContext()
     {
         return pathDepth > 0 && pathInArray[pathDepth - 1];
@@ -446,6 +494,7 @@ public final class JsonTokenizer
     // True when the member (object key or array element) at the current boundary was reached after a
     // separator comma — a sibling precedes it in its container — and false when it was the first member
     // after the container open. Read by a prune at a dropped member to decide leading-separator trimming.
+    @Override
     public boolean memberSeparated()
     {
         return memberSeparated;
@@ -454,6 +503,7 @@ public final class JsonTokenizer
     // True when the token just delivered was immediately preceded by a value-separator comma — one-shot per
     // token, unlike memberSeparated() which stays set across the whole member. A verbatim consumer emits one
     // SEPARATOR step per source comma directly from this, with no need to re-derive container structure.
+    @Override
     public boolean separatorBefore()
     {
         return separatorBefore;
@@ -461,6 +511,7 @@ public final class JsonTokenizer
 
     // True while a value-string is being delivered in fragments and more fragments follow the current
     // event; drives the parser's deferredBytes() for over-slot scalars.
+    @Override
     public boolean fragmenting()
     {
         return fragmenting;
@@ -468,11 +519,13 @@ public final class JsonTokenizer
 
     // True when the just-delivered value-string was streamed verbatim as raw bytes rather than decoded
     // into scratch; the parser then splices its raw token bytes instead of rendering canonically.
+    @Override
     public boolean stringVerbatim()
     {
         return stringVerbatim;
     }
 
+    @Override
     public String currentPath()
     {
         if (pathDepth == 0)
@@ -522,8 +575,7 @@ public final class JsonTokenizer
         }
     }
 
-    private void advanceOne(
-        InputStream in) throws IOException
+    private void advanceOne()
     {
         // a comma precedes only the token consumed at a member/element-start state; mirror that here so the
         // signal is one-shot per token — a starved scalar resumes via resumeScan, which leaves this untouched,
@@ -532,48 +584,47 @@ public final class JsonTokenizer
         switch (state)
         {
         case DOC_START:
-            consumeValue(in);
+            consumeValue();
             break;
         case OBJ_AFTER_OPEN:
             memberSeparated = false;
-            consumeKeyOrEnd(in);
+            consumeKeyOrEnd();
             break;
         case OBJ_AFTER_KEY:
-            consumeColon(in);
+            consumeColon();
             break;
         case OBJ_AFTER_COLON:
-            consumeValue(in);
+            consumeValue();
             break;
         case OBJ_AFTER_VALUE:
-            consumeSeparatorOrEnd(in, true);
+            consumeSeparatorOrEnd(true);
             break;
         case OBJ_AFTER_COMMA:
             memberSeparated = true;
-            consumeKey(in);
+            consumeKey();
             break;
         case ARR_AFTER_OPEN:
             memberSeparated = false;
-            consumeValueOrEnd(in);
+            consumeValueOrEnd();
             break;
         case ARR_AFTER_VALUE:
-            consumeSeparatorOrEnd(in, false);
+            consumeSeparatorOrEnd(false);
             break;
         case ARR_AFTER_COMMA:
             memberSeparated = true;
-            consumeValue(in);
+            consumeValue();
             break;
         default:
             throw new JsonParsingException("Unexpected parse state: " + state, null);
         }
     }
 
-    private void resumeScan(
-        InputStream in) throws IOException
+    private void resumeScan()
     {
         switch (resumeOp)
         {
         case KEY_STRING:
-            continueStringContent(in);
+            continueStringContent();
             if (!starved)
             {
                 pendingEvent = JsonParser.Event.KEY_NAME;
@@ -589,7 +640,7 @@ public final class JsonTokenizer
             scratch.delete(0, Math.min(scratchConsumed, scratch.length()));
             scratchConsumed = 0;
             fragmentStart = streamOffset;
-            continueStringContent(in);
+            continueStringContent();
             if (!starved)
             {
                 finishStringValue();
@@ -601,14 +652,14 @@ public final class JsonTokenizer
             scratch.delete(0, Math.min(scratchConsumed, scratch.length()));
             scratchConsumed = 0;
             fragmentStart = streamOffset;
-            continueNumberContent(in);
+            continueNumberContent();
             if (!starved)
             {
                 finishNumberValue();
             }
             break;
         case VALUE_TRUE:
-            continueLiteral(in, "true");
+            continueLiteral("true");
             if (!starved)
             {
                 pendingEvent = JsonParser.Event.VALUE_TRUE;
@@ -617,7 +668,7 @@ public final class JsonTokenizer
             }
             break;
         case VALUE_FALSE:
-            continueLiteral(in, "false");
+            continueLiteral("false");
             if (!starved)
             {
                 pendingEvent = JsonParser.Event.VALUE_FALSE;
@@ -626,7 +677,7 @@ public final class JsonTokenizer
             }
             break;
         case VALUE_NULL:
-            continueLiteral(in, "null");
+            continueLiteral("null");
             if (!starved)
             {
                 pendingEvent = JsonParser.Event.VALUE_NULL;
@@ -646,7 +697,7 @@ public final class JsonTokenizer
     }
 
     // Completes a VALUE_STRING scan: continueStringContent only returns here once the closing quote is
-    // seen (otherwise it throws EOFException and onScalarStarved decides fragment-vs-reassemble), so the
+    // seen (otherwise the window is exhausted and onScalarStarved decides fragment-vs-reassemble), so the
     // string is whole — the final fragment of a fragmented value, or a value that fit one window. It is
     // captured lazily and the parse state advances.
     private void finishStringValue()
@@ -685,20 +736,18 @@ public final class JsonTokenizer
         return path;
     }
 
-    private void consumeValue(
-        InputStream in) throws IOException
+    private void consumeValue()
     {
-        int c = skipWhitespace(in);
+        int c = skipWhitespace();
         if (!starved)
         {
-            parseValue(in, c);
+            parseValue(c);
         }
     }
 
-    private void consumeValueOrEnd(
-        InputStream in) throws IOException
+    private void consumeValueOrEnd()
     {
-        int c = skipWhitespace(in);
+        int c = skipWhitespace();
         if (!starved)
         {
             if (c == ']')
@@ -707,25 +756,23 @@ public final class JsonTokenizer
             }
             else
             {
-                parseValue(in, c);
+                parseValue(c);
             }
         }
     }
 
-    private void consumeKey(
-        InputStream in) throws IOException
+    private void consumeKey()
     {
-        int c = skipWhitespace(in);
+        int c = skipWhitespace();
         if (!starved)
         {
-            parseKey(in, c);
+            parseKey(c);
         }
     }
 
-    private void consumeKeyOrEnd(
-        InputStream in) throws IOException
+    private void consumeKeyOrEnd()
     {
-        int c = skipWhitespace(in);
+        int c = skipWhitespace();
         if (!starved)
         {
             if (c == '}')
@@ -734,15 +781,14 @@ public final class JsonTokenizer
             }
             else
             {
-                parseKey(in, c);
+                parseKey(c);
             }
         }
     }
 
-    private void consumeColon(
-        InputStream in) throws IOException
+    private void consumeColon()
     {
-        int c = skipWhitespace(in);
+        int c = skipWhitespace();
         if (!starved)
         {
             if (c != ':')
@@ -754,10 +800,9 @@ public final class JsonTokenizer
     }
 
     private void consumeSeparatorOrEnd(
-        InputStream in,
-        boolean inObject) throws IOException
+        boolean inObject)
     {
-        int c = skipWhitespace(in);
+        int c = skipWhitespace();
         if (!starved)
         {
             if (c == ',')
@@ -776,8 +821,7 @@ public final class JsonTokenizer
     }
 
     private void parseValue(
-        InputStream in,
-        int c) throws IOException
+        int c)
     {
         // a scalar-segment arm applies only to a value-string; clear it for any other value
         if (c != '"')
@@ -805,7 +849,7 @@ public final class JsonTokenizer
             resumeEscape = false;
             resumeUnicodePending = 0;
             resumeOp = ResumeOp.VALUE_STRING;
-            continueStringContent(in);
+            continueStringContent();
             if (!starved)
             {
                 finishStringValue();
@@ -814,7 +858,7 @@ public final class JsonTokenizer
         case 't':
             resumeLiteralIndex = 1;
             resumeOp = ResumeOp.VALUE_TRUE;
-            continueLiteral(in, "true");
+            continueLiteral("true");
             if (!starved)
             {
                 pendingEvent = JsonParser.Event.VALUE_TRUE;
@@ -825,7 +869,7 @@ public final class JsonTokenizer
         case 'f':
             resumeLiteralIndex = 1;
             resumeOp = ResumeOp.VALUE_FALSE;
-            continueLiteral(in, "false");
+            continueLiteral("false");
             if (!starved)
             {
                 pendingEvent = JsonParser.Event.VALUE_FALSE;
@@ -836,7 +880,7 @@ public final class JsonTokenizer
         case 'n':
             resumeLiteralIndex = 1;
             resumeOp = ResumeOp.VALUE_NULL;
-            continueLiteral(in, "null");
+            continueLiteral("null");
             if (!starved)
             {
                 pendingEvent = JsonParser.Event.VALUE_NULL;
@@ -857,7 +901,7 @@ public final class JsonTokenizer
                 appendScratch((char) c);
                 validateNumberChar(c);
                 resumeOp = ResumeOp.VALUE_NUMBER;
-                continueNumberContent(in);
+                continueNumberContent();
                 if (!starved)
                 {
                     finishNumberValue();
@@ -871,8 +915,7 @@ public final class JsonTokenizer
     }
 
     private void parseKey(
-        InputStream in,
-        int c) throws IOException
+        int c)
     {
         if (c != '"')
         {
@@ -882,7 +925,7 @@ public final class JsonTokenizer
         resumeEscape = false;
         resumeUnicodePending = 0;
         resumeOp = ResumeOp.KEY_STRING;
-        continueStringContent(in);
+        continueStringContent();
         if (!starved)
         {
             pendingEvent = JsonParser.Event.KEY_NAME;
@@ -975,35 +1018,32 @@ public final class JsonTokenizer
 
     // After a complete top-level value on a one-shot stream, only insignificant whitespace may
     // remain; any further token is invalid per RFC 8259. Chunked frame sources skip this check.
-    private void enforceEndOfInput(
-        InputStream in) throws IOException
+    private void enforceEndOfInput()
     {
-        int c = skipWhitespace(in);
+        int c = skipWhitespace();
         if (c != -1)
         {
             throw new JsonParsingException("Unexpected trailing content: " + describe(c), null);
         }
     }
 
-    private int skipWhitespace(
-        InputStream in) throws IOException
+    private int skipWhitespace()
     {
         int c;
         do
         {
-            c = readByte(in);
+            c = readByte();
         }
         while (c == ' ' || c == '\t' || c == '\n' || c == '\r');
         return c;
     }
 
     private void continueLiteral(
-        InputStream in,
-        String expected) throws IOException
+        String expected)
     {
         while (!starved && resumeLiteralIndex < expected.length())
         {
-            int c = readByte(in);
+            int c = readByte();
             if (!starved)
             {
                 if (c != expected.charAt(resumeLiteralIndex))
@@ -1015,14 +1055,13 @@ public final class JsonTokenizer
         }
     }
 
-    private void continueStringContent(
-        InputStream in) throws IOException
+    private void continueStringContent()
     {
         boolean complete = false;
         while (!complete && !starved)
         {
-            // Track each complete-unit boundary so an EOF mid-char/escape can rewind here: the chars
-            // decoded so far ship as a fragment and the partial unit's bytes stay unconsumed
+            // Track each complete-unit boundary so an exhausted window mid-char/escape can rewind here: the
+            // chars decoded so far ship as a fragment and the partial unit's bytes stay unconsumed
             // (position() reports unitStartOffset) for the caller to re-present on the next window.
             if (!resumeEscape && resumeUnicodePending == 0)
             {
@@ -1030,7 +1069,7 @@ public final class JsonTokenizer
                 unitLine = line;
                 unitColumn = column;
             }
-            int c = readByte(in);
+            int c = readByte();
             if (!starved)
             {
                 if (resumeUnicodePending > 0)
@@ -1093,7 +1132,7 @@ public final class JsonTokenizer
                 }
                 else
                 {
-                    int codePoint = decodeUtf8(in, c);
+                    int codePoint = decodeUtf8(c);
                     if (!starved)
                     {
                         appendCodePointScratch(codePoint);
@@ -1145,8 +1184,7 @@ public final class JsonTokenizer
     }
 
     private int decodeUtf8(
-        InputStream in,
-        int first) throws IOException
+        int first)
     {
         int remaining;
         int code;
@@ -1171,7 +1209,7 @@ public final class JsonTokenizer
         }
         for (int i = 0; !starved && i < remaining; i++)
         {
-            int cont = readByte(in);
+            int cont = readByte();
             if (!starved)
             {
                 if ((cont & 0xc0) != 0x80)
@@ -1202,31 +1240,34 @@ public final class JsonTokenizer
         throw new JsonParsingException("Invalid hex digit: " + describe(c), null);
     }
 
-    private void continueNumberContent(
-        InputStream in) throws IOException
+    private void continueNumberContent()
     {
         boolean complete = false;
         while (!complete && !starved)
         {
-            in.mark(1);
-            int c = in.read();
-            if (c == -1)
+            if (cursor >= limit)
             {
-                // terminal window: EOF ends the number; otherwise the window is exhausted mid-number
+                // terminal window: exhaustion ends the number; otherwise the window is exhausted mid-number
                 starved = !terminalEof;
                 complete = terminalEof;
             }
-            else if (c >= '0' && c <= '9' || c == '.' || c == '-' || c == '+' || c == 'e' || c == 'E')
-            {
-                streamOffset++;
-                advance(c);
-                validateNumberChar(c);
-                appendScratch((char) c);
-            }
             else
             {
-                in.reset();
-                complete = true;
+                // peek: a plain index read, no mark/reset needed — only advance the cursor if this byte
+                // actually belongs to the number, leaving it unconsumed as the next token's first byte
+                int c = segment.get(ValueLayout.JAVA_BYTE, cursor) & 0xff;
+                if (c >= '0' && c <= '9' || c == '.' || c == '-' || c == '+' || c == 'e' || c == 'E')
+                {
+                    cursor++;
+                    streamOffset++;
+                    advance(c);
+                    validateNumberChar(c);
+                    appendScratch((char) c);
+                }
+                else
+                {
+                    complete = true;
+                }
             }
         }
     }
@@ -1300,16 +1341,18 @@ public final class JsonTokenizer
         return c >= '0' && c <= '9';
     }
 
-    private int readByte(
-        InputStream in) throws IOException
+    private int readByte()
     {
-        int c = in.read();
-        if (c == -1)
+        int c;
+        if (cursor >= limit)
         {
+            c = -1;
             starved = true;
         }
         else
         {
+            c = segment.get(ValueLayout.JAVA_BYTE, cursor) & 0xff;
+            cursor++;
             streamOffset++;
             advance(c);
         }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerImpl.java
@@ -14,8 +14,6 @@
  */
 package io.aklivity.zilla.runtime.common.json.internal;
 
-import java.lang.foreign.MemorySegment;
-import java.lang.foreign.ValueLayout;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
@@ -140,9 +138,9 @@ public final class JsonTokenizerImpl implements JsonTokenizer
     private int windowLength = Integer.MAX_VALUE;
 
     // the currently wrapped input: advance() may be called many times against the same wrapped
-    // segment (once per token drained from it); cursor is the next unread position, persisting
+    // buffer (once per token drained from it); cursor is the next unread position, persisting
     // across those calls until the next wrap() rebinds it to a new window.
-    private MemorySegment segment;
+    private DirectBufferEx buffer;
     private int cursor;
     private int limit;
 
@@ -289,13 +287,28 @@ public final class JsonTokenizerImpl implements JsonTokenizer
     // particular wrapped range is.
     @Override
     public void wrap(
-        MemorySegment segment,
+        DirectBufferEx buffer,
         int offset,
         int limit)
     {
-        this.segment = segment;
+        this.buffer = buffer;
         this.cursor = offset;
         this.limit = limit;
+    }
+
+    // The last == true shorthand folds a terminal(true) into the rebind: this window's EOF is the
+    // terminal delimiter (one-shot or final window), so a trailing scalar completes at EOF and an
+    // incomplete value is rejected. last == false leaves EOF as a frame boundary with more bytes still
+    // to come, same as the three-argument overload.
+    @Override
+    public void wrap(
+        DirectBufferEx buffer,
+        int offset,
+        int limit,
+        boolean last)
+    {
+        wrap(buffer, offset, limit);
+        this.terminalEof = last;
     }
 
     // Set per input window: its byte length is the fragmentation bound — a value whose own bytes reach
@@ -323,16 +336,6 @@ public final class JsonTokenizerImpl implements JsonTokenizer
         boolean scalarSegment)
     {
         this.scalarSegment = scalarSegment;
-    }
-
-    // Set per input window: when true this window's EOF is the terminal delimiter (one-shot or final
-    // window), so a trailing scalar completes at EOF and an incomplete value is rejected; when false EOF
-    // is a frame boundary with more bytes still to come.
-    @Override
-    public void terminal(
-        boolean terminalEof)
-    {
-        this.terminalEof = terminalEof;
     }
 
     @Override
@@ -1310,7 +1313,7 @@ public final class JsonTokenizerImpl implements JsonTokenizer
             {
                 // peek: a plain index read, no mark/reset needed — only advance the cursor if this byte
                 // actually belongs to the number, leaving it unconsumed as the next token's first byte
-                int c = segment.get(ValueLayout.JAVA_BYTE, cursor) & 0xff;
+                int c = buffer.getByte(cursor) & 0xff;
                 if (c >= '0' && c <= '9' || c == '.' || c == '-' || c == '+' || c == 'e' || c == 'E')
                 {
                     cursor++;
@@ -1406,7 +1409,7 @@ public final class JsonTokenizerImpl implements JsonTokenizer
         }
         else
         {
-            c = segment.get(ValueLayout.JAVA_BYTE, cursor) & 0xff;
+            c = buffer.getByte(cursor) & 0xff;
             cursor++;
             streamOffset++;
             advance(c);

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerImplFactory.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerImplFactory.java
@@ -14,35 +14,30 @@
  */
 package io.aklivity.zilla.runtime.common.json.internal;
 
-import jakarta.json.stream.JsonLocation;
-
 import io.aklivity.zilla.runtime.common.json.JsonTokenizer;
+import io.aklivity.zilla.runtime.common.json.JsonTokenizerFactory;
 
-final class JsonLocationImpl implements JsonLocation
+// Always-present baseline provider: lowest priority, always available, so any registered
+// alternative provider wins selection but the engine never fails to find a tokenizer.
+public final class JsonTokenizerImplFactory implements JsonTokenizerFactory
 {
-    private final JsonTokenizer tokenizer;
-
-    JsonLocationImpl(
-        JsonTokenizer tokenizer)
+    @Override
+    public JsonTokenizer create(
+        boolean terminalEof,
+        int maxValueSize)
     {
-        this.tokenizer = tokenizer;
+        return new JsonTokenizerImpl(terminalEof, maxValueSize);
     }
 
     @Override
-    public long getLineNumber()
+    public int priority()
     {
-        return tokenizer.line();
+        return 0;
     }
 
     @Override
-    public long getColumnNumber()
+    public boolean available()
     {
-        return tokenizer.column();
-    }
-
-    @Override
-    public long getStreamOffset()
-    {
-        return tokenizer.streamOffset();
+        return true;
     }
 }

--- a/runtime/common-json/src/main/moditect/module-info.java
+++ b/runtime/common-json/src/main/moditect/module-info.java
@@ -20,6 +20,11 @@ module io.aklivity.zilla.runtime.common.json
 
     exports io.aklivity.zilla.runtime.common.json;
 
+    uses io.aklivity.zilla.runtime.common.json.JsonTokenizerFactory;
+
     provides jakarta.json.spi.JsonProvider
         with io.aklivity.zilla.runtime.common.json.internal.json.JsonProviderImpl;
+
+    provides io.aklivity.zilla.runtime.common.json.JsonTokenizerFactory
+        with io.aklivity.zilla.runtime.common.json.internal.JsonTokenizerImplFactory;
 }

--- a/runtime/common-json/src/main/resources/META-INF/services/io.aklivity.zilla.runtime.common.json.JsonTokenizerFactory
+++ b/runtime/common-json/src/main/resources/META-INF/services/io.aklivity.zilla.runtime.common.json.JsonTokenizerFactory
@@ -1,0 +1,1 @@
+io.aklivity.zilla.runtime.common.json.internal.JsonTokenizerImplFactory

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorStringViewTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorStringViewTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx.Completion;
+
+// Exercises JsonGeneratorImpl's instanceof JsonStringView fast path directly: a non-null getSegment()
+// splices bytes straight into string-body output instead of the ordinary codepoint-by-codepoint escape
+// path. No production JsonTokenizer implementation in this repo produces a segment-backed JsonStringView
+// yet -- JsonTokenizerImpl's stringView() always reports a null segment, correctly, since it only ever
+// decodes into scratch (see JsonTokenizerStringViewTest). This test uses a minimal fixture instead, to
+// verify the generator side of the contract independent of any specific producer: given a JsonStringView
+// with a segment, the generator either splices it whole (segment fits this call) or declines and falls
+// through unchanged to the pre-existing, already-covered codepoint path (segment does not fit) -- it
+// never assumes anything about how a producer resumes a value across multiple calls, since that is the
+// producer's contract to keep, not the generator's to enforce.
+class JsonGeneratorStringViewTest
+{
+    @Test
+    void shouldSpliceSegmentBackedValueUnbounded()
+    {
+        assertEquals("\"hello\"", generate(g -> g.write(segmentView("hello"))));
+    }
+
+    @Test
+    void shouldFallBackToOrdinaryPathWhenSegmentIsNullUnbounded()
+    {
+        assertEquals("\"hello\"", generate(g -> g.write(nullSegmentView("hello"))));
+    }
+
+    @Test
+    void shouldSpliceSegmentBackedValueBoundedWhenItFits()
+    {
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[512]);
+        JsonGeneratorEx generator = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+
+        generator.write(segmentView("hello"), Completion.COMPLETE);
+
+        assertEquals(5, generator.consumed());
+        assertEquals("\"hello\"", drain(generator, buffer));
+    }
+
+    @Test
+    void shouldDeclineFastPathAndFallBackWhenSegmentDoesNotFitBoundedOutput()
+    {
+        // 8-byte window: opening quote (1) + closing-quote reserve (1) leaves 6 bytes of budget, less
+        // than the 11-byte segment -- the fast path's own bound check must decline, falling through to
+        // the ordinary codepoint path, which partially consumes exactly as it would for a plain String
+        MutableDirectBufferEx fastPathBuffer = new UnsafeBufferEx(new byte[8]);
+        JsonGeneratorEx fastPathGenerator = JsonEx.createGenerator().wrap(fastPathBuffer, 0, fastPathBuffer.capacity());
+        fastPathGenerator.write(segmentView("hello world"), Completion.COMPLETE);
+
+        MutableDirectBufferEx plainBuffer = new UnsafeBufferEx(new byte[8]);
+        JsonGeneratorEx plainGenerator = JsonEx.createGenerator().wrap(plainBuffer, 0, plainBuffer.capacity());
+        plainGenerator.write("hello world", Completion.COMPLETE);
+
+        assertTrue(fastPathGenerator.consumed() < 11, "fast path must not have spliced the whole segment");
+        assertEquals(plainGenerator.consumed(), fastPathGenerator.consumed());
+        assertEquals(drain(plainGenerator, plainBuffer), drain(fastPathGenerator, fastPathBuffer));
+    }
+
+    private static JsonStringView segmentView(
+        String value)
+    {
+        byte[] bytes = value.getBytes(UTF_8);
+        DirectBufferEx segment = new UnsafeBufferEx(bytes);
+        return new JsonStringView()
+        {
+            @Override
+            public int length()
+            {
+                return value.length();
+            }
+
+            @Override
+            public char charAt(
+                int index)
+            {
+                return value.charAt(index);
+            }
+
+            @Override
+            public CharSequence subSequence(
+                int start,
+                int end)
+            {
+                return value.subSequence(start, end);
+            }
+
+            @Override
+            public String toString()
+            {
+                return value;
+            }
+
+            @Override
+            public DirectBufferEx getSegment()
+            {
+                return segment;
+            }
+        };
+    }
+
+    private static JsonStringView nullSegmentView(
+        String value)
+    {
+        return new JsonStringView()
+        {
+            @Override
+            public int length()
+            {
+                return value.length();
+            }
+
+            @Override
+            public char charAt(
+                int index)
+            {
+                return value.charAt(index);
+            }
+
+            @Override
+            public CharSequence subSequence(
+                int start,
+                int end)
+            {
+                return value.subSequence(start, end);
+            }
+
+            @Override
+            public String toString()
+            {
+                return value;
+            }
+
+            @Override
+            public DirectBufferEx getSegment()
+            {
+                return null;
+            }
+        };
+    }
+
+    private static String generate(
+        Consumer<JsonGeneratorEx> writer)
+    {
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[512]);
+        JsonGeneratorEx generator = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        writer.accept(generator);
+        return drain(generator, buffer);
+    }
+
+    private static String drain(
+        JsonGeneratorEx generator,
+        MutableDirectBufferEx buffer)
+    {
+        byte[] out = new byte[generator.length()];
+        buffer.getBytes(0, out);
+        return new String(out, UTF_8);
+    }
+}

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonParserTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonParserTest.java
@@ -320,6 +320,42 @@ class JsonParserTest
         assertThrows(NumberFormatException.class, parser::getInt);
     }
 
+    // getLong()/getInt() fuse digit accumulation into the tokenizer's own scan for a leading-digit run of
+    // at most 18 (JsonTokenizerImpl.LONG_SAFE_DIGITS -- the most digits a signed long can hold with zero
+    // overflow risk regardless of sign), falling back to the CharSequence-based Long.parseLong/
+    // Integer.parseInt path above that bound (already exercised by the Long.MIN/MAX_VALUE boundaries
+    // above, both 19 digits). This pins the fused path's own internal boundary specifically: an 18-digit
+    // value (positive and negative) takes the fused path, a 19-digit value one either side of it falls
+    // back, and both must agree exactly on the resulting value.
+    @Test
+    void shouldGetLongAtFusedPathDigitBoundary()
+    {
+        JsonParser parser = parserFor("[999999999999999999,-999999999999999999,1000000000000000000,-1000000000000000001]");
+
+        assertEquals(START_ARRAY, parser.next());
+        assertEquals(VALUE_NUMBER, parser.next());
+        assertEquals(999999999999999999L, parser.getLong());
+        assertEquals(VALUE_NUMBER, parser.next());
+        assertEquals(-999999999999999999L, parser.getLong());
+        assertEquals(VALUE_NUMBER, parser.next());
+        assertEquals(1000000000000000000L, parser.getLong());
+        assertEquals(VALUE_NUMBER, parser.next());
+        assertEquals(-1000000000000000001L, parser.getLong());
+        assertEquals(END_ARRAY, parser.next());
+    }
+
+    @Test
+    void shouldGetLongAndIntForNegativeZero()
+    {
+        JsonParser parser = parserFor("[-0]");
+
+        assertEquals(START_ARRAY, parser.next());
+        assertEquals(VALUE_NUMBER, parser.next());
+        assertEquals(0, parser.getInt());
+        assertEquals(0L, parser.getLong());
+        assertTrue(parser.isIntegralNumber());
+    }
+
     @Test
     void shouldDecodeTwoByteUtf8()
     {

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonTokenizerFactoryTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonTokenizerFactoryTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class JsonTokenizerFactoryTest
+{
+    @Test
+    void shouldSelectHighestPriorityAvailableCandidate()
+    {
+        JsonTokenizerFactory low = new FakeFactory(0, true);
+        JsonTokenizerFactory high = new FakeFactory(10, true);
+
+        JsonTokenizerFactory selected = JsonTokenizerFactory.instantiate(List.of(low, high));
+
+        assertSame(high, selected);
+    }
+
+    @Test
+    void shouldSkipUnavailableCandidateInFavorOfLowerPriorityAvailableOne()
+    {
+        JsonTokenizerFactory unavailableHigh = new FakeFactory(10, false);
+        JsonTokenizerFactory availableLow = new FakeFactory(0, true);
+
+        JsonTokenizerFactory selected = JsonTokenizerFactory.instantiate(List.of(unavailableHigh, availableLow));
+
+        assertSame(availableLow, selected);
+    }
+
+    @Test
+    void shouldSelectSoleAvailableCandidateRegardlessOfOrder()
+    {
+        JsonTokenizerFactory only = new FakeFactory(0, true);
+
+        JsonTokenizerFactory selected = JsonTokenizerFactory.instantiate(List.of(only));
+
+        assertSame(only, selected);
+    }
+
+    @Test
+    void shouldThrowWhenNoCandidateIsAvailable()
+    {
+        JsonTokenizerFactory unavailable = new FakeFactory(0, false);
+
+        assertThrows(IllegalStateException.class, () -> JsonTokenizerFactory.instantiate(List.of(unavailable)));
+    }
+
+    @Test
+    void shouldThrowWhenNoCandidatesAtAll()
+    {
+        assertThrows(IllegalStateException.class, () -> JsonTokenizerFactory.instantiate(List.of()));
+    }
+
+    @Test
+    void shouldDiscoverBuiltInFactoryViaServiceLoader()
+    {
+        JsonTokenizerFactory selected = JsonTokenizerFactory.instantiate();
+
+        JsonTokenizer tokenizer = selected.create(false, Integer.MAX_VALUE);
+
+        assertEquals("", tokenizer.currentPath());
+    }
+
+    private static final class FakeFactory implements JsonTokenizerFactory
+    {
+        private final int priority;
+        private final boolean available;
+
+        private FakeFactory(
+            int priority,
+            boolean available)
+        {
+            this.priority = priority;
+            this.available = available;
+        }
+
+        @Override
+        public JsonTokenizer create(
+            boolean terminalEof,
+            int maxValueSize)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int priority()
+        {
+            return priority;
+        }
+
+        @Override
+        public boolean available()
+        {
+            return available;
+        }
+    }
+}

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/bench/JsonNumberDecodeBM.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/bench/JsonNumberDecodeBM.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json.bench;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import jakarta.json.stream.JsonParser.Event;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.json.JsonEx;
+import io.aklivity.zilla.runtime.common.json.JsonParserEx;
+
+/**
+ * Isolates {@link JsonParserEx#getLong()} from the rest of the parse: drains every event of a flat
+ * number array, calling {@code getLong()} on each {@code VALUE_NUMBER}, so any change to number decoding
+ * (e.g. fusing digit accumulation into the tokenizer's scan instead of a second
+ * {@code Long.parseLong(CharSequence, ...)} pass) shows up directly in throughput and allocation here.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@Fork(3)
+@Warmup(iterations = 10, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = SECONDS)
+@OutputTimeUnit(SECONDS)
+public class JsonNumberDecodeBM
+{
+    private static final String NUMBER_ARRAY = numberArray(2000);
+
+    private DirectBufferEx buffer;
+    private int length;
+    private JsonParserEx parser;
+
+    @Setup(Level.Trial)
+    public void init()
+    {
+        byte[] bytes = NUMBER_ARRAY.getBytes(UTF_8);
+        buffer = new UnsafeBufferEx(bytes);
+        length = bytes.length;
+        parser = JsonEx.createParser();
+    }
+
+    @Benchmark
+    public long sumLongValues()
+    {
+        parser.reset();
+        parser.wrap(buffer, 0, length);
+        long sum = 0L;
+        while (parser.hasNext())
+        {
+            if (parser.next() == Event.VALUE_NUMBER)
+            {
+                sum += parser.getLong();
+            }
+        }
+        return sum;
+    }
+
+    private static String numberArray(
+        int count)
+    {
+        StringBuilder builder = new StringBuilder("[");
+        for (int i = 0; i < count; i++)
+        {
+            if (i > 0)
+            {
+                builder.append(',');
+            }
+            builder.append(123456789 + i);
+        }
+        return builder.append(']').toString();
+    }
+
+    public static void main(
+        String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+            .include(JsonNumberDecodeBM.class.getSimpleName())
+            .addProfiler("gc")
+            .forks(1)
+            .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerNumberValueTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerNumberValueTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json.internal;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.json.stream.JsonParser.Event;
+
+import org.junit.jupiter.api.Test;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.json.JsonTokenizer;
+
+// Direct, white-box coverage of numberIntegral()/numberInLongRange()/numberLongValue() -- the fused
+// digit accumulation JsonParserImpl.getInt()/getLong() build their fast path on. JsonParserTest's own
+// getInt()/getLong() tests exercise these transitively; this pins the tokenizer-level contract each of
+// the three methods promises independent of that caller.
+public class JsonTokenizerNumberValueTest
+{
+    @Test
+    public void shouldReportIntegralAndInLongRangeForPlainInteger()
+    {
+        final JsonTokenizer tokenizer = wrap("42");
+
+        assertEquals(Event.VALUE_NUMBER, tokenizer.event());
+        assertTrue(tokenizer.numberIntegral());
+        assertTrue(tokenizer.numberInLongRange());
+        assertEquals(42L, tokenizer.numberLongValue());
+    }
+
+    @Test
+    public void shouldReportNegativeValue()
+    {
+        final JsonTokenizer tokenizer = wrap("-42");
+
+        assertTrue(tokenizer.numberIntegral());
+        assertTrue(tokenizer.numberInLongRange());
+        assertEquals(-42L, tokenizer.numberLongValue());
+    }
+
+    @Test
+    public void shouldReportZeroForNegativeZero()
+    {
+        final JsonTokenizer tokenizer = wrap("-0");
+
+        assertTrue(tokenizer.numberIntegral());
+        assertTrue(tokenizer.numberInLongRange());
+        assertEquals(0L, tokenizer.numberLongValue());
+    }
+
+    @Test
+    public void shouldReportNotIntegralForDecimal()
+    {
+        final JsonTokenizer tokenizer = wrap("3.14");
+
+        assertFalse(tokenizer.numberIntegral());
+    }
+
+    @Test
+    public void shouldReportNotIntegralForExponent()
+    {
+        final JsonTokenizer tokenizer = wrap("1e10");
+
+        assertFalse(tokenizer.numberIntegral());
+    }
+
+    @Test
+    public void shouldReportInLongRangeAtEighteenDigits()
+    {
+        final JsonTokenizer tokenizer = wrap("999999999999999999");
+
+        assertTrue(tokenizer.numberIntegral());
+        assertTrue(tokenizer.numberInLongRange());
+        assertEquals(999999999999999999L, tokenizer.numberLongValue());
+    }
+
+    @Test
+    public void shouldReportOutOfLongRangeAtNineteenDigits()
+    {
+        final JsonTokenizer tokenizer = wrap("1000000000000000000");
+
+        assertTrue(tokenizer.numberIntegral());
+        assertFalse(tokenizer.numberInLongRange());
+    }
+
+    private static JsonTokenizer wrap(
+        String number)
+    {
+        final JsonTokenizer tokenizer = new JsonTokenizerImpl();
+        final byte[] bytes = number.getBytes(UTF_8);
+        tokenizer.wrap(new UnsafeBufferEx(bytes), 0, bytes.length, true);
+        tokenizer.advance();
+        return tokenizer;
+    }
+}

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerPathTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerPathTest.java
@@ -17,7 +17,6 @@ package io.aklivity.zilla.runtime.common.json.internal;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,6 +24,7 @@ import jakarta.json.stream.JsonParser;
 
 import org.junit.jupiter.api.Test;
 
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.common.json.JsonTokenizer;
 
 public class JsonTokenizerPathTest
@@ -125,7 +125,6 @@ public class JsonTokenizerPathTest
         String json)
     {
         final byte[] bytes = json.getBytes(UTF_8);
-        tokenizer.wrap(MemorySegment.ofArray(bytes), 0, bytes.length);
-        tokenizer.terminal(true);
+        tokenizer.wrap(new UnsafeBufferEx(bytes), 0, bytes.length, true);
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerPathTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerPathTest.java
@@ -17,10 +17,7 @@ package io.aklivity.zilla.runtime.common.json.internal;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,19 +25,20 @@ import jakarta.json.stream.JsonParser;
 
 import org.junit.jupiter.api.Test;
 
+import io.aklivity.zilla.runtime.common.json.JsonTokenizer;
+
 public class JsonTokenizerPathTest
 {
     @Test
-    public void shouldTrackPathThroughObjectsAndArrays() throws IOException
+    public void shouldTrackPathThroughObjectsAndArrays()
     {
         final String json = "{\"tools\":[{\"name\":\"X\"},{\"name\":\"Y\"}],\"id\":7}";
-        final JsonTokenizer tokenizer = new JsonTokenizer();
-        final InputStream in = new BufferedInputStream(
-            new ByteArrayInputStream(json.getBytes(UTF_8)));
+        final JsonTokenizer tokenizer = new JsonTokenizerImpl();
+        wrap(tokenizer, json);
 
         final List<String> pathAtEvent = new ArrayList<>();
         final List<JsonParser.Event> events = new ArrayList<>();
-        while (tokenizer.advance(in))
+        while (tokenizer.advance())
         {
             events.add(tokenizer.event());
             pathAtEvent.add(tokenizer.currentPath());
@@ -66,15 +64,14 @@ public class JsonTokenizerPathTest
     }
 
     @Test
-    public void shouldExposeFullPathForNestedObject() throws IOException
+    public void shouldExposeFullPathForNestedObject()
     {
         final String json = "{\"a\":{\"b\":{\"c\":42}}}";
-        final JsonTokenizer tokenizer = new JsonTokenizer();
-        final InputStream in = new BufferedInputStream(
-            new ByteArrayInputStream(json.getBytes(UTF_8)));
+        final JsonTokenizer tokenizer = new JsonTokenizerImpl();
+        wrap(tokenizer, json);
 
         String pathAtNumber = null;
-        while (tokenizer.advance(in))
+        while (tokenizer.advance())
         {
             if (tokenizer.event() == JsonParser.Event.VALUE_NUMBER)
             {
@@ -86,17 +83,16 @@ public class JsonTokenizerPathTest
     }
 
     @Test
-    public void shouldTrackPathWithEscapedSlashAndTilde() throws IOException
+    public void shouldTrackPathWithEscapedSlashAndTilde()
     {
         // RFC 6901 escapes in currentPath(): "/" encodes to "~1", "~" encodes to "~0"
-        final JsonTokenizer tokenizer = new JsonTokenizer();
+        final JsonTokenizer tokenizer = new JsonTokenizerImpl();
 
         final String json = "{\"a/b\":{\"c~d\":42}}";
-        final InputStream in = new BufferedInputStream(
-            new ByteArrayInputStream(json.getBytes(UTF_8)));
+        wrap(tokenizer, json);
 
         String observedPathAtNumber = null;
-        while (tokenizer.advance(in))
+        while (tokenizer.advance())
         {
             if (tokenizer.event() == JsonParser.Event.VALUE_NUMBER)
             {
@@ -108,20 +104,28 @@ public class JsonTokenizerPathTest
     }
 
     @Test
-    public void shouldHandleArrayDocument() throws IOException
+    public void shouldHandleArrayDocument()
     {
-        final JsonTokenizer tokenizer = new JsonTokenizer();
+        final JsonTokenizer tokenizer = new JsonTokenizerImpl();
 
         final String json = "[1,2,3]";
-        final InputStream in = new BufferedInputStream(
-            new ByteArrayInputStream(json.getBytes(UTF_8)));
+        wrap(tokenizer, json);
 
         int events = 0;
-        while (tokenizer.advance(in))
+        while (tokenizer.advance())
         {
             events++;
             tokenizer.clearEvent();
         }
         assertEquals(5, events); // [, 1, 2, 3, ]
+    }
+
+    private static void wrap(
+        JsonTokenizer tokenizer,
+        String json)
+    {
+        final byte[] bytes = json.getBytes(UTF_8);
+        tokenizer.wrap(MemorySegment.ofArray(bytes), 0, bytes.length);
+        tokenizer.terminal(true);
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerStringViewTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerStringViewTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json.internal;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.foreign.MemorySegment;
+
+import org.junit.jupiter.api.Test;
+
+import io.aklivity.zilla.runtime.common.json.JsonStringView;
+import io.aklivity.zilla.runtime.common.json.JsonTokenizer;
+
+// This tokenizer always decodes into scratch (a StringBuilder), so it never has a contiguous run of
+// source bytes corresponding 1:1 to a value's decoded chars once escapes or multi-byte UTF-8 are folded
+// in -- stringView()'s getSegment() must always report that honestly (null) rather than a caller
+// mistakenly treating decoded content as splice-able source bytes.
+public class JsonTokenizerStringViewTest
+{
+    @Test
+    public void shouldReturnNullSegmentForKeyStringView()
+    {
+        final JsonTokenizer tokenizer = new JsonTokenizerImpl();
+        wrap(tokenizer, "{\"a\":1}");
+
+        assertTrue(tokenizer.advance());
+        assertTrue(tokenizer.advance());
+        final JsonStringView view = tokenizer.stringView();
+
+        assertEquals("a", view.toString());
+        assertNull(view.getSegment());
+    }
+
+    @Test
+    public void shouldReturnNullSegmentForEscapedStringView()
+    {
+        final JsonTokenizer tokenizer = new JsonTokenizerImpl();
+        wrap(tokenizer, "[\"a\\nb\"]");
+
+        assertTrue(tokenizer.advance());
+        assertTrue(tokenizer.advance());
+        final JsonStringView view = tokenizer.stringView();
+
+        assertEquals("a\nb", view.toString());
+        assertNull(view.getSegment());
+    }
+
+    @Test
+    public void shouldReturnNullSegmentForNumberStringView()
+    {
+        final JsonTokenizer tokenizer = new JsonTokenizerImpl();
+        wrap(tokenizer, "[42]");
+
+        assertTrue(tokenizer.advance());
+        assertTrue(tokenizer.advance());
+        final JsonStringView view = tokenizer.stringView();
+
+        assertEquals("42", view.toString());
+        assertNull(view.getSegment());
+    }
+
+    private static void wrap(
+        JsonTokenizer tokenizer,
+        String json)
+    {
+        final byte[] bytes = json.getBytes(UTF_8);
+        tokenizer.wrap(MemorySegment.ofArray(bytes), 0, bytes.length);
+        tokenizer.terminal(true);
+    }
+}

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerStringViewTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerStringViewTest.java
@@ -19,10 +19,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.lang.foreign.MemorySegment;
-
 import org.junit.jupiter.api.Test;
 
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.common.json.JsonStringView;
 import io.aklivity.zilla.runtime.common.json.JsonTokenizer;
 
@@ -79,7 +78,6 @@ public class JsonTokenizerStringViewTest
         String json)
     {
         final byte[] bytes = json.getBytes(UTF_8);
-        tokenizer.wrap(MemorySegment.ofArray(bytes), 0, bytes.length);
-        tokenizer.terminal(true);
+        tokenizer.wrap(new UnsafeBufferEx(bytes), 0, bytes.length, true);
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerWrapTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizerWrapTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json.internal;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.json.stream.JsonParser.Event;
+
+import org.junit.jupiter.api.Test;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.json.JsonTokenizer;
+
+// wrap(buffer, offset, limit, last) folds terminal(boolean) into the rebind call; wrap(buffer, offset,
+// limit) is the leave-terminal-state-unchanged three-argument form (not a last == true shorthand, unlike
+// the JsonParserEx layer above it, since JsonParserImpl's own three-argument wrap() never touched terminal
+// state either -- see its wrap(DirectBufferEx, int, int) override).
+public class JsonTokenizerWrapTest
+{
+    @Test
+    public void shouldCompleteTrailingNumberWhenWrapMarksLast()
+    {
+        final JsonTokenizer tokenizer = new JsonTokenizerImpl();
+        final byte[] bytes = "42".getBytes(UTF_8);
+
+        tokenizer.wrap(new UnsafeBufferEx(bytes), 0, bytes.length, true);
+
+        assertTrue(tokenizer.advance());
+        assertEquals(Event.VALUE_NUMBER, tokenizer.event());
+        assertEquals("42", tokenizer.stringValue());
+    }
+
+    @Test
+    public void shouldStarveTrailingNumberWhenWrapDoesNotMarkLast()
+    {
+        final JsonTokenizer tokenizer = new JsonTokenizerImpl();
+        final byte[] bytes = "42".getBytes(UTF_8);
+
+        tokenizer.wrap(new UnsafeBufferEx(bytes), 0, bytes.length, false);
+
+        assertFalse(tokenizer.advance());
+    }
+
+    @Test
+    public void shouldLeaveTerminalStateUnchangedOnThreeArgumentWrap()
+    {
+        final JsonTokenizer tokenizer = new JsonTokenizerImpl();
+
+        // "1 " completes independent of terminal state (whitespace, not EOF, ends the number); this call
+        // exists only to mark the tokenizer terminal via the four-argument overload before reset()
+        final byte[] setup = "1 ".getBytes(UTF_8);
+        tokenizer.wrap(new UnsafeBufferEx(setup), 0, setup.length, true);
+        assertTrue(tokenizer.advance());
+        tokenizer.clearEvent();
+        tokenizer.reset();
+
+        // a fresh document, wrapped via the three-argument overload; if it left terminal state unchanged
+        // (still true from the earlier four-argument call) the bare trailing number completes at EOF
+        // instead of starving
+        final byte[] bytes = "42".getBytes(UTF_8);
+        tokenizer.wrap(new UnsafeBufferEx(bytes), 0, bytes.length);
+        assertTrue(tokenizer.advance());
+        assertEquals(Event.VALUE_NUMBER, tokenizer.event());
+        assertEquals("42", tokenizer.stringValue());
+    }
+}


### PR DESCRIPTION
## Description

Promotes `JsonTokenizer` (`common-json`) from a single hard-coded internal class to an exported, pluggable SPI:

- `JsonTokenizer` is now an exported interface with a `DirectBufferEx`-based scan entry point (`wrap(buffer, offset, limit)` / `wrap(buffer, offset, limit, boolean last)` + parameterless `advance()`) instead of the previous `InputStream`-only `advance(InputStream)`. `window(int)` remains a separate method, decoupled from `wrap()`.
- New `JsonTokenizerFactory` SPI (`ServiceLoader`-based) with `priority()`/`available()` capability-probe selection and a static `instantiate()` loader.
- The former concrete `internal.JsonTokenizer` is renamed to `JsonTokenizerImpl`, registered via a new `JsonTokenizerImplFactory` and `META-INF/services`/`module-info` `uses`/`provides`.
- `JsonParserImpl` obtains its tokenizer through `JsonTokenizerFactory.instantiate()` and feeds it its own wrapped `DirectBufferEx` directly, rather than an `InputStream`. The existing `InputStream`-constructor compatibility path (including external re-wraps of a `DirectBufferInputStreamEx`-backed input between `hasNext()` calls) is preserved unchanged via a `rewrapRawInputIfNeeded()` helper — no eager reads, no checked-exception surface change.
- New `JsonStringView` (extends `CharSequence`, adds `getSegment(): DirectBufferEx`) is now the declared return type of `JsonTokenizer.stringView()`, and `JsonGeneratorImpl` opportunistically splices its bytes directly when writing — see below.

No external call sites change: neither `model-json` nor `binding-mcp` touch `JsonTokenizer` directly, both go through `JsonParserEx`/`JsonPipeline`.

## Motivation and context

Decouples `JsonParserImpl` from a single hard-coded tokenizer implementation, allowing alternate `JsonTokenizer` providers to be plugged in via `ServiceLoader` and selected by priority with a capability probe (`available()`), while preserving default behavior with no available alternate provider.

Fixes # (none — this is SPI groundwork for a future pluggable, higher-throughput tokenizer provider; no in-tree consumer yet)

## `JsonStringView`: tokenizer-agnostic groundwork for zero-copy value splicing

`JsonTokenizer.stringView()` now declares `JsonStringView` (not plain `CharSequence`) as its return type. `JsonStringView` adds one method beyond `CharSequence`: `getSegment(): DirectBufferEx`, a nullable hint — the contiguous run of original source bytes a value's characters were decoded from, when such a run exists and corresponds 1:1 to the decoded content, or `null` when decoding transformed the bytes (an escape sequence, a folded multi-byte UTF-8 sequence) and there is no single source byte range left to point at. **When non-`null`, every byte in the segment is guaranteed plain ASCII and never requires escaping** — a hard invariant documented on the interface, since it's what lets a consumer splice the bytes directly with no re-encoding pass, and lets the segment's byte length be relied on as equal to the view's char length.

`JsonTokenizerImpl` always decodes into `scratch` (a `StringBuilder`), so it never has a byte-backed alternative to offer — its `stringView()` wraps whatever `CharSequence` it already returns in a small reused `DecodedStringView` flyweight whose `getSegment()` unconditionally returns `null`. This is a correct, honest answer for this tokenizer, not a placeholder.

`JsonParserImpl` needed no changes. `getStringView()`'s existing branch for verbatim/segment values already returns `tokenizer.stringView()` directly, unwrapped, so a tokenizer that *does* produce a real segment-backed `JsonStringView` will have that type flow through to callers automatically. The other branch (decoded char-scalars, tracking bounded/resumable output-write progress via `stringViewOffset`) is unaffected: its own `StringView` wrapper deliberately stays plain `CharSequence`, since decoded content has no segment to offer regardless of what wraps it.

**`JsonGeneratorImpl` now consumes this**, in both `write(CharSequence)` (unbounded) and `write(CharSequence, Completion)` (bounded): an `instanceof JsonStringView` check with a non-null `getSegment()` splices the segment's bytes directly via a bulk buffer copy instead of the codepoint-by-codepoint escape path — safe unconditionally per the ASCII/no-escaping invariant above. The bounded path only takes this shortcut when the *whole* segment fits the current output window; a segment too large for one call declines and falls through unchanged to the existing codepoint path, which already knows how to bound and resume a partial write correctly. This deliberately does not attempt to fast-path a multi-call resumed write of an oversized segment-backed value — that would require reasoning about how a future `JsonTokenizer` producer re-exposes "the remainder" of a segment across calls, which is that producer's contract to keep, not this generator's to assume; the fast path here only ever claims "this exact instance, on this exact call, either fits or it doesn't."

This is deliberately narrow, tokenizer-agnostic groundwork, not a full feature: no production `JsonTokenizer` implementation in this repo produces a real segment-backed `JsonStringView` yet (`JsonGeneratorStringViewTest` uses a minimal test fixture to verify the generator side of the contract independently). It establishes the shared vocabulary a future vectorized `JsonTokenizer` provider would need to plug into and get this benefit automatically, with no further changes on this side. A larger, related migration of `common-json`'s exported buffer surface from `DirectBufferEx` to `MemorySegment` was considered and explicitly deferred until `MemorySegment`/`asSlice()` gets Project Valhalla's value-class optimization, so it can be done together with proper performance validation rather than piecemeal; this `JsonStringView` addition does not depend on or block that.

## `wrap()` takes `DirectBufferEx` instead of `MemorySegment`; `terminal()` folds into `wrap()`

The scan entry point originally introduced in this PR took a raw `MemorySegment` plus a separate `terminal(boolean)` mutator. Both are replaced:

- `wrap(DirectBufferEx buffer, int offset, int limit)` / `wrap(DirectBufferEx buffer, int offset, int limit, boolean last)` — mirroring `JsonParserEx`'s own two-overload shape one layer up, instead of a bespoke tokenizer-only contract.
- The standalone `terminal(boolean)` mutator is removed; `last` is now a parameter of the four-argument `wrap()` overload, set atomically with the window rebind. The three-argument overload only rebinds the window and leaves terminal state untouched — this matches the prior behavior exactly, since `JsonParserImpl`'s own three-argument `wrap()` never called `terminal()` either.

This was previously forcing every caller of `JsonTokenizer.wrap()` to first unwrap a `DirectBufferEx` down to its raw backing `MemorySegment` and manually add `wrapAdjustment()` before calling in — `JsonParserImpl` had two such call sites doing that arithmetic redundantly. `JsonTokenizerImpl` now reads bytes via `DirectBufferEx.getByte(index)`, which already applies `wrapAdjustment()` internally, so both call sites simply pass their `DirectBufferEx` straight through. New `JsonTokenizerWrapTest` locks in the two-overload contract directly against `JsonTokenizerImpl`: a four-argument `wrap(..., true)` completes a bare trailing number at EOF, a four-argument `wrap(..., false)` correctly starves instead, and a subsequent three-argument `wrap()` call leaves a previously-set terminal state unchanged across a `reset()`.

## Fused integral number decode: `numberIntegral()`/`numberInLongRange()`/`numberLongValue()`

Adds three methods to `JsonTokenizer`, letting `JsonParserImpl.getInt()`/`getLong()` skip a second `CharSequence`-based pass through `Integer.parseInt`/`Long.parseLong` for the common case of a plain integral value. `JsonTokenizerImpl.validateNumberChar` — the existing RFC 8259 number-grammar state machine, already advanced one char at a time — now also accumulates sign and magnitude for the leading integer-part digits alongside its existing state transitions, so the value is available for free once the number completes.

`numberMagnitude` only accumulates up to 18 digits (`LONG_SAFE_DIGITS`): at or under that many digits a signed `long` cannot overflow regardless of sign, so no per-digit overflow check is needed. A longer integer (rare — both `Long.MIN_VALUE` and `Long.MAX_VALUE` are 19 digits) reports `numberInLongRange()` false, and `getInt()`/`getLong()` fall back to the original `CharSequence`-based path unchanged — the fast path only ever has to be correct for the case it claims to handle; every other case (non-integral values, out-of-range values, all existing `NumberFormatException`-throwing misuse) keeps its exact prior behavior via that fallback. `isIntegralNumber()` similarly reads `numberState` directly (`ZERO`/`INT` are the only accepting states never reached via a `DOT`/`EXP` transition) instead of re-scanning the `CharSequence` for `.`/`e`/`E`.

New `JsonNumberDecodeBM` isolates `getLong()` from the rest of the parse over a 2000-element number array. Before/after (stashing the fused implementation and re-running the identical benchmark): 5,288 → 5,622 ops/s (**+6.3%**), `gc.alloc.rate.norm` unchanged at ~1.3 B/op (`Long.parseLong(CharSequence, ...)` was already non-allocating; the win is skipping its virtual `charAt()` calls and redundant validity re-checking of digits the tokenizer's own grammar already validated). New `JsonTokenizerNumberValueTest` pins the three methods directly at the tokenizer level, including the 18-vs-19-digit fast-path boundary; two new `JsonParserTest` cases pin that same boundary and `-0` handling at the `JsonParserImpl` level.

This is the interface-level piece a related vectorized-scan design called out as needing a stable cross-repo contract before attempting (a vectorized digit-extent scan that currently only counts digits and never touches their values) — implemented here first since it's SIMD-agnostic; the SIMD provider adopting it is separate follow-up work.

## Test plan

- `./mvnw install -pl runtime/common-json`: checkstyle, license, and full test suite pass — 4851 tests, 0 failures, 0 errors.
- New tests: `JsonTokenizerFactoryTest` (priority ordering, availability filtering, throws-when-none-available, real `ServiceLoader` discovery of the built-in factory), updated `JsonTokenizerPathTest` (migrated to the `DirectBufferEx`-based entry point), `JsonTokenizerStringViewTest` (key/escaped-string/number `stringView()` calls all correctly report a `null` `getSegment()` for this tokenizer), `JsonGeneratorStringViewTest` (the generator's fast path fires and produces correct output when a segment fits, both unbounded and bounded; correctly falls back when the segment is `null` or too large for the current output window, producing byte-identical output to the plain-`String` path in that case), `JsonTokenizerWrapTest` (the `wrap()`/`last` contract described above), and `JsonTokenizerNumberValueTest`/two new `JsonParserTest` cases (the fused number-decode contract described above).
- JMH smoke pass on `JsonPipelineBM` after the `DirectBufferEx.getByte()` swap shows no allocation regression (near-zero `gc.alloc.rate.norm` on the pipeline paths, unchanged ~968 B/op on the schema-validation paths that were already allocating for unrelated reasons). New `JsonNumberDecodeBM` measures the number-decode fusion specifically (see above).
- Downstream consumers `model-json` and `binding-mcp` built and their test suites run against the changed `common-json` with no regressions and no call-site changes required.
- Moditect module packaging (`./mvnw clean install -pl runtime/common-json`) verified clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V4mgLEhQz15ZKQp6KKKsmX)_