### PR TITLE
Add OAuth2 flows and scopes support to OpenAPI security schemes

### DIFF
--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiDeserializers.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiDeserializers.java
@@ -68,6 +68,8 @@ public final class OpenapiDeserializers
             new OpenapiHeaderDeserializer(extensionTypes),
             new OpenapiLinkDeserializer(extensionTypes),
             new OpenapiOperationDeserializer(extensionTypes),
-            new OpenapiSecuritySchemeDeserializer(extensionTypes));
+            new OpenapiSecuritySchemeDeserializer(extensionTypes),
+            new OpenapiOAuthFlowDeserializer(extensionTypes),
+            new OpenapiOAuthFlowsDeserializer(extensionTypes));
     }
 }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiOAuthFlow.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiOAuthFlow.java
@@ -16,15 +16,12 @@ package io.aklivity.zilla.runtime.common.openapi.model;
 
 import java.util.Map;
 
-public class OpenapiSecurityScheme extends AbstractOpenapiResolvable
+public class OpenapiOAuthFlow
 {
-    public String type;
-    public String name;
-    public String in;
-    public String scheme;
-    public String bearerFormat;
-    public String openidConnectUrl;
-    public OpenapiOAuthFlows flows;
+    public String authorizationUrl;
+    public String tokenUrl;
+    public String refreshUrl;
+    public Map<String, String> scopes;
 
     public Map<String, Object> extensions;
 }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiOAuthFlowDeserializer.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiOAuthFlowDeserializer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.openapi.model;
+
+import java.lang.reflect.Type;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import jakarta.json.JsonObject;
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.serializer.DeserializationContext;
+import jakarta.json.bind.serializer.JsonbDeserializer;
+import jakarta.json.stream.JsonParser;
+
+public final class OpenapiOAuthFlowDeserializer implements JsonbDeserializer<OpenapiOAuthFlow>
+{
+    private final Map<String, Class<?>> extensionTypes;
+    private final Supplier<Jsonb> plain;
+
+    public OpenapiOAuthFlowDeserializer(
+        Map<String, Class<?>> extensionTypes)
+    {
+        this.extensionTypes = extensionTypes;
+        this.plain = OpenapiDeserializers.plain(extensionTypes, OpenapiOAuthFlowDeserializer.class);
+    }
+
+    @Override
+    public OpenapiOAuthFlow deserialize(
+        JsonParser parser,
+        DeserializationContext ctx,
+        Type type)
+    {
+        JsonObject object = parser.getObject();
+        OpenapiOAuthFlow model = plain.get().fromJson(object.toString(), OpenapiOAuthFlow.class);
+
+        Map<String, Object> extensions = null;
+        for (String name : object.keySet())
+        {
+            if (name.startsWith("x-"))
+            {
+                Class<?> extensionType = extensionTypes.get(name);
+                if (extensionType != null)
+                {
+                    if (extensions == null)
+                    {
+                        extensions = new LinkedHashMap<>();
+                    }
+                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
+                }
+            }
+        }
+        model.extensions = extensions;
+
+        return model;
+    }
+}

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiOAuthFlows.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiOAuthFlows.java
@@ -16,15 +16,12 @@ package io.aklivity.zilla.runtime.common.openapi.model;
 
 import java.util.Map;
 
-public class OpenapiSecurityScheme extends AbstractOpenapiResolvable
+public class OpenapiOAuthFlows
 {
-    public String type;
-    public String name;
-    public String in;
-    public String scheme;
-    public String bearerFormat;
-    public String openidConnectUrl;
-    public OpenapiOAuthFlows flows;
+    public OpenapiOAuthFlow implicit;
+    public OpenapiOAuthFlow password;
+    public OpenapiOAuthFlow clientCredentials;
+    public OpenapiOAuthFlow authorizationCode;
 
     public Map<String, Object> extensions;
 }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiOAuthFlowsDeserializer.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiOAuthFlowsDeserializer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.openapi.model;
