### PR TITLE
Support scoped AsyncAPI extensions

### DIFF
--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiExtension.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiExtension.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.asyncapi.config;
+
+public interface AsyncapiExtension
+{
+    enum Scope
+    {
+        ASYNCAPI,
+        SERVER,
+        SERVER_VARIABLE,
+        CHANNEL,
+        OPERATION,
+        MESSAGE,
+        TRAIT,
+        PARAMETER,
+        COMPONENTS,
+        SCHEMA,
+        SECURITY_SCHEME,
+        CORRELATION_ID,
+        REPLY
+    }
+
+    Scope scope();
+
+    String name();
+
+    Class<?> type();
+
+    static <T> AsyncapiExtension of(
+        Scope scope,
+        String name,
+        Class<T> type)
+    {
+        return new AsyncapiExtension()
+        {
+            @Override
+            public Scope scope()
+            {
+                return scope;
+            }
+
+            @Override
+            public String name()
+            {
+                return name;
+            }
+
+            @Override
+            public Class<?> type()
+            {
+                return type;
+            }
+        };
+    }
+}

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiParser.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiParser.java
@@ -52,8 +52,8 @@ public class AsyncapiParser
     private final Map<String, Class<?>> operationBindingTypes;
     private final Map<String, Class<?>> messageBindingTypes;
     private final Map<String, Class<?>> serverBindingTypes;
-    private final Map<String, Class<?>> extensionTypes;
-    private final Map<String, Class<?>> prefixExtensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes;
 
     public AsyncapiParser()
     {
@@ -64,8 +64,8 @@ public class AsyncapiParser
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes)
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         Map<String, JsonSchema> schemas = new Object2ObjectHashMap<>();
         schemas.put("2.6.0", schema("2.6.0"));

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiParserFactory.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiParserFactory.java
@@ -22,8 +22,8 @@ public final class AsyncapiParserFactory
     private final Map<String, Class<?>> operationBindingTypes;
     private final Map<String, Class<?>> messageBindingTypes;
     private final Map<String, Class<?>> serverBindingTypes;
-    private final Map<String, Class<?>> extensionTypes;
-    private final Map<String, Class<?>> prefixExtensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes;
 
     public AsyncapiParserFactory()
     {
@@ -58,18 +58,14 @@ public final class AsyncapiParserFactory
         return this;
     }
 
-    public <T> AsyncapiParserFactory withExtension(
-        String name,
-        Class<T> type)
+    public AsyncapiParserFactory withExtension(
+        AsyncapiExtension extension)
     {
-        if (name.endsWith("*"))
-        {
-            prefixExtensionTypes.put(name, type);
-        }
-        else
-        {
-            extensionTypes.put(name, type);
-        }
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> target = extension.name().endsWith("*")
+            ? prefixExtensionTypes
+            : extensionTypes;
+        target.computeIfAbsent(extension.scope(), scope -> new LinkedHashMap<>())
+            .put(extension.name(), extension.type());
         return this;
     }
 

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiChannelDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiChannelDeserializer.java
@@ -24,18 +24,20 @@ import jakarta.json.bind.serializer.DeserializationContext;
 import jakarta.json.bind.serializer.JsonbDeserializer;
 import jakarta.json.stream.JsonParser;
 
