### PR TITLE
fix(examples): fix flaky grpc.kafka.fanout test and harden zilla healthchecks

### DIFF
--- a/examples/amqp.reflect/compose.yaml
+++ b/examples/amqp.reflect/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7172"]
     environment:
       ZILLA_INCUBATOR_ENABLED: "true"

--- a/examples/asyncapi.http.kafka.proxy/compose.yaml
+++ b/examples/asyncapi.http.kafka.proxy/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       KAFKA_BOOTSTRAP_SERVER: kafka.examples.dev:29092

--- a/examples/asyncapi.mqtt.kafka.proxy/compose.yaml
+++ b/examples/asyncapi.mqtt.kafka.proxy/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7183"]
     environment:
       KAFKA_BOOTSTRAP_SERVER: kafka.examples.dev:29092

--- a/examples/asyncapi.mqtt.proxy/compose.yaml
+++ b/examples/asyncapi.mqtt.proxy/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7183"]
     environment:
       MOSQUITTO_BROKER_HOST: mosquitto

--- a/examples/asyncapi.sse.kafka.proxy/compose.yaml
+++ b/examples/asyncapi.sse.kafka.proxy/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       KAFKA_BOOTSTRAP_SERVER: kafka.examples.dev:29092

--- a/examples/asyncapi.sse.proxy/compose.yaml
+++ b/examples/asyncapi.sse.proxy/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       SSE_SERVER_HOST: sse-server

--- a/examples/grpc.echo/compose.yaml
+++ b/examples/grpc.echo/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7151"]
     environment:
       ZILLA_INCUBATOR_ENABLED: "true"

--- a/examples/grpc.kafka.echo/compose.yaml
+++ b/examples/grpc.kafka.echo/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7151"]
     environment:
       KAFKA_BOOTSTRAP_SERVER: kafka.examples.dev:29092

--- a/examples/grpc.kafka.fanout/.github/test.sh
+++ b/examples/grpc.kafka.fanout/.github/test.sh
@@ -20,8 +20,14 @@ echo
 # WHEN
 
 # produce the record once; the fanout stream replays it from the topic on every
-# connection, so re-reading below is safe and must not re-produce
-docker compose -p zilla-grpc-kafka-fanout exec kafkacat kafkacat -P -b kafka.examples.dev:29092 -t messages -k -e /tmp/binary.data
+# connection, so re-reading below is safe and must not re-produce.
+# the topic can exist (kafka-init's create call succeeded) before its metadata
+# has propagated to the point where a produce is accepted, so retry on failure
+# rather than leaving the topic empty and failing every read below
+produce_fanout() {
+  docker compose -p zilla-grpc-kafka-fanout exec kafkacat kafkacat -P -b kafka.examples.dev:29092 -t messages -k -e /tmp/binary.data
+}
+retry_until 10 3 produce_fanout
 
 # the grpc-kafka route warms up after the TCP healthcheck passes; retry the
 # streamed read until it returns the produced record or attempts are exhausted

--- a/examples/grpc.kafka.fanout/compose.yaml
+++ b/examples/grpc.kafka.fanout/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7151"]
     environment:
       KAFKA_BOOTSTRAP_SERVER: kafka.examples.dev:29092

--- a/examples/grpc.kafka.proxy/compose.yaml
+++ b/examples/grpc.kafka.proxy/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7151"]
     environment:
       KAFKA_BOOTSTRAP_SERVER: kafka.examples.dev:29092

--- a/examples/grpc.proxy/compose.yaml
+++ b/examples/grpc.proxy/compose.yaml
@@ -11,6 +11,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7153"]
     environment:
       KEYSTORE_PASSWORD: generated

--- a/examples/http.echo/compose.yaml
+++ b/examples/http.echo/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       ZILLA_INCUBATOR_ENABLED: "true"

--- a/examples/http.filesystem/compose.yaml
+++ b/examples/http.filesystem/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       ZILLA_INCUBATOR_ENABLED: "true"

--- a/examples/http.json.schema/compose.yaml
+++ b/examples/http.json.schema/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       ZILLA_INCUBATOR_ENABLED: "true"

--- a/examples/http.kafka.async/compose.yaml
+++ b/examples/http.kafka.async/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       KAFKA_BOOTSTRAP_SERVER: kafka.examples.dev:29092