+
+import java.lang.reflect.Type;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import jakarta.json.JsonObject;
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.serializer.DeserializationContext;
+import jakarta.json.bind.serializer.JsonbDeserializer;
+import jakarta.json.stream.JsonParser;
+
+public final class OpenapiOAuthFlowsDeserializer implements JsonbDeserializer<OpenapiOAuthFlows>
+{
+    private final Map<String, Class<?>> extensionTypes;
+    private final Supplier<Jsonb> plain;
+
+    public OpenapiOAuthFlowsDeserializer(
+        Map<String, Class<?>> extensionTypes)
+    {
+        this.extensionTypes = extensionTypes;
+        this.plain = OpenapiDeserializers.plain(extensionTypes, OpenapiOAuthFlowsDeserializer.class);
+    }
+
+    @Override
+    public OpenapiOAuthFlows deserialize(
+        JsonParser parser,
+        DeserializationContext ctx,
+        Type type)
+    {
+        JsonObject object = parser.getObject();
+        OpenapiOAuthFlows model = plain.get().fromJson(object.toString(), OpenapiOAuthFlows.class);
+
+        Map<String, Object> extensions = null;
+        for (String name : object.keySet())
+        {
+            if (name.startsWith("x-"))
+            {
+                Class<?> extensionType = extensionTypes.get(name);
+                if (extensionType != null)
+                {
+                    if (extensions == null)
+                    {
+                        extensions = new LinkedHashMap<>();
+                    }
+                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
+                }
+            }
+        }
+        model.extensions = extensions;
+
+        return model;
+    }
+}

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiOAuthFlowView.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiOAuthFlowView.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.openapi.view;
+
+import java.util.Map;
+import java.util.Optional;
+
+import io.aklivity.zilla.runtime.common.openapi.model.OpenapiOAuthFlow;
+
+public final class OpenapiOAuthFlowView
+{
+    public final String authorizationUrl;
+    public final String tokenUrl;
+    public final String refreshUrl;
+    public final Map<String, String> scopes;
+
+    private final Map<String, Object> extensions;
+
+    OpenapiOAuthFlowView(
+        OpenapiOAuthFlow model)
+    {
+        this.authorizationUrl = model.authorizationUrl;
+        this.tokenUrl = model.tokenUrl;
+        this.refreshUrl = model.refreshUrl;
+        this.scopes = model.scopes;
+        this.extensions = model.extensions;
+    }
+
+    public boolean hasExtension(
+        String name)
+    {
+        return extensions != null && extensions.containsKey(name);
+    }
+
+    public <T> Optional<T> extension(
+        String name,
+        Class<T> type)
+    {
+        return Optional.ofNullable(extensions != null ? type.cast(extensions.get(name)) : null);
+    }
+}

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiOAuthFlowsView.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiOAuthFlowsView.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.openapi.view;
+
+import java.util.Map;
+import java.util.Optional;
+
+import io.aklivity.zilla.runtime.common.openapi.model.OpenapiOAuthFlows;
+
+public final class OpenapiOAuthFlowsView
+{
+    public final OpenapiOAuthFlowView implicit;
+    public final OpenapiOAuthFlowView password;
+    public final OpenapiOAuthFlowView clientCredentials;
+    public final OpenapiOAuthFlowView authorizationCode;
+
+    private final Map<String, Object> extensions;
+
+    OpenapiOAuthFlowsView(
+        OpenapiOAuthFlows model)
+    {
+        this.implicit = model.implicit != null ? new OpenapiOAuthFlowView(model.implicit) : null;
+        this.password = model.password != null ? new OpenapiOAuthFlowView(model.password) : null;
+        this.clientCredentials = model.clientCredentials != null
+                ? new OpenapiOAuthFlowView(model.clientCredentials) : null;
+        this.authorizationCode = model.authorizationCode != null
+                ? new OpenapiOAuthFlowView(model.authorizationCode) : null;
+        this.extensions = model.extensions;
+    }
+
+    public boolean hasExtension(
+        String name)
+    {
+        return extensions != null && extensions.containsKey(name);
+    }
+
+    public <T> Optional<T> extension(
+        String name,
+        Class<T> type)
+    {
+        return Optional.ofNullable(extensions != null ? type.cast(extensions.get(name)) : null);
+    }
+}

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiSecuritySchemeView.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiSecuritySchemeView.java
@@ -14,9 +14,13 @@
  */
 package io.aklivity.zilla.runtime.common.openapi.view;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import io.aklivity.zilla.runtime.common.openapi.model.OpenapiSecurityScheme;
 import io.aklivity.zilla.runtime.common.openapi.model.resolver.OpenapiResolver;
@@ -29,6 +33,7 @@ public final class OpenapiSecuritySchemeView
     public final String scheme;
     public final String bearerFormat;
     public final String openidConnectUrl;
+    public final OpenapiOAuthFlowsView flows;
     public final List<String> scopes;
 
     private final Map<String, Object> extensions;
@@ -53,7 +58,8 @@ public final class OpenapiSecuritySchemeView
         this.scheme = resolved.scheme;
         this.bearerFormat = resolved.bearerFormat;
         this.openidConnectUrl = resolved.openidConnectUrl;