+import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiExtension;
+
 public final class AsyncapiChannelDeserializer implements JsonbDeserializer<AsyncapiChannel>
 {
-    private final Map<String, Class<?>> extensionTypes;
-    private final Map<String, Class<?>> prefixExtensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public AsyncapiChannelDeserializer(
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes)
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
@@ -52,7 +54,8 @@ public final class AsyncapiChannelDeserializer implements JsonbDeserializer<Asyn
     {
         JsonObject object = parser.getObject();
         AsyncapiChannel model = plain.get().fromJson(object.toString(), AsyncapiChannel.class);
-        model.extensions = AsyncapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
+        model.extensions = AsyncapiDeserializers.extensions(
+            object, AsyncapiExtension.Scope.CHANNEL, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiComponentsDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiComponentsDeserializer.java
@@ -24,18 +24,20 @@ import jakarta.json.bind.serializer.DeserializationContext;
 import jakarta.json.bind.serializer.JsonbDeserializer;
 import jakarta.json.stream.JsonParser;
 
+import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiExtension;
+
 public final class AsyncapiComponentsDeserializer implements JsonbDeserializer<AsyncapiComponents>
 {
-    private final Map<String, Class<?>> extensionTypes;
-    private final Map<String, Class<?>> prefixExtensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public AsyncapiComponentsDeserializer(
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes)
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
@@ -52,7 +54,8 @@ public final class AsyncapiComponentsDeserializer implements JsonbDeserializer<A
     {
         JsonObject object = parser.getObject();
         AsyncapiComponents model = plain.get().fromJson(object.toString(), AsyncapiComponents.class);
-        model.extensions = AsyncapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
+        model.extensions = AsyncapiDeserializers.extensions(
+            object, AsyncapiExtension.Scope.COMPONENTS, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiCorrelationIdDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiCorrelationIdDeserializer.java
@@ -24,18 +24,20 @@ import jakarta.json.bind.serializer.DeserializationContext;
 import jakarta.json.bind.serializer.JsonbDeserializer;
 import jakarta.json.stream.JsonParser;
 
+import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiExtension;
+
 public final class AsyncapiCorrelationIdDeserializer implements JsonbDeserializer<AsyncapiCorrelationId>
 {
-    private final Map<String, Class<?>> extensionTypes;
-    private final Map<String, Class<?>> prefixExtensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public AsyncapiCorrelationIdDeserializer(
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes)
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
@@ -52,7 +54,8 @@ public final class AsyncapiCorrelationIdDeserializer implements JsonbDeserialize
     {
         JsonObject object = parser.getObject();
         AsyncapiCorrelationId model = plain.get().fromJson(object.toString(), AsyncapiCorrelationId.class);
-        model.extensions = AsyncapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
+        model.extensions = AsyncapiDeserializers.extensions(
+            object, AsyncapiExtension.Scope.CORRELATION_ID, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiDeserializer.java
@@ -24,18 +24,20 @@ import jakarta.json.bind.serializer.DeserializationContext;
 import jakarta.json.bind.serializer.JsonbDeserializer;
 import jakarta.json.stream.JsonParser;
 
+import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiExtension;
+
 public final class AsyncapiDeserializer implements JsonbDeserializer<Asyncapi>
 {
-    private final Map<String, Class<?>> extensionTypes;
-    private final Map<String, Class<?>> prefixExtensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public AsyncapiDeserializer(
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes)
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
@@ -52,7 +54,8 @@ public final class AsyncapiDeserializer implements JsonbDeserializer<Asyncapi>
     {
         JsonObject object = parser.getObject();
         Asyncapi model = plain.get().fromJson(object.toString(), Asyncapi.class);
-        model.extensions = AsyncapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
+        model.extensions = AsyncapiDeserializers.extensions(
+            object, AsyncapiExtension.Scope.ASYNCAPI, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiDeserializers.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiDeserializers.java
@@ -14,6 +14,8 @@
  */
 package io.aklivity.zilla.runtime.common.asyncapi.model;
 
+import static java.util.Collections.emptyMap;
+
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +31,8 @@ import jakarta.json.bind.JsonbBuilder;
 import jakarta.json.bind.JsonbConfig;
 import jakarta.json.bind.serializer.JsonbDeserializer;
 
+import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiExtension;
+
 public final class AsyncapiDeserializers
 {
     private AsyncapiDeserializers()
@@ -39,8 +43,8 @@ public final class AsyncapiDeserializers
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes)
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         return List.of(
             new AsyncapiDeserializer(
@@ -79,8 +83,8 @@ public final class AsyncapiDeserializers
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes,
         Class<?>... excludes)
     {
         Jsonb[] cache = new Jsonb[1];
@@ -132,17 +136,21 @@ public final class AsyncapiDeserializers
 
     static Map<String, Object> extensions(
         JsonObject object,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes,
+        AsyncapiExtension.Scope scope,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes,
         Supplier<Jsonb> plain)
     {
+        Map<String, Class<?>> scopedExtensionTypes = extensionTypes.getOrDefault(scope, emptyMap());
+        Map<String, Class<?>> scopedPrefixExtensionTypes = prefixExtensionTypes.getOrDefault(scope, emptyMap());
+
         Map<String, Object> extensions = null;
 
         for (String name : object.keySet())
         {
             if (name.startsWith("x-"))
             {
-                Class<?> extensionType = extensionTypes.get(name);
+                Class<?> extensionType = scopedExtensionTypes.get(name);
                 if (extensionType != null)
                 {
                     if (extensions == null)
@@ -154,7 +162,7 @@ public final class AsyncapiDeserializers
             }
         }
 
-        for (Map.Entry<String, Class<?>> prefixExtensionType : prefixExtensionTypes.entrySet())
+        for (Map.Entry<String, Class<?>> prefixExtensionType : scopedPrefixExtensionTypes.entrySet())
         {
             String registeredName = prefixExtensionType.getKey();
             String prefix = registeredName.substring(0, registeredName.length() - 1);

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiMessageDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiMessageDeserializer.java
@@ -24,19 +24,21 @@ import jakarta.json.bind.serializer.DeserializationContext;
 import jakarta.json.bind.serializer.JsonbDeserializer;
 import jakarta.json.stream.JsonParser;
 
+import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiExtension;
+
 public final class AsyncapiMessageDeserializer implements JsonbDeserializer<AsyncapiMessage>
 {
     private final Map<String, Class<?>> messageBindingTypes;
-    private final Map<String, Class<?>> extensionTypes;
-    private final Map<String, Class<?>> prefixExtensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public AsyncapiMessageDeserializer(
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes)
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.messageBindingTypes = messageBindingTypes;
         this.extensionTypes = extensionTypes;
@@ -56,7 +58,8 @@ public final class AsyncapiMessageDeserializer implements JsonbDeserializer<Asyn
         AsyncapiMessage model = plain.get().fromJson(object.toString(), AsyncapiMessage.class);
 
         model.bindings = AsyncapiDeserializers.bindings(object, messageBindingTypes, plain.get());
-        model.extensions = AsyncapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
+        model.extensions = AsyncapiDeserializers.extensions(
+            object, AsyncapiExtension.Scope.MESSAGE, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiMultiFormatSchemaDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiMultiFormatSchemaDeserializer.java
@@ -24,18 +24,20 @@ import jakarta.json.bind.serializer.DeserializationContext;
 import jakarta.json.bind.serializer.JsonbDeserializer;
 import jakarta.json.stream.JsonParser;
 
+import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiExtension;
+
 public final class AsyncapiMultiFormatSchemaDeserializer implements JsonbDeserializer<AsyncapiMultiFormatSchema>
 {
-    private final Map<String, Class<?>> extensionTypes;
-    private final Map<String, Class<?>> prefixExtensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public AsyncapiMultiFormatSchemaDeserializer(
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes)
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
@@ -55,12 +57,13 @@ public final class AsyncapiMultiFormatSchemaDeserializer implements JsonbDeseria
 
     static AsyncapiMultiFormatSchema bind(
         JsonObject object,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes,
         Supplier<Jsonb> plain)
     {
         AsyncapiMultiFormatSchema model = plain.get().fromJson(object.toString(), AsyncapiMultiFormatSchema.class);
-        model.extensions = AsyncapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
+        model.extensions = AsyncapiDeserializers.extensions(
+            object, AsyncapiExtension.Scope.SCHEMA, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiOperationDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiOperationDeserializer.java
@@ -24,19 +24,21 @@ import jakarta.json.bind.serializer.DeserializationContext;
 import jakarta.json.bind.serializer.JsonbDeserializer;
 import jakarta.json.stream.JsonParser;
 
+import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiExtension;
+
 public final class AsyncapiOperationDeserializer implements JsonbDeserializer<AsyncapiOperation>
 {
     private final Map<String, Class<?>> operationBindingTypes;
-    private final Map<String, Class<?>> extensionTypes;
-    private final Map<String, Class<?>> prefixExtensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public AsyncapiOperationDeserializer(
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes)
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.operationBindingTypes = operationBindingTypes;
         this.extensionTypes = extensionTypes;
@@ -56,7 +58,8 @@ public final class AsyncapiOperationDeserializer implements JsonbDeserializer<As
         AsyncapiOperation model = plain.get().fromJson(object.toString(), AsyncapiOperation.class);
 
         model.bindings = AsyncapiDeserializers.bindings(object, operationBindingTypes, plain.get());
-        model.extensions = AsyncapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
+        model.extensions = AsyncapiDeserializers.extensions(
+            object, AsyncapiExtension.Scope.OPERATION, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiParameterDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiParameterDeserializer.java
@@ -24,18 +24,20 @@ import jakarta.json.bind.serializer.DeserializationContext;
 import jakarta.json.bind.serializer.JsonbDeserializer;
 import jakarta.json.stream.JsonParser;
 
+import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiExtension;
+
 public final class AsyncapiParameterDeserializer implements JsonbDeserializer<AsyncapiParameter>
 {
-    private final Map<String, Class<?>> extensionTypes;
-    private final Map<String, Class<?>> prefixExtensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public AsyncapiParameterDeserializer(
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes)
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
@@ -52,7 +54,8 @@ public final class AsyncapiParameterDeserializer implements JsonbDeserializer<As
     {
         JsonObject object = parser.getObject();
         AsyncapiParameter model = plain.get().fromJson(object.toString(), AsyncapiParameter.class);
-        model.extensions = AsyncapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
+        model.extensions = AsyncapiDeserializers.extensions(
+            object, AsyncapiExtension.Scope.PARAMETER, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiReplyDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiReplyDeserializer.java
@@ -24,18 +24,20 @@ import jakarta.json.bind.serializer.DeserializationContext;
 import jakarta.json.bind.serializer.JsonbDeserializer;
 import jakarta.json.stream.JsonParser;
 
+import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiExtension;
+
 public final class AsyncapiReplyDeserializer implements JsonbDeserializer<AsyncapiReply>
 {
-    private final Map<String, Class<?>> extensionTypes;
-    private final Map<String, Class<?>> prefixExtensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public AsyncapiReplyDeserializer(
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes)
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
@@ -52,7 +54,8 @@ public final class AsyncapiReplyDeserializer implements JsonbDeserializer<Asynca
     {
         JsonObject object = parser.getObject();
         AsyncapiReply model = plain.get().fromJson(object.toString(), AsyncapiReply.class);
-        model.extensions = AsyncapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
+        model.extensions = AsyncapiDeserializers.extensions(
+            object, AsyncapiExtension.Scope.REPLY, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiSchemaDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiSchemaDeserializer.java
@@ -26,18 +26,20 @@ import jakarta.json.bind.serializer.DeserializationContext;
 import jakarta.json.bind.serializer.JsonbDeserializer;
 import jakarta.json.stream.JsonParser;
 
+import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiExtension;
+
 public final class AsyncapiSchemaDeserializer implements JsonbDeserializer<AsyncapiSchema>
 {
-    private final Map<String, Class<?>> extensionTypes;
-    private final Map<String, Class<?>> prefixExtensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public AsyncapiSchemaDeserializer(
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes)
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
@@ -57,8 +59,8 @@ public final class AsyncapiSchemaDeserializer implements JsonbDeserializer<Async
 
     static AsyncapiSchema bind(
         JsonObject object,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes,
         Supplier<Jsonb> plain)
     {
         AsyncapiSchema model = plain.get().fromJson(object.toString(), AsyncapiSchema.class);
@@ -95,7 +97,8 @@ public final class AsyncapiSchemaDeserializer implements JsonbDeserializer<Async
             bindAll(model.anyOf, object.getJsonArray("anyOf"), extensionTypes, prefixExtensionTypes, plain);
         }
 
-        model.extensions = AsyncapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
+        model.extensions = AsyncapiDeserializers.extensions(
+            object, AsyncapiExtension.Scope.SCHEMA, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }
@@ -103,8 +106,8 @@ public final class AsyncapiSchemaDeserializer implements JsonbDeserializer<Async
     private static void bindAll(
         List<AsyncapiSchema> schemas,
         JsonArray objects,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes,
         Supplier<Jsonb> plain)
     {
         for (int i = 0; i < schemas.size(); i++)

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiSchemaItemDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiSchemaItemDeserializer.java
@@ -24,18 +24,20 @@ import jakarta.json.bind.serializer.DeserializationContext;
 import jakarta.json.bind.serializer.JsonbDeserializer;
 import jakarta.json.stream.JsonParser;
 
+import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiExtension;
+
 public final class AsyncapiSchemaItemDeserializer implements JsonbDeserializer<AsyncapiSchemaItem>
 {
-    private final Map<String, Class<?>> extensionTypes;
-    private final Map<String, Class<?>> prefixExtensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public AsyncapiSchemaItemDeserializer(
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes)
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiSecuritySchemeDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiSecuritySchemeDeserializer.java
@@ -24,18 +24,20 @@ import jakarta.json.bind.serializer.DeserializationContext;
 import jakarta.json.bind.serializer.JsonbDeserializer;
 import jakarta.json.stream.JsonParser;
 
+import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiExtension;
+
 public final class AsyncapiSecuritySchemeDeserializer implements JsonbDeserializer<AsyncapiSecurityScheme>
 {
-    private final Map<String, Class<?>> extensionTypes;
-    private final Map<String, Class<?>> prefixExtensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public AsyncapiSecuritySchemeDeserializer(
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes)
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
@@ -52,7 +54,8 @@ public final class AsyncapiSecuritySchemeDeserializer implements JsonbDeserializ
     {
         JsonObject object = parser.getObject();
         AsyncapiSecurityScheme model = plain.get().fromJson(object.toString(), AsyncapiSecurityScheme.class);
-        model.extensions = AsyncapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
+        model.extensions = AsyncapiDeserializers.extensions(
+            object, AsyncapiExtension.Scope.SECURITY_SCHEME, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiServerDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiServerDeserializer.java
@@ -24,19 +24,21 @@ import jakarta.json.bind.serializer.DeserializationContext;
 import jakarta.json.bind.serializer.JsonbDeserializer;
 import jakarta.json.stream.JsonParser;
 
+import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiExtension;
+
 public final class AsyncapiServerDeserializer implements JsonbDeserializer<AsyncapiServer>
 {
     private final Map<String, Class<?>> serverBindingTypes;
-    private final Map<String, Class<?>> extensionTypes;
-    private final Map<String, Class<?>> prefixExtensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public AsyncapiServerDeserializer(
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes)
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.serverBindingTypes = serverBindingTypes;
         this.extensionTypes = extensionTypes;
@@ -56,7 +58,8 @@ public final class AsyncapiServerDeserializer implements JsonbDeserializer<Async
         AsyncapiServer model = plain.get().fromJson(object.toString(), AsyncapiServer.class);
 
         model.bindings = AsyncapiDeserializers.bindings(object, serverBindingTypes, plain.get());
-        model.extensions = AsyncapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
+        model.extensions = AsyncapiDeserializers.extensions(
+            object, AsyncapiExtension.Scope.SERVER, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiServerVariableDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiServerVariableDeserializer.java
@@ -24,18 +24,20 @@ import jakarta.json.bind.serializer.DeserializationContext;
 import jakarta.json.bind.serializer.JsonbDeserializer;
 import jakarta.json.stream.JsonParser;
 
+import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiExtension;
+
 public final class AsyncapiServerVariableDeserializer implements JsonbDeserializer<AsyncapiServerVariable>
 {
-    private final Map<String, Class<?>> extensionTypes;
-    private final Map<String, Class<?>> prefixExtensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public AsyncapiServerVariableDeserializer(
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes)
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
@@ -52,7 +54,8 @@ public final class AsyncapiServerVariableDeserializer implements JsonbDeserializ
     {
         JsonObject object = parser.getObject();
         AsyncapiServerVariable model = plain.get().fromJson(object.toString(), AsyncapiServerVariable.class);
-        model.extensions = AsyncapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
+        model.extensions = AsyncapiDeserializers.extensions(
+            object, AsyncapiExtension.Scope.SERVER_VARIABLE, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiTraitDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiTraitDeserializer.java
@@ -24,18 +24,20 @@ import jakarta.json.bind.serializer.DeserializationContext;
 import jakarta.json.bind.serializer.JsonbDeserializer;
 import jakarta.json.stream.JsonParser;
 
+import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiExtension;
+
 public final class AsyncapiTraitDeserializer implements JsonbDeserializer<AsyncapiTrait>
 {
-    private final Map<String, Class<?>> extensionTypes;
-    private final Map<String, Class<?>> prefixExtensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes;
+    private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
 
     public AsyncapiTraitDeserializer(
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
-        Map<String, Class<?>> extensionTypes,
-        Map<String, Class<?>> prefixExtensionTypes)
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
+        Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
@@ -52,7 +54,8 @@ public final class AsyncapiTraitDeserializer implements JsonbDeserializer<Asynca
     {
         JsonObject object = parser.getObject();
         AsyncapiTrait model = plain.get().fromJson(object.toString(), AsyncapiTrait.class);
-        model.extensions = AsyncapiDeserializers.extensions(object, extensionTypes, prefixExtensionTypes, plain);
+        model.extensions = AsyncapiDeserializers.extensions(
+            object, AsyncapiExtension.Scope.TRAIT, extensionTypes, prefixExtensionTypes, plain);
 
         return model;
     }

--- a/runtime/common-asyncapi/src/test/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiParserTest.java
+++ b/runtime/common-asyncapi/src/test/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiParserTest.java
@@ -135,6 +135,11 @@ public class AsyncapiParserTest
         public String key;
     }
 
+    public static final class CountExtension
+    {
+        public String key;
+    }
+
     public static final class GoogleJwtExtension
     {
         public String issuer;
@@ -211,7 +216,8 @@ public class AsyncapiParserTest
     public void shouldExposeSpecificationExtensionsGenerically()
     {
         AsyncapiParser parser = new AsyncapiParserFactory()
-            .withExtension("x-zilla-sample", SampleExtension.class)
+            .withExtension(AsyncapiExtension.of(AsyncapiExtension.Scope.ASYNCAPI, "x-zilla-sample", SampleExtension.class))
+            .withExtension(AsyncapiExtension.of(AsyncapiExtension.Scope.OPERATION, "x-zilla-sample", SampleExtension.class))
             .createParser();
 
         Asyncapi model = parser.parse(EXT_SPEC);
@@ -236,7 +242,7 @@ public class AsyncapiParserTest
     public void shouldExposeMessageExtensionGenerically()
     {
         AsyncapiParser parser = new AsyncapiParserFactory()
-            .withExtension("x-zilla-sample", SampleExtension.class)
+            .withExtension(AsyncapiExtension.of(AsyncapiExtension.Scope.MESSAGE, "x-zilla-sample", SampleExtension.class))
             .createParser();
 
         Asyncapi model = parser.parse(EXT_SPEC);
@@ -252,7 +258,7 @@ public class AsyncapiParserTest
     public void shouldExposeServerExtensionGenerically()
     {
         AsyncapiParser parser = new AsyncapiParserFactory()
-            .withExtension("x-zilla-sample", SampleExtension.class)
+            .withExtension(AsyncapiExtension.of(AsyncapiExtension.Scope.SERVER, "x-zilla-sample", SampleExtension.class))
             .createParser();
 
         Asyncapi model = parser.parse(EXT_SPEC);
@@ -267,7 +273,7 @@ public class AsyncapiParserTest
     public void shouldExposeSchemaExtensionGenerically()
     {
         AsyncapiParser parser = new AsyncapiParserFactory()
-            .withExtension("x-zilla-sample", SampleExtension.class)
+            .withExtension(AsyncapiExtension.of(AsyncapiExtension.Scope.SCHEMA, "x-zilla-sample", SampleExtension.class))
             .createParser();
 
         Asyncapi model = parser.parse(EXT_SPEC);
@@ -282,7 +288,7 @@ public class AsyncapiParserTest
     public void shouldExposeSecuritySchemeExtensionGenerically()
     {
         AsyncapiParser parser = new AsyncapiParserFactory()
-            .withExtension("x-zilla-sample", SampleExtension.class)
+            .withExtension(AsyncapiExtension.of(AsyncapiExtension.Scope.SECURITY_SCHEME, "x-zilla-sample", SampleExtension.class))
             .createParser();
 
         Asyncapi model = parser.parse(EXT_SPEC);
@@ -300,7 +306,7 @@ public class AsyncapiParserTest
     public void shouldNotExposeUnregisteredExtensionType()
     {
         AsyncapiParser parser = new AsyncapiParserFactory()
-            .withExtension("x-zilla-sample", SampleExtension.class)
+            .withExtension(AsyncapiExtension.of(AsyncapiExtension.Scope.ASYNCAPI, "x-zilla-sample", SampleExtension.class))
             .createParser();
 
         Asyncapi model = parser.parse(EXT_SPEC);
@@ -331,7 +337,7 @@ public class AsyncapiParserTest
             """;
 
         AsyncapiParser parser = new AsyncapiParserFactory()
-            .withExtension("x-google-*", GoogleJwtExtension.class)
+            .withExtension(AsyncapiExtension.of(AsyncapiExtension.Scope.SECURITY_SCHEME, "x-google-*", GoogleJwtExtension.class))
             .createParser();
 
         Asyncapi model = parser.parse(spec);
@@ -353,7 +359,7 @@ public class AsyncapiParserTest
     public void shouldNotExposePrefixWildcardExtensionWhenAbsent()
     {
         AsyncapiParser parser = new AsyncapiParserFactory()
-            .withExtension("x-google-*", GoogleJwtExtension.class)
+            .withExtension(AsyncapiExtension.of(AsyncapiExtension.Scope.SECURITY_SCHEME, "x-google-*", GoogleJwtExtension.class))
             .createParser();
 
         Asyncapi model = parser.parse(EXT_SPEC);
@@ -365,5 +371,27 @@ public class AsyncapiParserTest
 
         assertFalse(scheme.hasExtension("x-google-*"));
         assertEquals(Optional.empty(), scheme.extension("x-google-*", GoogleJwtExtension.class));
+    }
+
+    @Test
+    public void shouldReuseExtensionNameWithDifferentTypesAcrossScopes()
+    {
+        AsyncapiParser parser = new AsyncapiParserFactory()
+            .withExtension(AsyncapiExtension.of(AsyncapiExtension.Scope.OPERATION, "x-zilla-sample", SampleExtension.class))
+            .withExtension(AsyncapiExtension.of(AsyncapiExtension.Scope.MESSAGE, "x-zilla-sample", CountExtension.class))
+            .createParser();
+
+        Asyncapi model = parser.parse(EXT_SPEC);
+        AsyncapiView view = AsyncapiView.of(model);
+        AsyncapiOperationView operation = view.operations.get("doSend");
+        AsyncapiMessageView message = operation.messages.get(0);
+
+        assertTrue(operation.hasExtension("x-zilla-sample"));
+        assertEquals("operation-value", operation.extension("x-zilla-sample", SampleExtension.class).get().key);
+
+        assertTrue(message.hasExtension("x-zilla-sample"));
+        assertEquals("message-value", message.extension("x-zilla-sample", CountExtension.class).get().key);
+
+        assertFalse(view.hasExtension("x-zilla-sample"));
     }
 }


### PR DESCRIPTION
## Description

This change introduces scope-aware extension registration for AsyncAPI specifications, allowing the same extension name to be registered for different scopes (e.g., OPERATION, MESSAGE, SCHEMA) with different types.

### Changes

- **New `AsyncapiExtension` interface**: Defines a scope-aware extension with methods for `scope()`, `name()`, and `type()`. Includes a factory method `of()` for convenient creation.

- **Scope enumeration**: Added `AsyncapiExtension.Scope` enum with values for all AsyncAPI specification elements (ASYNCAPI, SERVER, CHANNEL, OPERATION, MESSAGE, SCHEMA, SECURITY_SCHEME, etc.).

- **Updated extension registration**: Modified `AsyncapiParserFactory.withExtension()` to accept `AsyncapiExtension` objects instead of separate name/type parameters. Extensions are now stored in scope-keyed maps.

- **Scope-aware deserialization**: Updated all deserializers to pass the appropriate scope when processing extensions, enabling proper lookup of scope-specific extension types.

### Motivation

Previously, extensions were registered globally by name only, preventing the same extension name from being used with different types in different contexts. This change enables more flexible extension handling where, for example, `x-zilla-sample` could be a `SampleExtension` at the OPERATION scope and a `CountExtension` at the MESSAGE scope.

### Testing

Added comprehensive test case `shouldReuseExtensionNameWithDifferentTypesAcrossScopes()` that verifies:
- Same extension name can be registered for different scopes
- Each scope correctly deserializes to its registered type
- Extensions are properly isolated by scope

All existing extension tests updated to use the new `AsyncapiExtension.of()` factory method.

https://claude.ai/code/session_01EjcDVn4gZY6TQjXC4B4BZf