--- a/examples/http.kafka.avro.json/compose.yaml
+++ b/examples/http.kafka.avro.json/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       KAFKA_BOOTSTRAP_SERVER: kafka.examples.dev:29092

--- a/examples/http.kafka.cache/compose.yaml
+++ b/examples/http.kafka.cache/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       KAFKA_BOOTSTRAP_SERVER: kafka.examples.dev:29092

--- a/examples/http.kafka.crud/compose.yaml
+++ b/examples/http.kafka.crud/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       KAFKA_BOOTSTRAP_SERVER: kafka.examples.dev:29092

--- a/examples/http.kafka.oneway.oauthbearer/compose.yaml
+++ b/examples/http.kafka.oneway.oauthbearer/compose.yaml
@@ -9,6 +9,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       KAFKA_BOOTSTRAP_SERVER: kafka.examples.dev:9092

--- a/examples/http.kafka.oneway/compose.yaml
+++ b/examples/http.kafka.oneway/compose.yaml
@@ -9,6 +9,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       KAFKA_BOOTSTRAP_SERVER: kafka:9092

--- a/examples/http.kafka.proto.json/compose.yaml
+++ b/examples/http.kafka.proto.json/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       KAFKA_BOOTSTRAP_SERVER: kafka.examples.dev:29092

--- a/examples/http.kafka.proto.oneway/compose.yaml
+++ b/examples/http.kafka.proto.oneway/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       KAFKA_BOOTSTRAP_SERVER: kafka.examples.dev:29092

--- a/examples/http.kafka.sync/compose.yaml
+++ b/examples/http.kafka.sync/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       KAFKA_BOOTSTRAP_SERVER: kafka.examples.dev:29092

--- a/examples/http.metrics/compose.yaml
+++ b/examples/http.metrics/compose.yaml
@@ -11,6 +11,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       ZILLA_INCUBATOR_ENABLED: "true"

--- a/examples/http.proxy.jwt/compose.yaml
+++ b/examples/http.proxy.jwt/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       ZILLA_INCUBATOR_ENABLED: "true"

--- a/examples/http.proxy/compose.yaml
+++ b/examples/http.proxy/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7143"]
     environment:
       KEYSTORE_PASSWORD: generated

--- a/examples/mcp.proxy/compose.yaml
+++ b/examples/mcp.proxy/compose.yaml
@@ -12,6 +12,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       ZILLA_INCUBATOR_ENABLED: "true"

--- a/examples/mqtt.kafka.proxy/compose.yaml
+++ b/examples/mqtt.kafka.proxy/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7183"]
     environment:
       KAFKA_BOOTSTRAP_SERVER: kafka.examples.dev:29092

--- a/examples/mqtt.proxy.jwt/compose.yaml
+++ b/examples/mqtt.proxy.jwt/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7183"]
     environment:
       MOSQUITTO_BROKER_HOST: mosquitto

--- a/examples/openapi.asyncapi.kakfa.proxy/compose.yaml
+++ b/examples/openapi.asyncapi.kakfa.proxy/compose.yaml
@@ -11,6 +11,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       KAFKA_BOOTSTRAP_SERVER: kafka.examples.dev:29092

--- a/examples/openapi.proxy/compose.yaml
+++ b/examples/openapi.proxy/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       ZILLA_INCUBATOR_ENABLED: "true"

--- a/examples/sse.kafka.fanout.jwt/compose.yaml
+++ b/examples/sse.kafka.fanout.jwt/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7143"]
     environment:
       KAFKA_BOOTSTRAP_SERVER: kafka.examples.dev:29092

--- a/examples/sse.kafka.fanout/compose.yaml
+++ b/examples/sse.kafka.fanout/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       KAFKA_BOOTSTRAP_SERVER: kafka.examples.dev:29092

--- a/examples/sse.proxy.jwt/compose.yaml
+++ b/examples/sse.proxy.jwt/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7143"]
     environment:
       KEYSTORE_PASSWORD: generated

--- a/examples/tcp.echo/compose.yaml
+++ b/examples/tcp.echo/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/12345"]
     environment:
       ZILLA_INCUBATOR_ENABLED: "true"

--- a/examples/tcp.reflect/compose.yaml
+++ b/examples/tcp.reflect/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/12345"]
     environment:
       ZILLA_INCUBATOR_ENABLED: "true"

