### PR TITLE
Fix UnsafeBufferEx.asNative() to preserve offset for sub-range wraps

### DIFF
--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -2498,8 +2498,6 @@ public final class UnsafeBufferEx implements AtomicBufferEx, DirectBufferViewEx
                 : "UnsafeBufferEx.Native requires a native MemorySegment";
             assert byteBuffer != null && byteBuffer.isDirect()
                 : "UnsafeBufferEx.Native requires a direct ByteBuffer";
-            // Native's own base always corresponds to wrapAdjustment 0 (see wrapAdjustment() below), so
-            // a sub-range wrap(ByteBuffer, offset, length) is sliced here to that sub-range.
             this.segment = segment.asSlice(wrapAdjustment, capacity);
             this.addressOffset = this.segment.address();
             this.capacity = capacity;

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -2477,10 +2477,7 @@ public final class UnsafeBufferEx implements AtomicBufferEx, DirectBufferViewEx
             throw new IllegalStateException(
                 "UnsafeBufferEx.asNative requires a direct ByteBuffer-backed buffer");
         }
-        // Native's own base must already correspond to wrapAdjustment (it always reports 0), so a
-        // sub-range wrap(ByteBuffer, offset, length) is sliced to that sub-range here rather than
-        // carrying the whole-buffer segment forward.
-        return new Native(segment.asSlice(wrapAdjustment, capacity), byteBuffer);
+        return new Native(segment, wrapAdjustment, capacity, byteBuffer);
     }
 
     public static final class Native implements AtomicBufferEx, DirectBufferViewEx
@@ -2493,15 +2490,20 @@ public final class UnsafeBufferEx implements AtomicBufferEx, DirectBufferViewEx
 
         private Native(
             MemorySegment segment,
+            int wrapAdjustment,
+            int capacity,
             ByteBuffer byteBuffer)
         {
             assert segment.heapBase().isEmpty()
                 : "UnsafeBufferEx.Native requires a native MemorySegment";
             assert byteBuffer != null && byteBuffer.isDirect()
                 : "UnsafeBufferEx.Native requires a direct ByteBuffer";
-            this.segment = segment;
-            this.addressOffset = segment.address();
-            this.capacity = (int) segment.byteSize();
+            // Native's own base always corresponds to wrapAdjustment 0 (see wrapAdjustment() below), so
+            // a sub-range wrap(ByteBuffer, offset, length) is sliced to that sub-range here rather than
+            // carrying the whole-buffer segment forward.
+            this.segment = segment.asSlice(wrapAdjustment, capacity);
+            this.addressOffset = this.segment.address();
+            this.capacity = capacity;
             this.byteBuffer = byteBuffer;
             // clean duplicate (position 0, limit capacity) so the ByteBuffer.put bulk-copy fast path
             // is always in bounds without consulting the wrapped buffer's NIO limit (Agrona scratch

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -2477,7 +2477,10 @@ public final class UnsafeBufferEx implements AtomicBufferEx, DirectBufferViewEx
             throw new IllegalStateException(
                 "UnsafeBufferEx.asNative requires a direct ByteBuffer-backed buffer");
         }
-        return new Native(segment, byteBuffer);
+        // Native's own base must already correspond to wrapAdjustment (it always reports 0), so a
+        // sub-range wrap(ByteBuffer, offset, length) is sliced to that sub-range here rather than
+        // carrying the whole-buffer segment forward.
+        return new Native(segment.asSlice(wrapAdjustment, capacity), byteBuffer);
     }
 
     public static final class Native implements AtomicBufferEx, DirectBufferViewEx

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -2499,16 +2499,18 @@ public final class UnsafeBufferEx implements AtomicBufferEx, DirectBufferViewEx
             assert byteBuffer != null && byteBuffer.isDirect()
                 : "UnsafeBufferEx.Native requires a direct ByteBuffer";
             // Native's own base always corresponds to wrapAdjustment 0 (see wrapAdjustment() below), so
-            // a sub-range wrap(ByteBuffer, offset, length) is sliced to that sub-range here rather than
-            // carrying the whole-buffer segment forward.
+            // a sub-range wrap(ByteBuffer, offset, length) is sliced to that sub-range here for both the
+            // segment and the ByteBuffer — byteBufferView is derived from the latter, and every bulk-copy
+            // call site below indexes it without adding wrapAdjustment, so the two views must stay in
+            // sync or a sub-range write lands at the whole buffer's offset 0 instead of its true position.
             this.segment = segment.asSlice(wrapAdjustment, capacity);
             this.addressOffset = this.segment.address();
             this.capacity = capacity;
-            this.byteBuffer = byteBuffer;
+            this.byteBuffer = wrapAdjustment == 0 ? byteBuffer : byteBuffer.slice(wrapAdjustment, capacity);
             // clean duplicate (position 0, limit capacity) so the ByteBuffer.put bulk-copy fast path
             // is always in bounds without consulting the wrapped buffer's NIO limit (Agrona scratch
             // state, e.g. dirtied by CRC32.update)
-            this.byteBufferView = byteBuffer.duplicate();
+            this.byteBufferView = this.byteBuffer.duplicate();
             this.byteBufferView.clear();
         }
 

--- a/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
+++ b/runtime/common-agrona/src/main/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferEx.java
@@ -2499,10 +2499,7 @@ public final class UnsafeBufferEx implements AtomicBufferEx, DirectBufferViewEx
             assert byteBuffer != null && byteBuffer.isDirect()
                 : "UnsafeBufferEx.Native requires a direct ByteBuffer";
             // Native's own base always corresponds to wrapAdjustment 0 (see wrapAdjustment() below), so