-        this.scopes = List.of(); // TODO: resolved.scopes;
+        this.flows = resolved.flows != null ? new OpenapiOAuthFlowsView(resolved.flows) : null;
+        this.scopes = this.flows != null ? resolveScopes(this.flows) : List.of();
         this.extensions = resolved.extensions;
     }
 
@@ -68,5 +74,18 @@ public final class OpenapiSecuritySchemeView
         Class<T> type)
     {
         return Optional.ofNullable(extensions != null ? type.cast(extensions.get(name)) : null);
+    }
+
+    private static List<String> resolveScopes(
+        OpenapiOAuthFlowsView flows)
+    {
+        Set<String> scopes = new LinkedHashSet<>();
+        Stream.of(flows.implicit, flows.password, flows.clientCredentials, flows.authorizationCode)
+            .filter(Objects::nonNull)
+            .map(flow -> flow.scopes)
+            .filter(Objects::nonNull)
+            .forEach(flowScopes -> scopes.addAll(flowScopes.keySet()));
+
+        return List.copyOf(scopes);
     }
 }

--- a/runtime/common-openapi/src/test/java/io/aklivity/zilla/runtime/common/openapi/config/OpenapiParserTest.java
+++ b/runtime/common-openapi/src/test/java/io/aklivity/zilla/runtime/common/openapi/config/OpenapiParserTest.java
@@ -18,6 +18,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.Test;
@@ -182,6 +184,56 @@ public class OpenapiParserTest
 
         assertTrue(schema.hasExtension("x-zilla-sample"));
         assertEquals("schema-value", schema.extension("x-zilla-sample", SampleExtension.class).get().key);
