### PR TITLE
Support prefix wildcard extensions in OpenAPI parser

### DIFF
--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/config/OpenapiParser.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/config/OpenapiParser.java
@@ -49,20 +49,23 @@ public class OpenapiParser
     private static final Pattern VERSION_PATTERN = Pattern.compile("(\\d\\.\\d)\\.\\d+");
     private final Map<String, JsonSchema> schemas;
     private final Map<String, Class<?>> extensionTypes;
+    private final Map<String, Class<?>> prefixExtensionTypes;
 
     public OpenapiParser()
     {
-        this(emptyMap());
+        this(emptyMap(), emptyMap());
     }
 
     OpenapiParser(
-        Map<String, Class<?>> extensionTypes)
+        Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes)
     {
         Map<String, JsonSchema> schemas = new Object2ObjectHashMap<>();
         schemas.put("3.0", schema("3.0.3"));
         schemas.put("3.1", schema("3.1.0"));
         this.schemas = unmodifiableMap(schemas);
         this.extensionTypes = extensionTypes;
+        this.prefixExtensionTypes = prefixExtensionTypes;
     }
 
     public Openapi parse(
@@ -90,7 +93,7 @@ public class OpenapiParser
                 schema.validate(parser, problem -> errors.add(new OpenapiException(problem.toString())));
             }
 