-            // a sub-range wrap(ByteBuffer, offset, length) is sliced to that sub-range here for both the
-            // segment and the ByteBuffer — byteBufferView is derived from the latter, and every bulk-copy
-            // call site below indexes it without adding wrapAdjustment, so the two views must stay in
-            // sync or a sub-range write lands at the whole buffer's offset 0 instead of its true position.
+            // a sub-range wrap(ByteBuffer, offset, length) is sliced here to that sub-range.
             this.segment = segment.asSlice(wrapAdjustment, capacity);
             this.addressOffset = this.segment.address();
             this.capacity = capacity;

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExNativeTest.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExNativeTest.java
@@ -67,6 +67,24 @@ public class UnsafeBufferExNativeTest
     }
 
     @Test
+    public void asNativeOnSubRangeWrapPreservesOffset()
+    {
+        ByteBuffer source = ByteBuffer.allocateDirect(64);
+        UnsafeBufferEx whole = new UnsafeBufferEx(source);
+        UnsafeBufferEx subRange = new UnsafeBufferEx(source, 16, 32);
+        UnsafeBufferEx.Native native0 = subRange.asNative();
+
+        assertEquals(32, native0.capacity());
+        assertEquals(0, native0.wrapAdjustment());
+        assertEquals(subRange.addressOffset(), native0.addressOffset());
+
+        native0.putLong(0, 0x0123456789abcdefL);
+
+        assertEquals(0x0123456789abcdefL, subRange.getLong(0));
+        assertEquals(0x0123456789abcdefL, whole.getLong(16));
+    }
+
+    @Test
     public void wrapByteArrayUnsupported()
     {
         UnsafeBufferEx.Native native0 = new UnsafeBufferEx(ByteBuffer.allocateDirect(64)).asNative();

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExNativeTest.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExNativeTest.java
@@ -87,9 +87,6 @@ public class UnsafeBufferExNativeTest
     @Test
     public void putBytesOnSubRangeWrapUsesCorrectByteBufferOffset()
     {
-        // putBytes(index, byte[], offset, length) copies through byteBufferView, which must be
-        // sliced in step with segment/addressOffset or the write lands at the whole buffer's
-        // offset 0 instead of the sub-range's true position
         ByteBuffer source = ByteBuffer.allocateDirect(64);
         UnsafeBufferEx whole = new UnsafeBufferEx(source);
         UnsafeBufferEx subRange = new UnsafeBufferEx(source, 16, 32);

--- a/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExNativeTest.java
+++ b/runtime/common-agrona/src/test/java/io/aklivity/zilla/runtime/common/agrona/buffer/UnsafeBufferExNativeTest.java
@@ -85,6 +85,29 @@ public class UnsafeBufferExNativeTest
     }
 
     @Test
+    public void putBytesOnSubRangeWrapUsesCorrectByteBufferOffset()
+    {
+        // putBytes(index, byte[], offset, length) copies through byteBufferView, which must be
+        // sliced in step with segment/addressOffset or the write lands at the whole buffer's
+        // offset 0 instead of the sub-range's true position
+        ByteBuffer source = ByteBuffer.allocateDirect(64);
+        UnsafeBufferEx whole = new UnsafeBufferEx(source);
+        UnsafeBufferEx subRange = new UnsafeBufferEx(source, 16, 32);
+        UnsafeBufferEx.Native native0 = subRange.asNative();
+
+        byte[] payload = "hello-sub-range-bytes".getBytes();
+        native0.putBytes(0, payload);
+
+        byte[] readback = new byte[payload.length];
+        native0.getBytes(0, readback);
+        assertArrayEquals(payload, readback);
+
+        byte[] wholeReadback = new byte[payload.length];
+        whole.getBytes(16, wholeReadback);
+        assertArrayEquals(payload, wholeReadback);
+    }
+
+    @Test
     public void wrapByteArrayUnsupported()
     {
         UnsafeBufferEx.Native native0 = new UnsafeBufferEx(ByteBuffer.allocateDirect(64)).asNative();


### PR DESCRIPTION
## Description

Fixes an issue where `UnsafeBufferEx.asNative()` did not correctly preserve the offset when called on a buffer created with a sub-range wrap (i.e., `new UnsafeBufferEx(byteBuffer, offset, length)`).

### Changes

**UnsafeBufferEx.java**: Modified `asNative()` to slice the segment to the sub-range before creating the Native wrapper. This ensures that the Native buffer's address offset correctly reflects the original sub-range offset, rather than always starting from the beginning of the underlying ByteBuffer.

The fix accounts for the fact that `Native.wrapAdjustment()` always reports 0, so the segment passed to Native must already be adjusted to the correct sub-range boundaries.

**UnsafeBufferExNativeTest.java**: Added `asNativeOnSubRangeWrapPreservesOffset()` test to verify that:
- A Native wrapper created from a sub-range buffer has the correct capacity
- The address offset is preserved from the original sub-range
- Data written through the Native wrapper is correctly positioned in both the sub-range and whole buffers

### Test Plan

The new unit test `asNativeOnSubRangeWrapPreservesOffset()` validates the fix by creating a sub-range wrap, converting it to Native, writing data, and verifying correct positioning in both the sub-range and whole buffer views.

https://claude.ai/code/session_012aTZ6zyEtnxCRPUfWdbhsa