+    }
+
+    @Test
+    public void shouldResolveOAuthFlowsAndScopesFromSecurityScheme()
+    {
+        String spec =
+            """
+            {
+              "openapi": "3.1.0",
+              "info": { "title": "sample", "version": "1.0.0" },
+              "paths": {},
+              "components": {
+                "securitySchemes": {
+                  "oauth2Auth": {
+                    "type": "oauth2",
+                    "flows": {
+                      "authorizationCode": {
+                        "authorizationUrl": "https://example.com/authorize",
+                        "tokenUrl": "https://example.com/token",
+                        "refreshUrl": "https://example.com/refresh",
+                        "scopes": {
+                          "read": "Read access",
+                          "write": "Write access"
+                        },
+                        "x-zilla-sample": { "key": "flow-value" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        OpenapiParser parser = new OpenapiParserFactory()
+            .withExtension("x-zilla-sample", SampleExtension.class)
+            .createParser();
+
+        Openapi model = parser.parse(spec);
+        OpenapiView view = OpenapiView.of(model);
+        OpenapiSecuritySchemeView scheme = view.components.securitySchemes.get("oauth2Auth");
+
+        assertEquals("https://example.com/authorize", scheme.flows.authorizationCode.authorizationUrl);
+        assertEquals("https://example.com/token", scheme.flows.authorizationCode.tokenUrl);
+        assertEquals("https://example.com/refresh", scheme.flows.authorizationCode.refreshUrl);
+        assertEquals(Map.of("read", "Read access", "write", "Write access"), scheme.flows.authorizationCode.scopes);
+        assertEquals(List.of("read", "write"), scheme.scopes);
+
+        assertTrue(scheme.flows.authorizationCode.hasExtension("x-zilla-sample"));
+        assertEquals("flow-value",
+            scheme.flows.authorizationCode.extension("x-zilla-sample", SampleExtension.class).get().key);
     }
 
     @Test

--- a/runtime/common-openapi/src/test/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiViewTest.java
+++ b/runtime/common-openapi/src/test/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiViewTest.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.Test;
 
@@ -30,6 +31,8 @@ import io.aklivity.zilla.runtime.common.openapi.config.OpenapiServerConfig;
 import io.aklivity.zilla.runtime.common.openapi.model.Openapi;
 import io.aklivity.zilla.runtime.common.openapi.model.OpenapiComponents;
 import io.aklivity.zilla.runtime.common.openapi.model.OpenapiMediaType;
+import io.aklivity.zilla.runtime.common.openapi.model.OpenapiOAuthFlow;
+import io.aklivity.zilla.runtime.common.openapi.model.OpenapiOAuthFlows;
 import io.aklivity.zilla.runtime.common.openapi.model.OpenapiOperation;
 import io.aklivity.zilla.runtime.common.openapi.model.OpenapiPath;
 import io.aklivity.zilla.runtime.common.openapi.model.OpenapiRequestBody;
@@ -243,6 +246,63 @@ public class OpenapiViewTest
 
         assertTrue(schemeView.hasExtension("x-zilla-sample"));
         assertEquals("scheme-value", schemeView.extension("x-zilla-sample", SampleExtension.class).get().key);
+    }
+
+    @Test
+    public void shouldResolveSecuritySchemeOAuthFlowsAndScopes() throws Exception
+    {
+        OpenapiOAuthFlow implicit = new OpenapiOAuthFlow();
+        implicit.authorizationUrl = "https://example.com/authorize";
+        implicit.refreshUrl = "https://example.com/refresh";
+        implicit.scopes = Map.of("read", "Read access");
+
+        OpenapiOAuthFlow clientCredentials = new OpenapiOAuthFlow();
+        clientCredentials.tokenUrl = "https://example.com/token";
+        clientCredentials.scopes = Map.of("read", "Read access", "write", "Write access");
+
+        OpenapiOAuthFlows flows = new OpenapiOAuthFlows();
+        flows.implicit = implicit;
+        flows.clientCredentials = clientCredentials;
+
+        OpenapiSecurityScheme scheme = new OpenapiSecurityScheme();
+        scheme.type = "oauth2";
+        scheme.flows = flows;
+
+        OpenapiComponents components = new OpenapiComponents();
+        components.securitySchemes = Map.of("oauth2Auth", scheme);
+
+        Openapi model = new Openapi();
+        model.components = components;
+
+        OpenapiView view = OpenapiView.of(model);
+        OpenapiSecuritySchemeView schemeView = view.components.securitySchemes.get("oauth2Auth");
+
+        assertEquals("https://example.com/authorize", schemeView.flows.implicit.authorizationUrl);
+        assertEquals("https://example.com/refresh", schemeView.flows.implicit.refreshUrl);
+        assertEquals("https://example.com/token", schemeView.flows.clientCredentials.tokenUrl);
+        assertNull(schemeView.flows.password);
+        assertNull(schemeView.flows.authorizationCode);
+        assertEquals(Set.of("read", "write"), Set.copyOf(schemeView.scopes));
+    }
+
+    @Test
+    public void shouldNotResolveScopesWithoutFlows() throws Exception
+    {
+        OpenapiSecurityScheme scheme = new OpenapiSecurityScheme();
+        scheme.type = "http";
+        scheme.scheme = "bearer";
+
+        OpenapiComponents components = new OpenapiComponents();
+        components.securitySchemes = Map.of("bearerAuth", scheme);
+
+        Openapi model = new Openapi();
+        model.components = components;
+
+        OpenapiView view = OpenapiView.of(model);
+        OpenapiSecuritySchemeView schemeView = view.components.securitySchemes.get("bearerAuth");
+
+        assertNull(schemeView.flows);
+        assertEquals(List.of(), schemeView.scopes);
     }
 
     public static final class SampleExtension


### PR DESCRIPTION
## Description

This change adds support for OAuth2 flows and scopes in OpenAPI security scheme definitions. Previously, the security scheme model did not expose OAuth2 flow details or aggregate scopes across flows.

### Changes

- **New model classes**: Added `OpenapiOAuthFlow` and `OpenapiOAuthFlows` to represent OAuth2 flow configurations with support for authorization URLs, token URLs, refresh URLs, and scopes
- **New deserializers**: Added `OpenapiOAuthFlowDeserializer` and `OpenapiOAuthFlowsDeserializer` to handle custom extension deserialization for OAuth2 flows (following the existing pattern for other model types)
- **New view classes**: Added `OpenapiOAuthFlowView` and `OpenapiOAuthFlowsView` to provide a clean API for accessing OAuth2 flow information with extension support
- **Enhanced security scheme view**: Updated `OpenapiSecuritySchemeView` to expose OAuth2 flows and automatically aggregate all scopes across all configured flows (implicit, password, clientCredentials, authorizationCode)
- **Model updates**: Updated `OpenapiSecurityScheme` to include the `flows` field

### Tests

Added comprehensive test coverage:
- `OpenapiParserTest.shouldResolveOAuthFlowsAndScopesFromSecurityScheme()` - Validates parsing and resolution of OAuth2 flows with scopes and extensions from OpenAPI spec
- `OpenapiViewTest.shouldResolveSecuritySchemeOAuthFlowsAndScopes()` - Validates view layer correctly exposes flows and aggregates scopes
- `OpenapiViewTest.shouldNotResolveScopesWithoutFlows()` - Validates non-OAuth2 schemes return empty scopes list

Fixes #(issue)

https://claude.ai/code/session_01VKMGPiHNpMRS8LeU5yCXRw