-            List<JsonbDeserializer<?>> deserializers = OpenapiDeserializers.all(extensionTypes);
+            List<JsonbDeserializer<?>> deserializers = OpenapiDeserializers.all(extensionTypes, prefixExtensionTypes);
             Jsonb jsonb = JsonbBuilder.newBuilder()
                     .withProvider(provider)
                     .withConfig(new JsonbConfig()

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/config/OpenapiParserFactory.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/config/OpenapiParserFactory.java
@@ -20,22 +20,31 @@ import java.util.Map;
 public final class OpenapiParserFactory
 {
     private final Map<String, Class<?>> extensionTypes;
+    private final Map<String, Class<?>> prefixExtensionTypes;
 
     public OpenapiParserFactory()
     {
         this.extensionTypes = new LinkedHashMap<>();
+        this.prefixExtensionTypes = new LinkedHashMap<>();
     }
 
     public <T> OpenapiParserFactory withExtension(
         String name,
         Class<T> type)
     {
-        extensionTypes.put(name, type);
+        if (name.endsWith("*"))
+        {
+            prefixExtensionTypes.put(name, type);
+        }
+        else
+        {
+            extensionTypes.put(name, type);
+        }
         return this;
     }
 
     public OpenapiParser createParser()
     {
-        return new OpenapiParser(extensionTypes);
+        return new OpenapiParser(extensionTypes, prefixExtensionTypes);
     }
 }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiComponentsDeserializer.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiComponentsDeserializer.java
@@ -15,7 +15,6 @@
 package io.aklivity.zilla.runtime.common.openapi.model;
 
 import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -28,13 +27,16 @@ import jakarta.json.stream.JsonParser;
 public final class OpenapiComponentsDeserializer implements JsonbDeserializer<OpenapiComponents>
 {
     private final Map<String, Class<?>> extensionTypes;
+    private final Map<String, Class<?>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public OpenapiComponentsDeserializer(
-        Map<String, Class<?>> extensionTypes)
+        Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
-        this.plain = OpenapiDeserializers.plain(extensionTypes, OpenapiComponentsDeserializer.class);
+        this.prefixExtensionTypes = prefixExtensionTypes;
+        this.plain = OpenapiDeserializers.plain(extensionTypes, prefixExtensionTypes, OpenapiComponentsDeserializer.class);
     }
 
     @Override
@@ -45,24 +47,7 @@ public final class OpenapiComponentsDeserializer implements JsonbDeserializer<Op
     {
         JsonObject object = parser.getObject();
         OpenapiComponents model = plain.get().fromJson(object.toString(), OpenapiComponents.class);
-
-        Map<String, Object> extensions = null;
-        for (String name : object.keySet())
-        {
-            if (name.startsWith("x-"))
-            {
-                Class<?> extensionType = extensionTypes.get(name);
-                if (extensionType != null)
-                {
-                    if (extensions == null)
-                    {
-                        extensions = new LinkedHashMap<>();
-                    }
-                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
-                }
-            }
-        }
-        model.extensions = extensions;
+        model.extensions = OpenapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiDeserializer.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiDeserializer.java
@@ -15,7 +15,6 @@
 package io.aklivity.zilla.runtime.common.openapi.model;
 
 import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -28,13 +27,16 @@ import jakarta.json.stream.JsonParser;
 public final class OpenapiDeserializer implements JsonbDeserializer<Openapi>
 {
     private final Map<String, Class<?>> extensionTypes;
+    private final Map<String, Class<?>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public OpenapiDeserializer(
-        Map<String, Class<?>> extensionTypes)
+        Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
-        this.plain = OpenapiDeserializers.plain(extensionTypes, OpenapiDeserializer.class);
+        this.prefixExtensionTypes = prefixExtensionTypes;
+        this.plain = OpenapiDeserializers.plain(extensionTypes, prefixExtensionTypes, OpenapiDeserializer.class);
     }
 
     @Override
@@ -45,24 +47,7 @@ public final class OpenapiDeserializer implements JsonbDeserializer<Openapi>
     {
         JsonObject object = parser.getObject();
         Openapi model = plain.get().fromJson(object.toString(), Openapi.class);
-
-        Map<String, Object> extensions = null;
-        for (String name : object.keySet())
-        {
-            if (name.startsWith("x-"))
-            {
-                Class<?> extensionType = extensionTypes.get(name);
-                if (extensionType != null)
-                {
-                    if (extensions == null)
-                    {
-                        extensions = new LinkedHashMap<>();
-                    }
-                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
-                }
-            }
-        }
-        model.extensions = extensions;
+        model.extensions = OpenapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiDeserializers.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiDeserializers.java
@@ -14,10 +14,14 @@
  */
 package io.aklivity.zilla.runtime.common.openapi.model;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
 import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
 import jakarta.json.bind.JsonbConfig;
@@ -31,6 +35,7 @@ public final class OpenapiDeserializers
 
     static Supplier<Jsonb> plain(
         Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes,
         Class<?> exclude)
     {
         Jsonb[] cache = new Jsonb[1];
@@ -39,7 +44,7 @@ public final class OpenapiDeserializers
         {
             if (cache[0] == null)
             {
-                JsonbDeserializer<?>[] others = all(extensionTypes).stream()
+                JsonbDeserializer<?>[] others = all(extensionTypes, prefixExtensionTypes).stream()
                     .filter(deserializer -> deserializer.getClass() != exclude)
                     .toArray(JsonbDeserializer[]::new);
                 cache[0] = JsonbBuilder.newBuilder()
@@ -50,26 +55,83 @@ public final class OpenapiDeserializers
         };
     }
 
+    static Map<String, Object> extensions(
+        JsonObject object,
+        Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes,
+        Supplier<Jsonb> plain)
+    {
+        Map<String, Object> extensions = null;
+
+        for (String name : object.keySet())
+        {
+            if (name.startsWith("x-"))
+            {
+                Class<?> extensionType = extensionTypes.get(name);
+                if (extensionType != null)
+                {
+                    if (extensions == null)
+                    {
+                        extensions = new LinkedHashMap<>();
+                    }
+                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
+                }
+            }
+        }
+
+        for (Map.Entry<String, Class<?>> prefixExtensionType : prefixExtensionTypes.entrySet())
+        {
+            String registeredName = prefixExtensionType.getKey();
+            String prefix = registeredName.substring(0, registeredName.length() - 1);
+
+            JsonObjectBuilder aggregate = null;
+            for (String name : object.keySet())
+            {
+                if (name.startsWith(prefix))
+                {
+                    if (aggregate == null)
+                    {
+                        aggregate = Json.createObjectBuilder();
+                    }
+                    aggregate.add(name.substring(prefix.length()), object.get(name));
+                }
+            }
+
+            if (aggregate != null)
+            {
+                if (extensions == null)
+                {
+                    extensions = new LinkedHashMap<>();
+                }
+                extensions.put(registeredName,
+                    plain.get().fromJson(aggregate.build().toString(), prefixExtensionType.getValue()));
+            }
+        }
+
+        return extensions;
+    }
+
     public static List<JsonbDeserializer<?>> all(
-        Map<String, Class<?>> extensionTypes)
+        Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes)
     {
         return List.of(
-            new OpenapiDeserializer(extensionTypes),
-            new OpenapiServerDeserializer(extensionTypes),
-            new OpenapiServerVariableDeserializer(extensionTypes),
-            new OpenapiComponentsDeserializer(extensionTypes),
-            new OpenapiPathDeserializer(extensionTypes),
-            new OpenapiParameterDeserializer(extensionTypes),
-            new OpenapiRequestBodyDeserializer(extensionTypes),
-            new OpenapiMediaTypeDeserializer(extensionTypes),
-            new OpenapiEncodingDeserializer(extensionTypes),
-            new OpenapiSchemaDeserializer(extensionTypes),
-            new OpenapiResponseDeserializer(extensionTypes),
-            new OpenapiHeaderDeserializer(extensionTypes),
-            new OpenapiLinkDeserializer(extensionTypes),
-            new OpenapiOperationDeserializer(extensionTypes),
-            new OpenapiSecuritySchemeDeserializer(extensionTypes),
-            new OpenapiOAuthFlowDeserializer(extensionTypes),
-            new OpenapiOAuthFlowsDeserializer(extensionTypes));
+            new OpenapiDeserializer(extensionTypes, prefixExtensionTypes),
+            new OpenapiServerDeserializer(extensionTypes, prefixExtensionTypes),
+            new OpenapiServerVariableDeserializer(extensionTypes, prefixExtensionTypes),
+            new OpenapiComponentsDeserializer(extensionTypes, prefixExtensionTypes),
+            new OpenapiPathDeserializer(extensionTypes, prefixExtensionTypes),
+            new OpenapiParameterDeserializer(extensionTypes, prefixExtensionTypes),
+            new OpenapiRequestBodyDeserializer(extensionTypes, prefixExtensionTypes),
+            new OpenapiMediaTypeDeserializer(extensionTypes, prefixExtensionTypes),
+            new OpenapiEncodingDeserializer(extensionTypes, prefixExtensionTypes),
+            new OpenapiSchemaDeserializer(extensionTypes, prefixExtensionTypes),
+            new OpenapiResponseDeserializer(extensionTypes, prefixExtensionTypes),
+            new OpenapiHeaderDeserializer(extensionTypes, prefixExtensionTypes),
+            new OpenapiLinkDeserializer(extensionTypes, prefixExtensionTypes),
+            new OpenapiOperationDeserializer(extensionTypes, prefixExtensionTypes),
+            new OpenapiSecuritySchemeDeserializer(extensionTypes, prefixExtensionTypes),
+            new OpenapiOAuthFlowDeserializer(extensionTypes, prefixExtensionTypes),
+            new OpenapiOAuthFlowsDeserializer(extensionTypes, prefixExtensionTypes));
     }
 }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiEncodingDeserializer.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiEncodingDeserializer.java
@@ -15,7 +15,6 @@
 package io.aklivity.zilla.runtime.common.openapi.model;
 
 import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -28,13 +27,16 @@ import jakarta.json.stream.JsonParser;
 public final class OpenapiEncodingDeserializer implements JsonbDeserializer<OpenapiEncoding>
 {
     private final Map<String, Class<?>> extensionTypes;
+    private final Map<String, Class<?>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public OpenapiEncodingDeserializer(
-        Map<String, Class<?>> extensionTypes)
+        Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
-        this.plain = OpenapiDeserializers.plain(extensionTypes, OpenapiEncodingDeserializer.class);
+        this.prefixExtensionTypes = prefixExtensionTypes;
+        this.plain = OpenapiDeserializers.plain(extensionTypes, prefixExtensionTypes, OpenapiEncodingDeserializer.class);
     }
 
     @Override
@@ -45,24 +47,7 @@ public final class OpenapiEncodingDeserializer implements JsonbDeserializer<Open
     {
         JsonObject object = parser.getObject();
         OpenapiEncoding model = plain.get().fromJson(object.toString(), OpenapiEncoding.class);
-
-        Map<String, Object> extensions = null;
-        for (String name : object.keySet())
-        {
-            if (name.startsWith("x-"))
-            {
-                Class<?> extensionType = extensionTypes.get(name);
-                if (extensionType != null)
-                {
-                    if (extensions == null)
-                    {
-                        extensions = new LinkedHashMap<>();
-                    }
-                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
-                }
-            }
-        }
-        model.extensions = extensions;
+        model.extensions = OpenapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiHeaderDeserializer.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiHeaderDeserializer.java
@@ -15,7 +15,6 @@
 package io.aklivity.zilla.runtime.common.openapi.model;
 
 import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -28,13 +27,16 @@ import jakarta.json.stream.JsonParser;
 public final class OpenapiHeaderDeserializer implements JsonbDeserializer<OpenapiHeader>
 {
     private final Map<String, Class<?>> extensionTypes;
+    private final Map<String, Class<?>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public OpenapiHeaderDeserializer(
-        Map<String, Class<?>> extensionTypes)
+        Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
-        this.plain = OpenapiDeserializers.plain(extensionTypes, OpenapiHeaderDeserializer.class);
+        this.prefixExtensionTypes = prefixExtensionTypes;
+        this.plain = OpenapiDeserializers.plain(extensionTypes, prefixExtensionTypes, OpenapiHeaderDeserializer.class);
     }
 
     @Override
@@ -45,24 +47,7 @@ public final class OpenapiHeaderDeserializer implements JsonbDeserializer<Openap
     {
         JsonObject object = parser.getObject();
         OpenapiHeader model = plain.get().fromJson(object.toString(), OpenapiHeader.class);
-
-        Map<String, Object> extensions = null;
-        for (String name : object.keySet())
-        {
-            if (name.startsWith("x-"))
-            {
-                Class<?> extensionType = extensionTypes.get(name);
-                if (extensionType != null)
-                {
-                    if (extensions == null)
-                    {
-                        extensions = new LinkedHashMap<>();
-                    }
-                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
-                }
-            }
-        }
-        model.extensions = extensions;
+        model.extensions = OpenapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiLinkDeserializer.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiLinkDeserializer.java
@@ -15,7 +15,6 @@
 package io.aklivity.zilla.runtime.common.openapi.model;
 
 import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -28,13 +27,16 @@ import jakarta.json.stream.JsonParser;
 public final class OpenapiLinkDeserializer implements JsonbDeserializer<OpenapiLink>
 {
     private final Map<String, Class<?>> extensionTypes;
+    private final Map<String, Class<?>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public OpenapiLinkDeserializer(
-        Map<String, Class<?>> extensionTypes)
+        Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
-        this.plain = OpenapiDeserializers.plain(extensionTypes, OpenapiLinkDeserializer.class);
+        this.prefixExtensionTypes = prefixExtensionTypes;
+        this.plain = OpenapiDeserializers.plain(extensionTypes, prefixExtensionTypes, OpenapiLinkDeserializer.class);
     }
 
     @Override
@@ -45,24 +47,7 @@ public final class OpenapiLinkDeserializer implements JsonbDeserializer<OpenapiL
     {
         JsonObject object = parser.getObject();
         OpenapiLink model = plain.get().fromJson(object.toString(), OpenapiLink.class);
-
-        Map<String, Object> extensions = null;
-        for (String name : object.keySet())
-        {
-            if (name.startsWith("x-"))
-            {
-                Class<?> extensionType = extensionTypes.get(name);
-                if (extensionType != null)
-                {
-                    if (extensions == null)
-                    {
-                        extensions = new LinkedHashMap<>();
-                    }
-                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
-                }
-            }
-        }
-        model.extensions = extensions;
+        model.extensions = OpenapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiMediaTypeDeserializer.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiMediaTypeDeserializer.java
@@ -15,7 +15,6 @@
 package io.aklivity.zilla.runtime.common.openapi.model;
 
 import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -28,13 +27,16 @@ import jakarta.json.stream.JsonParser;
 public final class OpenapiMediaTypeDeserializer implements JsonbDeserializer<OpenapiMediaType>
 {
     private final Map<String, Class<?>> extensionTypes;
+    private final Map<String, Class<?>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public OpenapiMediaTypeDeserializer(
-        Map<String, Class<?>> extensionTypes)
+        Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
-        this.plain = OpenapiDeserializers.plain(extensionTypes, OpenapiMediaTypeDeserializer.class);
+        this.prefixExtensionTypes = prefixExtensionTypes;
+        this.plain = OpenapiDeserializers.plain(extensionTypes, prefixExtensionTypes, OpenapiMediaTypeDeserializer.class);
     }
 
     @Override
@@ -45,24 +47,7 @@ public final class OpenapiMediaTypeDeserializer implements JsonbDeserializer<Ope
     {
         JsonObject object = parser.getObject();
         OpenapiMediaType model = plain.get().fromJson(object.toString(), OpenapiMediaType.class);
-
-        Map<String, Object> extensions = null;
-        for (String name : object.keySet())
-        {
-            if (name.startsWith("x-"))
-            {
-                Class<?> extensionType = extensionTypes.get(name);
-                if (extensionType != null)
-                {
-                    if (extensions == null)
-                    {
-                        extensions = new LinkedHashMap<>();
-                    }
-                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
-                }
-            }
-        }
-        model.extensions = extensions;
+        model.extensions = OpenapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiOAuthFlowDeserializer.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiOAuthFlowDeserializer.java
@@ -15,7 +15,6 @@
 package io.aklivity.zilla.runtime.common.openapi.model;
 
 import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -28,13 +27,16 @@ import jakarta.json.stream.JsonParser;
 public final class OpenapiOAuthFlowDeserializer implements JsonbDeserializer<OpenapiOAuthFlow>
 {
     private final Map<String, Class<?>> extensionTypes;
+    private final Map<String, Class<?>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public OpenapiOAuthFlowDeserializer(
-        Map<String, Class<?>> extensionTypes)
+        Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
-        this.plain = OpenapiDeserializers.plain(extensionTypes, OpenapiOAuthFlowDeserializer.class);
+        this.prefixExtensionTypes = prefixExtensionTypes;
+        this.plain = OpenapiDeserializers.plain(extensionTypes, prefixExtensionTypes, OpenapiOAuthFlowDeserializer.class);
     }
 
     @Override
@@ -45,24 +47,7 @@ public final class OpenapiOAuthFlowDeserializer implements JsonbDeserializer<Ope
     {
         JsonObject object = parser.getObject();
         OpenapiOAuthFlow model = plain.get().fromJson(object.toString(), OpenapiOAuthFlow.class);
-
-        Map<String, Object> extensions = null;
-        for (String name : object.keySet())
-        {
-            if (name.startsWith("x-"))
-            {
-                Class<?> extensionType = extensionTypes.get(name);
-                if (extensionType != null)
-                {
-                    if (extensions == null)
-                    {
-                        extensions = new LinkedHashMap<>();
-                    }
-                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
-                }
-            }
-        }
-        model.extensions = extensions;
+        model.extensions = OpenapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiOAuthFlowsDeserializer.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiOAuthFlowsDeserializer.java
@@ -15,7 +15,6 @@
 package io.aklivity.zilla.runtime.common.openapi.model;
 
 import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -28,13 +27,16 @@ import jakarta.json.stream.JsonParser;
 public final class OpenapiOAuthFlowsDeserializer implements JsonbDeserializer<OpenapiOAuthFlows>
 {
     private final Map<String, Class<?>> extensionTypes;
+    private final Map<String, Class<?>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public OpenapiOAuthFlowsDeserializer(
-        Map<String, Class<?>> extensionTypes)
+        Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
-        this.plain = OpenapiDeserializers.plain(extensionTypes, OpenapiOAuthFlowsDeserializer.class);
+        this.prefixExtensionTypes = prefixExtensionTypes;
+        this.plain = OpenapiDeserializers.plain(extensionTypes, prefixExtensionTypes, OpenapiOAuthFlowsDeserializer.class);
     }
 
     @Override
@@ -45,24 +47,7 @@ public final class OpenapiOAuthFlowsDeserializer implements JsonbDeserializer<Op
     {
         JsonObject object = parser.getObject();
         OpenapiOAuthFlows model = plain.get().fromJson(object.toString(), OpenapiOAuthFlows.class);
-
-        Map<String, Object> extensions = null;
-        for (String name : object.keySet())
-        {
-            if (name.startsWith("x-"))
-            {
-                Class<?> extensionType = extensionTypes.get(name);
-                if (extensionType != null)
-                {
-                    if (extensions == null)
-                    {
-                        extensions = new LinkedHashMap<>();
-                    }
-                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
-                }
-            }
-        }
-        model.extensions = extensions;
+        model.extensions = OpenapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiOperationDeserializer.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiOperationDeserializer.java
@@ -15,7 +15,6 @@
 package io.aklivity.zilla.runtime.common.openapi.model;
 
 import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -28,13 +27,16 @@ import jakarta.json.stream.JsonParser;
 public final class OpenapiOperationDeserializer implements JsonbDeserializer<OpenapiOperation>
 {
     private final Map<String, Class<?>> extensionTypes;
+    private final Map<String, Class<?>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public OpenapiOperationDeserializer(
-        Map<String, Class<?>> extensionTypes)
+        Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
-        this.plain = OpenapiDeserializers.plain(extensionTypes, OpenapiOperationDeserializer.class);
+        this.prefixExtensionTypes = prefixExtensionTypes;
+        this.plain = OpenapiDeserializers.plain(extensionTypes, prefixExtensionTypes, OpenapiOperationDeserializer.class);
     }
 
     @Override
@@ -45,24 +47,7 @@ public final class OpenapiOperationDeserializer implements JsonbDeserializer<Ope
     {
         JsonObject object = parser.getObject();
         OpenapiOperation model = plain.get().fromJson(object.toString(), OpenapiOperation.class);
-
-        Map<String, Object> extensions = null;
-        for (String name : object.keySet())
-        {
-            if (name.startsWith("x-"))
-            {
-                Class<?> extensionType = extensionTypes.get(name);
-                if (extensionType != null)
-                {
-                    if (extensions == null)
-                    {
-                        extensions = new LinkedHashMap<>();
-                    }
-                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
-                }
-            }
-        }
-        model.extensions = extensions;
+        model.extensions = OpenapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiParameterDeserializer.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiParameterDeserializer.java
@@ -15,7 +15,6 @@
 package io.aklivity.zilla.runtime.common.openapi.model;
 
 import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -28,13 +27,16 @@ import jakarta.json.stream.JsonParser;
 public final class OpenapiParameterDeserializer implements JsonbDeserializer<OpenapiParameter>
 {
     private final Map<String, Class<?>> extensionTypes;
+    private final Map<String, Class<?>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public OpenapiParameterDeserializer(
-        Map<String, Class<?>> extensionTypes)
+        Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
-        this.plain = OpenapiDeserializers.plain(extensionTypes, OpenapiParameterDeserializer.class);
+        this.prefixExtensionTypes = prefixExtensionTypes;
+        this.plain = OpenapiDeserializers.plain(extensionTypes, prefixExtensionTypes, OpenapiParameterDeserializer.class);
     }
 
     @Override
@@ -45,24 +47,7 @@ public final class OpenapiParameterDeserializer implements JsonbDeserializer<Ope
     {
         JsonObject object = parser.getObject();
         OpenapiParameter model = plain.get().fromJson(object.toString(), OpenapiParameter.class);
-
-        Map<String, Object> extensions = null;
-        for (String name : object.keySet())
-        {
-            if (name.startsWith("x-"))
-            {
-                Class<?> extensionType = extensionTypes.get(name);
-                if (extensionType != null)
-                {
-                    if (extensions == null)
-                    {
-                        extensions = new LinkedHashMap<>();
-                    }
-                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
-                }
-            }
-        }
-        model.extensions = extensions;
+        model.extensions = OpenapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiPathDeserializer.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiPathDeserializer.java
@@ -15,7 +15,6 @@
 package io.aklivity.zilla.runtime.common.openapi.model;
 
 import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -28,13 +27,16 @@ import jakarta.json.stream.JsonParser;
 public final class OpenapiPathDeserializer implements JsonbDeserializer<OpenapiPath>
 {
     private final Map<String, Class<?>> extensionTypes;
+    private final Map<String, Class<?>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public OpenapiPathDeserializer(
-        Map<String, Class<?>> extensionTypes)
+        Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
-        this.plain = OpenapiDeserializers.plain(extensionTypes, OpenapiPathDeserializer.class);
+        this.prefixExtensionTypes = prefixExtensionTypes;
+        this.plain = OpenapiDeserializers.plain(extensionTypes, prefixExtensionTypes, OpenapiPathDeserializer.class);
     }
 
     @Override
@@ -45,24 +47,7 @@ public final class OpenapiPathDeserializer implements JsonbDeserializer<OpenapiP
     {
         JsonObject object = parser.getObject();
         OpenapiPath model = plain.get().fromJson(object.toString(), OpenapiPath.class);
-
-        Map<String, Object> extensions = null;
-        for (String name : object.keySet())
-        {
-            if (name.startsWith("x-"))
-            {
-                Class<?> extensionType = extensionTypes.get(name);
-                if (extensionType != null)
-                {
-                    if (extensions == null)
-                    {
-                        extensions = new LinkedHashMap<>();
-                    }
-                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
-                }
-            }
-        }
-        model.extensions = extensions;
+        model.extensions = OpenapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiRequestBodyDeserializer.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiRequestBodyDeserializer.java
@@ -15,7 +15,6 @@
 package io.aklivity.zilla.runtime.common.openapi.model;
 
 import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -28,13 +27,16 @@ import jakarta.json.stream.JsonParser;
 public final class OpenapiRequestBodyDeserializer implements JsonbDeserializer<OpenapiRequestBody>
 {
     private final Map<String, Class<?>> extensionTypes;
+    private final Map<String, Class<?>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public OpenapiRequestBodyDeserializer(
-        Map<String, Class<?>> extensionTypes)
+        Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
-        this.plain = OpenapiDeserializers.plain(extensionTypes, OpenapiRequestBodyDeserializer.class);
+        this.prefixExtensionTypes = prefixExtensionTypes;
+        this.plain = OpenapiDeserializers.plain(extensionTypes, prefixExtensionTypes, OpenapiRequestBodyDeserializer.class);
     }
 
     @Override
@@ -45,24 +47,7 @@ public final class OpenapiRequestBodyDeserializer implements JsonbDeserializer<O
     {
         JsonObject object = parser.getObject();
         OpenapiRequestBody model = plain.get().fromJson(object.toString(), OpenapiRequestBody.class);
-
-        Map<String, Object> extensions = null;
-        for (String name : object.keySet())
-        {
-            if (name.startsWith("x-"))
-            {
-                Class<?> extensionType = extensionTypes.get(name);
-                if (extensionType != null)
-                {
-                    if (extensions == null)
-                    {
-                        extensions = new LinkedHashMap<>();
-                    }
-                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
-                }
-            }
-        }
-        model.extensions = extensions;
+        model.extensions = OpenapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiResponseDeserializer.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiResponseDeserializer.java
@@ -15,7 +15,6 @@
 package io.aklivity.zilla.runtime.common.openapi.model;
 
 import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -28,13 +27,16 @@ import jakarta.json.stream.JsonParser;
 public final class OpenapiResponseDeserializer implements JsonbDeserializer<OpenapiResponse>
 {
     private final Map<String, Class<?>> extensionTypes;
+    private final Map<String, Class<?>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public OpenapiResponseDeserializer(
-        Map<String, Class<?>> extensionTypes)
+        Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
-        this.plain = OpenapiDeserializers.plain(extensionTypes, OpenapiResponseDeserializer.class);
+        this.prefixExtensionTypes = prefixExtensionTypes;
+        this.plain = OpenapiDeserializers.plain(extensionTypes, prefixExtensionTypes, OpenapiResponseDeserializer.class);
     }
 
     @Override
@@ -45,24 +47,7 @@ public final class OpenapiResponseDeserializer implements JsonbDeserializer<Open
     {
         JsonObject object = parser.getObject();
         OpenapiResponse model = plain.get().fromJson(object.toString(), OpenapiResponse.class);
-
-        Map<String, Object> extensions = null;
-        for (String name : object.keySet())
-        {
-            if (name.startsWith("x-"))
-            {
-                Class<?> extensionType = extensionTypes.get(name);
-                if (extensionType != null)
-                {
-                    if (extensions == null)
-                    {
-                        extensions = new LinkedHashMap<>();
-                    }
-                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
-                }
-            }
-        }
-        model.extensions = extensions;
+        model.extensions = OpenapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiSchemaDeserializer.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiSchemaDeserializer.java
@@ -15,7 +15,6 @@
 package io.aklivity.zilla.runtime.common.openapi.model;
 
 import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -30,13 +29,16 @@ import jakarta.json.stream.JsonParser;
 public final class OpenapiSchemaDeserializer implements JsonbDeserializer<OpenapiSchema>
 {
     private final Map<String, Class<?>> extensionTypes;
+    private final Map<String, Class<?>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public OpenapiSchemaDeserializer(
-        Map<String, Class<?>> extensionTypes)
+        Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
-        this.plain = OpenapiDeserializers.plain(extensionTypes, OpenapiSchemaDeserializer.class);
+        this.prefixExtensionTypes = prefixExtensionTypes;
+        this.plain = OpenapiDeserializers.plain(extensionTypes, prefixExtensionTypes, OpenapiSchemaDeserializer.class);
     }
 
     @Override
@@ -84,23 +86,7 @@ public final class OpenapiSchemaDeserializer implements JsonbDeserializer<Openap
             bindAll(model.anyOf, object.getJsonArray("anyOf"));
         }
 
-        Map<String, Object> extensions = null;
-        for (String name : object.keySet())
-        {
-            if (name.startsWith("x-"))
-            {
-                Class<?> extensionType = extensionTypes.get(name);
-                if (extensionType != null)
-                {
-                    if (extensions == null)
-                    {
-                        extensions = new LinkedHashMap<>();
-                    }
-                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
-                }
-            }
-        }
-        model.extensions = extensions;
+        model.extensions = OpenapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiSecuritySchemeDeserializer.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiSecuritySchemeDeserializer.java
@@ -15,7 +15,6 @@
 package io.aklivity.zilla.runtime.common.openapi.model;
 
 import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -28,13 +27,16 @@ import jakarta.json.stream.JsonParser;
 public final class OpenapiSecuritySchemeDeserializer implements JsonbDeserializer<OpenapiSecurityScheme>
 {
     private final Map<String, Class<?>> extensionTypes;
+    private final Map<String, Class<?>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public OpenapiSecuritySchemeDeserializer(
-        Map<String, Class<?>> extensionTypes)
+        Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
-        this.plain = OpenapiDeserializers.plain(extensionTypes, OpenapiSecuritySchemeDeserializer.class);
+        this.prefixExtensionTypes = prefixExtensionTypes;
+        this.plain = OpenapiDeserializers.plain(extensionTypes, prefixExtensionTypes, OpenapiSecuritySchemeDeserializer.class);
     }
 
     @Override
@@ -45,24 +47,7 @@ public final class OpenapiSecuritySchemeDeserializer implements JsonbDeserialize
     {
         JsonObject object = parser.getObject();
         OpenapiSecurityScheme model = plain.get().fromJson(object.toString(), OpenapiSecurityScheme.class);
-
-        Map<String, Object> extensions = null;
-        for (String name : object.keySet())
-        {
-            if (name.startsWith("x-"))
-            {
-                Class<?> extensionType = extensionTypes.get(name);
-                if (extensionType != null)
-                {
-                    if (extensions == null)
-                    {
-                        extensions = new LinkedHashMap<>();
-                    }
-                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
-                }
-            }
-        }
-        model.extensions = extensions;
+        model.extensions = OpenapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiServerDeserializer.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiServerDeserializer.java
@@ -15,7 +15,6 @@
 package io.aklivity.zilla.runtime.common.openapi.model;
 
 import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -28,13 +27,16 @@ import jakarta.json.stream.JsonParser;
 public final class OpenapiServerDeserializer implements JsonbDeserializer<OpenapiServer>
 {
     private final Map<String, Class<?>> extensionTypes;
+    private final Map<String, Class<?>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public OpenapiServerDeserializer(
-        Map<String, Class<?>> extensionTypes)
+        Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
-        this.plain = OpenapiDeserializers.plain(extensionTypes, OpenapiServerDeserializer.class);
+        this.prefixExtensionTypes = prefixExtensionTypes;
+        this.plain = OpenapiDeserializers.plain(extensionTypes, prefixExtensionTypes, OpenapiServerDeserializer.class);
     }
 
     @Override
@@ -45,24 +47,7 @@ public final class OpenapiServerDeserializer implements JsonbDeserializer<Openap
     {
         JsonObject object = parser.getObject();
         OpenapiServer model = plain.get().fromJson(object.toString(), OpenapiServer.class);
-
-        Map<String, Object> extensions = null;
-        for (String name : object.keySet())
-        {
-            if (name.startsWith("x-"))
-            {
-                Class<?> extensionType = extensionTypes.get(name);
-                if (extensionType != null)
-                {
-                    if (extensions == null)
-                    {
-                        extensions = new LinkedHashMap<>();
-                    }
-                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
-                }
-            }
-        }
-        model.extensions = extensions;
+        model.extensions = OpenapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiServerVariableDeserializer.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiServerVariableDeserializer.java
@@ -15,7 +15,6 @@
 package io.aklivity.zilla.runtime.common.openapi.model;
 
 import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -28,13 +27,16 @@ import jakarta.json.stream.JsonParser;
 public final class OpenapiServerVariableDeserializer implements JsonbDeserializer<OpenapiServerVariable>
 {
     private final Map<String, Class<?>> extensionTypes;
+    private final Map<String, Class<?>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public OpenapiServerVariableDeserializer(
-        Map<String, Class<?>> extensionTypes)
+        Map<String, Class<?>> extensionTypes,
+        Map<String, Class<?>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
-        this.plain = OpenapiDeserializers.plain(extensionTypes, OpenapiServerVariableDeserializer.class);
+        this.prefixExtensionTypes = prefixExtensionTypes;
+        this.plain = OpenapiDeserializers.plain(extensionTypes, prefixExtensionTypes, OpenapiServerVariableDeserializer.class);
     }
 
     @Override
@@ -45,24 +47,7 @@ public final class OpenapiServerVariableDeserializer implements JsonbDeserialize
     {
         JsonObject object = parser.getObject();
         OpenapiServerVariable model = plain.get().fromJson(object.toString(), OpenapiServerVariable.class);
-
-        Map<String, Object> extensions = null;
-        for (String name : object.keySet())
-        {
-            if (name.startsWith("x-"))
-            {
-                Class<?> extensionType = extensionTypes.get(name);
-                if (extensionType != null)
-                {
-                    if (extensions == null)
-                    {
-                        extensions = new LinkedHashMap<>();
-                    }
-                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
-                }
-            }
-        }
-        model.extensions = extensions;
+        model.extensions = OpenapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-openapi/src/test/java/io/aklivity/zilla/runtime/common/openapi/config/OpenapiParserTest.java
+++ b/runtime/common-openapi/src/test/java/io/aklivity/zilla/runtime/common/openapi/config/OpenapiParserTest.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import jakarta.json.bind.annotation.JsonbProperty;
+
 import org.junit.Test;
 
 import io.aklivity.zilla.runtime.common.openapi.model.Openapi;
@@ -79,6 +81,14 @@ public class OpenapiParserTest
     public static final class SampleExtension
     {
         public String key;
+    }
+
+    public static final class GoogleJwtExtension
+    {
+        public String issuer;
+        @JsonbProperty("jwks_uri")
+        public String jwksUri;
+        public String audiences;
     }
 
     @Test
@@ -234,6 +244,61 @@ public class OpenapiParserTest
         assertTrue(scheme.flows.authorizationCode.hasExtension("x-zilla-sample"));
         assertEquals("flow-value",
             scheme.flows.authorizationCode.extension("x-zilla-sample", SampleExtension.class).get().key);
+    }
+
+    @Test
+    public void shouldExposePrefixWildcardExtensionGenerically()
+    {
+        String spec =
+            """
+            {
+              "openapi": "3.1.0",
+              "info": { "title": "sample", "version": "1.0.0" },
+              "paths": {},
+              "components": {
+                "securitySchemes": {
+                  "googleJwt": {
+                    "type": "apiKey",
+                    "name": "Authorization",
+                    "in": "header",
+                    "x-google-issuer": "https://accounts.google.com",
+                    "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs",
+                    "x-google-audiences": "848149964201.apps.googleusercontent.com"
+                  }
+                }
+              }
+            }
+            """;
+
+        OpenapiParser parser = new OpenapiParserFactory()
+            .withExtension("x-google-*", GoogleJwtExtension.class)
+            .createParser();
+
+        Openapi model = parser.parse(spec);
+        OpenapiView view = OpenapiView.of(model);
+        OpenapiSecuritySchemeView scheme = view.components.securitySchemes.get("googleJwt");
+
+        assertTrue(scheme.hasExtension("x-google-*"));
+        Optional<GoogleJwtExtension> extension = scheme.extension("x-google-*", GoogleJwtExtension.class);
+        assertTrue(extension.isPresent());
+        assertEquals("https://accounts.google.com", extension.get().issuer);
+        assertEquals("https://www.googleapis.com/oauth2/v1/certs", extension.get().jwksUri);
+        assertEquals("848149964201.apps.googleusercontent.com", extension.get().audiences);
+    }
+
+    @Test
+    public void shouldNotExposePrefixWildcardExtensionWhenAbsent()
+    {
+        OpenapiParser parser = new OpenapiParserFactory()
+            .withExtension("x-google-*", GoogleJwtExtension.class)
+            .createParser();
+
+        Openapi model = parser.parse(SPEC);
+        OpenapiView view = OpenapiView.of(model);
+        OpenapiSecuritySchemeView scheme = view.components.securitySchemes.get("bearerAuth");
+
+        assertFalse(scheme.hasExtension("x-google-*"));
+        assertEquals(Optional.empty(), scheme.extension("x-google-*", GoogleJwtExtension.class));
     }
 
     @Test


### PR DESCRIPTION
## Description

Add support for prefix wildcard extensions (e.g., `x-google-*`) in the OpenAPI parser, enabling registration and deserialization of extension properties that share a common prefix.

### Changes

- **OpenapiDeserializers**: 
  - Added `prefixExtensionTypes` parameter throughout the deserializer chain
  - Introduced new `extensions()` static method that handles both exact-match extensions (`x-*`) and prefix wildcard extensions (`x-*-*`)
  - Prefix wildcard extensions are aggregated into a single object by stripping the prefix from matching property names

- **All deserializer classes** (Openapi, OpenapiServer, OpenapiParameter, OpenapiSchema, etc.):
  - Updated constructors to accept `prefixExtensionTypes` parameter
  - Replaced inline extension extraction logic with calls to `OpenapiDeserializers.extensions()`
  - Removed duplicate `LinkedHashMap` imports

- **OpenapiParserFactory**:
  - Enhanced `withExtension()` to distinguish between exact-match and prefix wildcard extensions based on whether the name ends with `*`
  - Routes wildcard extensions to `prefixExtensionTypes` map

- **OpenapiParser**:
  - Updated constructor to accept and pass through `prefixExtensionTypes`

- **Tests**:
  - Added `GoogleJwtExtension` test class with `@JsonbProperty` annotation support
  - Added `shouldExposePrefixWildcardExtensionGenerically()` test verifying prefix wildcard extension parsing
  - Added `shouldNotExposePrefixWildcardExtensionWhenAbsent()` test verifying graceful handling when extensions are absent

### Example Usage

```java
OpenapiParser parser = new OpenapiParserFactory()
    .withExtension("x-google-*", GoogleJwtExtension.class)
    .createParser();

// Properties like x-google-issuer, x-google-jwks_uri are aggregated into GoogleJwtExtension
```

### Test Plan

Existing and new unit tests in `OpenapiParserTest` verify:
- Prefix wildcard extensions are correctly parsed and aggregated
- Missing prefix wildcard extensions return empty Optional
- Exact-match extensions continue to work as before

https://claude.ai/code/session_01EGvwo66LXRm9DKHRgbhfQ7