--- a/examples/tls.echo/compose.yaml
+++ b/examples/tls.echo/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/23456"]
     environment:
       KEYSTORE_PASSWORD: generated

--- a/examples/tls.reflect/compose.yaml
+++ b/examples/tls.reflect/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/23456"]
     environment:
       KEYSTORE_PASSWORD: generated

--- a/examples/ws.echo/compose.yaml
+++ b/examples/ws.echo/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       ZILLA_INCUBATOR_ENABLED: "true"

--- a/examples/ws.proxy/compose.yaml
+++ b/examples/ws.proxy/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7143"]
     environment:
       ZILLA_INCUBATOR_ENABLED: "true"

--- a/examples/ws.reflect/compose.yaml
+++ b/examples/ws.reflect/compose.yaml
@@ -10,6 +10,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 15s
       test: ["CMD", "bash", "-c", "echo -n '' > /dev/tcp/127.0.0.1/7114"]
     environment:
       ZILLA_INCUBATOR_ENABLED: "true"


### PR DESCRIPTION
## Description

We frequently see some `examples/*` fail during PR builds. I investigated locally (started `dockerd`, built the `zilla` docker image, and ran the example `compose.yaml` + `.github/test.sh` flows one by one against real containers) instead of relying on CI.

I first mined recent GitHub Actions history for the `testing` matrix job to find which examples actually fail repeatedly:

| Example | Failures seen (of 8 recent runs checked) |
|---|---|
| `asyncapi.http.kafka.proxy` | 3 |
| `grpc.kafka.fanout` | 3 |
| `asyncapi.sse.proxy` | 1 |
| `amqp.reflect` | 1 |

**`grpc.kafka.fanout` — genuine, deterministically reproducible bug.** `examples/grpc.kafka.fanout/.github/test.sh` produces one Kafka record via `kafkacat` with no retry or exit-code check, then retries a gRPC streamed read up to 10× looking for it. Right after `docker compose up --wait` reports `kafka-init` (which creates the topic) healthy, the topic's metadata isn't always produce-ready yet. I reproduced the exact `% Delivery failed for message: Broker: Unknown topic or partition` error from that precise command on a fresh stack. When that race hits, the topic stays empty, so every read retry correctly finds nothing and the test fails with an empty `OUTPUT` — matching the CI failure logs exactly. The read side already got readiness-retry hardening in a previous change; the write side never did.

**Fix:** wrap the produce call in the same `retry_until` helper already used for the read side.

**`asyncapi.*` / `amqp.reflect` — not reproducible locally; consistent with CI-only startup-timing flakiness.** These came up healthy and passed on every local run (one passed its health check on the very first probe, ~1s after container start). No example's `compose.yaml` sets a healthcheck `start_period`, so every example shares the same tight ~20–25s all-or-nothing startup budget (`interval: 5s, timeout: 3s, retries: 5`). In CI, `docker compose up -d --wait` runs immediately after a CPU/I/O-heavy step (loading ~15 shared example images from a cached tarball), right when the Zilla JVM needs to boot — worse for AsyncAPI examples, which parse multiple catalogs/specs at startup. No config errors or crashes ever appear in the CI logs for these, consistent with startup-time variance rather than a code defect.

**Fix:** add a `start_period: 15s` to the `zilla` service healthcheck in every `examples/*/compose.yaml`, to absorb JVM boot variance under CI load without weakening the check itself.

## Changes

- `examples/grpc.kafka.fanout/.github/test.sh`: retry the Kafka produce step until it succeeds (mirrors the existing read-side retry).
- `examples/*/compose.yaml` (41 files): add `start_period: 15s` to the `zilla` service healthcheck only — no other healthcheck fields changed, no other services touched.

## Test plan

- [x] Built `ghcr.io/aklivity/zilla:develop-SNAPSHOT` locally via `./mvnw -pl cloud/docker-image -am install -DskipTests -DskipITs ...`
- [x] Reproduced the `grpc.kafka.fanout` failure on a fresh stack, then confirmed the fix passes 3/3 times on fresh stacks
- [x] Confirmed `asyncapi.http.kafka.proxy`, `asyncapi.sse.proxy`, and `amqp.reflect` pass locally (before and after the healthcheck change)
- [x] Validated all 41 edited `compose.yaml` files with `docker compose config -q`


---
_Generated by [Claude Code](https://claude.ai/code/session_01D9eYCxo6pL39BGfjjKpU5Q)_